### PR TITLE
Clean up for Anaconda log saving on *EL7.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/build_installer.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer.py
@@ -18,7 +18,8 @@
 Parameters (retrieved from instance metadata):
 google_cloud_repo: The package repo to use. Can be stable (default), staging, or unstable.
 el_release: rhel6, rhel7, centos6, centos7, oraclelinux6, or oraclelinux7
-byol: true if building a RHEL BYOL image.
+el_savelogs: true to ask Anaconda to save logs (for debugging).
+rhel_byol: true if building a RHEL BYOL image.
 """
 import difflib
 import logging
@@ -33,6 +34,8 @@ def main():
   # Get Parameters
   repo = utils.GetMetadataParam('google_cloud_repo', raise_on_not_found=True)
   release = utils.GetMetadataParam('el_release', raise_on_not_found=True)
+  savelogs = utils.GetMetadataParam('el_savelogs', raise_on_not_found=False)
+  savelogs = savelogs == 'true'
   byol = utils.GetMetadataParam('rhel_byol', raise_on_not_found=False)
   byol = byol == 'true'
 
@@ -88,6 +91,10 @@ def main():
         'text', 'ks=hd:/dev/sda1:/%s' % ks_cfg,
         'console=ttyS0,38400n8', 'sshd=1', 'loglevel=debug'
     ])
+    # Tell Anaconda not to store its logs in the installed image,
+    # unless requested to keep them for debugging.
+    if not savelogs:
+      args += ' inst.nosave=all'
     cfg = re.sub(r'append initrd=initrd\.img.*', r'\g<0> %s' % args, cfg)
 
     # Change labels to explicit partitions.

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The EL release name."
     },
+    "el_savelogs": {
+      "Value": "false",
+      "Description": "Save anaconda logs to the image (useful for debugging)."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -62,6 +66,7 @@
             "build_files_gcs_dir": "${SOURCESPATH}/build_files",
             "build_script": "build_installer.py",
             "el_release": "${el_release}",
+            "el_savelogs": "${el_savelogs}",
             "google_cloud_repo": "${google_cloud_repo}",
             "rhel_byol": "${rhel_byol}"
           },

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/co7-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/co7-post.cfg
@@ -58,8 +58,7 @@ echo "Backing up ks.cfg"
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg
 
 # Remove files which shouldn't make it into the image.
-rm -f /root/anaconda-ks.cfg /root/install.* /var/log/anaconda.* /etc/boto.cfg
-rm -f /etc/udev/rules.d/70-persistent-net.rules
+rm -f /etc/boto.cfg /etc/udev/rules.d/70-persistent-net.rules
 
 # Ensure no attempt will be made to persist network MAC addresses
 # and disable IPv6.

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
@@ -67,8 +67,7 @@ echo "Backing up ks.cfg"
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg
 
 # Remove files which shouldn't make it into the image.
-rm -f /root/anaconda-ks.cfg /root/install.* /var/log/anaconda.* /etc/boto.cfg
-rm -f /etc/udev/rules.d/70-persistent-net.rules
+rm -f /etc/boto.cfg /etc/udev/rules.d/70-persistent-net.rules
 
 # Ensure no attempt will be made to persist network MAC addresses
 # and disable IPv6./run/install/ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/ol7-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/ol7-post.cfg
@@ -60,8 +60,7 @@ echo "Backing up ks.cfg"
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg
 
 # Remove files which shouldn't make it into the image.
-rm -f /root/anaconda-ks.cfg /root/install.* /var/log/anaconda.* /etc/boto.cfg
-rm -f /etc/udev/rules.d/70-persistent-net.rules
+rm -f /etc/boto.cfg /etc/udev/rules.d/70-persistent-net.rules
 
 # Ensure no attempt will be made to persist network MAC addresses
 # and disable IPv6.


### PR DESCRIPTION
On EL7-based distros, Anaconda writes /var/log/anaconda and /root/*-ks.cfg
*after* all of the postinstall kickstart scripts have run. This means it's
not possible to remove all of these logs in a postinstall script. Instead,
the inst.nosave=all kernel param triggers it to avoid saving logs.

This change enables this parameter by default and adds an el_savelogs
option to the workflows to disable this for debugging purposes.

The relevant postinstall scripts are also fixed to remove the now unnecessary
cleanup.