### PR TITLE
Ensure gcs objects don't contain '\', add timestamp to scratchpath

### DIFF
--- a/daisy/workflow/common.go
+++ b/daisy/workflow/common.go
@@ -74,7 +74,7 @@ func isLink(s string) bool {
 
 func randString(n int) string {
 	gen := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := "abcdefghijklmnopqrstuvwxyz"
+	letters := "bdghjlmnpqrstvwxyz0123456789"
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letters[gen.Int63()%int64(len(letters))]

--- a/daisy/workflow/sources.go
+++ b/daisy/workflow/sources.go
@@ -37,7 +37,8 @@ func (w *Workflow) sourceExists(s string) bool {
 }
 
 func (w *Workflow) uploadFile(src, obj string) error {
-	dstPath := w.StorageClient.Bucket(w.bucket).Object(path.Join(w.sourcesPath, filepath.ToSlash(obj)))
+	obj = filepath.ToSlash(obj)
+	dstPath := w.StorageClient.Bucket(w.bucket).Object(path.Join(w.sourcesPath, obj))
 	gcs := dstPath.NewWriter(w.Ctx)
 	f, err := os.Open(src)
 	if err != nil {

--- a/daisy/workflow/sources.go
+++ b/daisy/workflow/sources.go
@@ -37,7 +37,7 @@ func (w *Workflow) sourceExists(s string) bool {
 }
 
 func (w *Workflow) uploadFile(src, obj string) error {
-	dstPath := w.StorageClient.Bucket(w.bucket).Object(path.Join(w.sourcesPath, obj))
+	dstPath := w.StorageClient.Bucket(w.bucket).Object(path.Join(w.sourcesPath, filepath.ToSlash(obj)))
 	gcs := dstPath.NewWriter(w.Ctx)
 	f, err := os.Open(src)
 	if err != nil {

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -415,6 +415,9 @@ func (w *Workflow) populateStep(step *Step) error {
 
 func (w *Workflow) populate() error {
 	w.id = randString(5)
+	now := time.Now()
+	datestamp := now.Format("20060102")
+	timestamp := strconv.FormatInt(now.Unix(), 10)
 
 	// Do replacement from Vars.
 	vars := map[string]string{}
@@ -433,7 +436,7 @@ func (w *Workflow) populate() error {
 		return err
 	}
 	w.bucket = bkt
-	w.scratchPath = path.Join(p, fmt.Sprintf("daisy-%s-%s", w.Name, w.id))
+	w.scratchPath = path.Join(p, fmt.Sprintf("daisy-%s-%s-%s", w.Name, timestamp, w.id))
 	w.sourcesPath = path.Join(w.scratchPath, "sources")
 	w.logsPath = path.Join(w.scratchPath, "logs")
 	w.outsPath = path.Join(w.scratchPath, "outs")
@@ -441,15 +444,15 @@ func (w *Workflow) populate() error {
 	// Do replacement for autovars. Autovars pull from workflow fields,
 	// so Vars replacement must run before this to resolve the final
 	// value for those fields.
-	now := time.Now()
+
 	autovars := map[string]string{
 		"ID":          w.id,
 		"NAME":        w.Name,
 		"ZONE":        w.Zone,
 		"PROJECT":     w.Project,
 		"GCSPATH":     w.GCSPath,
-		"DATE":        now.Format("20060102"),
-		"TIMESTAMP":   strconv.FormatInt(now.Unix(), 10),
+		"DATE":        datestamp,
+		"TIMESTAMP":   timestamp,
 		"SCRATCHPATH": fmt.Sprintf("gs://%s/%s", w.bucket, w.scratchPath),
 		"SOURCESPATH": fmt.Sprintf("gs://%s/%s", w.bucket, w.sourcesPath),
 		"LOGSPATH":    fmt.Sprintf("gs://%s/%s", w.bucket, w.logsPath),

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -396,7 +396,7 @@ func TestPopulate(t *testing.T) {
 
 	// For simplicity, here is the subworkflow scratch path.
 	// The subworkflow scratch path is a subdir of the parent workflow scratch path.
-	subScratch := fmt.Sprintf("%s/daisy-sub-%s", got.scratchPath, subGot.id)
+	subScratch := fmt.Sprintf("%s/daisy-sub-%d-%s", got.scratchPath, time.Now().Unix(), subGot.id)
 
 	want := &Workflow{
 		Name:         "parent",
@@ -418,17 +418,17 @@ func TestPopulate(t *testing.T) {
 			"wf-name":   "parent",
 		},
 		bucket:      "parent-bucket",
-		scratchPath: "images/daisy-parent-" + got.id,
-		sourcesPath: fmt.Sprintf("images/daisy-parent-%s/sources", got.id),
-		logsPath:    fmt.Sprintf("images/daisy-parent-%s/logs", got.id),
-		outsPath:    fmt.Sprintf("images/daisy-parent-%s/outs", got.id),
+		scratchPath: fmt.Sprintf("images/daisy-parent-%d-%s", time.Now().Unix(), got.id),
+		sourcesPath: fmt.Sprintf("%s/sources", got.scratchPath),
+		logsPath:    fmt.Sprintf("%s/logs", got.scratchPath),
+		outsPath:    fmt.Sprintf("%s/outs", got.scratchPath),
 		Steps: map[string]*Step{
 			"parent-step1": {
 				name:    "parent-step1",
 				Timeout: "60m",
 				timeout: time.Duration(60 * time.Minute),
 				CreateImages: &CreateImages{
-					{SourceFile: fmt.Sprintf("gs://parent-bucket/images/daisy-parent-%s/sources/image_file", got.id)},
+					{SourceFile: fmt.Sprintf("gs://parent-bucket/%s/sources/image_file", got.scratchPath)},
 				},
 			},
 			"parent-step2": {


### PR DESCRIPTION
ensure gcs objects don't contain '\' (the case when windows paths get translated to GCS objects)
add timestamp to scratchpath