### PR TITLE
Reduce QPS to compute API

### DIFF
--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -391,7 +391,7 @@ func (c *CreateInstances) run(ctx context.Context, s *Step) error {
 				eChan <- err
 				return
 			}
-			go logSerialOutput(ctx, w, ci.Name, 1, 1*time.Second)
+			go logSerialOutput(ctx, w, ci.Name, 1, 5*time.Second)
 		}(ci)
 	}
 

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-const defaultInterval = "5s"
+const defaultInterval = "10s"
 
 // WaitForInstancesSignal is a Daisy WaitForInstancesSignal workflow step.
 type WaitForInstancesSignal []*InstanceSignal

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -54,7 +54,7 @@ func TestWaitForInstancesSignalPopulate(t *testing.T) {
 		t.Fatalf("error running populate: %v", err)
 	}
 
-	want := &WaitForInstancesSignal{&InstanceSignal{Name: "test", Interval: "5s", interval: 5 * time.Second}}
+	want := &WaitForInstancesSignal{&InstanceSignal{Name: "test", Interval: "10s", interval: 10 * time.Second}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got != want:\ngot:  %+v\nwant: %+v", got, want)
 	}


### PR DESCRIPTION
Increase logSerialOutput interval from 1s to 5s
Increase default WaitForInstanceSignal interval from 5s to 10s

For normal workflows (WaitForInstanceSignal checking serial port and stopped status) this raises the number of concurrent instances from ~14 to ~50 while staying below 2000 QPS per 100s