### PR TITLE
Apply GCS ACLs on a recursive copy, add populate and validate for CopyGCSObjects

### DIFF
--- a/daisy/common_test.go
+++ b/daisy/common_test.go
@@ -51,17 +51,6 @@ func TestFilter(t *testing.T) {
 	}
 }
 
-func TestGetGCSAPIPath(t *testing.T) {
-	got, err := getGCSAPIPath("gs://foo/bar")
-	want := "https://storage.cloud.google.com/foo/bar"
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
-	if got != want {
-		t.Errorf("unexpected result: got: %q, want: %q", got, want)
-	}
-}
-
 func TestMinInt(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -319,39 +308,6 @@ func TestSubstitute(t *testing.T) {
 
 		if diff := pretty.Compare(tt.got, tt.want); diff != "" {
 			t.Errorf("test %d: post substitute workflow does not match expectation: (-got +want)\n%s", i, diff)
-		}
-	}
-}
-
-func TestSplitGCSPath(t *testing.T) {
-	tests := []struct {
-		input     string
-		bucket    string
-		object    string
-		shouldErr bool
-	}{
-		{"gs://foo", "foo", "", false},
-		{"gs://foo/bar", "foo", "bar", false},
-		{"http://foo.storage.googleapis.com/bar", "foo", "bar", false},
-		{"https://foo.storage.googleapis.com/bar", "foo", "bar", false},
-		{"http://storage.cloud.google.com/foo/bar", "foo", "bar", false},
-		{"https://storage.cloud.google.com/foo/bar/bar", "foo", "bar/bar", false},
-		{"http://storage.googleapis.com/foo/bar", "foo", "bar", false},
-		{"https://storage.googleapis.com/foo/bar", "foo", "bar", false},
-		{"http://commondatastorage.googleapis.com/foo/bar", "foo", "bar", false},
-		{"https://commondatastorage.googleapis.com/foo/bar", "foo", "bar", false},
-		{"/local/path", "", "", true},
-	}
-
-	for _, tt := range tests {
-		b, o, err := splitGCSPath(tt.input)
-		if tt.shouldErr && err == nil {
-			t.Errorf("splitGCSPath(%q) should have thrown an error", tt.input)
-		} else if !tt.shouldErr && err != nil {
-			t.Errorf("splitGCSPath(%q) should not have thrown an error", tt.input)
-		}
-		if b != tt.bucket || o != tt.object {
-			t.Errorf("splitGCSPath(%q) returned incorrect values -- want bucket=%q, object=%q; got bucket=%q, object=%q", tt.input, tt.bucket, tt.object, b, o)
 		}
 	}
 }

