### PR TITLE
image_import: increase libguestfs memory to 4G

### DIFF
--- a/daisy_workflows/image_import/linux_common/utils.py
+++ b/daisy_workflows/image_import/linux_common/utils.py
@@ -94,6 +94,8 @@ def MountDisk(disk):
   g.set_verbose(1)
   g.set_trace(1)
 
+  g.set_memsize(4096)
+
   # Enable network
   g.set_network(True)
 


### PR DESCRIPTION
libguestfs limits the memory to 500MB, this was causing the post install
script from google-compute-engine-oslogin package to run out of memory.
Increasing it to 4G solves the problem.