### PR TITLE
Hierarchical resource references. 

### DIFF
--- a/daisy/workflow/step_create_disks.go
+++ b/daisy/workflow/step_create_disks.go
@@ -72,11 +72,20 @@ func (c *CreateDisks) run(w *Workflow) error {
 			if !cd.ExactName {
 				name = w.genName(cd.Name)
 			}
-			imageLink := resolveLink(cd.SourceImage, w.imageRefs)
-			if imageLink == "" {
-				e <- fmt.Errorf("unresolved image %q", cd.SourceImage)
+
+			// Get the source image link.
+			var imageLink string
+			var image *resource
+			var err error
+			if isLink(cd.SourceImage) {
+				imageLink = cd.SourceImage
+			} else if image, err = w.getImage(cd.SourceImage); err == nil {
+				imageLink = image.link
+			} else {
+				e <- err
 				return
 			}
+
 			size, err := strconv.ParseInt(cd.SizeGB, 10, 64)
 			if err != nil {
 				e <- err

--- a/daisy/workflow/step_create_instances.go
+++ b/daisy/workflow/step_create_instances.go
@@ -89,14 +89,16 @@ func (c *CreateInstances) run(w *Workflow) error {
 			}
 
 			for i, sourceDisk := range ci.AttachedDisks {
+				var disk *resource
+				var err error
 				if isLink(sourceDisk) {
 					// Real link.
 					inst.AddPD("", sourceDisk, false, i == 0)
-				} else if r, ok := w.diskRefs.get(sourceDisk); ok {
+				} else if disk, err = w.getDisk(sourceDisk); err == nil {
 					// Reference.
-					inst.AddPD(r.name, r.link, false, i == 0)
+					inst.AddPD(disk.name, disk.link, false, i == 0)
 				} else {
-					e <- fmt.Errorf("unresolved disk %q", sourceDisk)
+					e <- err
 					return
 				}
 			}

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -84,12 +84,12 @@ func TestGetResource(t *testing.T) {
 	r3 := &resource{}
 	r4 := &resource{}
 	w := &Workflow{
-		diskRefs: &refMap{m: map[string]*resource{"foo": r1}},
-		imageRefs: &refMap{},
+		diskRefs:     &refMap{m: map[string]*resource{"foo": r1}},
+		imageRefs:    &refMap{},
 		instanceRefs: &refMap{m: map[string]*resource{"baz": r3}},
 		parent: &Workflow{
-			diskRefs: &refMap{},
-			imageRefs: &refMap{m: map[string]*resource{"bar": r2}},
+			diskRefs:     &refMap{},
+			imageRefs:    &refMap{m: map[string]*resource{"bar": r2}},
 			instanceRefs: &refMap{m: map[string]*resource{"baz": r4}},
 		},
 	}


### PR DESCRIPTION
Added get*() methods and a test for them. Resources are queried at the local workflow level, then the parent, then grandparent, etc.