### PR TITLE
translate_rhel: use Debian as the translator host

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -19,7 +19,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/rhel-cloud/global/images/family/rhel-6",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
         },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -19,7 +19,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/rhel-cloud/global/images/family/rhel-7",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
         },


### PR DESCRIPTION
Use the same platform for all VMs to do the translation, this will
ensure we install the good python dependencies and run the same
libguestfs, only the commands inside libguestfs will change.
This patch fixes fails in RHEL where the translate_el.sh script uses apt
to install the dependencies for translate_el.py script.