### PR TITLE
translate: remove unecessary overwrite of resolv.conf

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_el.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.py
@@ -127,10 +127,6 @@ def translate():
     except RuntimeError as msg:
       print '%s (ignored)' % msg
 
-  # Setup DNS for chroot.
-  g.rm('/etc/resolv.conf')
-  g.upload('/etc/resolv.conf', '/etc/resolv.conf')
-
   if rhel_license == 'true':
     if 'Red Hat' in g.cat('/etc/redhat-release'):
       g.command([

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.py
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.py
@@ -101,10 +101,6 @@ def translate():
     except RuntimeError as msg:
       print '%s (ignored)' % msg
 
-  # Setup DNS for chroot.
-  g.rm('/etc/resolv.conf')
-  g.upload('/etc/resolv.conf', '/etc/resolv.conf')
-
   if install_gce == 'true':
     g.command(['apt-get', 'update'])
     print 'Installing cloud-init.'


### PR DESCRIPTION
The libguestfs framework already copies the resolv.conf when network
option is set. Copying the /etc/resolv.conf file from the host is not
necessary.