### PR TITLE
Add text/template parsing to publish tool

### DIFF
--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -369,6 +369,9 @@ func createWorkflow(ctx context.Context, path string, varMap map[string]string) 
 	}
 
 	w := daisy.New()
+	for k, v := range varMap {
+		w.AddVar(k, v)
+	}
 	if p.WorkProject == "" {
 		if metadata.OnGCE() {
 			p.WorkProject, err = metadata.ProjectID()


### PR DESCRIPTION
The publish tool now takes the same -var: flags as daisy
Publish templates are run through text/template with the varMap created from the -var: flags as the data sctructure