### PR TITLE
 Cache image lists per project for publish tool

### DIFF
--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -222,6 +222,9 @@ func populateSteps(w *daisy.Workflow, prefix string, createImages *daisy.CreateI
 			return err
 		}
 		createStep.CreateImages = createImages
+		// The default of 10m is a bit low, 1h is excessive for most use cases.
+		// TODO(ajackura): Maybe add a timout field override to the template?
+		createStep.Timeout = "1h"
 	}
 
 	if deprecateImages != nil {

--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -383,7 +383,8 @@ func createWorkflow(ctx context.Context, path string) (*daisy.Workflow, error) {
 		return nil, err
 	}
 
-	pubImgs, ok := imagesCache[p.PublishProject]
+	cacheKey := w.ComputeClient.BasePath() + p.PublishProject
+	pubImgs, ok := imagesCache[cacheKey]
 	if !ok {
 		pubImgs, err := w.ComputeClient.ListImages(p.PublishProject, daisyCompute.OrderBy("creationTimestamp desc"))
 		if err != nil {
@@ -392,7 +393,7 @@ func createWorkflow(ctx context.Context, path string) (*daisy.Workflow, error) {
 		if imagesCache == nil {
 			imagesCache = map[string][]*compute.Image{}
 		}
-		imagesCache[p.PublishProject] = pubImgs
+		imagesCache[cacheKey] = pubImgs
 	}
 
 	if err := p.populateWorkflow(ctx, w, pubImgs, *rollback, *skipDup, *replace); err != nil {

--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -59,6 +59,7 @@ type Client interface {
 	InstanceStatus(project, zone, name string) (string, error)
 	InstanceStopped(project, zone, name string) (bool, error)
 	Retry(f func(opts ...googleapi.CallOption) (*compute.Operation, error), opts ...googleapi.CallOption) (op *compute.Operation, err error)
+	BasePath() string
 }
 
 // A ListCallOption is an option for a Google Compute API *ListCall.
@@ -180,6 +181,11 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (Client, error)
 	c.i = c
 
 	return c, nil
+}
+
+// BasePath returns the base path for this client.
+func (c *client) BasePath() string {
+	return c.raw.BasePath
 }
 
 func (c *client) operationsWait(project, zone, name string) error {

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -184,7 +184,7 @@ func (w *Workflow) addCleanupHook(hook func() dErr) {
 
 // Validate runs validation on the workflow.
 func (w *Workflow) Validate(ctx context.Context) error {
-	if err := w.populateClients(ctx); err != nil {
+	if err := w.PopulateClients(ctx); err != nil {
 		close(w.Cancel)
 		return errf("error populating workflow: %v", err)
 	}
@@ -274,7 +274,8 @@ func (w *Workflow) getSourceGCSAPIPath(s string) string {
 	return fmt.Sprintf("%s/%s", gcsAPIBase, path.Join(w.bucket, w.sourcesPath, s))
 }
 
-func (w *Workflow) populateClients(ctx context.Context) error {
+// PopulateClients populates the compute and storage clients for the workflow.
+func (w *Workflow) PopulateClients(ctx context.Context) error {
 	// API clients instantiation.
 	var err error
 
@@ -508,8 +509,8 @@ func (w *Workflow) NewSubWorkflowFromFile(file string) (*Workflow, error) {
 // Print populates then pretty prints the workflow.
 func (w *Workflow) Print(ctx context.Context) {
 	w.gcsLogging = false
-	if err := w.populateClients(ctx); err != nil {
-		fmt.Println("Error running populateClients:", err)
+	if err := w.PopulateClients(ctx); err != nil {
+		fmt.Println("Error running PopulateClients:", err)
 	}
 	if err := w.populate(ctx); err != nil {
 		fmt.Println("Error running populate:", err)


### PR DESCRIPTION
Make PopulateClients public in order to use the same compute and storage clients from calling code.