### PR TITLE
image_import: el: restore selinux labels

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -26,7 +26,7 @@ import logging
 
 import utils
 
-utils.AptGetInstall(['python-guestfs'])
+utils.AptGetInstall(['python-guestfs', 'libguestfs-tools'])
 
 import guestfs
 
@@ -140,10 +140,12 @@ def DistroSpecific(g):
 
 
 def main():
-  g = utils.MountDisk('/dev/sdb')
+  disk = '/dev/sdb'
+  g = utils.MountDisk(disk)
   DistroSpecific(g)
   utils.CommonRoutines(g)
   utils.UnmountDisk(g)
+  utils.Execute(['virt-customize', '-a', disk, '--selinux-relabel'])
 
 if __name__=='__main__':
   utils.RunTranslate(main) 


### PR DESCRIPTION
Restore selinux labels after the entire operation.
This is necessary after instaling package google-compute-engine-oslogin
as it installs a new selinux module.
This fixes the followin issues:
- Centos 7: useradd was unable to access ld.so.cache, making the image
unable to create new users
- Centos 6: the link to libaudit.so.1 was not defined, making the image
unable to login