### PR TITLE
Remove export from enterprise_linux workflows.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/centos_6.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_6.wf.json
@@ -19,7 +19,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJET."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/centos_6.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_6.wf.json
@@ -10,16 +10,12 @@
       "Description": "The CentOS 6 installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk": {
       "Value": "disk-centos-6",
       "Description": "Name of the disk to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "publish_project": {
       "Value": "${PROJECT}",
@@ -36,17 +32,6 @@
           "google_cloud_repo": "${google_cloud_repo}",
           "install_disk": "${install_disk}",
           "installer_iso": "${installer_iso}"
-        }
-      }
-    },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/centos-6-v${build_date}/root.tar.gz",
-          "licenses": "1000206",
-          "source_disk": "${install_disk}"
         }
       }
     },
@@ -68,7 +53,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-centos"],
-    "create-image": ["export-image"]
+    "create-image": ["build-centos"]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/centos_7.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_7.wf.json
@@ -10,16 +10,12 @@
       "Description": "The CentOS 7 installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk": {
       "Value": "disk-centos-7",
       "Description": "Name of the disk to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "publish_project": {
       "Value": "${PROJECT}",
@@ -36,17 +32,6 @@
           "google_cloud_repo": "${google_cloud_repo}",
           "install_disk": "${install_disk}",
           "installer_iso": "${installer_iso}"
-        }
-      }
-    },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/centos-7-v${build_date}/root.tar.gz",
-          "licenses": "1000207",
-          "source_disk": "${install_disk}"
         }
       }
     },
@@ -68,7 +53,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-centos"],
-    "create-image": ["export-image"]
+    "create-image": ["build-centos"]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/centos_7.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_7.wf.json
@@ -19,7 +19,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJET."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux.wf.json
@@ -31,7 +31,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJECT."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux.wf.json
@@ -18,16 +18,12 @@
       "Description": "The Oracle Linux installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk_prefix": {
       "Value": "disk-oraclelinux",
       "Description": "Prefix of the disk name to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "image_suffix": {
       "Value": "",
@@ -51,16 +47,6 @@
         }
       }
     },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/oraclelinux-${el_version_major}-v${build_date}/root.tar.gz",
-          "source_disk": "${install_disk_prefix}-${el_version_major}${el_version_minor}"
-        }
-      }
-    },
     "create-image": {
       "CreateImages": [
         {
@@ -78,7 +64,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-oraclelinux"],
-    "create-image": ["export-image"]
+    "create-image": ["build-oraclelinux"]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux6.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux6.wf.json
@@ -4,8 +4,7 @@
     "installer_iso":   { "Required": true },
     "version_major":   { "Required": true },
     "version_minor":   { "Required": true },
-    "build_date":      "${DATE}",
-    "export_gcs_path": "${OUTSPATH}",
+    "build_date":      "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
     "suffix":          ""
   },
@@ -20,7 +19,6 @@
           "el_version_major": "${version_major}",
           "el_version_minor": "${version_minor}",
           "build_date":       "${build_date}",
-          "export_gcs_path":  "${export_gcs_path}",
           "publish_project":  "${publish_project}"
         }
       }

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux7.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux7.wf.json
@@ -4,8 +4,7 @@
     "installer_iso":   { "Required": true },
     "version_major":   { "Required": true },
     "version_minor":   { "Required": true },
-    "build_date":      "${DATE}",
-    "export_gcs_path": "${OUTSPATH}",
+    "build_date":      "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
     "suffix":          ""
   },
@@ -20,7 +19,6 @@
           "el_version_major": "${version_major}",
           "el_version_minor": "${version_minor}",
           "build_date":       "${build_date}",
-          "export_gcs_path":  "${export_gcs_path}",
           "publish_project":  "${publish_project}"
         }
       }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_6.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_6.wf.json
