### PR TITLE
Split an "import_disk" workflow out of "import_image"...

### DIFF
--- a/daisy_workflows/e2e_tests/2008r2_vmware_translate.wf.json
+++ b/daisy_workflows/e2e_tests/2008r2_vmware_translate.wf.json
@@ -8,12 +8,21 @@
     "post_translate_test.ps1": "./scripts/post_translate_test.ps1"
   },
   "Steps": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "Name": "translate-me",
+          "SourceImage": "${source_image}",
+          "Type": "pd-ssd"
+        }
+      ]
+    },
     "translate-2008r2": {
       "Timeout": "30m",
       "IncludeWorkflow": {
         "Path": "../image_import/windows/translate_windows_2008_r2.wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "translate-me",
           "image_name": "${image_name}"
         }
       }
@@ -57,6 +66,7 @@
     }
   },
   "Dependencies": {
+    "translate-2008r2": ["create-disk-from-image"],
     "create-test-disk": ["translate-2008r2"],
     "delete-image": ["create-test-disk"],
     "create-test-instance": ["create-test-disk"],

--- a/daisy_workflows/e2e_tests/2012r2_vmware_translate.wf.json
+++ b/daisy_workflows/e2e_tests/2012r2_vmware_translate.wf.json
@@ -8,12 +8,21 @@
     "post_translate_test.ps1": "./scripts/post_translate_test.ps1"
   },
   "Steps": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "Name": "translate-me",
+          "SourceImage": "${source_image}",
+          "Type": "pd-ssd"
+        }
+      ]
+    },
     "translate-2012r2": {
       "Timeout": "30m",
       "IncludeWorkflow": {
         "Path": "../image_import/windows/translate_windows_2012_r2.wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "translate-me",
           "image_name": "${image_name}"
         }
       }
@@ -58,6 +67,7 @@
     }
   },
   "Dependencies": {
+    "translate-2012r2": ["create-disk-from-image"],
     "create-test-disk": ["translate-2012r2"],
     "delete-image": ["create-test-disk"],
     "create-test-instance": ["create-test-disk"],

--- a/daisy_workflows/e2e_tests/centos_6_qcow2_translate.wf.json
+++ b/daisy_workflows/e2e_tests/centos_6_qcow2_translate.wf.json
@@ -8,12 +8,20 @@
     "post_translate_test.sh": "./scripts/post_translate_test.sh"
   },
   "Steps": {
-    "translate-image": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "Name": "translate-me",
+          "SourceImage": "${source_image}"
+        }
+      ]
+    },
+    "translate-disk": {
       "Timeout": "30m",
       "IncludeWorkflow": {
         "Path": "../image_import/enterprise_linux/translate_centos_6.wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "translate-me",
           "image_name": "${image_name}"
         }
       }
@@ -58,7 +66,8 @@
     }
   },
   "Dependencies": {
-    "create-test-disk": ["translate-image"],
+    "translate-disk": ["create-disk-from-image"],
+    "create-test-disk": ["translate-disk"],
     "delete-image": ["create-test-disk"],
     "create-test-instance": ["create-test-disk"],
     "wait-for-test-instance": ["create-test-instance"]

--- a/daisy_workflows/e2e_tests/centos_7_qcow2_translate.wf.json
+++ b/daisy_workflows/e2e_tests/centos_7_qcow2_translate.wf.json
@@ -8,12 +8,20 @@
     "post_translate_test.sh": "./scripts/post_translate_test.sh"
   },
   "Steps": {
-    "translate-image": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "Name": "translate-me",
+          "SourceImage": "${source_image}"
+        }
+      ]
+    },
+    "translate-disk": {
       "Timeout": "30m",
       "IncludeWorkflow": {
         "Path": "../image_import/enterprise_linux/translate_centos_7.wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "translate-me",
           "image_name": "${image_name}"
         }
       }
