### PR TITLE
Globally lock during GCS validation

### DIFF
--- a/daisy/step_copy_gcs_objects_test.go
+++ b/daisy/step_copy_gcs_objects_test.go
@@ -99,6 +99,9 @@ func TestCopyGCSObjectsValidate(t *testing.T) {
 		if err := ws.validate(ctx, s); err == nil {
 			t.Error("expected error")
 		}
+		// Reset.
+		readableBkts = validatedBkts{}
+		writableBkts = validatedBkts{}
 	}
 }
 

--- a/daisy/storage.go
+++ b/daisy/storage.go
@@ -75,17 +75,5 @@ type validatedBkts struct {
 	bkts []string
 }
 
-func (v *validatedBkts) add(bkt string) {
-	v.mx.Lock()
-	defer v.mx.Unlock()
-	v.bkts = append(v.bkts, bkt)
-}
-
-func (v *validatedBkts) contains(bkt string) bool {
-	v.mx.Lock()
-	defer v.mx.Unlock()
-	return strIn(bkt, v.bkts)
-}
-
 var writableBkts validatedBkts
 var readableBkts validatedBkts


### PR DESCRIPTION
Multiple steps can have the same name (like inside an IncludeWorkflow)