--- a/daisy/step_copy_gcs_objects.go
+++ b/daisy/step_copy_gcs_objects.go
@@ -36,9 +36,53 @@ type CopyGCSObject struct {
 
 func (c *CopyGCSObjects) populate(ctx context.Context, s *Step) error { return nil }
 
-func (c *CopyGCSObjects) validate(ctx context.Context, s *Step) error { return nil }
+func (c *CopyGCSObjects) validate(ctx context.Context, s *Step) error {
+	for _, co := range *c {
+		sBkt, _, err := splitGCSPath(co.Source)
+		if err != nil {
+			return err
+		}
+		dBkt, _, err := splitGCSPath(co.Destination)
+		if err != nil {
+			return err
+		}
 
-func recursiveGCS(ctx context.Context, w *Workflow, sBkt, sPrefix, dBkt, dPrefix string) error {
+		// Check if source bucket exists and is readable.
+		if !readableBkts.contains(sBkt) {
+			if _, err := s.w.StorageClient.Bucket(sBkt).Attrs(ctx); err != nil {
+				return fmt.Errorf("error reading bucket %q: %v", sBkt, err)
+			}
+			readableBkts.add(sBkt)
+		}
+
+		// Check if destination bucket exists and is readable.
+		if writableBkts.contains(dBkt) {
+			continue
+		}
+
+		if _, err := s.w.StorageClient.Bucket(dBkt).Attrs(ctx); err != nil {
+			return fmt.Errorf("error reading bucket %q: %v", dBkt, err)
+		}
+
+		// Check if destination bucket is writable.
+		tObj := s.w.StorageClient.Bucket(dBkt).Object(s.w.id)
+		w := tObj.NewWriter(ctx)
+		if _, err := w.Write(nil); err != nil {
+			return err
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("error writing to bucket %q: %v", dBkt, err)
+		}
+		if err := tObj.Delete(ctx); err != nil {
+			return err
+		}
+		writableBkts.add(dBkt)
+	}
+
+	return nil
+}
+
+func recursiveGCS(ctx context.Context, w *Workflow, sBkt, sPrefix, dBkt, dPrefix string, acls []storage.ACLRule) error {
 	it := w.StorageClient.Bucket(sBkt).Objects(ctx, &storage.Query{Prefix: sPrefix})
 	for objAttr, err := it.Next(); err != iterator.Done; objAttr, err = it.Next() {
 		if err != nil {
@@ -52,6 +96,12 @@ func recursiveGCS(ctx context.Context, w *Workflow, sBkt, sPrefix, dBkt, dPrefix
 		dstPath := w.StorageClient.Bucket(dBkt).Object(o)
 		if _, err := dstPath.CopierFrom(srcPath).Run(ctx); err != nil {
 			return err
+		}
+
+		for _, acl := range acls {
+			if err := dstPath.ACL().Set(ctx, acl.Entity, acl.Role); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -77,7 +127,7 @@ func (c *CopyGCSObjects) run(ctx context.Context, s *Step) error {
 			}
 
 			if sObj == "" || strings.HasSuffix(sObj, "/") {
-				if err := recursiveGCS(ctx, s.w, sBkt, sObj, dBkt, dObj); err != nil {
+				if err := recursiveGCS(ctx, s.w, sBkt, sObj, dBkt, dObj, co.ACLRules); err != nil {
 					e <- fmt.Errorf("error copying from %s to %s: %v", co.Source, co.Destination, err)
 					return
 				}

--- a/daisy/step_copy_gcs_objects_test.go
+++ b/daisy/step_copy_gcs_objects_test.go
@@ -120,6 +120,7 @@ func TestCopyGCSObjectsRun(t *testing.T) {
 	for _, ws := range []*CopyGCSObjects{
 		{{Source: "gs://bucket", Destination: ""}},
 		{{Source: "", Destination: "gs://bucket"}},
+		{{Source: "gs://bucket/object/", Destination: "gs://bucket/object/", ACLRules: []*storage.ACLRule{{Entity: "someUser", Role: "OWNER"}}}},
 	} {
 		if err := ws.run(ctx, s); err == nil {
 			t.Error("expected error")

--- a/daisy/step_copy_gcs_objects_test.go
+++ b/daisy/step_copy_gcs_objects_test.go
@@ -16,15 +16,13 @@ package daisy
 
 import (
 	"context"
-	"testing"
-
-	"google.golang.org/api/option"
-
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
 )
 
 func TestCopyGCSObjectsPopulate(t *testing.T) {

--- a/daisy/storage.go
+++ b/daisy/storage.go
@@ -1,0 +1,91 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisy
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"sync"
+)
+
+var (
+	bucket = `([a-z0-9][-_.a-z0-9]*)`
+	object = `(.+)`
+	// Many of the Google Storage URLs are supported below.
+	// It is preferred that customers specify their object using
+	// its gs://<bucket>/<object> URL.
+	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/?$`, bucket))
+	gsRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://%s/%s$`, bucket, object))
+	// Check for the Google Storage URLs:
+	// http://<bucket>.storage.googleapis.com/<object>
+	// https://<bucket>.storage.googleapis.com/<object>
+	gsHTTPRegex1 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://%s\.storage\.googleapis\.com/%s$`, bucket, object))
+	// http://storage.cloud.google.com/<bucket>/<object>
+	// https://storage.cloud.google.com/<bucket>/<object>
+	gsHTTPRegex2 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://storage\.cloud\.google\.com/%s/%s$`, bucket, object))
+	// Check for the other possible Google Storage URLs:
+	// http://storage.googleapis.com/<bucket>/<object>
+	// https://storage.googleapis.com/<bucket>/<object>
+	//
+	// The following are deprecated but checked:
+	// http://commondatastorage.googleapis.com/<bucket>/<object>
+	// https://commondatastorage.googleapis.com/<bucket>/<object>
+	gsHTTPRegex3 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://(?:commondata)?storage\.googleapis\.com/%s/%s$`, bucket, object))
+
+	gcsAPIBase = "https://storage.cloud.google.com"
+)
+
+func getGCSAPIPath(p string) (string, error) {
+	b, o, e := splitGCSPath(p)
+	if e != nil {
+		return "", e
+	}
+	return fmt.Sprintf("%s/%s", gcsAPIBase, path.Join(b, o)), nil
+}
+
+func splitGCSPath(p string) (string, string, error) {
+	for _, rgx := range []*regexp.Regexp{gsRegex, gsHTTPRegex1, gsHTTPRegex2, gsHTTPRegex3} {
+		matches := rgx.FindStringSubmatch(p)
+		if matches != nil {
+			return matches[1], matches[2], nil
+		}
+	}
+	matches := bucketRegex.FindStringSubmatch(p)
+	if matches != nil {
+		return matches[1], "", nil
+	}
+	return "", "", fmt.Errorf("%q is not a valid GCS path", p)
+}
+
+type validatedBkts struct {
+	mx   sync.Mutex
+	bkts []string
+}
+
+func (v *validatedBkts) add(bkt string) {
+	v.mx.Lock()
+	defer v.mx.Unlock()
+	v.bkts = append(v.bkts, bkt)
+}
+
+func (v *validatedBkts) contains(bkt string) bool {
+	v.mx.Lock()
+	defer v.mx.Unlock()
+	return strIn(bkt, v.bkts)
+}
+
+var writableBkts validatedBkts
+var readableBkts validatedBkts

--- a/daisy/storage_test.go
+++ b/daisy/storage_test.go
@@ -1,0 +1,63 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisy
+
+import (
+	"testing"
+)
+
+func TestGetGCSAPIPath(t *testing.T) {
+	got, err := getGCSAPIPath("gs://foo/bar")
+	want := "https://storage.cloud.google.com/foo/bar"
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if got != want {
+		t.Errorf("unexpected result: got: %q, want: %q", got, want)
+	}
+}
+
+func TestSplitGCSPath(t *testing.T) {
+	tests := []struct {
+		input     string
+		bucket    string
+		object    string
+		shouldErr bool
+	}{
+		{"gs://foo", "foo", "", false},
+		{"gs://foo/bar", "foo", "bar", false},
+		{"http://foo.storage.googleapis.com/bar", "foo", "bar", false},
+		{"https://foo.storage.googleapis.com/bar", "foo", "bar", false},
+		{"http://storage.cloud.google.com/foo/bar", "foo", "bar", false},
+		{"https://storage.cloud.google.com/foo/bar/bar", "foo", "bar/bar", false},
+		{"http://storage.googleapis.com/foo/bar", "foo", "bar", false},
+		{"https://storage.googleapis.com/foo/bar", "foo", "bar", false},
+		{"http://commondatastorage.googleapis.com/foo/bar", "foo", "bar", false},
+		{"https://commondatastorage.googleapis.com/foo/bar", "foo", "bar", false},
+		{"/local/path", "", "", true},
+	}
+
+	for _, tt := range tests {
+		b, o, err := splitGCSPath(tt.input)
+		if tt.shouldErr && err == nil {
+			t.Errorf("splitGCSPath(%q) should have thrown an error", tt.input)
+		} else if !tt.shouldErr && err != nil {
+			t.Errorf("splitGCSPath(%q) should not have thrown an error", tt.input)
+		}
+		if b != tt.bucket || o != tt.object {
+			t.Errorf("splitGCSPath(%q) returned incorrect values -- want bucket=%q, object=%q; got bucket=%q, object=%q", tt.input, tt.bucket, tt.object, b, o)
+		}
+	}
+}

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -180,6 +180,10 @@ func newTestGCSClient() (*storage.Client, error) {
 			fmt.Fprint(w, `{"kind": "storage#objects", "items": [{"kind": "storage#object", "name": "object", "size": "1"},{"kind": "storage#object", "name": "folder/object", "size": "1"}]}`)
 		} else if m == "PUT" && u == "/b/bucket/o/object/acl/allUsers?alt=json" {
 			fmt.Fprint(w, `{}`)
+		} else if m == "PUT" && u == "/b/bucket/o/object%2Ffolder%2Ffolder%2Fobject/acl/allUsers?alt=json" {
+			fmt.Fprint(w, `{}`)
+		} else if m == "PUT" && u == "/b/bucket/o/object%2Ffolder%2Fobject/acl/allUsers?alt=json" {
+			fmt.Fprint(w, `{}`)
 		} else if m == "GET" && u == "/b?alt=json&pageToken=&prefix=&project=foo-project&projection=full" {
 			fmt.Fprint(w, `{}`)
 		} else if m == "GET" && u == "/b?alt=json&pageToken=&prefix=&project=bar-project&projection=full" {


### PR DESCRIPTION
Populate function ensures Role is uppercase
Validate function checks:
- read access to source 
- write access to destination
- ACLRule.Entity is not empty
- ACLRule.Entity can actually be used
- ACLRule.Role matches a known value

Reorganize GCS specific code.