### PR TITLE
Add import from image workflow

### DIFF
--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -19,10 +19,9 @@
     "create-disk": {
       "CreateDisks": [{
         "Name": "${disk_name}",
-        "SizeGb": "10",
         "Type": "pd-ssd",
         "ExactName": true,
-        "NoCleanup": true
+        "SourceImage": "${source_image}"
       }]
     },
     "translate-disk": {
@@ -34,15 +33,9 @@
         }
       },
       "Timeout": "1h"
-    },
-    "cleanup": {
-      "DeleteResources": {
-        "Disks": ["${disk_name}"]
-      }
     }
   },
   "Dependencies": {
-    "translate-disk": ["create-disk"],
-    "cleanup": ["translate-disk"]
+    "translate-disk": ["create-disk"]
   }
 }

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -1,0 +1,48 @@
+{
+  "Name": "import-from-image",
+  "Vars": {
+    "source_image": {
+      "Required": true,
+      "Description": "The GCE image to translate."
+    },
+    "image_name": {
+      "Required": true,
+      "Description": "The name of the imported image."
+    },
+    "translate_workflow": {
+      "Required": true,
+      "Description": "The path to the translation workflow to run."
+    },
+    "disk_name": "imported-disk-${ID}"
+  },
+  "Steps": {
+    "create-disk": {
+      "CreateDisks": [{
+        "Name": "${disk_name}",
+        "SizeGb": "10",
+        "Type": "pd-ssd",
+        "ExactName": true,
+        "NoCleanup": true
+      }]
+    },
+    "translate-disk": {
+      "IncludeWorkflow": {
+        "Path": "${translate_workflow}",
+        "Vars": {
+          "source_disk": "${disk_name}",
+          "image_name": "${image_name}"
+        }
+      },
+      "Timeout": "1h"
+    },
+    "cleanup": {
+      "DeleteResources": {
+        "Disks": ["${disk_name}"]
+      }
+    }
+  },
+  "Dependencies": {
+    "translate-disk": ["create-disk"],
+    "cleanup": ["translate-disk"]
+  }
+}

--- a/docs/daisy-workflow-config-spec.md
+++ b/docs/daisy-workflow-config-spec.md
@@ -641,7 +641,7 @@ or configuration into instance metadata.
   "Sources": {
     "my_source.sh": "./path/to/my/source.sh"
   },
-  "Steps":  
+  "Steps":
     "step1": {
       "CreateInstances": [
         {
@@ -653,3 +653,4 @@ or configuration into instance metadata.
     }
   }
 }
+```


### PR DESCRIPTION
After redoing all our image_import workflows, all the translation workflows now take a disk rather than an image as a starting point. This breaks image-from-image translation. This workflow acts as a wrapper to enable that behaviour again.