@@ -58,7 +66,8 @@
     }
   },
   "Dependencies": {
-    "create-test-disk": ["translate-image"],
+    "translate-disk": ["create-disk-from-image"],
+    "create-test-disk": ["translate-disk"],
     "delete-image": ["create-test-disk"],
     "create-test-instance": ["create-test-disk"],
     "wait-for-test-instance": ["create-test-instance"]

--- a/daisy_workflows/e2e_tests/ubuntu_1404_img_translate.wf.json
+++ b/daisy_workflows/e2e_tests/ubuntu_1404_img_translate.wf.json
@@ -8,12 +8,20 @@
     "post_translate_test.sh": "./scripts/post_translate_test.sh"
   },
   "Steps": {
-    "translate-image": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "Name": "translate-me",
+          "SourceImage": "${source_image}"
+        }
+      ]
+    },
+    "translate-disk": {
       "Timeout": "30m",
       "IncludeWorkflow": {
         "Path": "../image_import/ubuntu/translate_ubuntu_1404.wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "translate-me",
           "image_name": "${image_name}"
         }
       }
@@ -58,7 +66,8 @@
     }
   },
   "Dependencies": {
-    "create-test-disk": ["translate-image"],
+    "translate-disk": ["create-disk-from-image"],
+    "create-test-disk": ["translate-disk"],
     "delete-image": ["create-test-disk"],
     "create-test-instance": ["create-test-disk"],
     "wait-for-test-instance": ["create-test-instance"]

--- a/daisy_workflows/e2e_tests/ubuntu_1604_vmware_translate.wf.json
+++ b/daisy_workflows/e2e_tests/ubuntu_1604_vmware_translate.wf.json
@@ -8,12 +8,20 @@
     "post_translate_test.sh": "./scripts/post_translate_test.sh"
   },
   "Steps": {
-    "translate-image": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "Name": "translate-me",
+          "SourceImage": "${source_image}"
+        }
+      ]
+    },
+    "translate-disk": {
       "Timeout": "30m",
       "IncludeWorkflow": {
         "Path": "../image_import/ubuntu/translate_ubuntu_1604.wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "translate-me",
           "image_name": "${image_name}"
         }
       }
@@ -58,7 +66,8 @@
     }
   },
   "Dependencies": {
-    "create-test-disk": ["translate-image"],
+    "translate-disk": ["create-disk-from-image"],
+    "create-test-disk": ["translate-disk"],
     "delete-image": ["create-test-disk"],
     "create-test-instance": ["create-test-disk"],
     "wait-for-test-instance": ["create-test-instance"]

--- a/daisy_workflows/image_import/debian/translate_debian_8.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_8.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-debian-8",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Debian 8 GCE image to translate."
+      "Description": "The Debian 8 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -15,22 +15,13 @@
     }
   },
   "Steps": {
-    "setup-disk": {
-      "CreateDisks": [
-        {
-          "Name": "disk-deb-8-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
-        }
-      ]
-    },
     "translate-disk": {
       "IncludeWorkflow": {
         "Path": "./translate_debian.wf.json",
         "Vars": {
           "debian_release": "jessie",
           "install_gce_packages": "${install_gce_packages}",
-          "imported_disk": "disk-deb-8-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -39,7 +30,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-deb-8-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
         }
@@ -47,7 +38,6 @@
     }
   },
   "Dependencies": {
-    "translate-disk": ["setup-disk"],
     "create-image": ["translate-disk"]
   }
 }

