### PR TITLE
Resolve SourceFile in CreateDisks and some cleanups/TODOs

### DIFF
--- a/daisy/daisy.go
+++ b/daisy/daisy.go
@@ -64,8 +64,7 @@ func main() {
 
 	var wfs []*workflow.Workflow
 	for _, path := range flag.Args() {
-		wf := workflow.New(context.Background())
-		err := wf.FromFile(path)
+		wf, err := workflow.NewFromFile(context.Background(), path)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/daisy/workflow/common.go
+++ b/daisy/workflow/common.go
@@ -34,7 +34,10 @@ var (
 	// Check for the Google Storage URLs:
 	// http://<bucket>.storage.googleapis.com/<object>
 	// https://<bucket>.storage.googleapis.com/<object>
-	gsHTTPRegex = regexp.MustCompile(fmt.Sprintf(`^http[s]?://%s\.storage\.googleapis\.com/%s$`, bucket, object))
+	gsHTTPRegex1 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://%s\.storage\.googleapis\.com/%s$`, bucket, object))
+	// http://storage.cloud.google.com/<bucket>/<object>
+	// https://storage.cloud.google.com/<bucket>/<object>
+	gsHTTPRegex2 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://storage\.cloud\.google\.com/%s/%s$`, bucket, object))
 	// Check for the other possible Google Storage URLs:
 	// http://storage.googleapis.com/<bucket>/<object>
 	// https://storage.googleapis.com/<bucket>/<object>
@@ -42,7 +45,7 @@ var (
 	// The following are deprecated but checked:
 	// http://commondatastorage.googleapis.com/<bucket>/<object>
 	// https://commondatastorage.googleapis.com/<bucket>/<object>
-	gsHTTPRegex2 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://(?:commondata)?storage\.googleapis\.com/%s/%s$`, bucket, object))
+	gsHTTPRegex3 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://(?:commondata)?storage\.googleapis\.com/%s/%s$`, bucket, object))
 )
 
 func containsString(s string, ss []string) bool {
@@ -80,7 +83,7 @@ func randString(n int) string {
 }
 
 func splitGCSPath(p string) (string, string, error) {
-	for _, rgx := range []*regexp.Regexp{gsRegex, gsHTTPRegex, gsHTTPRegex2} {
+	for _, rgx := range []*regexp.Regexp{gsRegex, gsHTTPRegex1, gsHTTPRegex2, gsHTTPRegex3} {
 		matches := rgx.FindStringSubmatch(p)
 		if matches != nil {
 			return matches[1], matches[2], nil

--- a/daisy/workflow/common_test.go
+++ b/daisy/workflow/common_test.go
@@ -260,6 +260,8 @@ func TestSplitGCSPath(t *testing.T) {
 		{"gs://foo/bar", "foo", "bar", false},
 		{"http://foo.storage.googleapis.com/bar", "foo", "bar", false},
 		{"https://foo.storage.googleapis.com/bar", "foo", "bar", false},
+		{"http://storage.cloud.google.com/foo/bar", "foo", "bar", false},
+		{"https://storage.cloud.google.com/foo/bar/bar", "foo", "bar/bar", false},
 		{"http://storage.googleapis.com/foo/bar", "foo", "bar", false},
 		{"https://storage.googleapis.com/foo/bar", "foo", "bar", false},
 		{"http://commondatastorage.googleapis.com/foo/bar", "foo", "bar", false},

--- a/daisy/workflow/sources.go
+++ b/daisy/workflow/sources.go
@@ -1,12 +1,12 @@
 package workflow
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-	"fmt"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
@@ -29,6 +29,13 @@ func (w *Workflow) recursiveGCS(bkt, prefix, dst string) error {
 		}
 	}
 	return nil
+}
+
+func (w *Workflow) sourceExists(s string) bool {
+	if _, ok := w.Sources[s]; ok {
+		return true
+	}
+	return false
 }
 
 func (w *Workflow) uploadFile(src, obj string) error {

--- a/daisy/workflow/sources.go
+++ b/daisy/workflow/sources.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-
 	"fmt"
 
 	"cloud.google.com/go/storage"

--- a/daisy/workflow/sources.go
+++ b/daisy/workflow/sources.go
@@ -32,10 +32,8 @@ func (w *Workflow) recursiveGCS(bkt, prefix, dst string) error {
 }
 
 func (w *Workflow) sourceExists(s string) bool {
-	if _, ok := w.Sources[s]; ok {
-		return true
-	}
-	return false
+	_, ok := w.Sources[s]
+	return ok
 }
 
 func (w *Workflow) uploadFile(src, obj string) error {

--- a/daisy/workflow/step_create_disks_test.go
+++ b/daisy/workflow/step_create_disks_test.go
@@ -53,45 +53,47 @@ func TestCreateDisksValidate(t *testing.T) {
 	// Good case.
 	cd := CreateDisks{CreateDisk{Name: "d-bar", SourceImage: "i-foo", SizeGB: "50"}}
 	if err := cd.validate(w); err != nil {
-		t.Error(err)
+		t.Errorf("validation should not have failed: %v", err)
 	}
-	if !reflect.DeepEqual(validatedDisks, nameSet{w: {"d-foo", "d-bar"}}) {
-		t.Errorf("%v != %v", validatedDisks, nameSet{w: {"d-foo", "d-bar"}})
+	want := []string{"d-foo", "d-bar"}
+	if !reflect.DeepEqual(validatedDisks[w], want) {
+		t.Fatalf("got:(%v) != want(%v)", validatedDisks[w], want)
 	}
 
 	// Good case. No source image.
 	cd = CreateDisks{CreateDisk{Name: "d-baz", SizeGB: "50"}}
 	if err := cd.validate(w); err != nil {
-		t.Error(err)
+		t.Errorf("validation should not have failed: %v", err)
 	}
-	if !reflect.DeepEqual(validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}}) {
-		t.Errorf("%v != %v", validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}})
+	want = []string{"d-foo", "d-bar", "d-baz"}
+	if !reflect.DeepEqual(validatedDisks[w], want) {
+		t.Fatalf("got:(%v) != want(%v)", validatedDisks[w], want)
 	}
 
 	// Bad case. Dupe disk name.
 	cd = CreateDisks{CreateDisk{Name: "d-foo", SizeGB: "50"}}
 	if err := cd.validate(w); err == nil {
-		t.Error(err)
+		t.Errorf("validation should have failed: %v", err)
 	}
-	if !reflect.DeepEqual(validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}}) {
-		t.Errorf("%v != %v", validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}})
+	if !reflect.DeepEqual(validatedDisks[w], want) {
+		t.Fatalf("got:(%v) != want(%v)", validatedDisks[w], want)
 	}
 
 	// Bad case. No Size.
 	cd = CreateDisks{CreateDisk{Name: "d-new"}}
 	if err := cd.validate(w); err == nil {
-		t.Error(err)
+		t.Errorf("validation should have failed: %v", err)
 	}
-	if !reflect.DeepEqual(validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}}) {
-		t.Errorf("%v != %v", validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}})
+	if !reflect.DeepEqual(validatedDisks[w], want) {
+		t.Fatalf("got:(%v) != want(%v)", validatedDisks[w], want)
 	}
 
 	// Bad case. Image DNE.
 	cd = CreateDisks{CreateDisk{Name: "d-gaz", SourceImage: "i-dne"}}
 	if err := cd.validate(w); err == nil {
-		t.Error(err)
+		t.Errorf("validation should have failed: %v", err)
 	}
-	if !reflect.DeepEqual(validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}}) {
-		t.Errorf("%v != %v", validatedDisks, nameSet{w: {"d-foo", "d-bar", "d-baz"}})
+	if !reflect.DeepEqual(validatedDisks[w], want) {
+		t.Fatalf("got:(%v) != want(%v)", validatedDisks[w], want)
 	}
 }

