### PR TITLE
Add gce_inventory_agent and instance_inventory binaries.

### DIFF
--- a/cli_tools/gce_inventory_agent/main.go
+++ b/cli_tools/gce_inventory_agent/main.go
@@ -1,0 +1,190 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// gce_inventory_agent gathers and writes instance inventory to guest attributes.
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/osinfo"
+	"github.com/GoogleCloudPlatform/compute-image-tools/packages"
+	"github.com/google/logger"
+)
+
+const (
+	reportURL = "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes"
+)
+
+type instanceInventory struct {
+	Hostname          string
+	LongName          string
+	ShortName         string
+	Version           string
+	Architecture      string
+	KernelVersion     string
+	InstalledPackages map[string][]packages.PkgInfo
+	PackageUpdates    map[string][]packages.PkgInfo
+	Errors            []string
+}
+
+func postAttribute(url string, value io.Reader) error {
+	req, err := http.NewRequest("PUT", url, value)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Metadata-Flavor", "Google")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf(`recieved status code %q for request "%s %s"`, resp.Status, req.Method, req.URL.String())
+	}
+	return nil
+}
+
+func postAttributeCompressed(url string, body interface{}) error {
+	msg, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+
+	if _, err := zw.Write(msg); err != nil {
+		return err
+	}
+
+	if err := zw.Close(); err != nil {
+		return err
+	}
+
+	return postAttribute(url, strings.NewReader(base64.StdEncoding.EncodeToString(buf.Bytes())))
+}
+
+func writeInventory(state *instanceInventory, url string) {
+	logger.Info("Writing instance inventory.")
+
+	if err := postAttribute(url+"/Timestamp", strings.NewReader(time.Now().UTC().Format(time.RFC3339))); err != nil {
+		state.Errors = append(state.Errors, err.Error())
+		logger.Error(err)
+	}
+
+	e := reflect.ValueOf(state).Elem()
+	t := e.Type()
+	for i := 0; i < e.NumField(); i++ {
+		f := e.Field(i)
+		u := fmt.Sprintf("%s/%s", url, t.Field(i).Name)
+		switch f.Kind() {
+		case reflect.String:
+			if err := postAttribute(u, strings.NewReader(f.String())); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+		case reflect.Map:
+			if err := postAttributeCompressed(u, f.Interface()); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+		}
+	}
+
+	/*
+			if err := postAttribute(url+"/hostname", strings.NewReader(state.Hostname)); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+
+			if err := postAttribute(url+"/longName", strings.NewReader(state.LongName)); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+
+			if err := postAttribute(url+"/shortName", strings.NewReader(state.ShortName)); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+
+			if err := postAttribute(url+"/version", strings.NewReader(state.Version)); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+
+			if err := postAttribute(url+"/kernelVersion", strings.NewReader(state.KernelVersion)); err != nil {
+				state.Errors = append(state.Errors, err.Error())
+				logger.Error(err)
+			}
+
+		if err := postAttributeCompressed(url+"/installedPackages", state.InstalledPackages); err != nil {
+			state.Errors = append(state.Errors, err.Error())
+			logger.Error(err)
+		}
+
+		if err := postAttributeCompressed(url+"/packageUpdates", state.PackageUpdates); err != nil {
+			state.Errors = append(state.Errors, err.Error())
+			logger.Error(err)
+		}
+	*/
+}
+
+func main() {
+	logger.Init("inventory", true, false, ioutil.Discard)
+	logger.Info("Gathering instance inventory.")
+
+	hn, err := os.Hostname()
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	di, err := osinfo.GetDistributionInfo()
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	hs := &instanceInventory{
+		Hostname:      hn,
+		LongName:      di.LongName,
+		ShortName:     di.ShortName,
+		Version:       di.Version,
+		KernelVersion: di.Kernel,
+		Architecture:  di.Architecture,
+	}
+
+	var errs []string
+	hs.InstalledPackages, errs = packages.GetInstalledPackages()
+	if len(errs) != 0 {
+		hs.Errors = append(hs.Errors, errs...)
+	}
+
+	hs.PackageUpdates, errs = packages.GetPackageUpdates()
+	if len(errs) != 0 {
+		hs.Errors = append(hs.Errors, errs...)
+	}
+
+	writeInventory(hs, reportURL)
+}

