### PR TITLE
Unsubbed var checking.

### DIFF
--- a/daisy/workflow/common.go
+++ b/daisy/workflow/common.go
@@ -93,41 +93,48 @@ func splitGCSPath(p string) (string, string, error) {
 	return "", "", fmt.Errorf("%q is not a valid GCS path", p)
 }
 
-// substitute analyzes an element and subelements for strings.
-// A strings.Replacer is run on found string elements/fields.
-// Private fields of a struct are not modified.
+// substitute runs replacer on string elements within a complex data structure
+// (except those contained in private data structure fields).
 func substitute(v reflect.Value, replacer *strings.Replacer) {
+	traverseDataStructure(v, func(val reflect.Value) error {
+		switch val.Interface().(type) {
+		case string:
+			val.SetString(replacer.Replace(val.String()))
+		}
+		return nil
+	})
+}
+
+// traverseDataStructure traverses complex data structures and runs
+// a function, f, on its basic data types.
+// Traverses arrays, maps, slices, and public fields of structs.
+// For example, f will be run on bool, int, string, etc.
+// Slices, maps, and structs will not have f called on them, but will
+// traverse their subelements.
+// Errors returned from f will be returned by traverseDataStructure.
+func traverseDataStructure(v reflect.Value, f func(reflect.Value) error) error {
 	if !v.CanSet() {
-		return
+		// Don't run on private fields.
+		return nil
 	}
+
 	switch v.Kind() {
-	case reflect.Map, reflect.Slice, reflect.Ptr:
-		// A nil entry will cause additional reflect operations to panic.
+	case reflect.Chan, reflect.Func:
+		return nil
+	case reflect.Interface, reflect.Ptr, reflect.UnsafePointer:
 		if v.IsNil() {
-			return
+			return nil
 		}
-	}
-
-	if v.Kind() == reflect.Ptr {
-		// Dereference me.
-		substitute(v.Elem(), replacer)
-	}
-
-	// If this is a string, run the replacer on it.
-	switch v.Interface().(type) {
-	case string:
-		v.SetString(replacer.Replace(v.String()))
-		return
+		// I'm a pointer, dereference me.
+		return traverseDataStructure(v.Elem(), f)
 	}
 
 	switch v.Kind() {
-	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
-			substitute(v.Field(i), replacer)
-		}
-	case reflect.Slice:
+	case reflect.Array, reflect.Slice:
 		for i := 0; i < v.Len(); i++ {
-			substitute(v.Index(i), replacer)
+			if err := traverseDataStructure(v.Index(i), f); err != nil {
+				return err
+			}
 		}
 	case reflect.Map:
 		kvs := v.MapKeys()
@@ -140,15 +147,29 @@ func substitute(v reflect.Value, replacer *strings.Replacer) {
 			newKv.Set(kv)
 			newVv := reflect.New(vv.Type()).Elem()
 			newVv.Set(vv)
-			substitute(newKv, replacer)
-			substitute(newVv, replacer)
+			if err := traverseDataStructure(newKv, f); err != nil {
+				return err
+			}
+			if err := traverseDataStructure(newVv, f); err != nil {
+				return err
+			}
 
 			// Delete the old key-value.
 			v.SetMapIndex(kv, reflect.Value{})
 			// Set the new key-value.
 			v.SetMapIndex(newKv, newVv)
 		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if err := traverseDataStructure(v.Field(i), f); err != nil {
+				return err
+			}
+		}
+	default:
+		// As far as I can tell, this is a basic data type. Run f on it.
+		return f(v)
 	}
