### PR TITLE
Modify how vars are parsed to allow for additional fields

### DIFF
--- a/daisy/README.md
+++ b/daisy/README.md
@@ -453,7 +453,7 @@ is not set or is set as an empty string the workflow will fail with an error.
   "Zone": "${var2}",
   "Vars": {
     "var1": "",
-    "var2": {"Value": "foo-zone", "Description": "default zone to run the workflow in"}
+    "var2": {"Value": "foo-zone", "Description": "default zone to run the workflow in"},
     "var3": {"Required": true, "Description": "variable 3"}
   }
 }

--- a/daisy/README.md
+++ b/daisy/README.md
@@ -453,7 +453,7 @@ is not set or is set as an empty string the workflow will fail with an error.
   "Zone": "${var2}",
   "Vars": {
     "var1": "",
-    "var2": {"Value": "foo-zone, "Description": "default zone to run the workflow in"}
+    "var2": {"Value": "foo-zone", "Description": "default zone to run the workflow in"}
     "var3": {"Required": true, "Description": "variable 3"}
   }
 }

--- a/daisy/README.md
+++ b/daisy/README.md
@@ -433,6 +433,24 @@ step3 complete.
 }
 ```
 
+### RequiredVars
+RequiredVars is a list of Vars that must be provided to the Workflow in order
+to run. RequiredVars are checked at workflow setup and validation. 
+
+In this example `var1` is an optional variable with an empty string as the 
+default value, `var2` is an example of an optional variable with a default 
+value provided, `var3` is a required variable with no default value. If `var3`
+is not set or is set as an empty stringthe workflow will 
+```json
+{
+  "RequiredVars": ["var3"],
+  "Vars": {
+    "var1": "",
+    "var2": ""
+  }
+}
+```
+
 ### Vars
 Vars are a user-provided set of key-value pairs. Vars are used in string
 substitutions in the rest of the workflow config using the syntax `${key}`.

--- a/daisy/README.md
+++ b/daisy/README.md
@@ -433,38 +433,28 @@ step3 complete.
 }
 ```
 
-### RequiredVars
-RequiredVars is a list of Vars that must be provided to the Workflow in order
-to run. RequiredVars are checked at workflow setup and validation. 
-
-In this example `var1` is an optional variable with an empty string as the 
-default value, `var2` is an example of an optional variable with a default 
-value provided, `var3` is a required variable with no default value. If `var3`
-is not set or is set as an empty stringthe workflow will 
-```json
-{
-  "RequiredVars": ["var3"],
-  "Vars": {
-    "var1": "",
-    "var2": ""
-  }
-}
-```
-
 ### Vars
 Vars are a user-provided set of key-value pairs. Vars are used in string
 substitutions in the rest of the workflow config using the syntax `${key}`.
 Vars can be hardcoded into the workflow config or passed via the commandline.
 Vars passed via the commandline will override the hardcoded Vars.
 
-Example (incomplete) config:
+Vars can be either a simple key:value pairing or with the following fields:
++ Value: (string) value of the variable
++ Description: (string) description of the variable
++ Required: (bool) whether this variable is required to be non empty
+
+In this example `var1` is an optional variable with an empty string as the 
+default value, `var2` is an example of an optional variable with a default 
+value provided, `var3` is a required variable with no default value. If `var3`
+is not set or is set as an empty string the workflow will fail with an error.
 ```json
 {
-  "Name": "${var1}",
   "Zone": "${var2}",
   "Vars": {
-    "var1": "foo-name",
-    "var2": "foo-zone"
+    "var1": "",
+    "var2": {"Value": "foo-zone, "Description": "default zone to run the workflow in"}
+    "var3": {"Required": true, "Description": "variable 3"}
   }
 }
 ```

