### PR TITLE
Allow for unmount to fail in Ubuntu translations.

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_el.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.py
@@ -188,7 +188,12 @@ def translate():
   print "Removing SSH host keys."
   g.sh("rm -f /etc/ssh/ssh_host_*")
 
-  g.umount_all()
+  try:
+    g.umount_all()
+  except Exception as e:
+    print str(e)
+    print 'Unmount failed. Continuing anyway.'
+
 
 def main():
   try:

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.py
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.py
@@ -150,7 +150,11 @@ def translate():
   print 'Removing SSH host keys.'
   g.sh('rm -f /etc/ssh/ssh_host_*')
 
-  g.umount_all()
+  try:
+    g.umount_all()
+  except Exception as e:
+    print str(e)
+    print 'Unmount failed. Continuing anyway.'
 
 def main():
   try:


### PR DESCRIPTION
- It fails in 14.04 for one mount point that ultimately doesn't matter.