### PR TITLE
Images in state of OBSOLETE or DELETED still exist, use new typed error

### DIFF
--- a/daisy/disk_test.go
+++ b/daisy/disk_test.go
@@ -370,6 +370,11 @@ func TestDiskValidate(t *testing.T) {
 			false,
 		},
 		{
+			"image OBSOLETE case",
+			&Disk{Disk: compute.Disk{Name: "d1", SourceImage: fmt.Sprintf("projects/foo/global/images/%s", testImage), Type: ty}},
+			true,
+		},
+		{
 			"source image dne case",
 			&Disk{Disk: compute.Disk{Name: "d5", SourceImage: "dne", Type: ty}},
 			true,

--- a/daisy/error.go
+++ b/daisy/error.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	untypedError     = ""
-	multiError       = "MultiError"
-	fileIOError      = "FileIOError"
-	resourceDNEError = "ResourceDoesNotExist"
+	untypedError              = ""
+	multiError                = "MultiError"
+	fileIOError               = "FileIOError"
+	resourceDNEError          = "ResourceDoesNotExist"
+	imageObsoleteDeletedError = "ImageObsoleteOrDeleted"
 
 	apiError    = "APIError"
 	apiError404 = "APIError404"

--- a/daisy/resource_registry.go
+++ b/daisy/resource_registry.go
@@ -148,16 +148,18 @@ func (r *baseResourceRegistry) registerExisting(url string) (*Resource, dErr) {
 	if r, ok := r.m[url]; ok {
 		return r, nil
 	}
-	if exists, err := resourceExists(r.w.ComputeClient, url); err != nil {
-		return nil, err
-	} else if !exists {
+	exists, err := resourceExists(r.w.ComputeClient, url)
+	if !exists {
+		if err != nil {
+			return nil, err
+		}
 		return nil, typedErrf(resourceDNEError, "%s does not exist", url)
 	}
 
 	parts := strings.Split(url, "/")
 	res := &Resource{RealName: parts[len(parts)-1], link: url, NoCleanup: true}
 	r.m[url] = res
-	return res, nil
+	return res, err
 }
 
 func (r *baseResourceRegistry) registerUsage(name string, s *Step) (*Resource, dErr) {

--- a/daisy/step_delete_resources.go
+++ b/daisy/step_delete_resources.go
@@ -16,9 +16,8 @@ package daisy
 
 import (
 	"context"
-	"sync"
-
 	"log"
+	"sync"
 
 	compute "google.golang.org/api/compute/v1"
 )
@@ -77,6 +76,8 @@ func (d *DeleteResources) validateInstance(i string, s *Step) dErr {
 func (d *DeleteResources) checkError(err dErr, logger *log.Logger) dErr {
 	if err != nil && err.Type() == resourceDNEError {
 		logger.Printf("DeleteResources WARNING: Error validating deletion: %v", err)
+		return nil
+	} else if err != nil && err.Type() == imageObsoleteDeletedError {
 		return nil
 	}
 	return err

--- a/daisy/step_delete_resources_test.go
+++ b/daisy/step_delete_resources_test.go
@@ -120,7 +120,7 @@ func TestDeleteResourcesValidate(t *testing.T) {
 	}
 
 	// Good case.
-	dr := DeleteResources{Disks: []string{"d0"}, Images: []string{"im0"}, Instances: []string{"in0"}}
+	dr := DeleteResources{Disks: []string{"d0"}, Images: []string{"im0", "projects/foo/global/images/" + testImage, "projects/foo/global/images/family/foo"}, Instances: []string{"in0"}}
 	if err := dr.validate(ctx, s); err != nil {
 		t.Errorf("validation should not have failed: %v", err)
 	}

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -161,8 +161,11 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 	c.ListZonesFn = func(_ string, _ ...daisyCompute.ListCallOption) ([]*compute.Zone, error) {
 		return []*compute.Zone{{Name: testZone}}, nil
 	}
-	c.ListImagesFn = func(_ string, _ ...daisyCompute.ListCallOption) ([]*compute.Image, error) {
-		return []*compute.Image{{Name: testImage}}, nil
+	c.ListImagesFn = func(p string, _ ...daisyCompute.ListCallOption) ([]*compute.Image, error) {
+		if p == testProject {
+			return []*compute.Image{{Name: testImage}}, nil
+		}
+		return []*compute.Image{{Name: testImage, Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}}}, nil
 	}
 	c.ListDisksFn = func(p, z string, _ ...daisyCompute.ListCallOption) ([]*compute.Disk, error) {
 		if p != testProject {
@@ -199,6 +202,12 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 			return errors.New("bad source disk: " + i.SourceDisk)
 		}
 		return nil
+	}
+	c.GetImageFromFamilyFn = func(_, f string) (*compute.Image, error) {
+		if f == testFamily {
+			return &compute.Image{Name: testImage}, nil
+		}
+		return &compute.Image{Name: testImage, Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}}, nil
 	}
 
 	return c, err


### PR DESCRIPTION
Images in state of OBSOLETE or DELETED still exist and should be added to the registry
This allows DeleteResources to delete images in this state