+	return nil
 }
 
 func xor(x, y bool) bool {

--- a/daisy/workflow/common_test.go
+++ b/daisy/workflow/common_test.go
@@ -91,47 +91,47 @@ func TestSubstitute(t *testing.T) {
 		replacer  *strings.Replacer
 		got, want test
 	}{
+		{ // 0
+			strings.NewReplacer(),
+			test{String: "", private: ""},
+			test{String: "", private: ""},
+		},
 		{ // 1
 			strings.NewReplacer(),
-			test{String: "", private: ""},
-			test{String: "", private: ""},
+			test{String: "string"},
+			test{String: "string"},
 		},
 		{ // 2
-			strings.NewReplacer(),
-			test{String: "string"},
-			test{String: "string"},
-		},
-		{ // 3
 			strings.NewReplacer("key", "value"),
 			test{String: "key-string", private: "private-key-string"},
 			test{String: "value-string", private: "private-key-string"},
 		},
-		{ // 4
+		{ // 3
 			strings.NewReplacer("key", "value"),
 			test{String: "key-key"},
 			test{String: "value-value"},
 		},
-		{ // 5
+		{ // 4
 			strings.NewReplacer("key1", "value1", "key2", "value2"),
 			test{String: "key1-key2"},
 			test{String: "value1-value2"},
 		},
-		{ // 6
+		{ // 5
 			strings.NewReplacer(),
 			test{StringMap: map[string]string{"key1": "value1"}},
 			test{StringMap: map[string]string{"key1": "value1"}},
 		},
-		{ // 7
+		{ // 6
 			strings.NewReplacer("key1", "value1", "key2", "value2", "key3", "value3"),
 			test{StringMap: map[string]string{"key1": "key2key2", "key3": "value"}},
 			test{StringMap: map[string]string{"value1": "value2value2", "value3": "value"}},
 		},
-		{ // 8
+		{ // 7
 			strings.NewReplacer("key1", "value1", "key2", "value2", "key3", "value3"),
 			test{SliceStringMap: map[string][]string{"key": {"value1", "value2"}}},
 			test{SliceStringMap: map[string][]string{"key": {"value1", "value2"}}},
 		},
-		{ // 9
+		{ // 8
 			strings.NewReplacer("key1", "value1", "key2", "value2", "key3", "value3"),
 			test{
 				SliceStringMap: map[string][]string{
@@ -146,7 +146,7 @@ func TestSubstitute(t *testing.T) {
 				},
 			},
 		},
-		{ // 10
+		{ // 9
 			strings.NewReplacer("key1", "value1", "key2", "value2", "key3", "value3"),
 			test{
 				StringMap:      map[string]string{"key1": "key2key2", "key3": "value"},
@@ -244,7 +244,7 @@ func TestSubstitute(t *testing.T) {
 		substitute(s, tt.replacer)
 
 		if diff := pretty.Compare(tt.got, tt.want); diff != "" {
-			t.Errorf("test %d: post substitute workflow does not match expectation: (-got +want)\n%s", i+1, diff)
+			t.Errorf("test %d: post substitute workflow does not match expectation: (-got +want)\n%s", i, diff)
 		}
 	}
 }

--- a/daisy/workflow/validate.go
+++ b/daisy/workflow/validate.go
@@ -193,7 +193,7 @@ func (w *Workflow) validateDAG() error {
 
 func (w *Workflow) validateVarsSubbed() error {
 	unsubbedVarRgx := regexp.MustCompile(`\$\{[^}]+}`)
-	return traverseDataStructure(reflect.ValueOf(w).Elem(), func(v reflect.Value) error {
+	return traverseData(reflect.ValueOf(w).Elem(), func(v reflect.Value) error {
 		switch v.Interface().(type) {
 		case string:
 			if unsubbedVarRgx.MatchString(v.String()) {

--- a/daisy/workflow/validate_test.go
+++ b/daisy/workflow/validate_test.go
@@ -166,6 +166,18 @@ func TestNameSet(t *testing.T) {
 	}
 }
 
+func TestValidateVarsSubbed(t *testing.T) {
+	w := testWorkflow()
+
+	if err := w.validateVarsSubbed(); err != nil {
+		t.Errorf("unexpected error on good workflow: %s", err)
+	}
+
+	w.Name = "workflow-${unsubbed}"
+	if err := w.validateVarsSubbed(); err == nil {
+		t.Error("bad workflow with unsubbed var should have returned an error, but didn't")
+	}
+}
 func TestValidateWorkflow(t *testing.T) {
 	s := &Step{Timeout: "my-timeout", testType: &mockStep{}}
 


### PR DESCRIPTION
Unsubbed var checking. Moved traversal logic out of substitute(). Reused logic to traverse workflow data again looking for unsubbed vars.