### PR TITLE
translate_el: Fix translation of RHEL licensed

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_el.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.py
@@ -136,14 +136,11 @@ def translate():
 
   if rhel_license == 'true':
     if 'Red Hat' in g.cat('/etc/redhat-release'):
-      g.command([
-          'yum', 'install', '-y', '--downloadonly', '--downloaddir=/tmp',
-          'google-rhui-client-rhel%s' % el_release])
       g.command(['yum', 'remove', '-y', '*rhui*'])
       print 'Adding in GCE RHUI package.'
-      g.command([
-          'yum', 'install', '-y',
-          '/tmp/google-rhui-client-rhel%s*.rpm' % el_release])
+      g.write('/etc/yum.repos.d/google-cloud.repo', repo_compute % el_release)
+      g.command(
+          ['yum', 'install', '-y', 'google-rhui-client-rhel%s' % el_release])
 
   if install_gce == 'true':
     print 'Installing GCE packages.'

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -19,7 +19,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/rhel-cloud/global/images/family/rhel-6",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
         },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -19,7 +19,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/rhel-cloud/global/images/family/rhel-7",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
         },


### PR DESCRIPTION
RHEL licensed doesn't use Debian as host for the translation to allow
the system to download the google-rhui-client-rhel package.
Fix the bash script to install the dependencies using yum if available
and also fix the package installation process of the rhui.