--- a/daisy_workflows/image_import/debian/translate_debian_9.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_9.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-debian-9",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Debian 9 GCE image to translate."
+      "Description": "The Debian 9 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -15,22 +15,13 @@
     }
   },
   "Steps": {
-    "setup-disk": {
-      "CreateDisks": [
-        {
-          "Name": "disk-deb-9-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
-        }
-      ]
-    },
     "translate-disk": {
       "IncludeWorkflow": {
         "Path": "./translate_debian.wf.json",
         "Vars": {
           "debian_release": "stretch",
           "install_gce_packages": "${install_gce_packages}",
-          "imported_disk": "disk-deb-9-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -39,7 +30,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-deb-9-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-centos-6",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The CentOS 6 GCE image to translate."
+      "Description": "The CentOS 6 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -22,11 +22,6 @@
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-centos-6-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -37,7 +32,7 @@
           "el_release": "6",
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
-          "imported_disk": "disk-centos-6-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -46,7 +41,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-centos-6-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
 

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "translate-centos-7",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
       "Description": "The CentOS 7 GCE image to translate."
     },
@@ -22,11 +22,6 @@
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-centos-7-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -37,7 +32,7 @@
           "el_release": "7",
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
-          "imported_disk": "disk-centos-7-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -46,7 +41,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-centos-7-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
 

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -1,9 +1,9 @@
-
+{
   "Name": "translate-rhel-6-byol",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The RHEL 6 GCE image to translate."
+      "Description": "The RHEL 6 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -22,11 +22,6 @@
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-rhel-6-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -37,7 +32,7 @@
           "el_release": "6",
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
-          "imported_disk": "disk-rhel-6-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -46,7 +41,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-rhel-6-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
 

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "translate-rhel-6-licensed",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
       "Description": "The RHEL 6 GCE image to translate."
     },
@@ -22,11 +22,6 @@
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-rhel-6-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -37,7 +32,7 @@
           "el_release": "6",
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
-          "imported_disk": "disk-rhel-6-import",
+          "imported_disk": "${source_disk}",
           "use_rhel_gce_license": "true"
         }
       },
@@ -47,7 +42,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-rhel-6-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
 

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-rhel-7-byol",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The RHEL 7 GCE image to translate."
+      "Description": "The RHEL 7 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -22,11 +22,6 @@
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-rhel-7-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -37,7 +32,7 @@
           "el_release": "7",
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
-          "imported_disk": "disk-rhel-7-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -46,7 +41,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-rhel-7-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
 

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-rhel-7-licensed",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The RHEL 7 GCE image to translate."
+      "Description": "The RHEL 7 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -22,11 +22,6 @@
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
           "SizeGb": "10",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-rhel-7-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -37,7 +32,7 @@
           "el_release": "7",
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
-          "imported_disk": "disk-rhel-7-import",
+          "imported_disk": "${source_disk}",
           "use_rhel_gce_license": "true"
         }
       },
@@ -47,7 +42,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-rhel-7-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
 

