### PR TITLE
Update tables to make them render properly

### DIFF
--- a/docs/image-import.md
+++ b/docs/image-import.md
@@ -235,16 +235,18 @@ Not every VM image will be importable to GCE. Some VMs will have issues after
 import. Below is a list of known compatibility requirements and issues:
 
 ### Windows
+
 | Name | Severity | Description |
-|-|-|-|
+|---|---|---|
 | OS Version | Required | We support the following OS versions: Windows Server 2008 R2, 2012 R2, or 2016. |
 | OS Disk | Required | The disk containing the OS must be bootable and must be MBR. |
 | Multiple Disks | Warning  | Image import cannot directly handle multiple disk scenarios. Additional disks must be imported and attached separately. |
 | Powershell (Windows) | Warning | Warn if Powershell Version < 3. Powershell versions older than 3.0 can cause issues with GCE startup and shutdown scripts. |
 
 ### Linux
+
 | Name | Severity | Description |
-|-|-|-|    
+|---|---|---|    
 | OS Version | Required | We support the following OS versions: RHEL/CentOS/OEL 6 or 7; Debian 8 or 9; Ubuntu 14.04 or 16.04. |
 | OS Disk | Required | The disk containing the OS must be bootable. The disk must be MBR and have GRUB installed. |
 | Multiple Disks | Warning  | Image import cannot directly handle multiple disk scenarios. Additional disks must be imported and attached separately. |


### PR DESCRIPTION
When I view this page, https://googlecloudplatform.github.io/compute-image-tools/image-import.html#compatibility-and-known-limitations , the tables for "Windows" and "Linux" in the "Compatibility and Known Limitations" section are not appearing as tables. They appear as a long string of text, which is difficult to read.

Perhaps it is because "There must be at least 3 dashes separating each header cell" (from https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#tables).