### PR TITLE
image_build: Remove minor version var from Oracle Linux workflows.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/README.md
+++ b/daisy_workflows/image_build/enterprise_linux/README.md
@@ -40,6 +40,5 @@ daisy -project my-project \
       -oauth creds.json \
       -var:installer_iso=OracleLinux-R7-U4-Server-x86_64-dvd.iso \
       -var:version_major=7 \
-      -var:version_minor=4 \
       oraclelinux7.wf.json
 ```

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux.wf.json
@@ -5,10 +5,6 @@
       "Required": true,
       "Description": "Oracle Linux major version number to build."
     },
-    "el_version_minor": {
-      "Required": true,
-      "Description": "Oracle Linux minor version number to build."
-    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -42,7 +38,7 @@
         "Vars": {
           "el_release": "oraclelinux${el_version_major}",
           "google_cloud_repo": "${google_cloud_repo}",
-          "install_disk": "${install_disk_prefix}-${el_version_major}${el_version_minor}",
+          "install_disk": "${install_disk_prefix}-${el_version_major}",
           "installer_iso": "${installer_iso}"
         }
       }
@@ -51,7 +47,7 @@
       "CreateImages": [
         {
           "Name": "oraclelinux-${el_version_major}${image_suffix}-v${build_date}",
-          "SourceDisk": "${install_disk_prefix}-${el_version_major}${el_version_minor}",
+          "SourceDisk": "${install_disk_prefix}-${el_version_major}",
           "Licenses": [],
           "Description": "Oracle Linux, Oracle Linux, ${el_version_major}${image_suffix}, x86_64 built on ${build_date}",
           "GuestOsFeatures": [{"type": "VIRTIO_SCSI_MULTIQUEUE"}],

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux6.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux6.wf.json
@@ -3,7 +3,6 @@
   "Vars": {
     "installer_iso":   { "Required": true },
     "version_major":   { "Required": true },
-    "version_minor":   { "Required": true },
     "build_date":      "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
     "suffix":          ""
@@ -17,7 +16,6 @@
           "image_suffix":     "${suffix}",
           "installer_iso":    "${installer_iso}",
           "el_version_major": "${version_major}",
-          "el_version_minor": "${version_minor}",
           "build_date":       "${build_date}",
           "publish_project":  "${publish_project}"
         }

--- a/daisy_workflows/image_build/enterprise_linux/oraclelinux7.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/oraclelinux7.wf.json
@@ -3,7 +3,6 @@
   "Vars": {
     "installer_iso":   { "Required": true },
     "version_major":   { "Required": true },
-    "version_minor":   { "Required": true },
     "build_date":      "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
     "suffix":          ""
@@ -17,7 +16,6 @@
           "image_suffix":     "${suffix}",
           "installer_iso":    "${installer_iso}",
           "el_version_major": "${version_major}",
-          "el_version_minor": "${version_minor}",
           "build_date":       "${build_date}",
           "publish_project":  "${publish_project}"
         }


### PR DESCRIPTION
This variable isn't used for anything important and just results in one more
thing to specify when building an Oracle Linux image.