--- a/cli_tools/gce_inventory_agent/main.go
+++ b/cli_tools/gce_inventory_agent/main.go
@@ -113,43 +113,9 @@ func writeInventory(state *instanceInventory, url string) {
 			}
 		}
 	}
-
-	/*
-			if err := postAttribute(url+"/hostname", strings.NewReader(state.Hostname)); err != nil {
-				state.Errors = append(state.Errors, err.Error())
-				logger.Error(err)
-			}
-
-			if err := postAttribute(url+"/longName", strings.NewReader(state.LongName)); err != nil {
-				state.Errors = append(state.Errors, err.Error())
-				logger.Error(err)
-			}
-
-			if err := postAttribute(url+"/shortName", strings.NewReader(state.ShortName)); err != nil {
-				state.Errors = append(state.Errors, err.Error())
-				logger.Error(err)
-			}
-
-			if err := postAttribute(url+"/version", strings.NewReader(state.Version)); err != nil {
-				state.Errors = append(state.Errors, err.Error())
-				logger.Error(err)
-			}
-
-			if err := postAttribute(url+"/kernelVersion", strings.NewReader(state.KernelVersion)); err != nil {
-				state.Errors = append(state.Errors, err.Error())
-				logger.Error(err)
-			}
-
-		if err := postAttributeCompressed(url+"/installedPackages", state.InstalledPackages); err != nil {
-			state.Errors = append(state.Errors, err.Error())
-			logger.Error(err)
-		}
-
-		if err := postAttributeCompressed(url+"/packageUpdates", state.PackageUpdates); err != nil {
-			state.Errors = append(state.Errors, err.Error())
-			logger.Error(err)
-		}
-	*/
+	if err := postAttribute(url+"/Errors", strings.NewReader(fmt.Sprintf("%q", state.Errors))); err != nil {
+		logger.Error(err)
+	}
 }
 
 func main() {

--- a/cli_tools/gce_inventory_agent/main.go
+++ b/cli_tools/gce_inventory_agent/main.go
@@ -62,7 +62,7 @@ func postAttribute(url string, value io.Reader) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf(`recieved status code %q for request "%s %s"`, resp.Status, req.Method, req.URL.String())
+		return fmt.Errorf(`received status code %q for request "%s %s"`, resp.Status, req.Method, req.URL.String())
 	}
 	return nil
 }

--- a/cli_tools/instance_inventory/main.go
+++ b/cli_tools/instance_inventory/main.go
@@ -1,0 +1,135 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// instance_inventory pretty prints out an instances inventory data.
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/packages"
+	"google.golang.org/api/compute/v0.alpha"
+	"google.golang.org/api/option"
+	"google.golang.org/api/transport"
+)
+
+var (
+	project  = flag.String("project", "", "GCE Project")
+	zone     = flag.String("zone", "", "GCE Zone")
+	instance = flag.String("instance", "", "GCE Instance")
+)
+
+func getAttribute(service *compute.Service, p, z, i, at string) (string, error) {
+	ga, err := service.Instances.GetGuestAttributes(p, z, i).VariableKey(at).Do()
+	if err != nil {
+		return "", err
+	}
+	return ga.VariableValue, nil
+}
+
+func main() {
+	flag.Parse()
+	if *project == "" {
+		log.Fatal("The flag -project must be provided")
+	}
+	if *zone == "" {
+		log.Fatal("The flag -zone must be provided")
+	}
+	if *instance == "" {
+		log.Fatal("The flag -instance must be provided")
+	}
+
+	ctx := context.Background()
+
+	hc, _, err := transport.NewHTTPClient(ctx, []option.ClientOption{option.WithScopes(compute.ComputeScope)}...)
+	if err != nil {
+		log.Fatalf("error creating HTTP client: %v", err)
+	}
+	service, err := compute.New(hc)
+	if err != nil {
+		log.Fatalf("error creating compute client: %v", err)
+	}
+
+	ats := []string{"Timestamp", "Hostname", "LongName", "ShortName", "Version", "KernelVersion", "InstalledPackages", "PackageUpdates", "Errors"}
+
+	//ii := map[string]string{}
+	var ii sync.Map
+	var wg sync.WaitGroup
+	for _, at := range ats {
+		wg.Add(1)
+		go func(at string, eg *sync.WaitGroup) {
+			defer wg.Done()
+			value, err := getAttribute(service, *project, *zone, *instance, at)
+			if err != nil {
+				log.Printf("error getting attribute %q: %v", at, err)
+				return
+			}
+			if at == "InstalledPackages" || at == "PackageUpdates" {
+				decoded, err := base64.StdEncoding.DecodeString(value)
+				if err != nil {
+					log.Print(err)
+					return
+				}
+
+				zr, err := gzip.NewReader(bytes.NewReader(decoded))
+				if err != nil {
+					log.Print(err)
+					return
+				}
+
+				var buf bytes.Buffer
+				if _, err := io.Copy(&buf, zr); err != nil {
+					log.Print(err)
+					return
+				}
+				zr.Close()
+
+				// Unmarshal so we can then re-marshal to pretty print.
+				var pi map[string][]packages.PkgInfo
+				if err := json.Unmarshal(buf.Bytes(), &pi); err != nil {
+					log.Print(err)
+					return
+				}
+
+				out, err := json.MarshalIndent(pi, "", "  ")
+				if err != nil {
+					log.Print(err)
+					return
+				}
+
+				ii.Store(at, string(out))
+			} else {
+				ii.Store(at, value)
+			}
+		}(at, &wg)
+	}
+	wg.Wait()
+
+	for _, at := range ats {
+		v, ok := ii.Load(at)
+		if !ok {
+			continue
+		}
+		fmt.Printf("%s: %s\n", at, v.(string))
+	}
+}