@@ -10,16 +10,12 @@
       "Description": "The RHEL 6 installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk": {
       "Value": "disk-rhel-6",
       "Description": "Name of the disk to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "publish_project": {
       "Value": "${PROJECT}",
@@ -36,17 +32,6 @@
           "google_cloud_repo": "${google_cloud_repo}",
           "install_disk": "${install_disk}",
           "installer_iso": "${installer_iso}"
-        }
-      }
-    },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/rhel-6-v${build_date}/root.tar.gz",
-          "licenses": "1000002",
-          "source_disk": "${install_disk}"
         }
       }
     },
@@ -68,7 +53,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-rhel"],
-    "create-image": ["export-image"]
+    "create-image": ["build-rhel"]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_6.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_6.wf.json
@@ -19,7 +19,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJET."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/rhel_6_byol.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_6_byol.wf.json
@@ -10,16 +10,12 @@
       "Description": "The RHEL 6 installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk": {
       "Value": "disk-rhel-6",
       "Description": "Name of the disk to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "publish_project": {
       "Value": "${PROJECT}",
@@ -37,17 +33,6 @@
           "install_disk": "${install_disk}",
           "installer_iso": "${installer_iso}",
           "rhel_byol": "true"
-        }
-      }
-    },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/rhel-6-byol-v${build_date}/root.tar.gz",
-          "licenses": "2862452038400965874",
-          "source_disk": "${install_disk}"
         }
       }
     },
@@ -69,7 +54,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-rhel"],
-    "create-image": ["export-image"]
+    "create-image": ["build-rhel"]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_6_byol.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_6_byol.wf.json
@@ -19,7 +19,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJET."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/rhel_7.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_7.wf.json
@@ -19,7 +19,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJET."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/rhel_7.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_7.wf.json
@@ -10,16 +10,12 @@
       "Description": "The RHEL 7 installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk": {
       "Value": "disk-rhel-7",
       "Description": "Name of the disk to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "publish_project": {
       "Value": "${PROJECT}",
@@ -36,17 +32,6 @@
           "google_cloud_repo": "${google_cloud_repo}",
           "install_disk": "${install_disk}",
           "installer_iso": "${installer_iso}"
-        }
-      }
-    },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/rhel-7-v${build_date}/root.tar.gz",
-          "licenses": "1000006",
-          "source_disk": "${install_disk}"
         }
       }
     },
@@ -68,7 +53,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-rhel"],
-    "create-image": ["export-image"]
+    "create-image": ["build-rhel"]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_7_byol.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_7_byol.wf.json
@@ -19,7 +19,7 @@
     },
     "publish_project": {
       "Value": "${PROJECT}",
-      "Description": "A project to publish the resulting image to. Defaults to PROJET."
+      "Description": "A project to publish the resulting image to."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/rhel_7_byol.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_7_byol.wf.json
@@ -10,16 +10,12 @@
       "Description": "The RHEL 7 installer ISO to build from."
     },
     "build_date": {
-      "Value": "${DATE}",
+      "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
     "install_disk": {
       "Value": "disk-rhel-7",
       "Description": "Name of the disk to install onto."
-    },
-    "export_gcs_path": {
-      "Value": "${OUTSPATH}",
-      "Description": "A GCS path to export the image tar file to. Defaults to OUTSPATH."
     },
     "publish_project": {
       "Value": "${PROJECT}",
@@ -37,17 +33,6 @@
           "install_disk": "${install_disk}",
           "installer_iso": "${installer_iso}",
           "rhel_byol": "true"
-        }
-      }
-    },
-    "export-image": {
-      "Timeout": "60m",
-      "IncludeWorkflow": {
-        "Path": "../../export/disk_export.wf.json",
-        "Vars": {
-          "destination": "${export_gcs_path}/rhel-7-byol-v${build_date}/root.tar.gz",
-          "licenses": "4621277670514851623",
-          "source_disk": "${install_disk}"
         }
       }
     },
@@ -69,7 +54,6 @@
     }
   },
   "Dependencies": {
-    "export-image": ["build-rhel"],
-    "create-image": ["export-image"]
+    "create-image": ["build-rhel"]
   }
 }


### PR DESCRIPTION
Only create the image (faster).
Change default dates to use UTC timestamp for uniqueness.