### PR TITLE
Bug fixes: VM metadata and step_wait_for_instances_stopped

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -314,7 +314,8 @@ func (c *Client) NewInstance(name, project, zone, machineType string) (*Instance
 func (i *Instance) AddMetadata(metadata map[string]string) {
 	var md []*compute.MetadataItems
 	for k, v := range metadata {
-		md = append(md, &compute.MetadataItems{Key: k, Value: &v})
+		newV := v
+		md = append(md, &compute.MetadataItems{Key: k, Value: &newV})
 	}
 	if i.metadata == nil {
 		i.metadata = &compute.Metadata{Items: md}

--- a/daisy/workflow/step_wait_for_instances_stopped.go
+++ b/daisy/workflow/step_wait_for_instances_stopped.go
@@ -30,12 +30,12 @@ func (s *WaitForInstancesStopped) run(w *Workflow) error {
 		wg.Add(1)
 		go func(name string) {
 			defer wg.Done()
-			instanceLink := resolveLink(name, w.instanceRefs)
-			if instanceLink == "" {
+			i, ok := w.instanceRefs.get(name)
+			if !ok {
 				e <- fmt.Errorf("unresolved instance %q", name)
 				return
 			}
-			if err := w.ComputeClient.WaitForInstanceStopped(w.Project, w.Zone, instanceLink); err != nil {
+			if err := w.ComputeClient.WaitForInstanceStopped(w.Project, w.Zone, i.real); err != nil {
 				e <- err
 			}
 		}(name)


### PR DESCRIPTION
* VM metadata: all value strings were using the same pointer, setting all the values to the same string.
* step_wait_for_instances_stopped was passing the VM selfLink as the VM name.