--- a/daisy/daisy.go
+++ b/daisy/daisy.go
@@ -66,7 +66,7 @@ func parseWorkflows(paths []string, varMap map[string]string, project, zone, gcs
 			return nil, err
 		}
 		for k, v := range varMap {
-			w.Vars[k] = v
+			w.AddVar(k, v)
 		}
 		if project != "" {
 			w.Project = project

--- a/daisy/workflow/sources_test.go
+++ b/daisy/workflow/sources_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -23,6 +24,7 @@ func TestUploadSources(t *testing.T) {
 
 	w := testWorkflow()
 	sw := &Workflow{Name: "test-sw"}
+	sw.logger = log.New(ioutil.Discard, "", 0)
 	w.Steps = map[string]*Step{
 		"sub": {SubWorkflow: &SubWorkflow{workflow: sw}},
 	}

--- a/daisy/workflow/test.workflow
+++ b/daisy/workflow/test.workflow
@@ -5,7 +5,7 @@
   "gcsPath": "gs://some-bucket/images",
   "oauthPath": "somefile",
   "vars": {
-    "bootstrap_instance_name": "bootstrap",
+    "bootstrap_instance_name": {"Value": "bootstrap", "Required": true},
     "machine_type": "n1-standard-1"
   },
   "steps": {

--- a/daisy/workflow/validate.go
+++ b/daisy/workflow/validate.go
@@ -210,9 +210,6 @@ func (w *Workflow) validateVarsSubbed() error {
 		switch v.Interface().(type) {
 		case string:
 			if match := unsubbedVarRgx.FindStringSubmatch(v.String()); match != nil {
-				if containsString(match[1], w.RequiredVars) {
-					return fmt.Errorf("Unresolved required var %q found in %q", match[0], v.String())
-				}
 				return fmt.Errorf("Unresolved var %q found in %q", match[0], v.String())
 			}
 		}

--- a/daisy/workflow/validate_test.go
+++ b/daisy/workflow/validate_test.go
@@ -174,8 +174,15 @@ func TestValidateVarsSubbed(t *testing.T) {
 	}
 
 	w.Name = "workflow-${unsubbed}"
-	if err := w.validateVarsSubbed(); err == nil {
-		t.Error("bad workflow with unsubbed var should have returned an error, but didn't")
+	want := `Unresolved var "${unsubbed}" found in "workflow-${unsubbed}"`
+	if err := w.validateVarsSubbed(); err.Error() != want {
+		t.Errorf("workflow with unsubbed var bad error, want: %q got: %q", want, err.Error())
+	}
+
+	w.RequiredVars = []string{"unsubbed"}
+	want = `Unresolved required var "${unsubbed}" found in "workflow-${unsubbed}"`
+	if err := w.validateVarsSubbed(); err.Error() != want {
+		t.Errorf("workflow with unsubbed required var bad error, want: %q got: %q", want, err.Error())
 	}
 }
 

--- a/daisy/workflow/validate_test.go
+++ b/daisy/workflow/validate_test.go
@@ -179,11 +179,11 @@ func TestValidateVarsSubbed(t *testing.T) {
 		t.Errorf("workflow with unsubbed var bad error, want: %q got: %q", want, err.Error())
 	}
 
-	w.RequiredVars = []string{"unsubbed"}
-	want = `Unresolved required var "${unsubbed}" found in "workflow-${unsubbed}"`
-	if err := w.validateVarsSubbed(); err.Error() != want {
-		t.Errorf("workflow with unsubbed required var bad error, want: %q got: %q", want, err.Error())
-	}
+	//w.RequiredVars = []string{"unsubbed"}
+	//want = `Unresolved required var "${unsubbed}" found in "workflow-${unsubbed}"`
+	//if err := w.validateVarsSubbed(); err.Error() != want {
+	//	t.Errorf("workflow with unsubbed required var bad error, want: %q got: %q", want, err.Error())
+	//}
 }
 
 func TestValidateWorkflow(t *testing.T) {

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -30,9 +30,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
-
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"

--- a/daisy/workflow/workflow.go
+++ b/daisy/workflow/workflow.go
@@ -83,6 +83,8 @@ type Workflow struct {
 	OAuthPath string `json:",omitempty"`
 	// Sources used by this workflow, map of destination to source.
 	Sources map[string]string `json:",omitempty"`
+	// RequiredVars is the list of vars the caller must provide to this workflow.
+	RequiredVars []string `json:",omitempty"`
 	// Vars defines workflow variables, substitution is done at Workflow run time.
 	Vars  map[string]string `json:",omitempty"`
 	Steps map[string]*Step
@@ -245,6 +247,17 @@ func (w *Workflow) populate() error {
 		"DATETIME":  now.Format("20060102150405"),
 		"TIMESTAMP": strconv.FormatInt(now.Unix(), 10),
 		"USERNAME":  w.username,
+	}
+
+	for _, rv := range w.RequiredVars {
+		for k, v := range w.Vars {
+			if rv != k {
+				continue
+			}
+			if v == "" {
+				return fmt.Errorf("required var %q cannot be blank", k)
+			}
+		}
 	}
 
 	vars := map[string]string{}

--- a/daisy/workflow/workflow_test.go
+++ b/daisy/workflow/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -331,6 +332,7 @@ func TestPopulate(t *testing.T) {
 		Project:      "parent-project",
 		OAuthPath:    tf,
 		RequiredVars: []string{"bucket"},
+		logger:       log.New(ioutil.Discard, "", 0),
 		Vars: map[string]string{
 			"bucket":    "parent-bucket",
 			"step_name": "parent-step1",
@@ -362,6 +364,7 @@ func TestPopulate(t *testing.T) {
 						Project:   "sub-project",
 						Zone:      "sub-zone",
 						OAuthPath: "sub-oauth-path",
+						logger:    log.New(ioutil.Discard, "", 0),
 						Steps: map[string]*Step{
 							"${step_name}": {
 								Timeout: "${timeout}",


### PR DESCRIPTION
Vars can now be marked as required and have a description while still allowing for the old var style:
"Vars": {
  "some-normal-var": "some-string"
  "some-required-var": {"Required": true, "Description": "this is a description"}
}

Fix logging for subworkflows