### PR TITLE
Clean up cleanup on cancel, validate step and workflow names

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -188,19 +188,28 @@ func (c *Client) GetSerialPortOutput(project, zone, instance string, port, start
 	return c.raw.Instances.GetSerialPortOutput(project, zone, instance).Start(start).Port(port).Do()
 }
 
+// InstanceStatus returns an instances Status.
+func (c *Client) InstanceStatus(project, zone, instance string) (string, error) {
+	inst, err := c.raw.Instances.Get(project, zone, instance).Do()
+	if err != nil {
+		return "", err
+	}
+	return inst.Status, nil
+}
+
 // InstanceStopped checks if a GCE instance is in a 'TERMINATED' state.
 func (c *Client) InstanceStopped(project, zone, instance string) (bool, error) {
-	inst, err := c.raw.Instances.Get(project, zone, instance).Do()
+	status, err := c.InstanceStatus(project, zone, instance)
 	if err != nil {
 		return false, err
 	}
-	switch inst.Status {
+	switch status {
 	case "PROVISIONING", "RUNNING", "STAGING", "STOPPING":
 		return false, nil
 	case "TERMINATED":
 		return true, nil
 	default:
-		return false, fmt.Errorf("unexpected instance status %q: %+v", inst.Status, inst)
+		return false, fmt.Errorf("unexpected instance status %q", status)
 	}
 }
 

--- a/daisy/daisy.go
+++ b/daisy/daisy.go
@@ -113,7 +113,7 @@ func main() {
 		go func() {
 			select {
 			case <-c:
-				fmt.Printf("\nCtrl-C caught, stopping and cleaning up workflow %q, this may take a second...\n", w.Name)
+				fmt.Printf("\nCtrl-C caught, sending cancel signal to %q...\n", w.Name)
 				close(w.Cancel)
 				errors <- fmt.Errorf("workflow %q was canceled", w.Name)
 			case <-w.Cancel:

--- a/daisy/workflow/step_create_disks.go
+++ b/daisy/workflow/step_create_disks.go
@@ -118,7 +118,7 @@ func (c *CreateDisks) run(w *Workflow) error {
 			w.logger.Printf("CreateDisks: creating disk %q.", name)
 			description := cd.Description
 			if description == "" {
-				description = fmt.Sprintf("Disk created by Daisy in workflow %q on behalf of %q.", w.Name, w.username)
+				description = fmt.Sprintf("Disk created by Daisy in workflow %q on behalf of %s.", w.Name, w.username)
 			}
 			d, err := w.ComputeClient.CreateDisk(name, project, zone, imageLink, size, cd.Type, description)
 			if err != nil {

--- a/daisy/workflow/step_create_images.go
+++ b/daisy/workflow/step_create_images.go
@@ -127,7 +127,7 @@ func (c *CreateImages) run(w *Workflow) error {
 			w.logger.Printf("CreateImages: creating image %q.", name)
 			description := ci.Description
 			if description == "" {
-				description = fmt.Sprintf("Image created by Daisy in workflow %q on behalf of %q.", w.Name, w.username)
+				description = fmt.Sprintf("Image created by Daisy in workflow %q on behalf of %s.", w.Name, w.username)
 			}
 			i, err := w.ComputeClient.CreateImage(name, project, diskLink, sourceFile, ci.Family, description, ci.Licenses, ci.GuestOsFeatures)
 			if err != nil {

--- a/daisy/workflow/step_create_instances.go
+++ b/daisy/workflow/step_create_instances.go
@@ -177,7 +177,7 @@ func (c *CreateInstances) run(w *Workflow) error {
 			inst.Scopes = ci.Scopes
 			description := ci.Description
 			if description == "" {
-				description = fmt.Sprintf("Instance created by Daisy in workflow %q on behalf of %q.", w.Name, w.username)
+				description = fmt.Sprintf("Instance created by Daisy in workflow %q on behalf of %s.", w.Name, w.username)
 			}
 			inst.Description = description
 

--- a/daisy/workflow/step_sub_workflow.go
+++ b/daisy/workflow/step_sub_workflow.go
@@ -31,6 +31,7 @@ func (s *SubWorkflow) run(w *Workflow) error {
 	w.logger.Printf("Running subworkflow %q", s.workflow.Name)
 	if err := s.workflow.run(); err != nil {
 		s.workflow.logger.Printf("Error running subworkflow %q: %v", s.workflow.Name, err)
+		close(w.Cancel)
 		return err
 	}
 	return nil

--- a/daisy/workflow/step_wait_for_instances_signal_test.go
+++ b/daisy/workflow/step_wait_for_instances_signal_test.go
@@ -16,6 +16,7 @@ package workflow
 
 import (
 	"testing"
+	"time"
 )
 
 func TestWaitForInstancesSignalRun(t *testing.T) {
@@ -24,9 +25,21 @@ func TestWaitForInstancesSignalRun(t *testing.T) {
 		"i1": {"i1", wf.genName("i1"), "link", false},
 		"i2": {"i2", wf.genName("i2"), "link", false},
 		"i3": {"i3", wf.genName("i3"), "link", false}}
-	ws := &WaitForInstancesSignal{{Name: "i1", Stopped: true}, {Name: "i2", Stopped: true}, {Name: "i3", Stopped: true}}
+	ws := &WaitForInstancesSignal{
+		{Name: "i1", interval: 1 * time.Second, SerialOutput: &SerialOutput{Port: 1, SuccessMatch: "success"}},
+		{Name: "i2", interval: 1 * time.Second, SerialOutput: &SerialOutput{Port: 2, SuccessMatch: "success", FailureMatch: "fail"}},
+		{Name: "i3", Stopped: true},
+	}
 	if err := ws.run(wf); err != nil {
-		t.Fatalf("error running WaitForInstancesStopped.run(): %v", err)
+		t.Errorf("error running WaitForInstancesSignal.run(): %v", err)
+	}
+
+	ws = &WaitForInstancesSignal{
+		{Name: "i1", interval: 1 * time.Second, SerialOutput: &SerialOutput{Port: 1, FailureMatch: "fail", SuccessMatch: "success"}},
+		{Name: "i2", interval: 1 * time.Second, SerialOutput: &SerialOutput{Port: 2, FailureMatch: "fail"}},
+	}
+	if err := ws.run(wf); err == nil {
+		t.Error("expected error")
 	}
 }
 

--- a/daisy/workflow/test.workflow
+++ b/daisy/workflow/test.workflow
@@ -8,7 +8,7 @@
     "machine_type": "n1-standard-1"
   },
   "steps": {
-    "create disks": {
+    "create-disks": {
       "createDisks": [
         {
           "name": "bootstrap",
@@ -37,7 +37,7 @@
         }
       ]
     },
-    "${bootstrap_instance_name} stopped": {
+    "${bootstrap_instance_name}-stopped": {
       "timeout": "1h",
       "waitForInstancesSignal": [{"name": "${bootstrap_instance_name}", "stopped": true, "interval": "1s"}]
     },
@@ -51,10 +51,10 @@
         }
       ]
     },
-    "postinstall stopped": {
+    "postinstall-stopped": {
       "waitForInstancesSignal": [{"name": "postinstall", "stopped": true}]
     },
-    "create image": {
+    "create-image": {
       "createImages": [
         {
           "name": "image-from-disk",
@@ -62,19 +62,19 @@
         }
       ]
     },
-    "sub workflow": {
+    "sub-workflow": {
       "subWorkflow": {
         "path": "./test_sub.workflow"
       }
     }
   },
   "dependencies": {
-    "create disks": [],
-    "bootstrap": ["create disks"],
-    "bootstrap stopped": ["bootstrap"],
-    "postinstall": ["bootstrap stopped"],
-    "postinstall stopped": ["postinstall"],
-    "create image": ["postinstall stopped"],
-    "sub workflow": ["create image"]
+    "create-disks": [],
+    "bootstrap": ["create-disks"],
+    "bootstrap-stopped": ["bootstrap"],
+    "postinstall": ["bootstrap-stopped"],
+    "postinstall-stopped": ["postinstall"],
+    "create-image": ["postinstall-stopped"],
+    "sub-workflow": ["create-image"]
   }
 }

--- a/daisy/workflow/test_common.go
+++ b/daisy/workflow/test_common.go
@@ -91,7 +91,11 @@ func testWorkflow() *Workflow {
 
 func newTestGCEClient() (*compute.Client, error) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && strings.Contains(r.URL.String(), fmt.Sprintf("/%s/zones/%s/instances/", testProject, testZone)) {
+		if r.Method == "GET" && strings.Contains(r.URL.String(), "serialPort?alt=json&port=1") {
+			fmt.Fprintln(w, `{"Contents":"failsuccess","Start":"0"}`)
+		} else if r.Method == "GET" && strings.Contains(r.URL.String(), "serialPort?alt=json&port=2") {
+			fmt.Fprintln(w, `{"Contents":"successfail","Start":"0"}`)
+		} else if r.Method == "GET" && strings.Contains(r.URL.String(), fmt.Sprintf("/%s/zones/%s/instances/", testProject, testZone)) {
 			fmt.Fprintln(w, `{"Status":"TERMINATED","SelfLink":"link"}`)
 		} else if r.Method == "GET" && strings.Contains(r.URL.String(), fmt.Sprintf("/%s/zones/%s/machineTypes", testProject, testZone)) {
 			fmt.Fprintln(w, `{"Items":[{"Name": "foo-type"}]}`)

--- a/daisy/workflow/test_sub.workflow
+++ b/daisy/workflow/test_sub.workflow
@@ -1,6 +1,6 @@
 {
   "steps": {
-    "create disks": {
+    "create-disks": {
       "createDisks": [
         {
           "name": "bootstrap",
@@ -22,7 +22,7 @@
         }
       ]
     },
-    "bootstrap stopped": {
+    "bootstrap-stopped": {
       "timeout": "1h",
       "waitForInstancesSignal": [
         {"name": "bootstrap", "serialOutput": {"port": 1, "successMatch": "complete", "failureMatch": "fail"}}
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "bootstrap": ["create disks"],
-    "bootstrap stopped": ["bootstrap"]
+    "bootstrap": ["create-disks"],
+    "bootstrap-stopped": ["bootstrap"]
   }
 }

--- a/daisy/workflow/validate.go
+++ b/daisy/workflow/validate.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"sync"
 )
 
@@ -140,6 +141,9 @@ func projectExists(p string) bool {
 func (w *Workflow) validateRequiredFields() error {
 	if w.Name == "" {
 		return errors.New("must provide workflow field 'Name'")
+	}
+	if !rfc1035Rgx.MatchString(strings.ToLower(w.Name)) {
+		return errors.New("workflow field 'Name' must start with a letter and only contain letters, numbers, and hyphens")
 	}
 	if w.Project == "" {
 		return errors.New("must provide workflow field 'Project'")

--- a/daisy/workflow/validate_test.go
+++ b/daisy/workflow/validate_test.go
@@ -180,11 +180,14 @@ func TestValidateVarsSubbed(t *testing.T) {
 }
 
 func TestValidateWorkflow(t *testing.T) {
-	s := &Step{Timeout: "my-timeout", testType: &mockStep{}}
+	s := &Step{Timeout: "10s", testType: &mockStep{}}
 
 	// Normal, good validation.
 	w := testWorkflow()
 	w.Steps = map[string]*Step{"s0": s}
+	if err := w.populate(); err != nil {
+		t.Fatal(err)
+	}
 	if err := w.validate(); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -250,6 +253,9 @@ func TestValidateDAG(t *testing.T) {
 	}
 
 	// Normal case -- no issues.
+	if err := w.populate(); err != nil {
+		t.Fatal(err)
+	}
 	if err := w.validateDAG(); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -197,6 +197,9 @@ func (s *Step) run(w *Workflow) error {
 
 func (s *Step) validate(w *Workflow) error {
 	w.logger.Printf("Validating step %q", s.name)
+	if !rfc1035Rgx.MatchString(strings.ToLower(s.name)) {
+		return s.wrapValidateError(errors.New("step name must start with a letter and only contain letters, numbers, and hyphens"))
+	}
 	realStep, err := s.realStep()
 	if err != nil {
 		return s.wrapValidateError(err)
@@ -297,7 +300,11 @@ func (w *Workflow) Run() error {
 	w.logger.Print("Running workflow")
 	if err := w.run(); err != nil {
 		w.logger.Printf("Error running workflow: %v", err)
-		close(w.Cancel)
+		select {
+		case <-w.Cancel:
+		default:
+			close(w.Cancel)
+		}
 		return err
 	}
 	return nil
@@ -309,7 +316,14 @@ func (w *Workflow) String() string {
 }
 
 func (w *Workflow) cleanup() {
-	w.logger.Printf("Cleaning ephemeral resources for workflow %q.", w.Name)
+	// If canceled we don't want to log anymore.
+	select {
+	case <-w.Cancel:
+		w.logger.Printf("Workflow %q canceled, cleaning up (this may take up to 2 minutes).", w.Name)
+		w.logger = log.New(ioutil.Discard, "", 0)
+	default:
+		w.logger.Printf("Workflow %q complete, cleaning up ephemeral resources.", w.Name)
+	}
 	w.cleanupHelper(w.imageRefs, w.deleteImage)
 	w.cleanupHelper(w.instanceRefs, w.deleteInstance)
 	w.cleanupHelper(w.diskRefs, w.deleteDisk)
@@ -377,7 +391,7 @@ func (w *Workflow) genName(n string) string {
 	if len(result) > 64 {
 		result = result[0:63]
 	}
-	return result
+	return strings.ToLower(result)
 }
 
 func (w *Workflow) getDisk(n string) (*resource, error) {
@@ -441,6 +455,7 @@ func (w *Workflow) populateStep(step *Step) error {
 		return nil
 	}
 	step.SubWorkflow.workflow.GCSPath = fmt.Sprintf("gs://%s/%s", w.bucket, w.scratchPath)
+	step.SubWorkflow.workflow.Name = step.name
 	step.SubWorkflow.workflow.Project = w.Project
 	step.SubWorkflow.workflow.Zone = w.Zone
 	step.SubWorkflow.workflow.OAuthPath = w.OAuthPath

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -191,7 +191,11 @@ func (s *Step) run(w *Workflow) error {
 	if err = realStep.run(w); err != nil {
 		return s.wrapRunError(err)
 	}
-	w.logger.Printf("Step %q (%s) successfully finished.", s.name, st)
+	select {
+	case <-w.Cancel:
+	default:
+		w.logger.Printf("Step %q (%s) successfully finished.", s.name, st)
+	}
 	return nil
 }
 
@@ -320,7 +324,6 @@ func (w *Workflow) cleanup() {
 	select {
 	case <-w.Cancel:
 		w.logger.Printf("Workflow %q canceled, cleaning up (this may take up to 2 minutes).", w.Name)
-		w.logger = log.New(ioutil.Discard, "", 0)
 	default:
 		w.logger.Printf("Workflow %q complete, cleaning up ephemeral resources.", w.Name)
 	}

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -178,7 +178,7 @@ func TestFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	subGot := got.Steps["sub workflow"].SubWorkflow.workflow
+	subGot := got.Steps["sub-workflow"].SubWorkflow.workflow
 
 	want := &Workflow{
 		id:          got.id,
@@ -192,8 +192,8 @@ func TestFromFile(t *testing.T) {
 			"machine_type":            "n1-standard-1",
 		},
 		Steps: map[string]*Step{
-			"create disks": {
-				name: "create disks",
+			"create-disks": {
+				name: "create-disks",
 				CreateDisks: &CreateDisks{
 					{
 						Name:        "bootstrap",
@@ -221,8 +221,8 @@ func TestFromFile(t *testing.T) {
 					},
 				},
 			},
-			"${bootstrap_instance_name} stopped": {
-				name:                   "${bootstrap_instance_name} stopped",
+			"${bootstrap_instance_name}-stopped": {
+				name:                   "${bootstrap_instance_name}-stopped",
 				Timeout:                "1h",
 				WaitForInstancesSignal: &WaitForInstancesSignal{{Name: "${bootstrap_instance_name}", Stopped: true, Interval: "1s"}},
 			},
@@ -237,24 +237,24 @@ func TestFromFile(t *testing.T) {
 					},
 				},
 			},
-			"postinstall stopped": {
-				name: "postinstall stopped",
+			"postinstall-stopped": {
+				name: "postinstall-stopped",
 				WaitForInstancesSignal: &WaitForInstancesSignal{{Name: "postinstall", Stopped: true}},
 			},
-			"create image": {
-				name:         "create image",
+			"create-image": {
+				name:         "create-image",
 				CreateImages: &CreateImages{{Name: "image-from-disk", SourceDisk: "image"}},
 			},
-			"sub workflow": {
-				name: "sub workflow",
+			"sub-workflow": {
+				name: "sub-workflow",
 				SubWorkflow: &SubWorkflow{
 					Path: "./test_sub.workflow",
 					workflow: &Workflow{
 						id:          subGot.id,
 						workflowDir: wd,
 						Steps: map[string]*Step{
-							"create disks": {
-								name: "create disks",
+							"create-disks": {
+								name: "create-disks",
 								CreateDisks: &CreateDisks{
 									{
 										Name:        "bootstrap",
@@ -275,8 +275,8 @@ func TestFromFile(t *testing.T) {
 									},
 								},
 							},
-							"bootstrap stopped": {
-								name:    "bootstrap stopped",
+							"bootstrap-stopped": {
+								name:    "bootstrap-stopped",
 								Timeout: "1h",
 								WaitForInstancesSignal: &WaitForInstancesSignal{
 									{
@@ -289,21 +289,21 @@ func TestFromFile(t *testing.T) {
 							},
 						},
 						Dependencies: map[string][]string{
-							"bootstrap":         {"create disks"},
-							"bootstrap stopped": {"bootstrap"},
+							"bootstrap":         {"create-disks"},
+							"bootstrap-stopped": {"bootstrap"},
 						},
 					},
 				},
 			},
 		},
 		Dependencies: map[string][]string{
-			"create disks":        {},
-			"bootstrap":           {"create disks"},
-			"bootstrap stopped":   {"bootstrap"},
-			"postinstall":         {"bootstrap stopped"},
-			"postinstall stopped": {"postinstall"},
-			"create image":        {"postinstall stopped"},
-			"sub workflow":        {"create image"},
+			"create-disks":        {},
+			"bootstrap":           {"create-disks"},
+			"bootstrap-stopped":   {"bootstrap"},
+			"postinstall":         {"bootstrap-stopped"},
+			"postinstall-stopped": {"postinstall"},
+			"create-image":        {"postinstall-stopped"},
+			"sub-workflow":        {"create-image"},
 		},
 	}
 
@@ -464,7 +464,7 @@ func TestPopulate(t *testing.T) {
 						"overridden": "bar",
 					},
 					workflow: &Workflow{
-						Name:         "sub",
+						Name:         "parent-step3",
 						GCSPath:      fmt.Sprintf("gs://%s/%s", got.bucket, got.scratchPath),
 						Zone:         "parent-zone",
 						Project:      "parent-project",


### PR DESCRIPTION
WaitForInstancesSignal doesn't error when instance is stopped or stopping
Add tests for WaitForInstancesSignal
Fixed bug on subworkflow failure not ending workflow
Don't log errors after a workflow is canceled
Subworkflows are named after their step name
