### PR TITLE
fix Debian 9 translation workflow

### DIFF
--- a/daisy_workflows/image_import/debian/translate_debian_9.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_9.wf.json
@@ -38,7 +38,6 @@
     }
   },
   "Dependencies": {
-    "translate-disk": ["setup-disk"],
     "create-image": ["translate-disk"]
   }
 }


### PR DESCRIPTION
```
[Daisy] Errors in one or more workflows:

  import-and-translate: step "translate" validation error: Dependencies reference non existent step "setup-disk": "translate-disk":["setup-disk"]
```
I missed something when I re-did all the workflows last week.