### PR TITLE
Add additional checks for resources existing in GCE

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -38,12 +38,18 @@ type Client interface {
 	DeleteImage(project, name string) error
 	DeleteInstance(project, zone, name string) error
 	GetMachineType(project, zone, machineType string) (*compute.MachineType, error)
+	ListMachineTypes(project, zone string) (*compute.MachineTypeList, error)
 	GetProject(project string) (*compute.Project, error)
 	GetSerialPortOutput(project, zone, name string, port, start int64) (*compute.SerialPortOutput, error)
 	GetZone(project, zone string) (*compute.Zone, error)
+	ListZones(project string) (*compute.ZoneList, error)
 	GetInstance(project, zone, name string) (*compute.Instance, error)
+	ListInstances(project, zone string) (*compute.InstanceList, error)
 	GetDisk(project, zone, name string) (*compute.Disk, error)
+	ListDisks(project, zone string) (*compute.DiskList, error)
 	GetImage(project, name string) (*compute.Image, error)
+	GetImageFromFamily(project, family string) (*compute.Image, error)
+	ListImages(project string) (*compute.ImageList, error)
 	InstanceStatus(project, zone, name string) (string, error)
 	InstanceStopped(project, zone, name string) (bool, error)
 	Retry(f func(opts ...googleapi.CallOption) (*compute.Operation, error), opts ...googleapi.CallOption) (op *compute.Operation, err error)
@@ -267,6 +273,15 @@ func (c *client) GetMachineType(project, zone, machineType string) (*compute.Mac
 	return mt, err
 }
 
+// ListMachineTypes gets a list of GCE MachineTypes.
+func (c *client) ListMachineTypes(project, zone string) (*compute.MachineTypeList, error) {
+	mt, err := c.raw.MachineTypes.List(project, zone).Do()
+	if shouldRetryWithWait(c.hc.Transport, err, 2) {
+		return c.raw.MachineTypes.List(project, zone).Do()
+	}
+	return mt, err
+}
+
 // GetProject gets a GCE Project.
 func (c *client) GetProject(project string) (*compute.Project, error) {
 	p, err := c.raw.Projects.Get(project).Do()
@@ -294,11 +309,29 @@ func (c *client) GetZone(project, zone string) (*compute.Zone, error) {
 	return z, err
 }
 
+// ListZones gets a list GCE Zones.
+func (c *client) ListZones(project string) (*compute.ZoneList, error) {
+	z, err := c.raw.Zones.List(project).Do()
+	if shouldRetryWithWait(c.hc.Transport, err, 2) {
+		return c.raw.Zones.List(project).Do()
+	}
+	return z, err
+}
+
 // GetInstance gets a GCE Instance.
 func (c *client) GetInstance(project, zone, name string) (*compute.Instance, error) {
 	i, err := c.raw.Instances.Get(project, zone, name).Do()
 	if shouldRetryWithWait(c.hc.Transport, err, 2) {
 		return c.raw.Instances.Get(project, zone, name).Do()
+	}
+	return i, err
+}
+
+// ListInstances gets a list of GCE Instances.
+func (c *client) ListInstances(project, zone string) (*compute.InstanceList, error) {
+	i, err := c.raw.Instances.List(project, zone).Do()
+	if shouldRetryWithWait(c.hc.Transport, err, 2) {
+		return c.raw.Instances.List(project, zone).Do()
 	}
 	return i, err
 }
@@ -312,11 +345,38 @@ func (c *client) GetDisk(project, zone, name string) (*compute.Disk, error) {
 	return d, err
 }
 
+// ListDisks gets a list of GCE Disks.
+func (c *client) ListDisks(project, zone string) (*compute.DiskList, error) {
+	d, err := c.raw.Disks.List(project, zone).Do()
+	if shouldRetryWithWait(c.hc.Transport, err, 2) {
+		return c.raw.Disks.List(project, zone).Do()
+	}
+	return d, err
+}
+
 // GetImage gets a GCE Image.
 func (c *client) GetImage(project, name string) (*compute.Image, error) {
 	i, err := c.raw.Images.Get(project, name).Do()
 	if shouldRetryWithWait(c.hc.Transport, err, 2) {
 		return c.raw.Images.Get(project, name).Do()
+	}
+	return i, err
+}
+
+// GetImageFromFamily gets a GCE Image from an image family.
+func (c *client) GetImageFromFamily(project, family string) (*compute.Image, error) {
+	i, err := c.raw.Images.GetFromFamily(project, family).Do()
+	if shouldRetryWithWait(c.hc.Transport, err, 2) {
+		return c.raw.Images.GetFromFamily(project, family).Do()
+	}
+	return i, err
+}
+
+// ListImages gets a list of GCE Images.
+func (c *client) ListImages(project string) (*compute.ImageList, error) {
+	i, err := c.raw.Images.List(project).Do()
+	if shouldRetryWithWait(c.hc.Transport, err, 2) {
+		return c.raw.Images.List(project).Do()
 	}
 	return i, err
 }

--- a/daisy/compute/test_client.go
+++ b/daisy/compute/test_client.go
@@ -53,12 +53,18 @@ type TestClient struct {
 	DeleteImageFn         func(project, name string) error
 	DeleteInstanceFn      func(project, zone, name string) error
 	GetMachineTypeFn      func(project, zone, machineType string) (*compute.MachineType, error)
+	ListMachineTypesFn    func(project, zone string) (*compute.MachineTypeList, error)
 	GetProjectFn          func(project string) (*compute.Project, error)
 	GetSerialPortOutputFn func(project, zone, name string, port, start int64) (*compute.SerialPortOutput, error)
 	GetZoneFn             func(project, zone string) (*compute.Zone, error)
+	ListZonesFn           func(project string) (*compute.ZoneList, error)
 	GetInstanceFn         func(project, zone, name string) (*compute.Instance, error)
+	ListInstancesFn       func(project, zone string) (*compute.InstanceList, error)
 	GetDiskFn             func(project, zone, name string) (*compute.Disk, error)
+	ListDisksFn           func(project, zone string) (*compute.DiskList, error)
 	GetImageFn            func(project, name string) (*compute.Image, error)
+	GetImageFromFamilyFn  func(project, family string) (*compute.Image, error)
+	ListImagesFn          func(project string) (*compute.ImageList, error)
 	InstanceStatusFn      func(project, zone, name string) (string, error)
 	InstanceStoppedFn     func(project, zone, name string) (bool, error)
 	RetryFn               func(f func(opts ...googleapi.CallOption) (*compute.Operation, error), opts ...googleapi.CallOption) (op *compute.Operation, err error)
@@ -132,10 +138,18 @@ func (c *TestClient) GetProject(project string) (*compute.Project, error) {
 
 // GetMachineType uses the override method GetMachineTypeFn or the real implementation.
 func (c *TestClient) GetMachineType(project, zone, machineType string) (*compute.MachineType, error) {
-	if c.GetZoneFn != nil {
+	if c.GetMachineTypeFn != nil {
 		return c.GetMachineTypeFn(project, zone, machineType)
 	}
 	return c.client.GetMachineType(project, zone, machineType)
+}
+
+// ListMachineTypes uses the override method ListMachineTypesFn or the real implementation.
+func (c *TestClient) ListMachineTypes(project, zone string) (*compute.MachineTypeList, error) {
+	if c.ListMachineTypesFn != nil {
+		return c.ListMachineTypesFn(project, zone)
+	}
+	return c.client.ListMachineTypes(project, zone)
 }
 
 // GetZone uses the override method GetZoneFn or the real implementation.
@@ -146,12 +160,28 @@ func (c *TestClient) GetZone(project, zone string) (*compute.Zone, error) {
 	return c.client.GetZone(project, zone)
 }
 
+// ListZones uses the override method ListZonesFn or the real implementation.
+func (c *TestClient) ListZones(project string) (*compute.ZoneList, error) {
+	if c.ListZonesFn != nil {
+		return c.ListZonesFn(project)
+	}
+	return c.client.ListZones(project)
+}
+
 // GetInstance uses the override method GetZoneFn or the real implementation.
 func (c *TestClient) GetInstance(project, zone, name string) (*compute.Instance, error) {
 	if c.GetInstanceFn != nil {
 		return c.GetInstanceFn(project, zone, name)
 	}
 	return c.client.GetInstance(project, zone, name)
+}
+
+// ListInstances uses the override method ListInstancesFn or the real implementation.
+func (c *TestClient) ListInstances(project, zone string) (*compute.InstanceList, error) {
+	if c.ListInstancesFn != nil {
+		return c.ListInstancesFn(project, zone)
+	}
+	return c.client.ListInstances(project, zone)
 }
 
 // GetDisk uses the override method GetZoneFn or the real implementation.
@@ -162,12 +192,36 @@ func (c *TestClient) GetDisk(project, zone, name string) (*compute.Disk, error) 
 	return c.client.GetDisk(project, zone, name)
 }
 
-// GetImage uses the override method GetZoneFn or the real implementation.
+// ListDisks uses the override method ListDisksFn or the real implementation.
+func (c *TestClient) ListDisks(project, zone string) (*compute.DiskList, error) {
+	if c.ListDisksFn != nil {
+		return c.ListDisksFn(project, zone)
+	}
+	return c.client.ListDisks(project, zone)
+}
+
+// GetImage uses the override method GetImageFn or the real implementation.
 func (c *TestClient) GetImage(project, name string) (*compute.Image, error) {
 	if c.GetImageFn != nil {
 		return c.GetImageFn(project, name)
 	}
 	return c.client.GetImage(project, name)
+}
+
+// GetImageFromFamily uses the override method GetImageFromFamilyFn or the real implementation.
+func (c *TestClient) GetImageFromFamily(project, family string) (*compute.Image, error) {
+	if c.GetImageFromFamilyFn != nil {
+		return c.GetImageFromFamilyFn(project, family)
+	}
+	return c.client.GetImageFromFamily(project, family)
+}
+
+// ListImages uses the override method ListImagesFn or the real implementation.
+func (c *TestClient) ListImages(project string) (*compute.ImageList, error) {
+	if c.ListImagesFn != nil {
+		return c.ListImagesFn(project)
+	}
+	return c.client.ListImages(project)
 }
 
 // GetSerialPortOutput uses the override method GetSerialPortOutputFn or the real implementation.

--- a/daisy/compute/test_client_test.go
+++ b/daisy/compute/test_client_test.go
@@ -48,10 +48,16 @@ func TestTestClient(t *testing.T) {
 		{"get serial port", func() { c.GetSerialPortOutput("a", "b", "c", 1, 2) }},
 		{"get project", func() { c.GetProject("a") }},
 		{"get machine type", func() { c.GetMachineType("a", "b", "c") }},
+		{"list machine types", func() { c.ListMachineTypes("a", "b") }},
 		{"get zone", func() { c.GetZone("a", "b") }},
+		{"list zones", func() { c.ListZones("a") }},
 		{"get instance", func() { c.GetInstance("a", "b", "c") }},
+		{"list instances", func() { c.ListInstances("a", "b") }},
+		{"get image from family", func() { c.GetImageFromFamily("a", "b") }},
 		{"get image", func() { c.GetImage("a", "b") }},
+		{"list images", func() { c.ListImages("a") }},
 		{"get disk", func() { c.GetDisk("a", "b", "c") }},
+		{"list disks", func() { c.ListDisks("a", "b") }},
 		{"instance status", func() { c.InstanceStatus("a", "b", "c") }},
 		{"instance stopped", func() { c.InstanceStopped("a", "b", "c") }},
 		{"operation wait", func() { c.operationsWait("a", "b", "c") }},
@@ -90,10 +96,16 @@ func TestTestClient(t *testing.T) {
 	}
 	c.GetProjectFn = func(_ string) (*compute.Project, error) { fakeCalled = true; return nil, nil }
 	c.GetZoneFn = func(_, _ string) (*compute.Zone, error) { fakeCalled = true; return nil, nil }
+	c.ListZonesFn = func(_ string) (*compute.ZoneList, error) { fakeCalled = true; return nil, nil }
 	c.GetInstanceFn = func(_, _, _ string) (*compute.Instance, error) { fakeCalled = true; return nil, nil }
+	c.ListInstancesFn = func(_, _ string) (*compute.InstanceList, error) { fakeCalled = true; return nil, nil }
 	c.GetDiskFn = func(_, _, _ string) (*compute.Disk, error) { fakeCalled = true; return nil, nil }
+	c.ListDisksFn = func(_, _ string) (*compute.DiskList, error) { fakeCalled = true; return nil, nil }
+	c.GetImageFromFamilyFn = func(_, _ string) (*compute.Image, error) { fakeCalled = true; return nil, nil }
 	c.GetImageFn = func(_, _ string) (*compute.Image, error) { fakeCalled = true; return nil, nil }
+	c.ListImagesFn = func(_ string) (*compute.ImageList, error) { fakeCalled = true; return nil, nil }
 	c.GetMachineTypeFn = func(_, _, _ string) (*compute.MachineType, error) { fakeCalled = true; return nil, nil }
+	c.ListMachineTypesFn = func(_, _ string) (*compute.MachineTypeList, error) { fakeCalled = true; return nil, nil }
 	c.InstanceStatusFn = func(_, _, _ string) (string, error) { fakeCalled = true; return "", nil }
 	c.InstanceStoppedFn = func(_, _, _ string) (bool, error) { fakeCalled = true; return false, nil }
 	c.operationsWaitFn = func(_, _, _ string) error { fakeCalled = true; return nil }

--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -168,6 +168,8 @@ var diskCache struct {
 	mu     sync.Mutex
 }
 
+// diskExists should only be used during validation for existing GCE disks
+// and should not be relied or populated for daisy created resources.
 func diskExists(client compute.Client, project, zone, disk string) (bool, error) {
 	diskCache.mu.Lock()
 	defer diskCache.mu.Unlock()

--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -17,6 +17,9 @@ package daisy
 import (
 	"fmt"
 	"regexp"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
 var (
@@ -158,4 +161,32 @@ func (dr *diskRegistry) registerAllDetachments(iName string, s *Step) error {
 		}
 	}
 	return errs.cast()
+}
+
+var diskCache struct {
+	exists map[string]map[string][]string
+	mu     sync.Mutex
+}
+
+func diskExists(client compute.Client, project, zone, disk string) (bool, error) {
+	diskCache.mu.Lock()
+	defer diskCache.mu.Unlock()
+	if diskCache.exists == nil {
+		diskCache.exists = map[string]map[string][]string{}
+	}
+	if _, ok := diskCache.exists[project]; !ok {
+		diskCache.exists[project] = map[string][]string{}
+	}
+	if _, ok := diskCache.exists[project][zone]; !ok {
+		dl, err := client.ListDisks(project, zone)
+		if err != nil {
+			return false, fmt.Errorf("error listing disks for project %q: %v", project, err)
+		}
+		var disks []string
+		for _, d := range dl.Items {
+			disks = append(disks, d.Name)
+		}
+		diskCache.exists[project][zone] = disks
+	}
+	return strIn(disk, diskCache.exists[project][zone]), nil
 }

--- a/daisy/instance.go
+++ b/daisy/instance.go
@@ -100,6 +100,8 @@ var instanceCache struct {
 	mu     sync.Mutex
 }
 
+// instanceExists should only be used during validation for existing GCE instances
+// and should not be relied or populated for daisy created resources.
 func instanceExists(client compute.Client, project, zone, instance string) (bool, error) {
 	instanceCache.mu.Lock()
 	defer instanceCache.mu.Unlock()

--- a/daisy/project.go
+++ b/daisy/project.go
@@ -22,15 +22,15 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-var projectResource struct {
+var projectCache struct {
 	exists []string
 	mu     sync.Mutex
 }
 
 func projectExists(client compute.Client, project string) (bool, error) {
-	projectResource.mu.Lock()
-	defer projectResource.mu.Unlock()
-	if strIn(project, projectResource.exists) {
+	projectCache.mu.Lock()
+	defer projectCache.mu.Unlock()
+	if strIn(project, projectCache.exists) {
 		return true, nil
 	}
 	if _, err := client.GetProject(project); err != nil {
@@ -40,6 +40,6 @@ func projectExists(client compute.Client, project string) (bool, error) {
 			return false, err
 		}
 	}
-	projectResource.exists = append(projectResource.exists, project)
+	projectCache.exists = append(projectCache.exists, project)
 	return true, nil
 }

--- a/daisy/project.go
+++ b/daisy/project.go
@@ -15,25 +15,31 @@
 package daisy
 
 import (
+	"net/http"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"google.golang.org/api/googleapi"
 )
 
-var projects struct {
-	valid []string
-	mu    sync.Mutex
+var projectResource struct {
+	exists []string
+	mu     sync.Mutex
 }
 
-func checkProject(client compute.Client, project string) error {
-	projects.mu.Lock()
-	defer projects.mu.Unlock()
-	if strIn(project, projects.valid) {
-		return nil
+func projectExists(client compute.Client, project string) (bool, error) {
+	projectResource.mu.Lock()
+	defer projectResource.mu.Unlock()
+	if strIn(project, projectResource.exists) {
+		return true, nil
 	}
 	if _, err := client.GetProject(project); err != nil {
-		return err
+		if apiErr, ok := err.(*googleapi.Error); ok && apiErr.Code == http.StatusNotFound {
+			return false, nil
+		} else {
+			return false, err
+		}
 	}
-	projects.valid = append(projects.valid, project)
-	return nil
+	projectResource.exists = append(projectResource.exists, project)
+	return true, nil
 }

--- a/daisy/resources_test.go
+++ b/daisy/resources_test.go
@@ -16,12 +16,11 @@ package daisy
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
-
-	"fmt"
 
 	"github.com/kylelemons/godebug/pretty"
 )

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -95,12 +95,18 @@ func (c *CreateDisks) validate(ctx context.Context, s *Step) error {
 		if !checkName(cd.Name) {
 			return fmt.Errorf("cannot create disk: bad name: %q", cd.Name)
 		}
-		if err := checkProject(s.w.ComputeClient, cd.Project); err != nil {
-			return fmt.Errorf("cannot create disk: bad project: %q, error: %v", cd.Project, err)
+		if exists, err := projectExists(s.w.ComputeClient, cd.Project); err != nil {
+			return fmt.Errorf("cannot create disk: bad project lookup: %q, error: %v", cd.Project, err)
+		} else if !exists {
+			return fmt.Errorf("cannot create disk: project does not exist: %q", cd.Project)
 		}
-		if err := checkZone(s.w.ComputeClient, cd.Project, cd.Zone); err != nil {
-			return fmt.Errorf("cannot create disk: bad zone: %q, error: %v", cd.Zone, err)
+
+		if exists, err := zoneExists(s.w.ComputeClient, cd.Project, cd.Zone); err != nil {
+			return fmt.Errorf("cannot create disk: bad zone lookup: %q, error: %v", cd.Zone, err)
+		} else if !exists {
+			return fmt.Errorf("cannot create disk: zone does not exist: %q", cd.Zone)
 		}
+
 		if !diskTypeURLRgx.MatchString(cd.Type) {
 			return fmt.Errorf("cannot create disk: bad disk type: %q", cd.Type)
 		}

--- a/daisy/step_create_disks_test.go
+++ b/daisy/step_create_disks_test.go
@@ -144,19 +144,6 @@ func TestCreateDisksValidate(t *testing.T) {
 	ctx := context.Background()
 	// Set up.
 	w := testWorkflow()
-	listZonesFn := func(_ string) (*compute.ZoneList, error) {
-		return &compute.ZoneList{Items: []*compute.Zone{{Name: testZone}}}, nil
-	}
-	getProjectFn := func(p string) (*compute.Project, error) {
-		if p == testProject {
-			return nil, nil
-		}
-		return nil, errors.New("bad project")
-	}
-	w.ComputeClient = &daisyCompute.TestClient{
-		ListZonesFn:  listZonesFn,
-		GetProjectFn: getProjectFn,
-	}
 
 	iCreator := &Step{name: "iCreator", w: w}
 	w.Steps["iCreator"] = iCreator
@@ -177,7 +164,7 @@ func TestCreateDisksValidate(t *testing.T) {
 		},
 		{
 			"source image url case",
-			&CreateDisk{daisyName: "d2", Disk: compute.Disk{Name: n, SourceImage: "projects/p/global/images/i", Type: ty}, Project: testProject, Zone: testZone},
+			&CreateDisk{daisyName: "d2", Disk: compute.Disk{Name: n, SourceImage: fmt.Sprintf("projects/%s/global/images/%s", testProject, testImage), Type: ty}, Project: testProject, Zone: testZone},
 			false,
 		},
 		{
@@ -229,7 +216,7 @@ func TestCreateDisksValidate(t *testing.T) {
 	// These track the expected state of the disk references and the image reference.
 	// Each good case adds a disk reference and adds a user to the image.
 	wantDisks := map[string]*resource{}
-	wantImages := &baseResourceRegistry{m: map[string]*resource{"i1": {creator: iCreator}}, urlRgx: imageURLRgx}
+	wantImages := &baseResourceRegistry{w: w, m: map[string]*resource{"i1": {creator: iCreator}}, urlRgx: imageURLRgx}
 
 	// These are compare helper functions. These clear up infinite recursion issues.
 	preCompare := func() {

--- a/daisy/step_create_disks_test.go
+++ b/daisy/step_create_disks_test.go
@@ -144,6 +144,19 @@ func TestCreateDisksValidate(t *testing.T) {
 	ctx := context.Background()
 	// Set up.
 	w := testWorkflow()
+	listZonesFn := func(_ string) (*compute.ZoneList, error) {
+		return &compute.ZoneList{Items: []*compute.Zone{{Name: testZone}}}, nil
+	}
+	getProjectFn := func(p string) (*compute.Project, error) {
+		if p == testProject {
+			return nil, nil
+		}
+		return nil, errors.New("bad project")
+	}
+	w.ComputeClient = &daisyCompute.TestClient{
+		ListZonesFn:  listZonesFn,
+		GetProjectFn: getProjectFn,
+	}
 
 	iCreator := &Step{name: "iCreator", w: w}
 	w.Steps["iCreator"] = iCreator

--- a/daisy/step_create_images.go
+++ b/daisy/step_create_images.go
@@ -94,8 +94,10 @@ func (c *CreateImages) validate(ctx context.Context, s *Step) error {
 		}
 
 		// Project checking.
-		if err := checkProject(s.w.ComputeClient, ci.Project); err != nil {
-			return fmt.Errorf("cannot create image: bad project: %q, error: %v", ci.Project, err)
+		if exists, err := projectExists(s.w.ComputeClient, ci.Project); err != nil {
+			return fmt.Errorf("cannot create image: bad project lookup: %q, error: %v", ci.Project, err)
+		} else if !exists {
+			return fmt.Errorf("cannot create image: project does not exist: %q", ci.Project)
 		}
 
 		// Source disk checking.

--- a/daisy/step_create_images_test.go
+++ b/daisy/step_create_images_test.go
@@ -17,9 +17,9 @@ package daisy
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
+	"fmt"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/kylelemons/godebug/pretty"
 	compute "google.golang.org/api/compute/v1"
@@ -173,10 +173,6 @@ func TestCreateImagesValidate(t *testing.T) {
 	ctx := context.Background()
 
 	w := testWorkflow()
-	_, err := newTestGCEClient()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	d1Creator := &Step{name: "d1Creator", w: w}
 	w.Steps["d1Creator"] = d1Creator
@@ -187,10 +183,18 @@ func TestCreateImagesValidate(t *testing.T) {
 	w.Dependencies["d2Deleter"] = []string{"d2Creator"}
 	d3Creator := &Step{name: "d3Creator", w: w}
 	w.Steps["d3Creator"] = d3Creator
-	disks[w].registerCreation("d1", &resource{}, d1Creator)
-	disks[w].registerCreation("d2", &resource{}, d2Creator)
-	disks[w].registerDeletion("d2", d2Deleter)
-	disks[w].registerCreation("d3", &resource{}, d3Creator)
+	if err := disks[w].registerCreation("d1", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d1", testProject, testZone)}, d1Creator); err != nil {
+		t.Fatal(err)
+	}
+	if err := disks[w].registerCreation("d2", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d2", testProject, testZone)}, d2Creator); err != nil {
+		t.Fatal(err)
+	}
+	if err := disks[w].registerDeletion("d2", d2Deleter); err != nil {
+		t.Fatal(err)
+	}
+	if err := disks[w].registerCreation("d3", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d3", testProject, testZone)}, d3Creator); err != nil {
+		t.Fatal(err)
+	}
 	w.Sources = map[string]string{"source": "gs://some/file"}
 
 	n := "n"

--- a/daisy/step_create_images_test.go
+++ b/daisy/step_create_images_test.go
@@ -173,6 +173,10 @@ func TestCreateImagesValidate(t *testing.T) {
 	ctx := context.Background()
 
 	w := testWorkflow()
+	_, err := newTestGCEClient()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	d1Creator := &Step{name: "d1Creator", w: w}
 	w.Steps["d1Creator"] = d1Creator
@@ -198,10 +202,11 @@ func TestCreateImagesValidate(t *testing.T) {
 		{"good disk case", &CreateImage{daisyName: "i1", Project: testProject, Image: compute.Image{Name: n, SourceDisk: "d1"}}, false},
 		{"good raw disk case", &CreateImage{daisyName: "i2", Project: testProject, Image: compute.Image{Name: n, RawDisk: &compute.ImageRawDisk{Source: "source"}}}, false},
 		{"good raw disk case 2", &CreateImage{daisyName: "i3", Project: testProject, Image: compute.Image{Name: n, RawDisk: &compute.ImageRawDisk{Source: "gs://some/path"}}}, false},
-		{"good disk url case ", &CreateImage{daisyName: "i5", Project: testProject, Image: compute.Image{Name: n, SourceDisk: fmt.Sprintf("projects/%s/zones/z/disks/d", testProject)}}, false},
+		{"good disk url case ", &CreateImage{daisyName: "i5", Project: testProject, Image: compute.Image{Name: n, SourceDisk: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, testDisk)}}, false},
 		{"bad name case", &CreateImage{Project: testProject, Image: compute.Image{Name: "bad!", SourceDisk: "d1"}}, true},
 		{"bad project case", &CreateImage{Project: "bad!", Image: compute.Image{Name: "i6", SourceDisk: "d1"}}, true},
 		{"bad dupe name case", &CreateImage{daisyName: "i1", Project: testProject, Image: compute.Image{Name: n, SourceDisk: "d1"}}, true},
+		{"bad dupe image name case", &CreateImage{Project: testProject, Image: compute.Image{Name: testImage, SourceDisk: "d1"}}, true},
 		{"bad missing dep on disk creator case", &CreateImage{Project: testProject, Image: compute.Image{Name: "i6", SourceDisk: "d3"}}, true},
 		{"bad disk deleted case", &CreateImage{Project: testProject, Image: compute.Image{Name: "i6", SourceDisk: "d2"}}, true},
 		{"bad using disk and raw disk case", &CreateImage{Project: testProject, Image: compute.Image{Name: "i6", SourceDisk: "d1", RawDisk: &compute.ImageRawDisk{Source: "gs://some/path"}}}, true},

--- a/daisy/step_create_images_test.go
+++ b/daisy/step_create_images_test.go
@@ -17,9 +17,9 @@ package daisy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
-	"fmt"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/kylelemons/godebug/pretty"
 	compute "google.golang.org/api/compute/v1"

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"path"
 	"reflect"
 	"sort"
@@ -533,8 +532,16 @@ func TestCreateInstanceValidateDiskInitializeParams(t *testing.T) {
 func TestCreateInstanceValidateMachineType(t *testing.T) {
 	c, err := newTestGCEClient()
 	if err != nil {
-		t.Fatalf("error creating test client: %v", err)
+		t.Fatal(err)
 	}
+	getMachineTypeFn := func(_, _, mt string) (*compute.MachineType, error) {
+		if mt != "custom" {
+			return nil, errors.New("bad machine type")
+		}
+		return nil, nil
+	}
+
+	c.GetMachineTypeFn = getMachineTypeFn
 
 	tests := []struct {
 		desc      string
@@ -542,6 +549,7 @@ func TestCreateInstanceValidateMachineType(t *testing.T) {
 		shouldErr bool
 	}{
 		{"good case", fmt.Sprintf("projects/%s/zones/%s/machineTypes/%s", testProject, testZone, testMachineType), false},
+		{"custom case", fmt.Sprintf("projects/%s/zones/%s/machineTypes/%s", testProject, testZone, "custom"), false},
 		{"bad machine type case", fmt.Sprintf("projects/%s/zones/%s/machineTypes/bad-mt", testProject, testZone), true},
 		{"bad project case", fmt.Sprintf("projects/p2/zones/%s/machineTypes/%s", testZone, testMachineType), true},
 		{"bad zone case", fmt.Sprintf("projects/%s/zones/z2/machineTypes/%s", testProject, testMachineType), true},
@@ -584,53 +592,53 @@ func TestCreateInstanceValidateNetworks(t *testing.T) {
 
 func TestCreateInstancesValidate(t *testing.T) {
 	ctx := context.Background()
+	// Set up.
 	w := testWorkflow()
 
-	_, c, err := daisyCompute.NewTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.String() == "/p/zones/z?alt=json" {
-			fmt.Fprintln(w, `{}`)
-		} else if r.Method == "GET" && r.URL.String() == "/p.com%3Asomething?alt=json" {
-			fmt.Fprintln(w, `{}`)
-		} else if r.Method == "GET" && r.URL.String() == "/p.com%3Asomething/zones/z?alt=json" {
-			fmt.Fprintln(w, `{}`)
-		} else if r.Method == "GET" && r.URL.String() == "/p.com%3Asomething/zones/z/machineTypes/mt?alt=json" {
-			fmt.Fprintln(w, `{}`)
-		} else if r.Method == "GET" && r.URL.String() == "/p/zones/z/machineTypes/mt?alt=json" {
-			fmt.Fprintln(w, `{}`)
-		} else if r.Method == "GET" && r.URL.String() == "/p?alt=json" {
-			fmt.Fprintln(w, `{}`)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
-			fmt.Fprintf(w, "bad request: %+v", r)
+	getProjectFn := func(p string) (*compute.Project, error) {
+		if p == testProject || p == "p.com:something" {
+			return nil, nil
 		}
-	}))
-	if err != nil {
-		t.Fatalf("error creating test client: %v", err)
+		return nil, errors.New("bad project: " + p)
 	}
+	listMachineTypesFn := func(p, z string) (*compute.MachineTypeList, error) {
+		if p != testProject && p != "p.com:something" {
+			return nil, errors.New("bad project: " + p)
+		}
+		if z != testZone {
+			return nil, errors.New("bad zone: " + z)
+		}
+		return &compute.MachineTypeList{Items: []*compute.MachineType{{Name: testMachineType}}}, nil
+	}
+	c, err := newTestGCEClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.GetProjectFn = getProjectFn
+	c.ListMachineTypesFn = listMachineTypesFn
 	w.ComputeClient = c
 
-	p := "p"
-	z := "z"
 	ad := []*compute.AttachedDisk{{Source: "d", Mode: defaultDiskMode}}
 	ad2 := []*compute.AttachedDisk{{Source: "d2", Mode: defaultDiskMode}}
-	mt := fmt.Sprintf("projects/%s/zones/%s/machineTypes/mt", p, z)
+	mt := fmt.Sprintf("projects/%s/zones/%s/machineTypes/%s", testProject, testZone, testMachineType)
 	dCreator := &Step{name: "dCreator", w: w}
 	w.Steps["dCreator"] = dCreator
-	disks[w].registerCreation("d", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", p, z)}, dCreator)
-	disks[w].registerCreation("d2", &resource{link: fmt.Sprintf("projects/p.com:something/zones/%s/disks/d", z)}, dCreator)
+	disks[w].registerCreation("d", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, dCreator)
+	disks[w].registerCreation("d2", &resource{link: fmt.Sprintf("projects/p.com:something/zones/%s/disks/d", testZone)}, dCreator)
 
 	tests := []struct {
 		desc      string
 		input     *CreateInstance
 		shouldErr bool
 	}{
-		{"normal case", &CreateInstance{Instance: compute.Instance{Name: "foo", Disks: ad, MachineType: mt}, Project: p, Zone: z}, false},
-		{"normal case2", &CreateInstance{daisyName: "foo2", Instance: compute.Instance{Name: "foo2", Disks: ad2, MachineType: fmt.Sprintf("projects/p.com:something/zones/%s/machineTypes/mt", z)}, Project: "p.com:something", Zone: z}, false},
-		{"bad dupe case", &CreateInstance{Instance: compute.Instance{Name: "foo", Disks: ad, MachineType: mt}, Project: p, Zone: z}, true},
-		{"bad name case", &CreateInstance{Instance: compute.Instance{Name: "bad!", Disks: ad, MachineType: mt}, Project: p, Zone: z}, true},
-		{"bad project case", &CreateInstance{Instance: compute.Instance{Name: "bar", Disks: ad, MachineType: mt}, Project: "bad!", Zone: z}, true},
-		{"bad zone case", &CreateInstance{Instance: compute.Instance{Name: "baz", Disks: ad, MachineType: mt}, Project: p, Zone: "bad!"}, true},
-		{"machine type validation fails case", &CreateInstance{Instance: compute.Instance{Name: "gaz", Disks: ad, MachineType: "bad machine type!"}, Project: p, Zone: z, daisyName: "gaz"}, true},
+		{"normal case", &CreateInstance{Instance: compute.Instance{Name: "foo", Disks: ad, MachineType: mt}, Project: testProject, Zone: testZone}, false},
+		{"normal case2", &CreateInstance{daisyName: "foo2", Instance: compute.Instance{Name: "foo2", Disks: ad2, MachineType: fmt.Sprintf("projects/p.com:something/zones/%s/machineTypes/%s", testZone, testMachineType)}, Project: "p.com:something", Zone: testZone}, false},
+		{"bad dupe case", &CreateInstance{Instance: compute.Instance{Name: "foo", Disks: ad, MachineType: mt}, Project: testProject, Zone: testZone}, true},
+		{"bad name case", &CreateInstance{Instance: compute.Instance{Name: "bad!", Disks: ad, MachineType: mt}, Project: testProject, Zone: testZone}, true},
+		{"bad project case", &CreateInstance{Instance: compute.Instance{Name: "bar", Disks: ad, MachineType: mt}, Project: "bad!", Zone: testZone}, true},
+		{"bad zone case", &CreateInstance{Instance: compute.Instance{Name: "baz", Disks: ad, MachineType: mt}, Project: testProject, Zone: "bad!"}, true},
+		{"machine type validation fails case", &CreateInstance{Instance: compute.Instance{Name: "gaz", Disks: ad, MachineType: "bad machine type!"}, Project: testProject, Zone: testZone, daisyName: "gaz"}, true},
 	}
 
 	for _, tt := range tests {

--- a/daisy/step_includeworkflow_test.go
+++ b/daisy/step_includeworkflow_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -112,7 +113,9 @@ func TestIncludeWorkflowValidate(t *testing.T) {
 	w.AddDependency("incStep", "dCreator")
 	dDeleter, _ := iw.NewStep("dDeleter")
 	dDeleter.DeleteResources = &DeleteResources{Disks: []string{"d"}}
-	disks[w].registerCreation("d", &resource{}, dCreator)
+	if err := disks[w].registerCreation("d", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, dCreator); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := w.populate(ctx); err != nil {
 		t.Fatal(err)

--- a/daisy/step_includeworkflow_test.go
+++ b/daisy/step_includeworkflow_test.go
@@ -16,10 +16,10 @@ package daisy
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"fmt"
 	"github.com/kylelemons/godebug/pretty"
 )
 

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -167,7 +167,9 @@ func TestWaitForInstancesSignalValidate(t *testing.T) {
 	iCreator, _ := w.NewStep("iCreator")
 	iCreator.CreateInstances = &CreateInstances{&CreateInstance{}}
 	w.AddDependency("s", "iCreator")
-	instances[w].registerCreation("instance1", &resource{}, iCreator)
+	if err := instances[w].registerCreation("instance1", &resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, iCreator); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		desc      string

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -64,6 +64,8 @@ var (
 	testWf          = "test-wf"
 	testProject     = "test-project"
 	testZone        = "test-zone"
+	testDisk        = "test-disk"
+	testImage        = "test-image"
 	testMachineType = "test-machine-type"
 	testGCSPath     = "gs://test-bucket"
 	testGCSObjs     []string
@@ -96,10 +98,6 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 			fmt.Fprintln(w, `{"Contents":"failsuccess","Start":"0"}`)
 		} else if r.Method == "GET" && strings.Contains(r.URL.String(), "serialPort?alt=json&port=2") {
 			fmt.Fprintln(w, `{"Contents":"successfail","Start":"0"}`)
-		} else if r.Method == "GET" && strings.Contains(r.URL.String(), fmt.Sprintf("/%s/zones/%s/instances/", testProject, testZone)) {
-			fmt.Fprintln(w, `{"Status":"TERMINATED","SelfLink":"link"}`)
-		} else if r.Method == "GET" && strings.Contains(r.URL.String(), fmt.Sprintf("/%s/zones/%s/machineTypes", testProject, testZone)) {
-			fmt.Fprintln(w, `{"Items":[{"Name": "foo-type"}]}`)
 		} else {
 			fmt.Fprintln(w, `{"Status":"DONE","SelfLink":"link"}`)
 		}
@@ -122,6 +120,30 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 			return nil, nil
 		}
 		return nil, errors.New("bad machinetype")
+	}
+	c.ListMachineTypesFn = func(p, z string) (*compute.MachineTypeList, error) {
+		if p != testProject {
+			return nil, errors.New("bad project")
+		}
+		if z != testZone {
+			return nil, errors.New("bad zone")
+		}
+		return &compute.MachineTypeList{Items: []*compute.MachineType{{Name: testMachineType}}}, nil
+	}
+	c.ListZonesFn = func(_ string) (*compute.ZoneList, error) {
+		return &compute.ZoneList{Items: []*compute.Zone{{Name: testZone}}}, nil
+	}
+	c.ListImagesFn = func(_ string) (*compute.ImageList, error) {
+		return &compute.ImageList{Items: []*compute.Image{{Name: testImage}}}, nil
+	}
+	c.ListDisksFn = func(p, z string) (*compute.DiskList, error) {
+		if p != testProject {
+			return nil, errors.New("bad project")
+		}
+		if z != testZone {
+			return nil, errors.New("bad zone")
+		}
+		return &compute.DiskList{Items: []*compute.Disk{{Name: testDisk}}}, nil
 	}
 
 	return c, err

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -65,7 +65,7 @@ var (
 	testProject     = "test-project"
 	testZone        = "test-zone"
 	testDisk        = "test-disk"
-	testImage        = "test-image"
+	testImage       = "test-image"
 	testMachineType = "test-machine-type"
 	testGCSPath     = "gs://test-bucket"
 	testGCSObjs     []string
@@ -123,10 +123,10 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 	}
 	c.ListMachineTypesFn = func(p, z string) (*compute.MachineTypeList, error) {
 		if p != testProject {
-			return nil, errors.New("bad project")
+			return nil, errors.New("bad project: " + p)
 		}
 		if z != testZone {
-			return nil, errors.New("bad zone")
+			return nil, errors.New("bad zone: " + z)
 		}
 		return &compute.MachineTypeList{Items: []*compute.MachineType{{Name: testMachineType}}}, nil
 	}
@@ -138,10 +138,10 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 	}
 	c.ListDisksFn = func(p, z string) (*compute.DiskList, error) {
 		if p != testProject {
-			return nil, errors.New("bad project")
+			return nil, errors.New("bad project: " + p)
 		}
 		if z != testZone {
-			return nil, errors.New("bad zone")
+			return nil, errors.New("bad zone: " + z)
 		}
 		return &compute.DiskList{Items: []*compute.Disk{{Name: testDisk}}}, nil
 	}


### PR DESCRIPTION
Checks for dependency existence of any non workflow created resources
Checks for naming collisions of workflow created resources
Lookups are cached to limit the amount of API calls needed.