### PR TITLE
Initial commit of the gce_image_publish tool

### DIFF
--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -46,23 +46,40 @@ var (
 )
 
 type publish struct {
-	Name            string
-	WorkProject     string
-	SourceProject   string
-	SourceGCSPath   string
-	PublishProject  string
+	// Name for this publish template.
+	Name string
+	// Project to perform the work in.
+	WorkProject string
+	// Project to source images from, should not be used with SourceGCSPath.
+	SourceProject string
+	// GCS path to source images from, should not be used with SourceProject.
+	SourceGCSPath string
+	// Project to publish images to.
+	PublishProject string
+	// Optional compute endpoint override
 	ComputeEndpoint string
-	Images          []image
+	// Images to publish.
+	Images []image
 
+	// Populated from the source_version flag, added to the image prefix to
+	// lookup source image.
+	sourceVersion string
+	// Populated from the publish_version flag, added to the image prefix to
+	// create the publish name.
 	publishVersion string
-	sourceVersion  string
 }
 
 type image struct {
-	Prefix          string
-	Family          string
-	Description     string
-	Licenses        []string
+	// Prefix for the image, image naming format is '${ImagePrefix}-v${ImageVersion}'.
+	// This prefix is used for source image lookup and publish image name.
+	Prefix string
+	// Image family to set for the image.
+	Family string
+	// Image description to set for the image.
+	Description string
+	// Licenses to add to the image.
+	Licenses []string
+	// GuestOsFeatures to add to the image.
 	GuestOsFeatures []string
 }
 

