### PR TITLE
Update README.md to reflect new path to main package

### DIFF
--- a/daisy/README.md
+++ b/daisy/README.md
@@ -85,7 +85,7 @@ Daisy containers built with the beta Compute api
 ### Build from source
 Daisy can be easily built from source with the [Golang SDK](https://golang.org)
 ```shell
-go get github.com/GoogleCloudPlatform/compute-image-tools/daisy
+go get github.com/GoogleCloudPlatform/compute-image-tools/daisy/daisy
 ```
 This will place the Daisy binary in $GOPATH/bin.
 


### PR DESCRIPTION
#118 moved the `main` package from github.com/GoogleCloudPlatform/compute-image-tools/daisy to github.com/GoogleCloudPlatform/compute-image-tools/daisy/daisy this change updates the README.md build from source instructions to reflect the new path.