--- a/daisy_workflows/image_import/import_and_translate.wf.json
+++ b/daisy_workflows/image_import/import_and_translate.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "import-and-translate",
   "Vars": {
-    "source_disk_uri": {
+    "source_disk_file": {
       "Required": true,
       "Description": "The GCS path to the virtual disk to import."
     },
@@ -16,25 +16,39 @@
   },
   "Steps": {
     "import": {
-      "SubWorkflow": {
-        "Path": "import_image.wf.json",
+      "IncludeWorkflow": {
+        "Path": "import_disk.wf.json",
         "Vars": {
-          "source_disk_file": "${source_disk_uri}",
+          "source_disk_file": "${source_disk_file}",
+          "import_disk_name": "temp-translation-disk-${ID}"
+        }
+      }
+    },
+    "take-image-of-untranslated-disk": {
+      "CreateImages": [{
+        "Name": "${image_name}-untranslated",
+        "SourceDisk": "temp-translation-disk-${ID}"
+      }]
+    },
+    "translate": {
+      "IncludeWorkflow": {
+        "Path": "${translate_workflow}",
+        "Vars": {
+          "source_disk": "temp-translation-disk-${ID}",
           "image_name": "${image_name}"
         }
       }
     },
-    "translate": {
-      "SubWorkflow": {
-        "Path": "${translate_workflow}",
-        "Vars": {
-          "source_image": "global/images/${image_name}",
-          "image_name": "${image_name}"
-        }
+    "cleanup": {
+      "DeleteResources": {
+        "Disks": ["temp-translation-disk-${ID}"],
+        "Images": ["${image_name}-untranslated"]
       }
     }
   },
   "Dependencies": {
-    "translate": ["import"]
+    "take-image-of-untranslated-disk": ["import"],
+    "translate": ["take-image-of-untranslated-disk"],
+    "cleanup": ["translate"]
   }
 }

--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -1,0 +1,72 @@
+{
+  "Name": "import-disk",
+  "Vars": {
+    "source_disk_file": {
+      "Required": true,
+      "Description": "The GCS path to the virtual disk to import."
+    },
+    "importer_instance_disk_size": {
+      "Value": "10",
+      "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
+    },
+    "disk_name": "imported-disk-${ID}"
+  },
+  "Sources": {
+    "import_image.sh": "./import_image.sh",
+    "source_disk_file": "${source_disk_file}"
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-importer",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SizeGb": "${importer_instance_disk_size}",
+          "Type": "pd-ssd"
+        },
+        {
+          "Name": "${disk_name}",
+          "SizeGb": "10",
+          "Type": "pd-ssd",
+          "ExactName": true,
+          "NoCleanup": true
+        }
+      ]
+    },
+    "import-virtual-disk": {
+      "CreateInstances": [
+        {
+          "Name": "inst-importer",
+          "Disks": [{"Source": "disk-importer"}],
+          "MachineType": "n1-standard-4",
+          "Metadata": {
+            "disk_name": "${disk_name}"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write",
+            "https://www.googleapis.com/auth/compute"
+          ],
+          "StartupScript": "import_image.sh"
+        }
+      ]
+    },
+    "wait-for-signal": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-importer",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "ImportSuccess:",
+            "FailureMatch": "ImportFailed:",
+            "StatusMatch": "Import:"
+          }
+        }
+      ],
+      "Timeout": "60m"
+    }
+  },
+  "Dependencies": {
+    "import-virtual-disk": ["setup-disks"],
+    "wait-for-signal": ["import-virtual-disk"]
+  }
+}

--- a/daisy_workflows/image_import/import_image.wf.json
+++ b/daisy_workflows/image_import/import_image.wf.json
@@ -13,74 +13,37 @@
       "Value": "10",
       "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
     },