--- a/daisy/workflow/step_create_instances.go
+++ b/daisy/workflow/step_create_instances.go
@@ -60,7 +60,7 @@ func (c *CreateInstances) validate(w *Workflow) error {
 		}
 
 		// Startup script checking.
-		if !sourceExists(ci.StartupScript) {
+		if ci.StartupScript != "" && !w.sourceExists(ci.StartupScript) {
 			return fmt.Errorf("cannot create instance: file not found: %s", ci.StartupScript)
 		}
 

--- a/daisy/workflow/validate.go
+++ b/daisy/workflow/validate.go
@@ -21,11 +21,9 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 )
 
 const defaultTimeout = "10m"
-const defaultTimeoutParsed = time.Duration(10 * time.Minute)
 
 type nameSet map[*Workflow]*[]string
 

--- a/daisy/workflow/validate.go
+++ b/daisy/workflow/validate.go
@@ -25,7 +25,7 @@ import (
 
 const defaultTimeout = "10m"
 
-type nameSet map[*Workflow]*[]string
+type nameSet map[*Workflow][]string
 
 var (
 	// The steps DAG is inspected in DAG order.
@@ -63,29 +63,29 @@ func (n nameSet) add(w *Workflow, s string) error {
 	ss := n.getNames(w)
 
 	// Name checking first.
-	if containsString(s, *ss) {
+	if containsString(s, ss) {
 		return fmt.Errorf("workflow %q has duplicate references for %q", w.Name, s)
 	}
 	if !checkName(s) {
 		return fmt.Errorf("bad name %q", s)
 	}
 
-	*ss = append(*ss, s)
+	n[w] = append(ss, s)
 	return nil
 }
 
-func (n nameSet) getNames(w *Workflow) *[]string {
+func (n nameSet) getNames(w *Workflow) []string {
 	if ss, ok := n[w]; ok {
 		return ss
 	}
-	n[w] = &[]string{}
+	n[w] = []string{}
 	return n[w]
 }
 
 func (n nameSet) has(w *Workflow, s string) bool {
 	nameSetsMx.Lock()
 	defer nameSetsMx.Unlock()
-	return containsString(s, *n.getNames(w))
+	return containsString(s, n.getNames(w))
 }
 
 func checkName(s string) bool {
@@ -118,11 +118,6 @@ func instanceValid(w *Workflow, i string) bool {
 }
 
 func projectExists(p string) bool {
-	// TODO(crunkleton)
-	return true
-}
-
-func sourceExists(s string) bool {
 	// TODO(crunkleton)
 	return true
 }

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -256,56 +256,6 @@ type Workflow struct {
 	logger        *log.Logger
 }
 
-// FromFile reads and unmarshals a workflow file.
-// Recursively reads subworkflow steps as well.
-func (w *Workflow) FromFile(file string) error {
-	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(data, &w); err != nil {
-		// If this is a syntax error return a useful error.
-		sErr, ok := err.(*json.SyntaxError)
-		if !ok {
-			return err
-		}
-
-		// Byte number where the error line starts.
-		start := bytes.LastIndex(data[:sErr.Offset], []byte("\n")) + 1
-		// Assume end byte of error line is EOF unless this isn't the last line.
-		end := len(data)
-		if i := bytes.Index(data[start:], []byte("\n")); i >= 0 {
-			end = start + i
-		}
-
-		// Line number of error.
-		line := bytes.Count(data[:start], []byte("\n")) + 1
-		// Position of error in line (where to place the '^').
-		pos := int(sErr.Offset) - start - 1
-
-		return fmt.Errorf("%s: JSON syntax error in line %d: %s \n%s\n%s^", file, line, err, data[start:end], strings.Repeat(" ", pos))
-	}
-
-	// We need to unmarshal any SubWorkflows.
-	for name, step := range w.Steps {
-		step.name = name
-
-		if step.SubWorkflow == nil {
-			continue
-		}
-
-		sw := New(w.Ctx)
-		if err := sw.FromFile(step.SubWorkflow.Path); err != nil {
-			return err
-		}
-		step.SubWorkflow.workflow = sw
-		sw.parent = w
-	}
-
-	return nil
-}
-
 // Run runs a workflow.
 func (w *Workflow) Run() error {
 	if err := w.populate(); err != nil {
@@ -661,6 +611,57 @@ func New(ctx context.Context) *Workflow {
 	// We can't use context.WithCancel as we use the context even after cancel for cleanup.
 	w.Cancel = make(chan struct{})
 	return &w
+}
+
+// NewFromFile reads and unmarshals a workflow file.
+// Recursively reads subworkflow steps as well.
+func NewFromFile(ctx context.Context, file string) (*Workflow, error) {
+	w := New(ctx)
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &w); err != nil {
+		// If this is a syntax error return a useful error.
+		sErr, ok := err.(*json.SyntaxError)
+		if !ok {
+			return nil, err
+		}
+
+		// Byte number where the error line starts.
+		start := bytes.LastIndex(data[:sErr.Offset], []byte("\n")) + 1
+		// Assume end byte of error line is EOF unless this isn't the last line.
+		end := len(data)
+		if i := bytes.Index(data[start:], []byte("\n")); i >= 0 {
+			end = start + i
+		}
+
+		// Line number of error.
+		line := bytes.Count(data[:start], []byte("\n")) + 1
+		// Position of error in line (where to place the '^').
+		pos := int(sErr.Offset) - start - 1
+
+		return nil, fmt.Errorf("%s: JSON syntax error in line %d: %s \n%s\n%s^", file, line, err, data[start:end], strings.Repeat(" ", pos))
+	}
+
+	// We need to unmarshal any SubWorkflows.
+	for name, step := range w.Steps {
+		step.name = name
+
+		if step.SubWorkflow == nil {
+			continue
+		}
+
+		sw, err := NewFromFile(w.Ctx, step.SubWorkflow.Path)
+		if err != nil {
+			return nil, err
+		}
+		step.SubWorkflow.workflow = sw
+		sw.parent = w
+	}
+
+	return w, nil
 }
 
 // stepsListen returns the first step that finishes/errs.

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -407,6 +407,8 @@ func (w *Workflow) populateStep(step *Step) error {
 	step.SubWorkflow.workflow.OAuthPath = w.OAuthPath
 	step.SubWorkflow.workflow.ComputeClient = w.ComputeClient
 	step.SubWorkflow.workflow.StorageClient = w.StorageClient
+	step.SubWorkflow.workflow.Ctx = w.Ctx
+	step.SubWorkflow.workflow.Cancel = w.Cancel
 	for k, v := range step.SubWorkflow.Vars {
 		step.SubWorkflow.workflow.Vars[k] = v
 	}

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -128,8 +128,6 @@ func TestGetResource(t *testing.T) {
 }
 
 func TestFromFileSyntax(t *testing.T) {
-	got := New(context.Background())
-
 	td, err := ioutil.TempDir(os.TempDir(), "")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
@@ -157,17 +155,16 @@ func TestFromFileSyntax(t *testing.T) {
 			t.Fatalf("error creating json file: %v", err)
 		}
 
-		if err := got.FromFile(tf); err == nil {
+		if _, err := NewFromFile(context.Background(), tf); err == nil {
 			t.Error("expected error, got nil")
 		} else if err.Error() != tt.error {
-			t.Errorf("did not get expected error from FromFile():\ngot: %q\nwant: %q", err.Error(), tt.error)
+			t.Errorf("did not get expected error from NewFromFile():\ngot: %q\nwant: %q", err.Error(), tt.error)
 		}
 	}
 }
 
 func TestFromFile(t *testing.T) {
-	got := New(context.Background())
-	err := got.FromFile("./test.workflow")
+	got, err := NewFromFile(context.Background(), "./test.workflow")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Resolve SourceFile in CreateDisks
  - SourceFile can be either GCS path or a file reference from sources.
- Test cleanups
- Change FromFile to NewFromFile
- Allow for storage and compute endpoint overrides