### PR TITLE
Add StatusMatch to WaitForInstancesSignal

### DIFF
--- a/daisy/README.md
+++ b/daisy/README.md
@@ -506,8 +506,11 @@ SerialOutput:
 | Port | int64 | The serial port number to listen to. GCE VMs have serial ports 1-4. |
 | FailureMatch | string | *Optional, but this or SuccessMatch must be provided.* An expected string in case of a failure. |
 | SuccessMatch | string | *Optional, but this or FailureMatch must be provided.* An expected string when the VM performed its task successfully. |
+| StatusMatch | string | *Optional* An informational status line to print out. |
 
-This example step waits for VM "foo" to stop and for a signal from VM "bar":
+If any serial line matches FailureMatch, SuccessMatch or StatusMatch the line
+from the match onward will be logged. This example step waits for VM "foo" to 
+stop and for a signal from VM "bar":
 ```json
 "step-name": {
     "WaitForInstancesSignal": [
@@ -519,8 +522,9 @@ This example step waits for VM "foo" to stop and for a signal from VM "bar":
             "Name": "bar",
             "SerialOutput": {
                 "Port": 1,
-                "SuccessMatch": "this means I'm done! :)",
-                "FailureMatch": "this means I failed... :("
+                "SuccessMatch": "DasiySuccess:",
+                "FailureMatch": "DasiyFailure:",
+                "StatusMatch": "DaisyStatus:"
             }
         }
     ]

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -108,7 +108,7 @@ func TestWaitForInstancesSignalRun(t *testing.T) {
 
 	// Normal run, no error.
 	ws := &WaitForInstancesSignal{
-		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success"}},
+		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{StatusMatch: "success", SuccessMatch: "success"}},
 		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success", FailureMatch: "fail"}},
 		{Name: "i3", interval: 1 * time.Microsecond, Stopped: true},
 	}
@@ -175,13 +175,14 @@ func TestWaitForInstancesSignalValidate(t *testing.T) {
 		shouldErr bool
 	}{
 		{"normal case Stopped", WaitForInstancesSignal{{Name: "instance1", Stopped: true, interval: 1 * time.Second}}, false},
-		{"normal SerialOutput SuccessMatch", WaitForInstancesSignal{{Name: "instance1", SerialOutput: &SerialOutput{Port: 1, SuccessMatch: "test"}, interval: 1 * time.Second}}, false},
+		{"normal SerialOutput SuccessMatch", WaitForInstancesSignal{{Name: "instance1", SerialOutput: &SerialOutput{Port: 1, StatusMatch: "test", SuccessMatch: "test"}, interval: 1 * time.Second}}, false},
 		{"normal SerialOutput FailureMatch", WaitForInstancesSignal{{Name: "instance1", SerialOutput: &SerialOutput{Port: 1, FailureMatch: "fail"}, interval: 1 * time.Second}}, false},
 		{"normal SerialOutput FailureMatch", WaitForInstancesSignal{{Name: "instance1", SerialOutput: &SerialOutput{Port: 1, SuccessMatch: "test", FailureMatch: "fail"}, interval: 1 * time.Second}}, false},
 		{"SerialOutput no port", WaitForInstancesSignal{{Name: "instance1", SerialOutput: &SerialOutput{SuccessMatch: "test"}, interval: 1 * time.Second}}, true},
 		{"SerialOutput no SuccessMatch or FailureMatch", WaitForInstancesSignal{{Name: "instance1", SerialOutput: &SerialOutput{Port: 1}, interval: 1 * time.Second}}, true},
 		{"instance DNE error check", WaitForInstancesSignal{{Name: "instance1", Stopped: true, interval: 1 * time.Second}, {Name: "instance2", Stopped: true, interval: 1 * time.Second}}, true},
 		{"no interval", WaitForInstancesSignal{{Name: "instance1", Stopped: true, Interval: "0s"}}, true},
+		{"no signal", WaitForInstancesSignal{{Name: "instance1", interval: 1 * time.Second}}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Serial output matching FailureMatch, SuccessMatch or StatusMatch will log for easier debugging.