-    "import_disk_name": "disk-import-${ID}"
-  },
-  "Sources": {
-    "import_image.sh": "./import_image.sh",
-    "source_disk_file": "${source_disk_file}"
+    "import_disk_name": "disk-import"
   },
   "Steps": {
-    "setup-disks": {
-      "CreateDisks": [
-        {
-          "Name": "disk-importer",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
-          "SizeGb": "${importer_instance_disk_size}",
-          "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-import",
-          "SizeGb": "10",
-          "Type": "pd-ssd",
-          "RealName": "${import_disk_name}"
+    "import-disk": {
+      "IncludeWorkflow": {
+        "Path": "./import_disk.wf.json",
+        "Vars": {
+          "source_disk_file": "${source_disk_file}",
+          "importer_instance_disk_size": "${importer_instance_disk_size}",
+          "disk_name": "${import_disk_name}"
         }
-      ]
-    },
-    "import-virtual-disk": {
-      "CreateInstances": [
-        {
-          "Name": "inst-importer",
-          "Disks": [{"Source": "disk-importer"}],
-          "MachineType": "n1-standard-4",
-          "Metadata": {
-            "disk_name": "${import_disk_name}"
-          },
-          "Scopes": [
-            "https://www.googleapis.com/auth/devstorage.read_write",
-            "https://www.googleapis.com/auth/compute"
-          ],
-          "StartupScript": "import_image.sh"
-        }
-      ]
-    },
-    "wait-for-signal": {
-      "WaitForInstancesSignal": [
-        {
-          "Name": "inst-importer",
-          "SerialOutput": {
-            "Port": 1,
-            "SuccessMatch": "ImportSuccess:",
-            "FailureMatch": "ImportFailed:",
-            "StatusMatch": "Import:"
-          }
-        }
-      ],
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-import",
+          "SourceDisk": "${import_disk_name}",
           "ExactName": true,
           "NoCleanup": true
         }
       ]
+    },
+    "delete-disk": {
+      "DeleteResources": {
+        "Disks": ["${import_disk_name}"]
+      }
     }
   },
   "Dependencies": {
-    "import-virtual-disk": ["setup-disks"],
-    "wait-for-signal": ["import-virtual-disk"],
-    "create-image": ["wait-for-signal"]
+    "create-image": ["import-disk"],
+    "delete-disk": ["create-image"]
   }
 }

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-ubuntu-1404",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Ubuntu 14.04 GCE image to translate."
+      "Description": "The Ubuntu 14.04 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -15,22 +15,13 @@
     }
   },
   "Steps": {
-    "setup-disk": {
-      "CreateDisks": [
-        {
-          "Name": "disk-ubu-1404-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
-        }
-      ]
-    },
     "translate-disk": {
       "IncludeWorkflow": {
         "Path": "./translate_ubuntu.wf.json",
         "Vars": {
           "ubuntu_release": "trusty",
           "install_gce_packages": "${install_gce_packages}",
-          "imported_disk": "disk-ubu-1404-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -39,7 +30,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-ubu-1404-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
         }
@@ -47,7 +38,6 @@
     }
   },
   "Dependencies": {
-    "translate-disk": ["setup-disk"],
     "create-image": ["translate-disk"]
   }
 }

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-ubuntu-1604",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Ubuntu 16.04 GCE image to translate."
+      "Description": "The Ubuntu 16.04 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -15,22 +15,13 @@
     }
   },
   "Steps": {
-    "setup-disk": {
-      "CreateDisks": [
-        {
-          "Name": "disk-ubu-1604-import",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
-        }
-      ]
-    },
     "translate-disk": {
       "IncludeWorkflow": {
         "Path": "./translate_ubuntu.wf.json",
         "Vars": {
           "ubuntu_release": "xenial",
           "install_gce_packages": "${install_gce_packages}",
-          "imported_disk": "disk-ubu-1604-import"
+          "imported_disk": "${source_disk}"
         }
       },
       "Timeout": "60m"
@@ -39,7 +30,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "disk-ubu-1604-import",
+          "SourceDisk": "${source_disk}",
           "ExactName": true,
           "NoCleanup": true
         }
@@ -47,7 +38,6 @@
     }
   },
   "Dependencies": {
-    "translate-disk": ["setup-disk"],
     "create-image": ["translate-disk"]
   }
 }

--- a/daisy_workflows/image_import/windows/translate_windows_2008_r2.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2008_r2.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-windows-2008-r2",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Windows 2008R2 GCE image to translate."
+      "Description": "The Windows 2008R2 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -16,18 +16,16 @@
     "image_name": {
       "Value": "windows-server-2008-r2-${ID}",
       "Description": "The name of the translated Server 2016 image."
-    },
-    "disk_name": "disk-translate"
+    }
   },
   "Steps": {
-    "translate-image": {
+    "translate-disk": {
       "IncludeWorkflow": {
         "Path": "./translate_windows_wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "${source_disk}",
           "install_gce_packages": "${install_gce_packages}",
           "sysprep": "${sysprep}",
-          "imported_disk": "${disk_name}",
           "drivers": "gs://gce-windows-drivers-public/release/win6.1/",
           "version": "6.1",
           "task_reg": "./task_reg_2008r2",
@@ -40,7 +38,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "${disk_name}",
+          "SourceDisk": "${source_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-server-2008-r2-dc"],
           "GuestOsFeatures": [{"Type":"VIRTIO_SCSI_MULTIQUEUE"}, {"Type":"WINDOWS"}],
           "Family": "windows-2008-r2",
@@ -51,6 +49,6 @@
     }
   },
   "Dependencies": {
-    "create-image": ["translate-image"]
+    "create-image": ["translate-disk"]
   }
 }

