### PR TITLE
Use the same builder image for Debian image builds.

### DIFF
--- a/daisy_workflows/e2e_tests/README.md
+++ b/daisy_workflows/e2e_tests/README.md
@@ -16,14 +16,14 @@ periodically against HEAD.
    finally `foo014.wf.json`.
 
 ## Test Environment Details
-* Tests run in the GCP project `gce-daisy-test` and have permissions:
+* Tests run in the GCP project `compute-image-tools-test` and have permissions:
   * GCE read/write
-  * GCS read on the `gce-daisy-test-resources` bucket.
-  * GCS read/write on the `gce-daisy-test-sandbox` bucket.
-* Test logs are written to the `gce-daisy-test` GCS bucket for Gubenator and 
+  * GCS read on the `compute-image-tools-test-resources` bucket.
+  * GCS read/write on the `compute-image-tools-test-sandbox` bucket.
+* Test logs are written to the `compute-image-tools-test` GCS bucket for Gubenator and
   testgrid to pick up.
 * Defaults are provided for workflow `Project` and `Zone` fields.
-  * `Project` is `gce-daisy-test`
+  * `Project` is `compute-image-tools-test`
   * `Zone` is variable.
 * The following args are passed to the test workflows:
   * `test-id`: The ID of this test run. Useful for sharing resources between

--- a/daisy_workflows/e2e_tests/scripts/retrieve-files-from-gcs.sh
+++ b/daisy_workflows/e2e_tests/scripts/retrieve-files-from-gcs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-retrieve_me='gs://gce-daisy-test-sandbox/copy-gcs-object-test.txt'
+retrieve_me='gs://compute-image-tools-test-sandbox/copy-gcs-object-test.txt'
 gsutil cp $retrieve_me . && gsutil rm $retrieve_me && echo 'SUCCESS wVnWw3a41CVe3mBVvTMn' || echo 'FAILURE wVnWw3a41CVe3mBVvTMn'
 

--- a/daisy_workflows/image_build/debian/debian.wf.json
+++ b/daisy_workflows/image_build/debian/debian.wf.json
@@ -3,6 +3,10 @@
   "Vars": {
     "bootstrap_vz_manifest": {"Required": true, "Description": "The bootstrap-vz manifest to build."},
     "bootstrap_vz_version": {"Required": true, "Description": "The bootstrap-vz github commit ID to use."},
+    "builder_source_image": {
+      "Value": "projects/debian-cloud/global/images/family/debian-9",
+      "Description": "The image used to run bootstrap-vz."
+    },
     "google_cloud_repo": {"Required": true, "Description": "The Google Cloud Repo branch to use."},
     "image_dest": {"Required": true, "Description": "The GCS path for the destination image.."}
   },
@@ -17,7 +21,7 @@
       "CreateDisks": [
         {
           "Name": "disk-builder",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "${builder_source_image}",
           "SizeGb": "50",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_build/debian/debian_8.wf.json
+++ b/daisy_workflows/image_build/debian/debian_8.wf.json
@@ -16,6 +16,7 @@
         "Vars": {
           "bootstrap_vz_manifest": "official/gce/jessie.yml",
           "bootstrap_vz_version": "${bootstrap_vz_version}",
+          "builder_source_image": "projects/debian-cloud/global/images/family/debian-8",
           "google_cloud_repo": "${google_cloud_repo}",
           "image_dest": "${image_dest}"
         }

--- a/daisy_workflows/image_build/debian/debian_9.wf.json
+++ b/daisy_workflows/image_build/debian/debian_9.wf.json
@@ -16,6 +16,7 @@
         "Vars": {
           "bootstrap_vz_manifest": "official/gce/stretch.yml",
           "bootstrap_vz_version": "${bootstrap_vz_version}",
+          "builder_source_image": "projects/debian-cloud/global/images/family/debian-9",
           "google_cloud_repo": "${google_cloud_repo}",
           "image_dest": "${image_dest}"
         }


### PR DESCRIPTION
This fixes an issue with how the filesystem is being created on the
resulting image. The e2fs version in Debian 8 does not support
metadata_checksums. If the partition is created from a Debian 9 e2fs
toolset, fsck will fail on Debian 8 boots.
systemd-fsck[121]: /dev/sda1 has unsupported feature(s): metadata_csum