### PR TITLE
Added ExactName to resource creation steps. Renamed Persist field. Also renamed ephemeralName.

### DIFF
--- a/daisy/workflow/step_create_disks.go
+++ b/daisy/workflow/step_create_disks.go
@@ -70,7 +70,7 @@ func (c *CreateDisks) run(w *Workflow) error {
 			defer wg.Done()
 			name := cd.Name
 			if !cd.ExactName {
-				name = w.ephemeralName(cd.Name)
+				name = w.genName(cd.Name)
 			}
 			imageLink := resolveLink(cd.SourceImage, w.imageRefs)
 			if imageLink == "" {

--- a/daisy/workflow/step_create_disks_test.go
+++ b/daisy/workflow/step_create_disks_test.go
@@ -27,7 +27,8 @@ func TestCreateDisksRun(t *testing.T) {
 	cd := &CreateDisks{
 		{Name: "d1", SourceImage: "i1", SizeGB: "100", SSD: false},
 		{Name: "d2", SourceImage: "projects/global/images/i2", SizeGB: "100", SSD: false},
-		{Name: "d3", SourceImage: "i1", SizeGB: "100", SSD: false, Persist: true}}
+		{Name: "d3", SourceImage: "i1", SizeGB: "100", SSD: false, NoCleanup: true},
+		{Name: "d4", SourceImage: "i1", SizeGB: "100", SSD: false, ExactName: true}}
 	if err := cd.run(wf); err != nil {
 		t.Fatalf("error running CreateDisks.run(): %v", err)
 	}
@@ -35,7 +36,8 @@ func TestCreateDisksRun(t *testing.T) {
 	want := map[string]*resource{
 		"d1": {"d1", wf.ephemeralName("d1"), "link", false},
 		"d2": {"d2", wf.ephemeralName("d2"), "link", false},
-		"d3": {"d3", wf.ephemeralName("d3"), "link", true}}
+		"d3": {"d3", wf.ephemeralName("d3"), "link", true},
+		"d4": {"d4", "d4", "link", false}}
 
 	if diff := pretty.Compare(wf.diskRefs.m, want); diff != "" {
 		t.Errorf("diskRefs do not match expectation: (-got +want)\n%s", diff)

--- a/daisy/workflow/step_create_disks_test.go
+++ b/daisy/workflow/step_create_disks_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestCreateDisksRun(t *testing.T) {
 	wf := testWorkflow()
-	wf.imageRefs.m = map[string]*resource{"i1": {"i1", wf.ephemeralName("i1"), "link", false}}
+	wf.imageRefs.m = map[string]*resource{"i1": {"i1", wf.genName("i1"), "link", false}}
 	cd := &CreateDisks{
 		{Name: "d1", SourceImage: "i1", SizeGB: "100", SSD: false},
 		{Name: "d2", SourceImage: "projects/global/images/i2", SizeGB: "100", SSD: false},
@@ -34,9 +34,9 @@ func TestCreateDisksRun(t *testing.T) {
 	}
 
 	want := map[string]*resource{
-		"d1": {"d1", wf.ephemeralName("d1"), "link", false},
-		"d2": {"d2", wf.ephemeralName("d2"), "link", false},
-		"d3": {"d3", wf.ephemeralName("d3"), "link", true},
+		"d1": {"d1", wf.genName("d1"), "link", false},
+		"d2": {"d2", wf.genName("d2"), "link", false},
+		"d3": {"d3", wf.genName("d3"), "link", true},
 		"d4": {"d4", "d4", "link", false}}
 
 	if diff := pretty.Compare(wf.diskRefs.m, want); diff != "" {

--- a/daisy/workflow/step_create_images.go
+++ b/daisy/workflow/step_create_images.go
@@ -82,7 +82,7 @@ func (c *CreateImages) run(w *Workflow) error {
 			defer wg.Done()
 			name := ci.Name
 			if !ci.ExactName {
-				name = w.ephemeralName(ci.Name)
+				name = w.genName(ci.Name)
 			}
 			var diskLink string
 			if ci.SourceDisk != "" {

--- a/daisy/workflow/step_create_images_test.go
+++ b/daisy/workflow/step_create_images_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestCreateImagesRun(t *testing.T) {
 	wf := testWorkflow()
-	wf.diskRefs.m = map[string]*resource{"d": {"d", wf.ephemeralName("d"), "link", false}}
+	wf.diskRefs.m = map[string]*resource{"d": {"d", wf.genName("d"), "link", false}}
 	ci := &CreateImages{
 		{Name: "i1", SourceDisk: "d"},
 		{Name: "i2", SourceFile: "f"},
@@ -35,9 +35,9 @@ func TestCreateImagesRun(t *testing.T) {
 	}
 
 	want := map[string]*resource{
-		"i1": {"i1", wf.ephemeralName("i1"), "link", false},
-		"i2": {"i2", wf.ephemeralName("i2"), "link", false},
-		"i3": {"i3", wf.ephemeralName("i3"), "link", true},
+		"i1": {"i1", wf.genName("i1"), "link", false},
+		"i2": {"i2", wf.genName("i2"), "link", false},
+		"i3": {"i3", wf.genName("i3"), "link", true},
 		"i4": {"i4", "i4", "link", false},
 	}
 

--- a/daisy/workflow/step_create_images_test.go
+++ b/daisy/workflow/step_create_images_test.go
@@ -27,7 +27,8 @@ func TestCreateImagesRun(t *testing.T) {
 	ci := &CreateImages{
 		{Name: "i1", SourceDisk: "d"},
 		{Name: "i2", SourceFile: "f"},
-		{Name: "i3", SourceDisk: "d", Persist: true},
+		{Name: "i3", SourceDisk: "d", NoCleanup: true},
+		{Name: "i4", SourceDisk: "d", ExactName: true},
 	}
 	if err := ci.run(wf); err != nil {
 		t.Fatalf("error running CreateImages.run(): %v", err)
@@ -37,6 +38,7 @@ func TestCreateImagesRun(t *testing.T) {
 		"i1": {"i1", wf.ephemeralName("i1"), "link", false},
 		"i2": {"i2", wf.ephemeralName("i2"), "link", false},
 		"i3": {"i3", wf.ephemeralName("i3"), "link", true},
+		"i4": {"i4", "i4", "link", false},
 	}
 
 	if diff := pretty.Compare(wf.imageRefs.m, want); diff != "" {

--- a/daisy/workflow/step_create_instances.go
+++ b/daisy/workflow/step_create_instances.go
@@ -79,7 +79,7 @@ func (c *CreateInstances) run(w *Workflow) error {
 			defer wg.Done()
 			name := ci.Name
 			if !ci.ExactName {
-				name = w.ephemeralName(ci.Name)
+				name = w.genName(ci.Name)
 			}
 
 			inst, err := w.ComputeClient.NewInstance(name, w.Project, w.Zone, ci.MachineType)

--- a/daisy/workflow/step_create_instances.go
+++ b/daisy/workflow/step_create_instances.go
@@ -38,8 +38,10 @@ type CreateInstance struct {
 	StartupScript string `json:"startup_script"`
 	// Additional metadata to set for the instance.
 	Metadata map[string]string
-	// Should this resource persist?
-	Persist bool
+	// Should this resource be cleaned up after the workflow?
+	NoCleanup bool `json:"no_cleanup"`
+	// Should we use the user-provided reference name as the actual resource name?
+	ExactName bool `json:"exact_name"`
 }
 
 func (c *CreateInstances) validate(w *Workflow) error {
@@ -75,7 +77,10 @@ func (c *CreateInstances) run(w *Workflow) error {
 		wg.Add(1)
 		go func(ci CreateInstance) {
 			defer wg.Done()
-			name := w.ephemeralName(ci.Name)
+			name := ci.Name
+			if !ci.ExactName {
+				name = w.ephemeralName(ci.Name)
+			}
 
 			inst, err := w.ComputeClient.NewInstance(name, w.Project, w.Zone, ci.MachineType)
 			if err != nil {
@@ -120,7 +125,7 @@ func (c *CreateInstances) run(w *Workflow) error {
 				e <- err
 				return
 			}
-			w.instanceRefs.add(ci.Name, &resource{ci.Name, name, i.SelfLink, ci.Persist})
+			w.instanceRefs.add(ci.Name, &resource{ci.Name, name, i.SelfLink, ci.NoCleanup})
 		}(ci)
 	}
 

--- a/daisy/workflow/step_create_instances_test.go
+++ b/daisy/workflow/step_create_instances_test.go
@@ -24,9 +24,9 @@ import (
 func TestCreateInstancesRun(t *testing.T) {
 	wf := testWorkflow()
 	wf.diskRefs.m = map[string]*resource{
-		"d1": {"d1", wf.ephemeralName("d1"), "link", false},
-		"d2": {"d2", wf.ephemeralName("d2"), "link", false},
-		"d3": {"d3", wf.ephemeralName("d3"), "link", false},
+		"d1": {"d1", wf.genName("d1"), "link", false},
+		"d2": {"d2", wf.genName("d2"), "link", false},
+		"d3": {"d3", wf.genName("d3"), "link", false},
 	}
 	ci := &CreateInstances{
 		{Name: "i1", MachineType: "foo-type", AttachedDisks: []string{"d1"}},
@@ -39,9 +39,9 @@ func TestCreateInstancesRun(t *testing.T) {
 	}
 
 	want := map[string]*resource{
-		"i1": {"i1", wf.ephemeralName("i1"), "link", false},
-		"i2": {"i2", wf.ephemeralName("i2"), "link", false},
-		"i3": {"i3", wf.ephemeralName("i3"), "link", true},
+		"i1": {"i1", wf.genName("i1"), "link", false},
+		"i2": {"i2", wf.genName("i2"), "link", false},
+		"i3": {"i3", wf.genName("i3"), "link", true},
 		"i4": {"i4", "i4", "link", false},
 	}
 

--- a/daisy/workflow/step_create_instances_test.go
+++ b/daisy/workflow/step_create_instances_test.go
@@ -31,7 +31,8 @@ func TestCreateInstancesRun(t *testing.T) {
 	ci := &CreateInstances{
 		{Name: "i1", MachineType: "foo-type", AttachedDisks: []string{"d1"}},
 		{Name: "i2", MachineType: "foo-type", AttachedDisks: []string{"d2"}},
-		{Name: "i3", MachineType: "foo-type", AttachedDisks: []string{"d3"}, Persist: true},
+		{Name: "i3", MachineType: "foo-type", AttachedDisks: []string{"d3"}, NoCleanup: true},
+		{Name: "i4", MachineType: "foo-type", AttachedDisks: []string{"d3"}, ExactName: true},
 	}
 	if err := ci.run(wf); err != nil {
 		t.Fatalf("error running CreateInstances.run(): %v", err)
@@ -41,6 +42,7 @@ func TestCreateInstancesRun(t *testing.T) {
 		"i1": {"i1", wf.ephemeralName("i1"), "link", false},
 		"i2": {"i2", wf.ephemeralName("i2"), "link", false},
 		"i3": {"i3", wf.ephemeralName("i3"), "link", true},
+		"i4": {"i4", "i4", "link", false},
 	}
 
 	if diff := pretty.Compare(wf.instanceRefs.m, want); diff != "" {

--- a/daisy/workflow/step_delete_resources_test.go
+++ b/daisy/workflow/step_delete_resources_test.go
@@ -23,20 +23,20 @@ import (
 func TestDeleteResourcesRun(t *testing.T) {
 	wf := testWorkflow()
 	wf.instanceRefs.m = map[string]*resource{
-		"in1": {"in1", wf.ephemeralName("in1"), "link", false},
-		"in2": {"in2", wf.ephemeralName("in2"), "link", false},
-		"in3": {"in3", wf.ephemeralName("in3"), "link", false},
-		"in4": {"in4", wf.ephemeralName("in4"), "link", false}}
+		"in1": {"in1", wf.genName("in1"), "link", false},
+		"in2": {"in2", wf.genName("in2"), "link", false},
+		"in3": {"in3", wf.genName("in3"), "link", false},
+		"in4": {"in4", wf.genName("in4"), "link", false}}
 	wf.imageRefs.m = map[string]*resource{
-		"im1": {"im1", wf.ephemeralName("im1"), "link", false},
-		"im2": {"im2", wf.ephemeralName("im2"), "link", false},
-		"im3": {"im3", wf.ephemeralName("im3"), "link", false},
-		"im4": {"im4", wf.ephemeralName("im4"), "link", false}}
+		"im1": {"im1", wf.genName("im1"), "link", false},
+		"im2": {"im2", wf.genName("im2"), "link", false},
+		"im3": {"im3", wf.genName("im3"), "link", false},
+		"im4": {"im4", wf.genName("im4"), "link", false}}
 	wf.diskRefs.m = map[string]*resource{
-		"d1": {"d1", wf.ephemeralName("d1"), "link", false},
-		"d2": {"d2", wf.ephemeralName("d2"), "link", false},
-		"d3": {"d3", wf.ephemeralName("d3"), "link", false},
-		"d4": {"d4", wf.ephemeralName("d4"), "link", false}}
+		"d1": {"d1", wf.genName("d1"), "link", false},
+		"d2": {"d2", wf.genName("d2"), "link", false},
+		"d3": {"d3", wf.genName("d3"), "link", false},
+		"d4": {"d4", wf.genName("d4"), "link", false}}
 
 	dr := &DeleteResources{
 		Instances: []string{"in1", "in2", "in3"},
@@ -46,17 +46,17 @@ func TestDeleteResourcesRun(t *testing.T) {
 		t.Fatalf("error running DeleteResources.run(): %v", err)
 	}
 
-	want := map[string]*resource{"in4": {"in4", wf.ephemeralName("in4"), "link", false}}
+	want := map[string]*resource{"in4": {"in4", wf.genName("in4"), "link", false}}
 	if diff := pretty.Compare(wf.instanceRefs.m, want); diff != "" {
 		t.Errorf("instanceRefs do not match expectation: (-got +want)\n%s", diff)
 	}
 
-	want = map[string]*resource{"im4": {"im4", wf.ephemeralName("im4"), "link", false}}
+	want = map[string]*resource{"im4": {"im4", wf.genName("im4"), "link", false}}
 	if diff := pretty.Compare(wf.imageRefs.m, want); diff != "" {
 		t.Errorf("imageRefs do not match expectation: (-got +want)\n%s", diff)
 	}
 
-	want = map[string]*resource{"d4": {"d4", wf.ephemeralName("d4"), "link", false}}
+	want = map[string]*resource{"d4": {"d4", wf.genName("d4"), "link", false}}
 	if diff := pretty.Compare(wf.diskRefs.m, want); diff != "" {
 		t.Errorf("diskRefs do not match expectation: (-got +want)\n%s", diff)
 	}

--- a/daisy/workflow/step_import_disks.go
+++ b/daisy/workflow/step_import_disks.go
@@ -23,8 +23,10 @@ type ImportDisks []ImportDisk
 // This step is used to import vmdk, vhd or RAW disks.
 type ImportDisk struct {
 	Name, File string
-	// Should this resource persist?
-	Persist bool
+	// Should this resource be cleaned up after the workflow?
+	NoCleanup bool `json:"no_cleanup"`
+	// Should we use the user-provided reference name as the actual resource name?
+	ExactName bool `json:"exact_name"`
 }
 
 func (i *ImportDisks) validate(w *Workflow) error {

--- a/daisy/workflow/step_wait_for_instances_stopped_test.go
+++ b/daisy/workflow/step_wait_for_instances_stopped_test.go
@@ -21,9 +21,9 @@ import (
 func TestWaitForInstancesStoppedRun(t *testing.T) {
 	wf := testWorkflow()
 	wf.instanceRefs.m = map[string]*resource{
-		"i1": {"i1", wf.ephemeralName("i1"), "link", false},
-		"i2": {"i2", wf.ephemeralName("i2"), "link", false},
-		"i3": {"i3", wf.ephemeralName("i3"), "link", false}}
+		"i1": {"i1", wf.genName("i1"), "link", false},
+		"i2": {"i2", wf.genName("i2"), "link", false},
+		"i3": {"i3", wf.genName("i3"), "link", false}}
 	ws := &WaitForInstancesStopped{"i1", "i2", "i3"}
 	if err := ws.run(wf); err != nil {
 		t.Fatalf("error running WaitForInstancesStopped.run(): %v", err)

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -319,7 +319,7 @@ func (w *Workflow) deleteInstance(r *resource) error {
 	return nil
 }
 
-func (w *Workflow) ephemeralName(n string) string {
+func (w *Workflow) genName(n string) string {
 	prefix := fmt.Sprintf("%s-%s", n, w.Name)
 	if len(prefix) > 57 {
 		prefix = prefix[0:56]

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -66,7 +66,7 @@ func (rm *refMap) get(name string) (*resource, bool) {
 
 type resource struct {
 	name, real, link string
-	persist          bool
+	noCleanup        bool
 }
 
 type step interface {
@@ -279,7 +279,7 @@ func (w *Workflow) cleanupHelper(rm *refMap, deleteFn func(*resource) error) {
 	toDel := map[string]*resource{}
 	for ref, res := range rm.m {
 		// Delete only non-persistent resources.
-		if !res.persist {
+		if !res.noCleanup {
 			toDel[ref] = res
 		}
 	}

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -37,12 +37,12 @@ import (
 func TestCleanup(t *testing.T) {
 	w := testWorkflow()
 
-	d1 := &resource{name: "d1", link: "link", persist: false}
-	d2 := &resource{name: "d2", link: "link", persist: true}
-	im1 := &resource{name: "im1", link: "link", persist: false}
-	im2 := &resource{name: "im2", link: "link", persist: true}
-	in1 := &resource{name: "in1", link: "link", persist: false}
-	in2 := &resource{name: "in2", link: "link", persist: true}
+	d1 := &resource{name: "d1", link: "link", noCleanup: false}
+	d2 := &resource{name: "d2", link: "link", noCleanup: true}
+	im1 := &resource{name: "im1", link: "link", noCleanup: false}
+	im2 := &resource{name: "im2", link: "link", noCleanup: true}
+	in1 := &resource{name: "in1", link: "link", noCleanup: false}
+	in2 := &resource{name: "in2", link: "link", noCleanup: true}
 	w.diskRefs.m = map[string]*resource{"d1": d1, "d2": d2}
 	w.imageRefs.m = map[string]*resource{"im1": im1, "im2": im2}
 	w.instanceRefs.m = map[string]*resource{"in1": in1, "in2": in2}

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -63,7 +63,7 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
-func TestEphemeralName(t *testing.T) {
+func TestGenName(t *testing.T) {
 	tests := []struct{ name, wfName, wfID, want string }{
 		{"name", "wfname", "123456789", "name-wfname-123456789"},
 		{"super-long-name-really-long", "super-long-workflow-name-like-really-really-long", "1", "super-long-name-really-long-super-long-workflow-name-lik-1"},
@@ -73,7 +73,7 @@ func TestEphemeralName(t *testing.T) {
 	for _, tt := range tests {
 		w.id = tt.wfID
 		w.Name = tt.wfName
-		result := w.ephemeralName(tt.name)
+		result := w.genName(tt.name)
 		if result != tt.want {
 			t.Errorf("bad result, input: name=%s wfName=%s wfId=%s; got: %s; want: %s", tt.name, tt.wfName, tt.wfID, result, tt.want)
 		}


### PR DESCRIPTION
Resource creation steps' Persist field is now NoCleanup.
Workflow.ephemeralName is now Workflow.genName.