### PR TITLE
Daisy: moving resource registries into Workflow struct.

### DIFF
--- a/daisy/common_test.go
+++ b/daisy/common_test.go
@@ -265,7 +265,7 @@ func TestSubstitute(t *testing.T) {
 		s := reflect.ValueOf(&tt.got).Elem()
 		substitute(s, tt.replacer)
 
-		if diffRes := diff(tt.got, tt.want); diffRes != "" {
+		if diffRes := diff(tt.got, tt.want, 0); diffRes != "" {
 			t.Errorf("test %d: post substitute workflow does not match expectation: (-got +want)\n%s", i, diffRes)
 		}
 	}

--- a/daisy/error_test.go
+++ b/daisy/error_test.go
@@ -34,10 +34,10 @@ func TestAddErrs(t *testing.T) {
 
 	for _, tt := range tests {
 		got := addErrs(tt.base, tt.errs...)
-		if diffRes := diff(got, tt.want); diffRes != "" {
+		if diffRes := diff(got, tt.want, 0); diffRes != "" {
 			t.Errorf("%s: (-got,+want)\n%s", tt.desc, diffRes)
 		}
-		if diffRes := diff(tt.base, tt.want); tt.base != nil && diffRes != "" {
+		if diffRes := diff(tt.base, tt.want, 0); tt.base != nil && diffRes != "" {
 			t.Errorf("%s: base dErr not modified as expected: (-got,+want)\n%s", tt.desc, diffRes)
 		}
 	}
@@ -70,7 +70,7 @@ func TestErrf(t *testing.T) {
 	got := errf("%s %s", "hello", "world")
 
 	want := &dErrImpl{errs: []error{errors.New("hello world")}}
-	if diffRes := diff(got, want); diffRes != "" {
+	if diffRes := diff(got, want, 0); diffRes != "" {
 		t.Errorf("Error not created as expected: (-got,+want)\n%s", diffRes)
 	}
 }
@@ -78,7 +78,7 @@ func TestErrf(t *testing.T) {
 func TestTypedErrf(t *testing.T) {
 	got := typedErrf("FOO", "%s %s", "hello", "world")
 	want := &dErrImpl{errs: []error{errors.New("hello world")}, errType: "FOO"}
-	if diffRes := diff(got, want); diffRes != "" {
+	if diffRes := diff(got, want, 0); diffRes != "" {
 		t.Errorf("Error not created as expected: (-got,+want)\n%s", diffRes)
 	}
 }
@@ -111,7 +111,7 @@ func TestDErrImplAdd(t *testing.T) {
 
 	for _, tt := range tests {
 		tt.base.add(tt.add)
-		if diffRes := diff(tt.base, tt.want); diffRes != "" {
+		if diffRes := diff(tt.base, tt.want, 0); diffRes != "" {
 			t.Errorf("%s: base dErrImpl not modified as expected: (-got,+want)\n%s", tt.desc, diffRes)
 		}
 	}

--- a/daisy/image.go
+++ b/daisy/image.go
@@ -150,14 +150,14 @@ func (i *Image) validate(ctx context.Context, s *Step) dErr {
 
 	// Source disk checking.
 	if i.SourceDisk != "" {
-		if _, err := disks[s.w].registerUsage(i.SourceDisk, s); err != nil {
+		if _, err := s.w.disks.registerUsage(i.SourceDisk, s); err != nil {
 			errs = addErrs(errs, newErr(err))
 		}
 	}
 
 	// Source image checking.
 	if i.SourceImage != "" {
-		_, err := images[s.w].registerUsage(i.SourceImage, s)
+		_, err := s.w.images.registerUsage(i.SourceImage, s)
 		errs = addErrs(errs, err)
 	}
 
@@ -181,7 +181,7 @@ func (i *Image) validate(ctx context.Context, s *Step) dErr {
 	}
 
 	// Register image creation.
-	errs = addErrs(errs, images[s.w].registerCreation(i.daisyName, &i.Resource, s, i.OverWrite))
+	errs = addErrs(errs, s.w.images.registerCreation(i.daisyName, &i.Resource, s, i.OverWrite))
 	return errs
 }
 

--- a/daisy/image_test.go
+++ b/daisy/image_test.go
@@ -109,7 +109,7 @@ func TestImagePopulate(t *testing.T) {
 			}
 		} else if err != nil {
 			t.Errorf("%s: unexpected error: %v", tt.desc, err)
-		} else if diffRes := diff(tt.input, tt.want); diffRes != "" {
+		} else if diffRes := diff(tt.input, tt.want, 0); diffRes != "" {
 			t.Errorf("%s: populated Image does not match expectation: (-got,+want)\n%s", tt.desc, diffRes)
 		}
 	}
@@ -127,12 +127,12 @@ func TestImageValidate(t *testing.T) {
 	e6 := w.AddDependency(d2Deleter, d2Creator)
 
 	// Set up some test resources
-	e7 := disks[w].registerCreation("d1", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d1", w.Project, w.Zone)}, d1Creator, false)
-	e8 := disks[w].registerCreation("d2", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d2", w.Project, w.Zone)}, d2Creator, false)
-	e9 := disks[w].registerDeletion("d2", d2Deleter)
-	e10 := disks[w].registerCreation("d3", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d3", w.Project, w.Zone)}, d3Creator, false)
+	e7 := w.disks.registerCreation("d1", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d1", w.Project, w.Zone)}, d1Creator, false)
+	e8 := w.disks.registerCreation("d2", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d2", w.Project, w.Zone)}, d2Creator, false)
+	e9 := w.disks.registerDeletion("d2", d2Deleter)
+	e10 := w.disks.registerCreation("d3", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d3", w.Project, w.Zone)}, d3Creator, false)
 	si1 := &Resource{link: fmt.Sprintf("projects/%s/global/images/si1", w.Project)}
-	e11 := images[w].registerCreation("si1", si1, si1Creator, false)
+	e11 := w.images.registerCreation("si1", si1, si1Creator, false)
 	if errs := addErrs(nil, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11); errs != nil {
 		t.Fatalf("test set up error: %v", errs)
 	}

--- a/daisy/resource_registry.go
+++ b/daisy/resource_registry.go
@@ -21,62 +21,6 @@ import (
 	"sync"
 )
 
-var (
-	disks       = map[*Workflow]*diskRegistry{}
-	disksMu     sync.Mutex
-	images      = map[*Workflow]*imageRegistry{}
-	imagesMu    sync.Mutex
-	instances   = map[*Workflow]*instanceRegistry{}
-	instancesMu sync.Mutex
-	networks    = map[*Workflow]*networkRegistry{}
-	networksMu  sync.Mutex
-)
-
-func initWorkflowResourceRegistries(w *Workflow) {
-	disksMu.Lock()
-	disks[w] = newDiskRegistry(w)
-	disksMu.Unlock()
-
-	imagesMu.Lock()
-	images[w] = newImageRegistry(w)
-	imagesMu.Unlock()
-
-	instancesMu.Lock()
-	instances[w] = newInstanceRegistry(w)
-	instancesMu.Unlock()
-
-	networksMu.Lock()
-	networks[w] = newNetworkRegistry(w)
-	networksMu.Unlock()
-
-	w.addCleanupHook(resourceRegistryCleanupHook(w))
-}
-
-func resourceRegistryCleanupHook(w *Workflow) func() dErr {
-	return func() dErr {
-		images[w].cleanup()
-		instances[w].cleanup()
-		disks[w].cleanup()
-		networks[w].cleanup()
-		return nil
-	}
-}
-
-func shareWorkflowResourceRegistries(giver, taker *Workflow) {
-	disksMu.Lock()
-	disks[taker] = disks[giver]
-	disksMu.Unlock()
-	imagesMu.Lock()
-	images[taker] = images[giver]
-	imagesMu.Unlock()
-	instancesMu.Lock()
-	instances[taker] = instances[giver]
-	instancesMu.Unlock()
-	networksMu.Lock()
-	networks[taker] = networks[giver]
-	networksMu.Unlock()
-}
-
 type baseResourceRegistry struct {
 	w  *Workflow
 	m  map[string]*Resource

--- a/daisy/resource_registry_test.go
+++ b/daisy/resource_registry_test.go
@@ -31,9 +31,9 @@ func TestResourceRegistryCleanup(t *testing.T) {
 	im2 := &Resource{RealName: "im2", link: "link", NoCleanup: true}
 	in1 := &Resource{RealName: "in1", link: "link", NoCleanup: false}
 	in2 := &Resource{RealName: "in2", link: "link", NoCleanup: true}
-	disks[w].m = map[string]*Resource{"d1": d1, "d2": d2}
-	images[w].m = map[string]*Resource{"im1": im1, "im2": im2}
-	instances[w].m = map[string]*Resource{"in1": in1, "in2": in2}
+	w.disks.m = map[string]*Resource{"d1": d1, "d2": d2}
+	w.images.m = map[string]*Resource{"im1": im1, "im2": im2}
+	w.instances.m = map[string]*Resource{"in1": in1, "in2": in2}
 
 	w.cleanup()
 
@@ -119,7 +119,7 @@ func TestResourceRegistryDelete(t *testing.T) {
 		"foo": {deleted: true, deleteMx: r.m["foo"].deleteMx},
 		"baz": {deleted: false, deleteMx: r.m["baz"].deleteMx},
 	}
-	if diffRes := diff(r.m, wantM); diffRes != "" {
+	if diffRes := diff(r.m, wantM, 0); diffRes != "" {
 		t.Errorf("resourceMap not modified as expected: (-got,+want)\n%s", diffRes)
 	}
 }
@@ -158,7 +158,7 @@ func TestResourceRegistryRegisterCreation(t *testing.T) {
 	if r.creator != s {
 		t.Error("foo does not have the correct creator")
 	}
-	if diffRes := diff(rr.m, map[string]*Resource{"foo": r}); diffRes != "" {
+	if diffRes := diff(rr.m, map[string]*Resource{"foo": r}, 0); diffRes != "" {
 		t.Errorf("resource registry does not match expectation: (-got +want)\n%s", diffRes)
 	}
 
@@ -237,7 +237,7 @@ func TestResourceRegistryRegisterExisting(t *testing.T) {
 		if !tt.shouldErr {
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tt.desc, err)
-			} else if diffRes := diff(r, tt.wantR); diffRes != "" {
+			} else if diffRes := diff(r, tt.wantR, 0); diffRes != "" {
 				t.Errorf("%s: generated resource doesn't match expectation (-got +want)\n%s", tt.desc, diffRes)
 			} else if rr.m[tt.url] != r {
 				t.Errorf("%s: resource was not added to the resource map", tt.desc)
@@ -247,7 +247,7 @@ func TestResourceRegistryRegisterExisting(t *testing.T) {
 		}
 	}
 
-	if diffRes := diff(rr.m, map[string]*Resource{defURL: {RealName: testDisk, link: defURL, NoCleanup: true}}); diffRes != "" {
+	if diffRes := diff(rr.m, map[string]*Resource{defURL: {RealName: testDisk, link: defURL, NoCleanup: true}}, 0); diffRes != "" {
 		t.Errorf("resource registry doesn't match expectation (-got +want)\n%s", diffRes)
 	}
 }
@@ -301,10 +301,10 @@ func TestResourceRegistryRegisterUsage(t *testing.T) {
 	for _, s := range ss {
 		s.w = nil
 	}
-	if diffRes := diff(r1.users, []*Step{user}); diffRes != "" {
+	if diffRes := diff(r1.users, []*Step{user}, 0); diffRes != "" {
 		t.Errorf("r1 users list does not match expectation: (-got +want)\n%s", diffRes)
 	}
-	if diffRes := diff(r2.users, []*Step(nil)); diffRes != "" {
+	if diffRes := diff(r2.users, []*Step(nil), 0); diffRes != "" {
 		t.Errorf("r2 users list does not match expectation: (-got +want)\n%s", diffRes)
 	}
 

--- a/daisy/resource_test.go
+++ b/daisy/resource_test.go
@@ -56,7 +56,7 @@ func TestResourcePopulate(t *testing.T) {
 		} else if !tt.wantErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", tt.desc, err)
 		} else if err == nil {
-			if diffRes := diff(tt.r, tt.wantR); diffRes != "" {
+			if diffRes := diff(tt.r, tt.wantR, 0); diffRes != "" {
 				t.Errorf("%s: populated Resource does not match expectation: (-got +want)\n%s", tt.desc, diffRes)
 			}
 			if gotName != tt.wantName {

--- a/daisy/step_copy_gcs_objects_test.go
+++ b/daisy/step_copy_gcs_objects_test.go
@@ -41,7 +41,7 @@ func TestCopyGCSObjectsPopulate(t *testing.T) {
 		{Source: "gs://bucket/object", Destination: "gs://bucket/object", ACLRules: []*storage.ACLRule{{Entity: "allUsers", Role: "OWNER"}}},
 		{Source: "gs://bucket/object", Destination: "gs://bucket/object", ACLRules: []*storage.ACLRule{{Entity: "allAuthenticatedUsers", Role: "WRITER"}}},
 	}
-	if diffRes := diff(ws, want); diffRes != "" {
+	if diffRes := diff(ws, want, 0); diffRes != "" {
 		t.Errorf("populated CopyGCSObjects does not match expectation: (-got +want)\n%s", diffRes)
 	}
 }

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -49,7 +49,7 @@ func (c *CreateDisks) run(ctx context.Context, s *Step) dErr {
 
 			// Get the source image link if using a source image.
 			if cd.SourceImage != "" {
-				image, _ := images[w].get(cd.SourceImage)
+				image, _ := w.images.get(cd.SourceImage)
 				cd.SourceImage = image.link
 			}
 

--- a/daisy/step_create_disks_test.go
+++ b/daisy/step_create_disks_test.go
@@ -26,7 +26,7 @@ func TestCreateDisksRun(t *testing.T) {
 	ctx := context.Background()
 	w := testWorkflow()
 	s := &Step{w: w}
-	images[w].m = map[string]*Resource{"i1": {RealName: "i1", link: "i1link"}}
+	w.images.m = map[string]*Resource{"i1": {RealName: "i1", link: "i1link"}}
 
 	e := errf("error")
 	tests := []struct {
@@ -48,7 +48,7 @@ func TestCreateDisksRun(t *testing.T) {
 		if err := cds.run(ctx, s); err != tt.wantErr {
 			t.Errorf("%s: unexpected error returned, got: %v, want: %v", tt.desc, err, tt.wantErr)
 		}
-		if diffRes := diff(gotD, tt.wantD); diffRes != "" {
+		if diffRes := diff(gotD, tt.wantD, 0); diffRes != "" {
 			t.Errorf("%s: client got incorrect disk, got: %v, want: %v", tt.desc, gotD, tt.wantD)
 		}
 	}

--- a/daisy/step_create_images.go
+++ b/daisy/step_create_images.go
@@ -52,7 +52,7 @@ func (c *CreateImages) run(ctx context.Context, s *Step) dErr {
 		go func(ci *Image) {
 			defer wg.Done()
 			// Get source disk link if SourceDisk is a daisy reference to a disk.
-			if d, ok := disks[w].get(ci.SourceDisk); ok {
+			if d, ok := w.disks.get(ci.SourceDisk); ok {
 				ci.SourceDisk = d.link
 			}
 

--- a/daisy/step_create_images_test.go
+++ b/daisy/step_create_images_test.go
@@ -25,7 +25,7 @@ func TestCreateImagesRun(t *testing.T) {
 	ctx := context.Background()
 	w := testWorkflow()
 	s := &Step{w: w}
-	disks[w].m = map[string]*Resource{testDisk: {RealName: w.genName(testDisk), link: testDisk}}
+	w.disks.m = map[string]*Resource{testDisk: {RealName: w.genName(testDisk), link: testDisk}}
 	w.Sources = map[string]string{"file": "gs://some/path"}
 
 	tests := []struct {

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -43,7 +43,7 @@ func logSerialOutput(ctx context.Context, w *Workflow, name string, port int64, 
 			resp, err := w.ComputeClient.GetSerialPortOutput(w.Project, w.Zone, name, port, start)
 			if err != nil {
 				// Instance was deleted by this workflow.
-				if _, ok := instances[w].get(name); !ok {
+				if _, ok := w.instances.get(name); !ok {
 					return
 				}
 				// Instance is stopped.
@@ -104,7 +104,7 @@ func (c *CreateInstances) run(ctx context.Context, s *Step) dErr {
 			defer wg.Done()
 
 			for _, d := range ci.Disks {
-				if diskRes, ok := disks[w].get(d.Source); ok {
+				if diskRes, ok := w.disks.get(d.Source); ok {
 					d.Source = diskRes.link
 				}
 			}

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -29,7 +29,7 @@ import (
 func TestLogSerialOutput(t *testing.T) {
 	ctx := context.Background()
 	w := testWorkflow()
-	instances[w].m = map[string]*Resource{
+	w.instances.m = map[string]*Resource{
 		"i1": {RealName: w.genName("i1"), link: "link"},
 		"i2": {RealName: w.genName("i2"), link: "link"},
 		"i3": {RealName: w.genName("i3"), link: "link"},
@@ -97,7 +97,7 @@ func TestCreateInstancesRun(t *testing.T) {
 	}
 	s := &Step{w: w}
 	w.Sources = map[string]string{"file": "gs://some/file"}
-	disks[w].m = map[string]*Resource{
+	w.disks.m = map[string]*Resource{
 		"d0": {RealName: w.genName("d0"), link: "diskLink0"},
 	}
 
@@ -108,15 +108,15 @@ func TestCreateInstancesRun(t *testing.T) {
 	if err := ci.run(ctx, s); err != nil {
 		t.Errorf("unexpected error running CreateInstances.run(): %v", err)
 	}
-	if i0.Disks[0].Source != disks[w].m["d0"].link {
-		t.Errorf("instance disk link did not resolve properly: want: %q, got: %q", disks[w].m["d0"].link, i0.Disks[0].Source)
+	if i0.Disks[0].Source != w.disks.m["d0"].link {
+		t.Errorf("instance disk link did not resolve properly: want: %q, got: %q", w.disks.m["d0"].link, i0.Disks[0].Source)
 	}
 	if i1.Disks[0].Source != "other" {
 		t.Errorf("instance disk link did not resolve properly: want: %q, got: %q", "other", i1.Disks[0].Source)
 	}
 
 	// Bad case: compute client Instance error. Check instance ref map doesn't update.
-	instances[w].m = map[string]*Resource{}
+	w.instances.m = map[string]*Resource{}
 	createErr = errf("client error")
 	ci = &CreateInstances{
 		{Resource: Resource{daisyName: "i0"}, Instance: compute.Instance{Name: "realI0", MachineType: "foo-type", Disks: []*compute.AttachedDisk{{Source: "d0"}}}},

--- a/daisy/step_delete_resources_test.go
+++ b/daisy/step_delete_resources_test.go
@@ -40,7 +40,7 @@ func TestDeleteResourcesPopulate(t *testing.T) {
 		Images:    []string{"i", fmt.Sprintf("projects/%s/global/images/i", w.Project)},
 		Instances: []string{"i", fmt.Sprintf("projects/%s/zones/z/instances/i", w.Project)},
 	}
-	if diffRes := diff(s.DeleteResources, want); diffRes != "" {
+	if diffRes := diff(s.DeleteResources, want, 0); diffRes != "" {
 		t.Errorf("DeleteResources not populated as expected: (-got,+want)\n%s", diffRes)
 	}
 }
@@ -53,9 +53,9 @@ func TestDeleteResourcesRun(t *testing.T) {
 	ins := []*Resource{{RealName: "in0", link: "link"}, {RealName: "in1", link: "link"}}
 	ims := []*Resource{{RealName: "im0", link: "link"}, {RealName: "im1", link: "link"}}
 	ds := []*Resource{{RealName: "d0", link: "link"}, {RealName: "d1", link: "link"}}
-	instances[w].m = map[string]*Resource{"in0": ins[0], "in1": ins[1]}
-	images[w].m = map[string]*Resource{"im0": ims[0], "im1": ims[1]}
-	disks[w].m = map[string]*Resource{"d0": ds[0], "d1": ds[1]}
+	w.instances.m = map[string]*Resource{"in0": ins[0], "in1": ins[1]}
+	w.images.m = map[string]*Resource{"im0": ims[0], "im1": ims[1]}
+	w.disks.m = map[string]*Resource{"d0": ds[0], "d1": ds[1]}
 
 	dr := &DeleteResources{Instances: []string{"in0"}, Images: []string{"im0"}, Disks: []string{"d0"}}
 	if err := dr.run(ctx, s); err != nil {
@@ -101,9 +101,9 @@ func TestDeleteResourcesValidate(t *testing.T) {
 	ds := []*Resource{{RealName: "d0", link: "link", creator: dC}, {RealName: "d1", link: "link", creator: dC}}
 	ims := []*Resource{{RealName: "im0", link: "link", creator: imC}, {RealName: "im1", link: "link", creator: imC}}
 	ins := []*Resource{{RealName: "in0", link: "link", creator: inC}, {RealName: "in1", link: "link", creator: inC}}
-	instances[w].m = map[string]*Resource{"in0": ins[0], "in1": ins[1]}
-	images[w].m = map[string]*Resource{"im0": ims[0], "im1": ims[1]}
-	disks[w].m = map[string]*Resource{"d0": ds[0], "d1": ds[1]}
+	w.instances.m = map[string]*Resource{"in0": ins[0], "in1": ins[1]}
+	w.images.m = map[string]*Resource{"im0": ims[0], "im1": ims[1]}
+	w.disks.m = map[string]*Resource{"d0": ds[0], "d1": ds[1]}
 	ads := []*compute.AttachedDisk{{Source: "d1"}}
 	inC.CreateInstances = &CreateInstances{{Resource: Resource{daisyName: "in0"}, Instance: compute.Instance{Disks: ads}}}
 
@@ -111,7 +111,7 @@ func TestDeleteResourcesValidate(t *testing.T) {
 		for _, s := range []*Step{dC, imC, inC, s, otherDeleter} {
 			s.w = nil
 		}
-		if diffRes := diff(got, want); diffRes != "" {
+		if diffRes := diff(got, want, 0); diffRes != "" {
 			t.Errorf("resources weren't registered for deletion as expected: (-got,+want)\n%s", diffRes)
 		}
 		for _, s := range []*Step{dC, imC, inC, s, otherDeleter} {

--- a/daisy/step_deprecate_images.go
+++ b/daisy/step_deprecate_images.go
@@ -57,10 +57,10 @@ func (d *DeprecateImages) validate(ctx context.Context, s *Step) dErr {
 
 		// registerUsage needs the partal url of a non daisy resource.
 		lookup := di.Image
-		if _, ok := images[s.w].get(di.Image); !ok {
+		if _, ok := s.w.images.get(di.Image); !ok {
 			lookup = fmt.Sprintf("projects/%s/global/images/%s", di.Project, di.Image)
 		}
-		if _, err := images[s.w].registerUsage(lookup, s); err != nil {
+		if _, err := s.w.images.registerUsage(lookup, s); err != nil {
 			return newErr(err)
 		}
 	}

--- a/daisy/step_deprecate_images_test.go
+++ b/daisy/step_deprecate_images_test.go
@@ -55,7 +55,7 @@ func TestDeprecateImagesPopulate(t *testing.T) {
 			Project: "foo",
 		},
 	}
-	if diffRes := diff(s.DeprecateImages, want); diffRes != "" {
+	if diffRes := diff(s.DeprecateImages, want, 0); diffRes != "" {
 		t.Errorf("DeprecateImages not populated as expected: (-got,+want)\n%s", diffRes)
 	}
 }
@@ -66,7 +66,7 @@ func TestDeprecateImagesValidate(t *testing.T) {
 
 	iCreator := &Step{name: "iCreator", w: w}
 	w.Steps["iCreator"] = iCreator
-	images[w].m = map[string]*Resource{"i1": {creator: iCreator}}
+	w.images.m = map[string]*Resource{"i1": {creator: iCreator}}
 
 	tests := []struct {
 		desc      string
@@ -125,7 +125,7 @@ func TestDeprecateImagesRun(t *testing.T) {
 	ctx := context.Background()
 	w := testWorkflow()
 	s := &Step{w: w}
-	images[w].m = map[string]*Resource{"i1": {RealName: "i1", link: "i1link"}}
+	w.images.m = map[string]*Resource{"i1": {RealName: "i1", link: "i1link"}}
 
 	e := errf("error")
 	tests := []struct {

--- a/daisy/step_includeworkflow_test.go
+++ b/daisy/step_includeworkflow_test.go
@@ -91,10 +91,10 @@ func TestIncludeWorkflowPopulate(t *testing.T) {
 		}
 	}
 
-	if diffRes := diff(got, want); diffRes != "" {
+	if diffRes := diff(got, want, 0); diffRes != "" {
 		t.Errorf("populated IncludeWorkflow does not match expectation: (-got +want)\n%s", diffRes)
 	}
-	if diffRes := diff(w.Sources, got.Sources); diffRes != "" {
+	if diffRes := diff(w.Sources, got.Sources, 0); diffRes != "" {
 		t.Errorf("parent workflow sources don't match expectation: (-got +want)\n%s", diffRes)
 	}
 }
@@ -112,7 +112,7 @@ func TestIncludeWorkflowValidate(t *testing.T) {
 	w.AddDependency(incStep, dCreator)
 	dDeleter, _ := iw.NewStep("dDeleter")
 	dDeleter.DeleteResources = &DeleteResources{Disks: []string{"d"}}
-	if err := disks[w].registerCreation("d", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, dCreator, false); err != nil {
+	if err := w.disks.registerCreation("d", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, dCreator, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -167,7 +167,7 @@ func (w *WaitForInstancesSignal) run(ctx context.Context, s *Step) dErr {
 		wg.Add(1)
 		go func(is *InstanceSignal) {
 			defer wg.Done()
-			i, ok := instances[s.w].get(is.Name)
+			i, ok := s.w.instances.get(is.Name)
 			if !ok {
 				e <- errf("unresolved instance %q", is.Name)
 				return
@@ -216,7 +216,7 @@ func (w *WaitForInstancesSignal) run(ctx context.Context, s *Step) dErr {
 func (w *WaitForInstancesSignal) validate(ctx context.Context, s *Step) dErr {
 	// Instance checking.
 	for _, i := range *w {
-		if _, err := instances[s.w].registerUsage(i.Name, s); err != nil {
+		if _, err := s.w.instances.registerUsage(i.Name, s); err != nil {
 			return err
 		}
 		if i.interval == 0*time.Second {

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -97,7 +97,7 @@ func TestWaitForInstancesSignalRun(t *testing.T) {
 	}
 
 	s := &Step{w: w}
-	instances[w].m = map[string]*Resource{
+	w.instances.m = map[string]*Resource{
 		"i1": {link: fmt.Sprintf("projects/%s/zones/%s/instances/%s", testProject, testZone, w.genName("i1"))},
 		"i2": {link: fmt.Sprintf("projects/%s/zones/%s/instances/%s", testProject, testZone, w.genName("i2"))},
 		"i3": {link: fmt.Sprintf("projects/%s/zones/%s/instances/%s", testProject, testZone, w.genName("i3"))},
@@ -167,7 +167,7 @@ func TestWaitForInstancesSignalValidate(t *testing.T) {
 	iCreator, _ := w.NewStep("iCreator")
 	iCreator.CreateInstances = &CreateInstances{&Instance{}}
 	w.AddDependency(s, iCreator)
-	if err := instances[w].registerCreation("instance1", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, iCreator); err != nil {
+	if err := w.instances.registerCreation("instance1", &Resource{link: fmt.Sprintf("projects/%s/zones/%s/disks/d", testProject, testZone)}, iCreator); err != nil {
 		t.Fatal(err)
 	}
 

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -80,9 +80,8 @@ var (
 	testGCSObjsMx   = sync.Mutex{}
 
 	spewCfg = spew.ConfigState{
-		Indent:                  "  ",
+		Indent:                  "\t",
 		DisableCapacities:       true,
-		DisableMethods:          true,
 		DisablePointerAddresses: true,
 		SortKeys:                true,
 		SpewKeys:                true,
@@ -109,8 +108,10 @@ func addGCSObj(o string) {
 	testGCSObjs = append(testGCSObjs, o)
 }
 
-func diff(x, y interface{}) string {
-	return godebugDiff.Diff(spewCfg.Sdump(x), spewCfg.Sdump(y))
+func diff(x, y interface{}, depth int) string {
+	cfg := spewCfg
+	cfg.MaxDepth = depth
+	return godebugDiff.Diff(cfg.Sdump(x), cfg.Sdump(y))
 }
 
 func newTestGCEClient() (*daisyCompute.TestClient, error) {

--- a/daisy/validate_test.go
+++ b/daisy/validate_test.go
@@ -96,7 +96,7 @@ func TestValidateWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		tt.wf.Cancel = make(chan struct{})
 		if err := tt.wf.Validate(ctx); err == nil {
-			t.Errorf("validation should have failed on %s because of %q", tt.wf, tt.desc)
+			t.Errorf("validation should have failed on %v because of %q", tt.wf, tt.desc)
 		}
 	}
 }


### PR DESCRIPTION
- Moved registries into Workflow.
- Changed the way disk registry's disk attachments are indexed (uses string instead of *Resource now)
- Added depth arg to diff().
- Fixed a couple go vet errors.