--- a/cli_tools/instance_inventory/main.go
+++ b/cli_tools/instance_inventory/main.go
@@ -72,7 +72,6 @@ func main() {
 
 	ats := []string{"Timestamp", "Hostname", "LongName", "ShortName", "Version", "KernelVersion", "InstalledPackages", "PackageUpdates", "Errors"}
 
-	//ii := map[string]string{}
 	var ii sync.Map
 	var wg sync.WaitGroup
 	for _, at := range ats {

--- a/cli_tools/instance_inventory/main.go
+++ b/cli_tools/instance_inventory/main.go
@@ -77,7 +77,7 @@ func main() {
 	var wg sync.WaitGroup
 	for _, at := range ats {
 		wg.Add(1)
-		go func(at string, eg *sync.WaitGroup) {
+		go func(at string, wg *sync.WaitGroup) {
 			defer wg.Done()
 			value, err := getAttribute(service, *project, *zone, *instance, at)
 			if err != nil {

--- a/packages/packages_linux.go
+++ b/packages/packages_linux.go
@@ -139,7 +139,7 @@ func aptUpdates() ([]PkgInfo, error) {
 	     google-cloud-sdk libdns-export162 libisc-export160
 	   3 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
 	   Inst google-cloud-sdk [168.0.0-0] (171.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [all])
-	   Inst libisc-export160 [1:9.10.3.dfsg.P4-12.3+deb9u2] (1:9.10.3.dfsg.P4-12.3+deb9u3 Debian:stable-updates [amd64])
+	   Inst python2.7 [2.7.13-2] (2.7.13-2+deb9u2 Debian:9.3/stable [amd64]) []
 	   Inst libdns-export162 [1:9.10.3.dfsg.P4-12.3+deb9u2] (1:9.10.3.dfsg.P4-12.3+deb9u3 Debian:stable-updates [amd64])
 	   Conf google-cloud-sdk (171.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [all])
 	   Conf libisc-export160 (1:9.10.3.dfsg.P4-12.3+deb9u3 Debian:stable-updates [amd64])
@@ -154,7 +154,7 @@ func aptUpdates() ([]PkgInfo, error) {
 		if pkg[0] != "Inst" {
 			continue
 		}
-		if len(pkg) != 6 {
+		if len(pkg) < 6 {
 			logger.Errorf("%q does not represent an apt update", ln)
 			continue
 		}


### PR DESCRIPTION
gce_inventory_agent gathers and writes instance inventory to guest attributes.
instance_inventory pretty prints out an instances inventory data, this is mainly meant to be used as a testing tool during the POC phase.