--- a/daisy_workflows/image_import/windows/translate_windows_2012_r2.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_r2.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-windows-2012-r2",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Windows 2012R2 GCE image to translate."
+      "Description": "The Windows 2012R2 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -16,18 +16,16 @@
     "image_name": {
       "Value": "windows-server-2012-r2-${ID}",
       "Description": "The name of the translated Server 2016 image."
-    },
-    "disk_name": "disk-translate"
+    }
   },
   "Steps": {
     "translate-image": {
       "IncludeWorkflow": {
         "Path": "./translate_windows_wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "${source_disk}",
           "install_gce_packages": "${install_gce_packages}",
           "sysprep": "${sysprep}",
-          "imported_disk": "${disk_name}",
           "drivers": "gs://gce-windows-drivers-public/release/win6.3/",
           "version": "6.3",
           "task_reg": "./task_reg_2012r2",
@@ -40,7 +38,7 @@
       "CreateImages": [
         {
           "Name": "${image_name}",
-          "SourceDisk": "${disk_name}",
+          "SourceDisk": "${source_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"],
           "GuestOsFeatures": [{"Type":"VIRTIO_SCSI_MULTIQUEUE"}, {"Type":"WINDOWS"}],
           "Family": "windows-2012-r2",

--- a/daisy_workflows/image_import/windows/translate_windows_2016.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2016.wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-windows-2016",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "The Windows 2016 GCE image to translate."
+      "Description": "The Windows 2016 GCE disk to translate."
     },
     "install_gce_packages": {
       "Value": "true",
@@ -24,7 +24,7 @@
       "IncludeWorkflow": {
         "Path": "./translate_windows_wf.json",
         "Vars": {
-          "source_image": "${source_image}",
+          "source_disk": "${source_disk}",
           "install_gce_packages": "${install_gce_packages}",
           "sysprep": "${sysprep}",
           "imported_disk": "${disk_name}",

--- a/daisy_workflows/image_import/windows/translate_windows_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_wf.json
@@ -1,9 +1,9 @@
 {
   "Name": "translate-windows",
   "Vars": {
-    "source_image": {
+    "source_disk": {
       "Required": true,
-      "Description": "Image to translate"
+      "Description": "Disk to translate"
     },
     "install_gce_packages": {
       "Value": "true",
@@ -20,6 +20,12 @@
     "version": {
       "Required": true,
       "Description": "Windows OS Version to translate (https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx)"
+    },
+    "task_reg": {
+      "Required": true
+    },
+    "task_xml": {
+      "Required": true
     }
   },
   "Sources": {
@@ -37,11 +43,6 @@
           "Name": "disk-bootstrap",
           "SourceImage": "projects/windows-cloud/global/images/family/windows-2016-core",
           "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-translate",
-          "SourceImage": "${source_image}",
-          "Type": "pd-ssd"
         }
       ]
     },
@@ -51,7 +52,7 @@
           "Name": "inst-bootstrap",
           "Disks": [
             {"Source": "disk-bootstrap"},
-            {"Source": "disk-translate"}
+            {"Source": "${source_disk}"}
           ],
           "MachineType": "n1-standard-2",
           "Metadata": {
@@ -87,7 +88,7 @@
         {
           "Name": "inst-translate",
           "Disks": [
-            {"Source": "disk-translate"}
+            {"Source": "${source_disk}"}
           ],
           "MachineType": "n1-standard-2",
           "Metadata": {


### PR DESCRIPTION
…to save on the number of copies of a disk we need to make to do translation.