--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -1,0 +1,388 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// gce_image_publish is a tool for publishing GCE images.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+const gcsImageObj = "root.tar.gz"
+
+var (
+	now            = time.Now().UTC()
+	oauth          = flag.String("oauth", "", "path to oauth json file")
+	sourceVersion  = flag.String("source_version", now.Format("20060102"), "version on source image")
+	publishVersion = flag.String("publish_version", *sourceVersion, "version for published image if different from source")
+	skipDup        = flag.Bool("skip_duplicates", false, "skip publishing an image that already exists")
+	rollback       = flag.Bool("rollback", false, "rollback image publish")
+	noConfirm      = flag.Bool("noConfirm", false, "don't ask for confirmation")
+)
+
+type publish struct {
+	Name            string
+	WorkProject     string
+	SourceProject   string
+	SourceGCSPath   string
+	PublishProject  string
+	ComputeEndpoint string
+	Images          []image
+
+	publishVersion string
+	sourceVersion  string
+}
+
+type image struct {
+	Prefix          string
+	Family          string
+	Description     string
+	Licenses        []string
+	GuestOsFeatures []string
+}
+
+func publishImage(p *publish, img image, pubImgs []*compute.Image) (*daisy.CreateImages, *daisy.DeprecateImages, error) {
+	publishName := fmt.Sprintf("%s-v%s", img.Prefix, p.publishVersion)
+	sourceName := fmt.Sprintf("%s-v%s", img.Prefix, p.sourceVersion)
+	var gosf []*compute.GuestOsFeature
+	for _, f := range img.GuestOsFeatures {
+		gosf = append(gosf, &compute.GuestOsFeature{Type: f})
+	}
+
+	// Replace text in Description for the print out, let daisy replace other fields.
+	replacer := strings.NewReplacer("${source_version}", p.sourceVersion, "${publish_version}", p.publishVersion)
+	ci := daisy.CreateImage{
+		Image: compute.Image{
+			Name:            publishName,
+			Description:     replacer.Replace(img.Description),
+			Licenses:        img.Licenses,
+			GuestOsFeatures: gosf,
+			Family:          img.Family,
+		},
+		NoCleanup: true,
+		Project:   p.PublishProject,
+		RealName:  publishName,
+	}
+
+	var source string
+	if p.SourceProject != "" && p.SourceGCSPath != "" {
+		return nil, nil, errors.New("only one of SourceProject or SourceGCSPath should be set")
+	}
+	if p.SourceProject != "" {
+		source = fmt.Sprintf("projects/%s/global/images/%s", p.SourceProject, sourceName)
+		ci.Image.SourceImage = source
+	} else if p.SourceGCSPath != "" {
+		source = fmt.Sprintf("%s/%s/%s", p.SourceGCSPath, sourceName, gcsImageObj)
+		ci.Image.RawDisk = &compute.ImageRawDisk{Source: source}
+	} else {
+		return nil, nil, errors.New("neither SourceProject or SourceGCSPath was set")
+	}
+	cis := &daisy.CreateImages{&ci}
+
+	dis := &daisy.DeprecateImages{}
+	for _, pubImg := range pubImgs {
+		if pubImg.Name == publishName {
+			msg := fmt.Sprintf("image %q already exists in project %q", publishName, p.PublishProject)
+			if !*skipDup {
+				return nil, nil, errors.New(msg)
+			}
+			log.Printf("%s, skipping image creation", msg)
+			cis = nil
+			continue
+		}
+
+		// Deprecate all images in the same family.
+		if pubImg.Family == img.Family && (pubImg.Deprecated == nil || pubImg.Deprecated.State == "") {
+			*dis = append(*dis, &daisy.DeprecateImage{
+				Image:   pubImg.Name,
+				Project: p.PublishProject,
+				DeprecationStatus: compute.DeprecationStatus{
+					State:       "DEPRECATED",
+					Replacement: fmt.Sprintf(fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/images/%s", p.PublishProject, publishName)),
+				},
+			})
+		}
+	}
+	if len(*dis) == 0 {
+		dis = nil
+	}
+
+	return cis, dis, nil
+}
+
+func rollbackImage(p *publish, img image, pubImgs []*compute.Image) (*daisy.DeleteResources, *daisy.DeprecateImages, error) {
+	publishName := fmt.Sprintf("%s-v%s", img.Prefix, p.publishVersion)
+	dr := &daisy.DeleteResources{}
+	dis := &daisy.DeprecateImages{}
+	for _, pubImg := range pubImgs {
+		if pubImg.Name != publishName || pubImg.Deprecated != nil {
+			continue
+		}
+		dr.Images = []string{fmt.Sprintf("projects/%s/global/images/%s", p.PublishProject, publishName)}
+	}
+
+	if len(dr.Images) == 0 {
+		log.Printf("%q does not exist in %q, not rolling back", publishName, p.PublishProject)
+		return nil, nil, nil
+	}
+
+	for _, pubImg := range pubImgs {
+		// Un-deprecate the first deprecated image in the family based on insertion time.
+		if pubImg.Family == img.Family && pubImg.Deprecated != nil {
+			*dis = append(*dis, &daisy.DeprecateImage{
+				Image:   pubImg.Name,
+				Project: p.PublishProject,
+				DeprecationStatus: compute.DeprecationStatus{
+					// Setting a blank State un-deprecates the image.
+					State: "",
+				},
+			})
+			break
+		}
+	}
+	return dr, dis, nil
+}
+
+func printList(list []string) {
+	for _, i := range list {
+		fmt.Printf(" - [ %s ]\n", i)
+	}
+}
+
+func populateSteps(w *daisy.Workflow, prefix string, createImages *daisy.CreateImages, deprecateImages *daisy.DeprecateImages, deleteResources *daisy.DeleteResources) error {
+	var createStep *daisy.Step
+	var deprecateStep *daisy.Step
+	var deleteStep *daisy.Step
+	var err error
+	if createImages != nil {
+		createStep, err = w.NewStep("publish-" + prefix)
+		if err != nil {
+			return err
+		}
+		createStep.CreateImages = createImages
+	}
+
+	if deprecateImages != nil {
+		deprecateStep, err = w.NewStep("deprecate-" + prefix)
+		if err != nil {
+			return err
+		}
+		deprecateStep.DeprecateImages = deprecateImages
+	}
+
+	if deleteResources != nil {
+		deleteStep, err = w.NewStep("delete-" + prefix)
+		if err != nil {
+			return err
+		}
+		deleteStep.DeleteResources = deleteResources
+	}
+
+	// Create before deprecate on publish.
+	if deprecateStep != nil && createStep != nil {
+		w.AddDependency(deprecateStep, createStep)
+	}
+
+	// Un-deprecate before delete on rollback.
+	if deleteStep != nil && deprecateStep != nil {
+		w.AddDependency(deleteStep, deprecateStep)
+	}
+
+	return nil
+}
+
+func createPrintOut(createImages *daisy.CreateImages) []string {
+	if createImages == nil {
+		return nil
+	}
+	var toCreate []string
+	for _, ci := range *createImages {
+		toCreate = append(toCreate, fmt.Sprintf("%s: (%s)", ci.Name, ci.Description))
+	}
+	return toCreate
+}
+
+func deletePrintOut(deleteResources *daisy.DeleteResources) []string {
+	if deleteResources == nil {
+		return nil
+	}
+
+	var toDelete []string
+	for _, img := range deleteResources.Images {
+		toDelete = append(toDelete, path.Base(img))
+	}
+	return toDelete
+}
+
+func deprecatePrintOut(deprecateImages *daisy.DeprecateImages) ([]string, []string, []string) {
+	if deprecateImages == nil {
+		return nil, nil, nil
+	}
+
+	var toDeprecate []string
+	var toObsolete []string
+	var toUndeprecate []string
+	for _, di := range *deprecateImages {
+		image := path.Base(di.Image)
+		switch di.DeprecationStatus.State {
+		case "DEPRECATED":
+			toDeprecate = append(toDeprecate, image)
+		case "OBSOLETE":
+			toObsolete = append(toObsolete, image)
+		case "":
+			toUndeprecate = append(toUndeprecate, image)
+		}
+	}
+	return toDeprecate, toObsolete, toUndeprecate
+}
+
+func populateWorkflow(ctx context.Context, w *daisy.Workflow, p *publish, rb bool) error {
+	var err error
+
+	w.Name = p.Name
+	w.Project = p.WorkProject
+	w.AddVar("source_version", p.sourceVersion)
+	w.AddVar("publish_version", p.publishVersion)
+
+	if p.ComputeEndpoint != "" {
+		w.ComputeClient, err = daisyCompute.NewClient(ctx, option.WithEndpoint(p.ComputeEndpoint))
+		if err != nil {
+			return err
+		}
+	}
+
+	var toCreate []string
+	var toDelete []string
+	var toDeprecate []string
+	var toObsolete []string
+	var toUndeprecate []string
+
+	pubImgs, err := w.ComputeClient.ListImages(p.PublishProject, daisyCompute.OrderBy("creationTimestamp desc"))
+	if err != nil {
+		return err
+	}
+	for _, img := range p.Images {
+		var createImages *daisy.CreateImages
+		var deprecateImages *daisy.DeprecateImages
+		var deleteResources *daisy.DeleteResources
+		if rb {
+			deleteResources, deprecateImages, err = rollbackImage(p, img, pubImgs)
+			if err != nil {
+				return err
+			}
+		} else {
+			createImages, deprecateImages, err = publishImage(p, img, pubImgs)
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := populateSteps(w, img.Prefix, createImages, deprecateImages, deleteResources); err != nil {
+			return err
+		}
+
+		toCreate = append(toCreate, createPrintOut(createImages)...)
+		toDelete = append(toDelete, deletePrintOut(deleteResources)...)
+		td, to, tu := deprecatePrintOut(deprecateImages)
+		toDeprecate = append(toDeprecate, td...)
+		toObsolete = append(toObsolete, to...)
+		toUndeprecate = append(toUndeprecate, tu...)
+	}
+
+	if len(toCreate) > 0 {
+		fmt.Printf("The following images will be created in %q:\n", p.PublishProject)
+		printList(toCreate)
+	}
+
+	if len(toDeprecate) > 0 {
+		fmt.Printf("\nThe following images will be deprecated in %q:\n", p.PublishProject)
+		printList(toDeprecate)
+	}
+
+	if len(toObsolete) > 0 {
+		fmt.Printf("\nThe following images will be obsoleted in %q:\n", p.PublishProject)
+		printList(toObsolete)
+	}
+
+	if len(toUndeprecate) > 0 {
+		fmt.Printf("\nThe following images will be un-deprecated in %q:\n", p.PublishProject)
+		printList(toUndeprecate)
+	}
+
+	if len(toDelete) > 0 {
+		fmt.Printf("The following images will be deleted in %q:\n", p.PublishProject)
+		printList(toDelete)
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	if len(flag.Args()) == 0 {
+		log.Fatal("Not enough args, first arg needs to be the path to a publish template.")
+	}
+	ctx := context.Background()
+
+	f := flag.Arg(0)
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var p publish
+	if err := json.Unmarshal(data, &p); err != nil {
+		log.Fatal(daisy.JSONError(f, data, err))
+	}
+	p.sourceVersion = *sourceVersion
+	p.publishVersion = *publishVersion
+
+	w := daisy.New()
+	if err := populateWorkflow(ctx, w, &p, *rollback); err != nil {
+		log.Fatal(err)
+	}
+
+	if len(w.Steps) == 0 {
+		fmt.Println("Nothing to do.")
+		return
+	}
+	if !*noConfirm {
+		var c string
+		fmt.Print("\nContinue with publish? (y/N): ")
+		fmt.Scanln(&c)
+		c = strings.ToLower(c)
+		if c != "y" && c != "yes" {
+			return
+		}
+	}
+
+	if err := w.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -36,9 +36,8 @@ import (
 const gcsImageObj = "root.tar.gz"
 
 var (
-	now            = time.Now().UTC()
 	oauth          = flag.String("oauth", "", "path to oauth json file")
-	sourceVersion  = flag.String("source_version", now.Format("20060102"), "version on source image")
+	sourceVersion  = flag.String("source_version", time.Now().UTC().Format("20060102"), "version on source image")
 	publishVersion = flag.String("publish_version", *sourceVersion, "version for published image if different from source")
 	skipDup        = flag.Bool("skip_duplicates", false, "skip publishing an image that already exists")
 	rollback       = flag.Bool("rollback", false, "rollback image publish")

--- a/cli_tools/gce_image_publish/main_test.go
+++ b/cli_tools/gce_image_publish/main_test.go
@@ -1,0 +1,104 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	compute "google.golang.org/api/compute/v1"
+)
+
+func TestCreatePrintOut(t *testing.T) {
+	tests := []struct {
+		name string
+		args *daisy.CreateImages
+		want []string
+	}{
+		{"empty", nil, nil},
+		{"one image", &daisy.CreateImages{&daisy.CreateImage{Image: compute.Image{Name: "foo", Description: "bar"}}}, []string{"foo: (bar)"}},
+		{"two images", &daisy.CreateImages{
+			&daisy.CreateImage{Image: compute.Image{Name: "foo1", Description: "bar1"}},
+			&daisy.CreateImage{Image: compute.Image{Name: "foo2", Description: "bar2"}}},
+			[]string{"foo1: (bar1)", "foo2: (bar2)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToCreate := createPrintOut(tt.args)
+			if !reflect.DeepEqual(gotToCreate, tt.want) {
+				t.Errorf("createPrintOut() got = %v, want %v", gotToCreate, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeletePrintOut(t *testing.T) {
+	tests := []struct {
+		name string
+		args *daisy.DeleteResources
+		want []string
+	}{
+		{"empty", nil, nil},
+		{"not an image", &daisy.DeleteResources{Disks: []string{"foo"}}, nil},
+		{"one image", &daisy.DeleteResources{Images: []string{"foo"}}, []string{"foo"}},
+		{"two images", &daisy.DeleteResources{Images: []string{"foo", "bar"}}, []string{"foo", "bar"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToDelete := deletePrintOut(tt.args)
+			if !reflect.DeepEqual(gotToDelete, tt.want) {
+				t.Errorf("deletePrintOut() got = %v, want %v", gotToDelete, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeprecatePrintOut(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          *daisy.DeprecateImages
+		toDeprecate   []string
+		toObsolete    []string
+		toUndeprecate []string
+	}{
+		{"empty", nil, nil, nil, nil},
+		{"unknown state", &daisy.DeprecateImages{&daisy.DeprecateImage{Image: "foo", DeprecationStatus: compute.DeprecationStatus{State: "foo"}}}, nil, nil, nil},
+		{"only DEPRECATED", &daisy.DeprecateImages{&daisy.DeprecateImage{Image: "foo", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED"}}}, []string{"foo"}, nil, nil},
+		{"only OBSOLETE", &daisy.DeprecateImages{&daisy.DeprecateImage{Image: "foo", DeprecationStatus: compute.DeprecationStatus{State: "OBSOLETE"}}}, nil, []string{"foo"}, nil},
+		{"only un-deprecated", &daisy.DeprecateImages{&daisy.DeprecateImage{Image: "foo", DeprecationStatus: compute.DeprecationStatus{State: ""}}}, nil, nil, []string{"foo"}},
+		{"all three", &daisy.DeprecateImages{
+			&daisy.DeprecateImage{Image: "foo", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED"}},
+			&daisy.DeprecateImage{Image: "bar", DeprecationStatus: compute.DeprecationStatus{State: "OBSOLETE"}},
+			&daisy.DeprecateImage{Image: "baz", DeprecationStatus: compute.DeprecationStatus{State: ""}}},
+			[]string{"foo"}, []string{"bar"}, []string{"baz"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToDeprecate, gotToObsolete, gotToUndeprecate := deprecatePrintOut(tt.args)
+			if !reflect.DeepEqual(gotToDeprecate, tt.toDeprecate) {
+				t.Errorf("deprecatePrintOut() got = %v, want %v", gotToDeprecate, tt.toDeprecate)
+			}
+			if !reflect.DeepEqual(gotToObsolete, tt.toObsolete) {
+				t.Errorf("deprecatePrintOut() got1 = %v, want %v", gotToObsolete, tt.toObsolete)
+			}
+			if !reflect.DeepEqual(gotToUndeprecate, tt.toUndeprecate) {
+				t.Errorf("deprecatePrintOut() got2 = %v, want %v", gotToUndeprecate, tt.toUndeprecate)
+			}
+		})
+	}
+}

--- a/daisy/step_deprecate_images.go
+++ b/daisy/step_deprecate_images.go
@@ -38,10 +38,6 @@ type DeprecateImage struct {
 func (d *DeprecateImages) populate(ctx context.Context, s *Step) dErr {
 	for _, di := range *d {
 		di.Project = strOr(di.Project, s.w.Project)
-
-		//if di.DeprecationStatus.State == "" && di.DeprecationStatus.ForceSendFields == nil {
-		//	di.DeprecationStatus.ForceSendFields = []string{"Status"}
-		//}
 	}
 	return nil
 }

--- a/daisy/step_deprecate_images.go
+++ b/daisy/step_deprecate_images.go
@@ -39,9 +39,9 @@ func (d *DeprecateImages) populate(ctx context.Context, s *Step) dErr {
 	for _, di := range *d {
 		di.Project = strOr(di.Project, s.w.Project)
 
-		if di.DeprecationStatus.State == "" && di.DeprecationStatus.ForceSendFields == nil {
-			di.DeprecationStatus.ForceSendFields = []string{"Status"}
-		}
+		//if di.DeprecationStatus.State == "" && di.DeprecationStatus.ForceSendFields == nil {
+		//	di.DeprecationStatus.ForceSendFields = []string{"Status"}
+		//}
 	}
 	return nil
 }

--- a/daisy/step_deprecate_images_test.go
+++ b/daisy/step_deprecate_images_test.go
@@ -27,7 +27,6 @@ func TestDeprecateImagesPopulate(t *testing.T) {
 	w := testWorkflow()
 	s, _ := w.NewStep("s")
 	s.DeprecateImages = &DeprecateImages{
-		// Not setting DeprecationStatus.State should populate ForceSendFields.
 		&DeprecateImage{
 			Image: testImage,
 		},
@@ -46,10 +45,7 @@ func TestDeprecateImagesPopulate(t *testing.T) {
 
 	want := &DeprecateImages{
 		&DeprecateImage{
-			Image: testImage,
-			DeprecationStatus: compute.DeprecationStatus{
-				ForceSendFields: []string{"Status"},
-			},
+			Image:   testImage,
 			Project: testProject,
 		},
 		&DeprecateImage{

--- a/daisy/step_includeworkflow_test.go
+++ b/daisy/step_includeworkflow_test.go
@@ -63,7 +63,7 @@ func TestIncludeWorkflowPopulate(t *testing.T) {
 		Zone:    w.Zone,
 		GCSPath: w.GCSPath,
 		id:      w.id,
-		Vars: map[string]wVar{
+		Vars: map[string]Var{
 			"foo": {Value: "bar"},
 		},
 		Sources: map[string]string{

--- a/daisy/step_sub_workflow.go
+++ b/daisy/step_sub_workflow.go
@@ -48,7 +48,7 @@ func (s *SubWorkflow) populate(ctx context.Context, st *Step) dErr {
 	s.Workflow.StorageClient = s.Workflow.parent.StorageClient
 	s.Workflow.gcsLogWriter = s.Workflow.parent.gcsLogWriter
 	for k, v := range s.Vars {
-		s.Workflow.Vars[k] = wVar{Value: v}
+		s.Workflow.Vars[k] = Var{Value: v}
 	}
 	return s.Workflow.populate(ctx)
 }

--- a/daisy/step_sub_workflow_test.go
+++ b/daisy/step_sub_workflow_test.go
@@ -26,7 +26,7 @@ func TestSubWorkflowPopulate(t *testing.T) {
 	w := testWorkflow()
 	w.populate(ctx)
 	sw := &Workflow{parent: w}
-	sw.Vars = map[string]wVar{"foo": {Value: "bar1"}, "baz": {Value: "gaz"}}
+	sw.Vars = map[string]Var{"foo": {Value: "bar1"}, "baz": {Value: "gaz"}}
 	s := &Step{
 		name: "sw-step",
 		w:    w,
@@ -52,7 +52,7 @@ func TestSubWorkflowPopulate(t *testing.T) {
 	if sw.GCSPath != wantGCSPath {
 		t.Errorf("unexpected subworkflow GCSPath: %q != %q", sw.GCSPath, wantGCSPath)
 	}
-	wantVars := map[string]wVar{"foo": {Value: "bar2"}, "baz": {Value: "gaz"}, "hello": {Value: "world"}}
+	wantVars := map[string]Var{"foo": {Value: "bar2"}, "baz": {Value: "gaz"}, "hello": {Value: "world"}}
 	if !reflect.DeepEqual(sw.Vars, wantVars) {
 		t.Errorf("unexpected subworkflow Vars: %v != %v", sw.Vars, wantVars)
 	}

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -220,7 +220,7 @@ func TestNewFromFile(t *testing.T) {
 		Zone:        "us-central1-a",
 		GCSPath:     "gs://some-bucket/images",
 		OAuthPath:   filepath.Join(wd, "test_data", "somefile"),
-		Vars: map[string]wVar{
+		Vars: map[string]Var{
 			"bootstrap_instance_name": {Value: "bootstrap-${NAME}", Required: true},
 			"machine_type":            {Value: "n1-standard-1"},
 		},
@@ -381,7 +381,7 @@ func TestPopulate(t *testing.T) {
 	got.Project = "bar-project"
 	got.OAuthPath = tf
 	got.Logger = log.New(ioutil.Discard, "", 0)
-	got.Vars = map[string]wVar{
+	got.Vars = map[string]Var{
 		"bucket":    {Value: "wf-bucket", Required: true},
 		"step_name": {Value: "step1"},
 		"timeout":   {Value: "60m"},
@@ -414,7 +414,7 @@ func TestPopulate(t *testing.T) {
 		id:         got.id,
 		gcsLogging: true,
 		Cancel:     got.Cancel,
-		Vars: map[string]wVar{
+		Vars: map[string]Var{
 			"bucket":    {Value: "wf-bucket", Required: true},
 			"step_name": {Value: "step1"},
 			"timeout":   {Value: "60m"},
@@ -474,11 +474,11 @@ func TestRequiredVars(t *testing.T) {
 
 	tests := []struct {
 		desc      string
-		vars      map[string]wVar
+		vars      map[string]Var
 		shouldErr bool
 	}{
-		{"normal case", map[string]wVar{"foo": {Value: "foo", Required: true, Description: "foo"}}, false},
-		{"missing req case", map[string]wVar{"foo": {Value: "", Required: true, Description: "foo"}}, true},
+		{"normal case", map[string]Var{"foo": {Value: "foo", Required: true, Description: "foo"}}, false},
+		{"missing req case", map[string]Var{"foo": {Value: "", Required: true, Description: "foo"}}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is a preliminary commit so that I can get feedback on anything I may be missing. From my testing this works as expected for publish and rollback of images (at least the same as our current tool).
Docs and additional unit tests still need to be written.

The idea is you write a publish template json file and point this tool at that, the template contains all the options you need to publish a set of images. Source images can be either a GCS image file or a GCE image, a daisy workflow is generated for the publish task.