### PR TITLE
Fixed SubWorkflow cleanup issue.

### DIFF
--- a/daisy/workflow/sources_test.go
+++ b/daisy/workflow/sources_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"runtime"
 )
 
 func TestUploadSources(t *testing.T) {
@@ -29,6 +30,10 @@ func TestUploadSources(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	local_dne_err := "stat this/file/dne: no such file or directory"
+	if runtime.GOOS == "windows" {
+		local_dne_err = "GetFileAttributesEx this\\file\\dne: The system cannot find the path specified."
+	}
 	tests := []struct {
 		desc    string
 		sources map[string]string
@@ -39,7 +44,7 @@ func TestUploadSources(t *testing.T) {
 		{"normal local folder to GCS", map[string]string{"local": dir}, "", []string{w.sourcesPath + "/local/test"}},
 		{"normal GCS obj to GCS", map[string]string{"gcs": "gs://gcs/file"}, "", []string{w.sourcesPath + "/gcs"}},
 		{"normal GCS bkt to GCS", map[string]string{"gcs": "gs://gcs/folder/"}, "", []string{w.sourcesPath + "/gcs/object", w.sourcesPath + "/gcs/folder/object"}},
-		{"dne local path", map[string]string{"local": "./this/file/dne"}, "stat this/file/dne: no such file or directory", nil},
+		{"dne local path", map[string]string{"local": "./this/file/dne"}, local_dne_err, nil},
 		{"dne GCS path", map[string]string{"gcs": "gs://gcs/path/dne"}, `error copying from file gs://gcs/path/dne: googleapi: got HTTP response code 404 with body: storage: object doesn't exist`, nil},
 		{"GCS path, no object", map[string]string{"gcs": "gs://folder"}, "", []string{w.sourcesPath + "/gcs/object", w.sourcesPath + "/gcs/folder/object"}},
 	}

--- a/daisy/workflow/sources_test.go
+++ b/daisy/workflow/sources_test.go
@@ -4,9 +4,9 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
-	"runtime"
 )
 
 func TestUploadSources(t *testing.T) {
@@ -30,9 +30,9 @@ func TestUploadSources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	local_dne_err := "stat this/file/dne: no such file or directory"
+	localDNEErr := "stat this/file/dne: no such file or directory"
 	if runtime.GOOS == "windows" {
-		local_dne_err = "GetFileAttributesEx this\\file\\dne: The system cannot find the path specified."
+		localDNEErr = "GetFileAttributesEx this\\file\\dne: The system cannot find the path specified."
 	}
 	tests := []struct {
 		desc    string
@@ -44,7 +44,7 @@ func TestUploadSources(t *testing.T) {
 		{"normal local folder to GCS", map[string]string{"local": dir}, "", []string{w.sourcesPath + "/local/test"}},
 		{"normal GCS obj to GCS", map[string]string{"gcs": "gs://gcs/file"}, "", []string{w.sourcesPath + "/gcs"}},
 		{"normal GCS bkt to GCS", map[string]string{"gcs": "gs://gcs/folder/"}, "", []string{w.sourcesPath + "/gcs/object", w.sourcesPath + "/gcs/folder/object"}},
-		{"dne local path", map[string]string{"local": "./this/file/dne"}, local_dne_err, nil},
+		{"dne local path", map[string]string{"local": "./this/file/dne"}, localDNEErr, nil},
 		{"dne GCS path", map[string]string{"gcs": "gs://gcs/path/dne"}, `error copying from file gs://gcs/path/dne: googleapi: got HTTP response code 404 with body: storage: object doesn't exist`, nil},
 		{"GCS path, no object", map[string]string{"gcs": "gs://folder"}, "", []string{w.sourcesPath + "/gcs/object", w.sourcesPath + "/gcs/folder/object"}},
 	}


### PR DESCRIPTION
 SubWorkflows weren't cleaning up if they were running when the root workflow exits from another step failing. Also was happening if the SubWorkflow step times out.
Added a redundant backstop Subworkflow cleanup() call in the parent workflows' cleanup().

Also, fixed TestUploadSources on Windows.