### PR TITLE
Add basic Cloud Logging support.

### DIFF
--- a/cli_tools/daisy/main_test.go
+++ b/cli_tools/daisy/main_test.go
@@ -79,18 +79,21 @@ func TestParseWorkflows(t *testing.T) {
 	zone := "zone"
 	gcsPath := "gcspath"
 	oauth := "oauthpath"
-	w, err := parseWorkflow(context.Background(), path, varMap, project, zone, gcsPath, oauth, "")
+	gcsLogging := false
+	stdoutLogging := false
+	w, err := parseWorkflow(context.Background(), path, varMap, project, zone, gcsPath, oauth, "", gcsLogging, stdoutLogging)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
-		want, got string
+		want, got interface{}
 	}{
 		{w.Project, project},
 		{w.Zone, zone},
 		{w.GCSPath, gcsPath},
-		{w.OAuthPath, oauth},
+		{w.GcsLogging, gcsLogging},
+		{w.StdoutLogging, stdoutLogging},
 	}
 
 	for _, tt := range tests {

--- a/daisy/logger.go
+++ b/daisy/logger.go
@@ -1,0 +1,188 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"path"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/logging"
+	"cloud.google.com/go/storage"
+)
+
+// Logger is a helper that encapsulates the logging logic for Daisy.
+type Logger interface {
+	StepInfo(w *Workflow, stepName string, format string, a ...interface{})
+	WorkflowInfo(w *Workflow, format string, a ...interface{})
+	FlushAll()
+}
+
+type logger struct {
+	gcsLogWriter  *syncedWriter
+	cloudLogger   *logging.Logger
+	stdoutLogging bool
+}
+
+// CreateLogger builds a Logger.
+func CreateLogger(ctx context.Context, w *Workflow, cloudLogging bool, gcsLogging bool, stdoutLogging bool) *logger {
+
+	logger := &logger{
+		stdoutLogging: stdoutLogging,
+	}
+
+	if cloudLogging && w.cloudLoggingClient != nil {
+		cloudLogName := fmt.Sprintf("daisy-workflow-%s", w.id)
+		logger.cloudLogger = w.cloudLoggingClient.Logger(cloudLogName)
+		periodicFlush(func() { logger.cloudLogger.Flush() })
+	}
+
+	// Use GCS if unable to use Cloud Logging.
+	gcsLogging = gcsLogging || w.cloudLoggingClient == nil
+
+	if gcsLogging {
+		logger.gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&gcsLogger{client: w.StorageClient, bucket: w.bucket, object: path.Join(w.logsPath, "daisy.log"), ctx: ctx})}
+		periodicFlush(func() { logger.gcsLogWriter.Flush() })
+	}
+
+	return logger
+}
+
+// StepInfo logs information for the workflow step.
+func (l *logger) StepInfo(w *Workflow, stepName string, format string, a ...interface{}) {
+	entry := &logEntry{
+		LocalTimestamp: time.Now(),
+		WorkflowName:   getAbsoluteName(w),
+		StepName:       stepName,
+		Message:        fmt.Sprintf(format, a...),
+	}
+	l.writeLogEntry(entry)
+}
+
+// WorkflowInfo logs information for the workflow.
+func (l *logger) WorkflowInfo(w *Workflow, format string, a ...interface{}) {
+	entry := &logEntry{
+		LocalTimestamp: time.Now(),
+		WorkflowName:   getAbsoluteName(w),
+		Message:        fmt.Sprintf(format, a...),
+	}
+	l.writeLogEntry(entry)
+}
+
+// FlushAll flushes all loggers.
+func (l *logger) FlushAll() {
+	if l.gcsLogWriter != nil {
+		l.gcsLogWriter.Flush()
+	}
+
+	if l.cloudLogger != nil {
+		l.cloudLogger.Flush()
+	}
+}
+
+type logEntry struct {
+	LocalTimestamp time.Time `json:"localTimestamp"`
+	WorkflowName   string    `json:"workflow"`
+	StepName       string    `json:"step,omitempty"`
+	Message        string    `json:"message"`
+}
+
+func (l *logger) writeLogEntry(e *logEntry) {
+	if l.cloudLogger != nil {
+		l.cloudLogger.Log(logging.Entry{Payload: e})
+	}
+
+	if l.gcsLogWriter != nil {
+		l.gcsLogWriter.Write([]byte(e.String()))
+	}
+
+	if l.stdoutLogging {
+		fmt.Print(e)
+	}
+}
+
+type syncedWriter struct {
+	buf *bufio.Writer
+	mx  sync.Mutex
+}
+
+func (l *syncedWriter) Write(b []byte) (int, error) {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+	return l.buf.Write(b)
+}
+
+func (l *syncedWriter) Flush() error {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+	return l.buf.Flush()
+}
+
+type gcsLogger struct {
+	client         *storage.Client
+	bucket, object string
+	buf            *bytes.Buffer
+	ctx            context.Context
+}
+
+func (l *gcsLogger) Write(b []byte) (int, error) {
+	if l.buf == nil {
+		l.buf = new(bytes.Buffer)
+	}
+	l.buf.Write(b)
+	wc := l.client.Bucket(l.bucket).Object(l.object).NewWriter(l.ctx)
+	wc.ContentType = "text/plain"
+	n, err := wc.Write(l.buf.Bytes())
+	if err != nil {
+		return 0, err
+	}
+	if err := wc.Close(); err != nil {
+		return 0, err
+	}
+	return n, err
+}
+
+func periodicFlush(f func()) {
+	go func() {
+		for {
+			time.Sleep(5 * time.Second)
+			f()
+		}
+	}()
+}
+
+func getAbsoluteName(w *Workflow) string {
+	name := w.Name
+	for parent := w.parent; parent != nil; parent = parent.parent {
+		name = parent.Name + "." + name
+	}
+	return name
+}
+
+func (e *logEntry) String() string {
+	var msg string
+	if e.StepName != "" {
+		msg = fmt.Sprintf("%s: %s", e.StepName, e.Message)
+	} else {
+		msg = e.Message
+	}
+
+	timestamp := e.LocalTimestamp.Format("2006/01/02 15:04:05 MST")
+	return fmt.Sprintf("[%s]: %s %s\n", e.WorkflowName, timestamp, msg)
+}

--- a/daisy/logger_test.go
+++ b/daisy/logger_test.go
@@ -1,0 +1,146 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/logging"
+)
+
+type MockLogger struct {
+	entries []*logEntry
+}
+
+// StepInfo logs information for the workflow step.
+func (l *MockLogger) StepInfo(w *Workflow, stepName string, format string, a ...interface{}) {
+	entry := &logEntry{
+		LocalTimestamp: time.Now(),
+		WorkflowName:   getAbsoluteName(w),
+		StepName:       stepName,
+		Message:        fmt.Sprintf(format, a...),
+	}
+	l.entries = append(l.entries, entry)
+}
+
+// WorkflowInfo logs information for the workflow.
+func (l *MockLogger) WorkflowInfo(w *Workflow, format string, a ...interface{}) {
+	entry := &logEntry{
+		LocalTimestamp: time.Now(),
+		WorkflowName:   getAbsoluteName(w),
+		Message:        fmt.Sprintf(format, a...),
+	}
+	l.entries = append(l.entries, entry)
+}
+
+// FlushAll flushes all loggers.
+func (l *MockLogger) FlushAll() {
+	// nop
+}
+
+func TestCreateLogger(t *testing.T) {
+	ctx := context.Background()
+	prj := "test-project"
+
+	workflowWithoutCloudLoggingClient := New()
+	workflowWithCloudLoggingClient := New()
+	c, err := logging.NewClient(ctx, prj)
+	if err != nil {
+		t.Errorf("Unabled to create test logging client.")
+	}
+	workflowWithCloudLoggingClient.cloudLoggingClient = c
+
+	tests := []struct {
+		w *Workflow
+		cloudLogging, gcsLogging, stdout,
+		wantCloudLogging, wantGcsLogging, wantStdout bool
+	}{
+		{
+			workflowWithCloudLoggingClient,
+			false, false, false,
+			false, false, false,
+		},
+		{
+			workflowWithCloudLoggingClient,
+			true, true, true,
+			true, true, true,
+		},
+		{
+			workflowWithoutCloudLoggingClient,
+			true, false, true,
+			false, true, true,
+		},
+	}
+
+	for _, tt := range tests {
+		logger := CreateLogger(ctx, tt.w, tt.cloudLogging, tt.gcsLogging, tt.stdout)
+
+		if (logger.cloudLogger == nil) == tt.wantCloudLogging {
+			t.Errorf("Wanted cloud logger (%t), got %t", tt.wantCloudLogging, logger.cloudLogger == nil)
+		}
+		if (logger.gcsLogWriter == nil) == tt.wantGcsLogging {
+			t.Errorf("Wanted gcs logger (%t), got %t", tt.wantGcsLogging, logger.gcsLogWriter == nil)
+		}
+		if logger.stdoutLogging != tt.wantStdout {
+			t.Errorf("Wanted serial logging (%t), got %t", tt.wantStdout, logger.stdoutLogging)
+		}
+	}
+}
+
+func TestWriteWorkflowInfo(t *testing.T) {
+
+	w := New()
+	w.Name = "Test"
+	logger := CreateLogger(context.Background(), w, false, false, false)
+
+	var b bytes.Buffer
+	logger.gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&b)}
+
+	logger.WorkflowInfo(w, "test %s", "a")
+	logger.gcsLogWriter.Flush()
+
+	got := b.String()
+	want := "\\[Test\\]: \\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2} [A-Z]{1,3} test a"
+	match, _ := regexp.MatchString(want, got)
+	if !match {
+		t.Errorf("Wanted to match %s, got %s", want, got)
+	}
+}
+
+func TestWriteStepInfo(t *testing.T) {
+
+	w := New()
+	w.Name = "Test"
+	logger := CreateLogger(context.Background(), w, false, false, false)
+
+	var b bytes.Buffer
+	logger.gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&b)}
+
+	logger.StepInfo(w, "StepName", "test %s", "a")
+	logger.FlushAll()
+
+	got := b.String()
+	want := "\\[Test\\]: \\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2} [A-Z]{1,3} StepName: test a"
+	match, _ := regexp.MatchString(want, got)
+	if !match {
+		t.Errorf("Wanted to match %s, got %s", want, got)
+	}
+}

--- a/daisy/sources_test.go
+++ b/daisy/sources_test.go
@@ -17,7 +17,6 @@ package daisy
 import (
 	"context"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -41,7 +40,7 @@ func TestUploadSources(t *testing.T) {
 	w := testWorkflow()
 	sw := w.NewSubWorkflow()
 	sw.Name = "test-sw"
-	sw.Logger = log.New(ioutil.Discard, "", 0)
+	sw.Logger = &MockLogger{}
 	w.Steps = map[string]*Step{
 		"sub": {w: w, SubWorkflow: &SubWorkflow{Workflow: sw}},
 	}

--- a/daisy/step.go
+++ b/daisy/step.go
@@ -194,7 +194,7 @@ func (s *Step) getChain() []*Step {
 }
 
 func (s *Step) populate(ctx context.Context) dErr {
-	s.w.Logger.Printf("Populating step %q", s.name)
+	s.w.Logger.WorkflowInfo(s.w, "Populating step %q", s.name)
 	impl, err := s.stepImpl()
 	if err != nil {
 		return s.wrapPopulateError(err)
@@ -216,20 +216,20 @@ func (s *Step) run(ctx context.Context) dErr {
 	} else {
 		st = t.Name()
 	}
-	s.w.Logger.Printf("Running step %q (%s)", s.name, st)
+	s.w.Logger.WorkflowInfo(s.w, "Running step %q (%s)", s.name, st)
 	if err = impl.run(ctx, s); err != nil {
 		return s.wrapRunError(err)
 	}
 	select {
 	case <-s.w.Cancel:
 	default:
-		s.w.Logger.Printf("Step %q (%s) successfully finished.", s.name, st)
+		s.w.Logger.WorkflowInfo(s.w, "Step %q (%s) successfully finished.", s.name, st)
 	}
 	return nil
 }
 
 func (s *Step) validate(ctx context.Context) dErr {
-	s.w.Logger.Printf("Validating step %q", s.name)
+	s.w.Logger.WorkflowInfo(s.w, "Validating step %q", s.name)
 	if !rfc1035Rgx.MatchString(strings.ToLower(s.name)) {
 		return s.wrapValidateError(errf("step name must start with a letter and only contain letters, numbers, and hyphens"))
 	}

--- a/daisy/step_attach_disks.go
+++ b/daisy/step_attach_disks.go
@@ -16,7 +16,6 @@ package daisy
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"sync"
 
@@ -52,7 +51,6 @@ func (a *AttachDisks) populate(ctx context.Context, s *Step) dErr {
 func (a *AttachDisks) validate(ctx context.Context, s *Step) (errs dErr) {
 	for _, ad := range *a {
 		if !checkDiskMode(ad.Mode) {
-			fmt.Println("adding err")
 			errs = addErrs(errs, errf("cannot attach disk: bad disk mode: %q", ad.Mode))
 		}
 		if ad.Source == "" {
@@ -112,7 +110,7 @@ func (a *AttachDisks) run(ctx context.Context, s *Step) dErr {
 				ad.Instance = instRes.RealName
 			}
 
-			w.Logger.Printf("AttachDisks: attaching disk %q to instance %q.", ad.AttachedDisk.Source, inst)
+			w.Logger.StepInfo(s.w, "AttachDisks", "attaching disk %q to instance %q.", ad.AttachedDisk.Source, inst)
 			if err := w.ComputeClient.AttachDisk(ad.project, ad.zone, ad.Instance, &ad.AttachedDisk); err != nil {
 				e <- newErr(err)
 				return

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -53,7 +53,7 @@ func (c *CreateDisks) run(ctx context.Context, s *Step) dErr {
 				cd.SourceImage = image.link
 			}
 
-			w.Logger.Printf("CreateDisks: creating disk %q.", cd.Name)
+			w.Logger.StepInfo(s.w, "CreateDisks", "creating disk %q.", cd.Name)
 			if err := w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk); err != nil {
 				e <- newErr(err)
 				return

--- a/daisy/step_create_images.go
+++ b/daisy/step_create_images.go
@@ -67,7 +67,7 @@ func (c *CreateImages) run(ctx context.Context, s *Step) dErr {
 				}
 			}
 
-			w.Logger.Printf("CreateImages: creating image %q.", ci.Name)
+			w.Logger.StepInfo(s.w, "CreateImages", "creating image %q.", ci.Name)
 			if err := w.ComputeClient.CreateImage(ci.Project, &ci.Image); err != nil {
 				e <- newErr(err)
 				return

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -30,7 +30,7 @@ type CreateInstances []*Instance
 
 func logSerialOutput(ctx context.Context, w *Workflow, name string, port int64, interval time.Duration) {
 	logsObj := path.Join(w.logsPath, fmt.Sprintf("%s-serial-port%d.log", name, port))
-	w.Logger.Printf("CreateInstances: streaming instance %q serial port %d output to gs://%s/%s", name, port, w.bucket, logsObj)
+	w.Logger.StepInfo(w, "CreateInstances", "streaming instance %q serial port %d output to gs://%s/%s", name, port, w.bucket, logsObj)
 	var start int64
 	var buf bytes.Buffer
 	var errs int
@@ -51,7 +51,7 @@ func logSerialOutput(ctx context.Context, w *Workflow, name string, port int64, 
 				if stopped && sErr == nil {
 					return
 				}
-				w.Logger.Printf("CreateInstances: instance %q: error getting serial port: %v", name, err)
+				w.Logger.StepInfo(w, "CreateInstances", "instance %q: error getting serial port: %v", name, err)
 				return
 			}
 			start = resp.Next
@@ -59,7 +59,7 @@ func logSerialOutput(ctx context.Context, w *Workflow, name string, port int64, 
 			wc := w.StorageClient.Bucket(w.bucket).Object(logsObj).NewWriter(ctx)
 			wc.ContentType = "text/plain"
 			if _, err := wc.Write(buf.Bytes()); err != nil {
-				w.Logger.Printf("CreateInstances: instance %q: error writing log to GCS: %v", name, err)
+				w.Logger.StepInfo(w, "CreateInstances", "instance %q: error writing log to GCS: %v", name, err)
 				return
 			}
 			if err := wc.Close(); err != nil {
@@ -67,7 +67,7 @@ func logSerialOutput(ctx context.Context, w *Workflow, name string, port int64, 
 					errs++
 					continue
 				}
-				w.Logger.Printf("CreateInstances: instance %q: error saving log to GCS: %v", name, err)
+				w.Logger.StepInfo(w, "CreateInstances", "instance %q: error saving log to GCS: %v", name, err)
 				return
 			}
 			errs = 0
@@ -115,7 +115,7 @@ func (c *CreateInstances) run(ctx context.Context, s *Step) dErr {
 				}
 			}
 
-			w.Logger.Printf("CreateInstances: creating instance %q.", i.Name)
+			w.Logger.StepInfo(w, "CreateInstances", "creating instance %q.", i.Name)
 			if err := w.ComputeClient.CreateInstance(i.Project, i.Zone, &i.Instance); err != nil {
 				eChan <- newErr(err)
 				return

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -85,16 +85,17 @@ func TestLogSerialOutput(t *testing.T) {
 		mockLogger := &MockLogger{}
 		w.Logger = mockLogger
 		logSerialOutput(ctx, w, tt.name, 0, 1*time.Microsecond)
-		gotStep := mockLogger.entries[0].StepName
+		logEntries := mockLogger.GetEntries()
+		gotStep := logEntries[0].StepName
 		if gotStep != tt.wantStep {
 			t.Errorf("%s: got: %q, want: %q", tt.test, gotStep, tt.wantStep)
 		}
-		gotMessage := mockLogger.entries[0].Message
+		gotMessage := logEntries[0].Message
 		if gotMessage != tt.wantMessage1 {
 			t.Errorf("%s: got: %q, want: %q", tt.test, gotMessage, tt.wantMessage1)
 		}
 		if tt.wantMessage2 != "" {
-			gotMessage := mockLogger.entries[1].Message
+			gotMessage := logEntries[1].Message
 			if gotMessage != tt.wantMessage2 {
 				t.Errorf("%s: got: %q, want: %q", tt.test, gotMessage, tt.wantMessage2)
 			}

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -15,10 +15,8 @@
 package daisy
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"log"
 	"testing"
 	"time"
 
@@ -50,39 +48,56 @@ func TestLogSerialOutput(t *testing.T) {
 
 	w.bucket = "test-bucket"
 
-	var buf bytes.Buffer
-	w.Logger = log.New(&buf, "", 0)
-
 	tests := []struct {
-		test, want, name string
+		test, wantStep, wantMessage1, wantMessage2, name string
 	}{
 		{
 			"Error but instance stopped",
-			"CreateInstances: streaming instance \"i1\" serial port 0 output to gs://test-bucket/i1-serial-port0.log\n",
+			"CreateInstances",
+			"streaming instance \"i1\" serial port 0 output to gs://test-bucket/i1-serial-port0.log",
+			"",
 			"i1",
 		},
 		{
 			"Error but instance running",
-			"CreateInstances: streaming instance \"i2\" serial port 0 output to gs://test-bucket/i2-serial-port0.log\nCreateInstances: instance \"i2\": error getting serial port: fail\n",
+			"CreateInstances",
+			"streaming instance \"i2\" serial port 0 output to gs://test-bucket/i2-serial-port0.log",
+			"instance \"i2\": error getting serial port: fail",
 			"i2",
 		},
 		{
 			"Normal flow",
-			"CreateInstances: streaming instance \"i3\" serial port 0 output to gs://test-bucket/i3-serial-port0.log\n",
+			"CreateInstances",
+			"streaming instance \"i3\" serial port 0 output to gs://test-bucket/i3-serial-port0.log",
+			"",
 			"i3",
 		},
 		{
 			"Error but instance deleted",
-			"CreateInstances: streaming instance \"i4\" serial port 0 output to gs://test-bucket/i4-serial-port0.log\n",
+			"CreateInstances",
+			"streaming instance \"i4\" serial port 0 output to gs://test-bucket/i4-serial-port0.log",
+			"",
 			"i4",
 		},
 	}
 
 	for _, tt := range tests {
-		buf.Reset()
+		mockLogger := &MockLogger{}
+		w.Logger = mockLogger
 		logSerialOutput(ctx, w, tt.name, 0, 1*time.Microsecond)
-		if buf.String() != tt.want {
-			t.Errorf("%s: got: %q, want: %q", tt.test, buf.String(), tt.want)
+		gotStep := mockLogger.entries[0].StepName
+		if gotStep != tt.wantStep {
+			t.Errorf("%s: got: %q, want: %q", tt.test, gotStep, tt.wantStep)
+		}
+		gotMessage := mockLogger.entries[0].Message
+		if gotMessage != tt.wantMessage1 {
+			t.Errorf("%s: got: %q, want: %q", tt.test, gotMessage, tt.wantMessage1)
+		}
+		if tt.wantMessage2 != "" {
+			gotMessage := mockLogger.entries[1].Message
+			if gotMessage != tt.wantMessage2 {
+				t.Errorf("%s: got: %q, want: %q", tt.test, gotMessage, tt.wantMessage2)
+			}
 		}
 	}
 }

--- a/daisy/step_create_networks.go
+++ b/daisy/step_create_networks.go
@@ -47,7 +47,7 @@ func (c *CreateNetworks) run(ctx context.Context, s *Step) dErr {
 		go func(n *Network) {
 			defer wg.Done()
 
-			w.Logger.Printf("CreateNetworks: creating network %q.", n.Name)
+			w.Logger.StepInfo(w, "CreateNetworks", "creating network %q.", n.Name)
 			if err := w.ComputeClient.CreateNetwork(n.Project, &n.Network); err != nil {
 				e <- newErr(err)
 				return

--- a/daisy/step_deprecate_images.go
+++ b/daisy/step_deprecate_images.go
@@ -77,7 +77,7 @@ func (d *DeprecateImages) run(ctx context.Context, s *Step) dErr {
 		go func(di *DeprecateImage) {
 			defer wg.Done()
 
-			s.w.Logger.Printf("DeprecateImages: %q --> %q.", di.Image, di.DeprecationStatus.State)
+			w.Logger.StepInfo(w, "DeprecateImages", "%q --> %q.", di.Image, di.DeprecationStatus.State)
 			if err := w.ComputeClient.DeprecateImage(di.Project, di.Image, &di.DeprecationStatus); err != nil {
 				e <- newErr(err)
 			}

--- a/daisy/step_includeworkflow.go
+++ b/daisy/step_includeworkflow.go
@@ -44,22 +44,8 @@ func (i *IncludeWorkflow) populate(ctx context.Context, s *Step) dErr {
 		return errf("IncludeWorkflow %q does not have a workflow", s.name)
 	}
 
-	i.Workflow.id = s.w.id
-	i.Workflow.username = s.w.username
-	i.Workflow.ComputeClient = s.w.ComputeClient
-	i.Workflow.StorageClient = s.w.StorageClient
-	i.Workflow.GCSPath = s.w.GCSPath
+	s.w.copySettings(i.Workflow)
 	i.Workflow.Name = s.name
-	i.Workflow.Project = s.w.Project
-	i.Workflow.Zone = s.w.Zone
-	i.Workflow.autovars = s.w.autovars
-	i.Workflow.bucket = s.w.bucket
-	i.Workflow.scratchPath = s.w.scratchPath
-	i.Workflow.sourcesPath = s.w.sourcesPath
-	i.Workflow.logsPath = s.w.logsPath
-	i.Workflow.outsPath = s.w.outsPath
-	i.Workflow.gcsLogWriter = s.w.gcsLogWriter
-	i.Workflow.gcsLogging = s.w.gcsLogging
 
 	var errs dErr
 Loop:

--- a/daisy/step_includeworkflow_test.go
+++ b/daisy/step_includeworkflow_test.go
@@ -88,7 +88,6 @@ func TestIncludeWorkflowPopulate(t *testing.T) {
 		wf.Logger = nil
 		wf.cleanupHooks = nil
 		wf.parent = nil
-		wf.gcsLogWriter = nil
 		for _, s := range wf.Steps {
 			s.w = nil
 		}

--- a/daisy/step_sub_workflow.go
+++ b/daisy/step_sub_workflow.go
@@ -46,7 +46,7 @@ func (s *SubWorkflow) populate(ctx context.Context, st *Step) dErr {
 	s.Workflow.OAuthPath = s.Workflow.parent.OAuthPath
 	s.Workflow.ComputeClient = s.Workflow.parent.ComputeClient
 	s.Workflow.StorageClient = s.Workflow.parent.StorageClient
-	s.Workflow.gcsLogWriter = s.Workflow.parent.gcsLogWriter
+	s.Workflow.Logger = s.Workflow.parent.Logger
 
 	var errs dErr
 Loop:
@@ -81,9 +81,9 @@ func (s *SubWorkflow) run(ctx context.Context, st *Step) dErr {
 		return nil
 	})
 
-	st.w.Logger.Printf("Running subworkflow %q", s.Workflow.Name)
+	st.w.Logger.WorkflowInfo(st.w, "Running subworkflow %q", s.Workflow.Name)
 	if err := s.Workflow.run(ctx); err != nil {
-		s.Workflow.Logger.Printf("Error running subworkflow %q: %v", s.Workflow.Name, err)
+		s.Workflow.Logger.WorkflowInfo(s.Workflow, "Error running subworkflow %q: %v", s.Workflow.Name, err)
 		close(st.w.Cancel)
 		return err
 	}

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -57,7 +57,7 @@ type InstanceSignal struct {
 }
 
 func waitForInstanceStopped(w *Workflow, project, zone, name string, interval time.Duration) dErr {
-	w.Logger.Printf("WaitForInstancesSignal: waiting for instance %q to stop.", name)
+	w.Logger.StepInfo(w, "WaitForInstancesSignal", "waiting for instance %q to stop.", name)
 	tick := time.Tick(interval)
 	for {
 		select {
@@ -69,7 +69,7 @@ func waitForInstanceStopped(w *Workflow, project, zone, name string, interval ti
 				return typedErr(apiError, err)
 			}
 			if stopped {
-				w.Logger.Printf("WaitForInstancesSignal: instance %q stopped.", name)
+				w.Logger.StepInfo(w, "WaitForInstancesSignal", "instance %q stopped.", name)
 				return nil
 			}
 		}
@@ -87,7 +87,7 @@ func waitForSerialOutput(w *Workflow, project, zone, name string, so *SerialOutp
 	if so.StatusMatch != "" {
 		msg += fmt.Sprintf(", StatusMatch: %q", so.StatusMatch)
 	}
-	w.Logger.Print(msg + ".")
+	w.Logger.WorkflowInfo(w, msg+".")
 	var start int64
 	var errs int
 	tick := time.Tick(interval)
@@ -106,7 +106,7 @@ func waitForSerialOutput(w *Workflow, project, zone, name string, so *SerialOutp
 				}
 
 				if status == "TERMINATED" || status == "STOPPED" {
-					w.Logger.Printf("WaitForInstancesSignal: instance %q stopped, not waiting for serial output.", name)
+					w.Logger.StepInfo(w, "WaitForInstancesSignal", "instance %q stopped, not waiting for serial output.", name)
 					return nil
 				}
 				// Keep retrying until the instance is STOPPED.
@@ -125,7 +125,7 @@ func waitForSerialOutput(w *Workflow, project, zone, name string, so *SerialOutp
 			for _, ln := range strings.Split(resp.Contents, "\n") {
 				if so.StatusMatch != "" {
 					if i := strings.Index(ln, so.StatusMatch); i != -1 {
-						w.Logger.Printf("WaitForInstancesSignal: StatusMatch found for %q: %q", name, strings.TrimSpace(ln[i:]))
+						w.Logger.StepInfo(w, "WaitForInstancesSignal", "StatusMatch found for %q: %q", name, strings.TrimSpace(ln[i:]))
 					}
 				}
 				if so.FailureMatch != "" {
@@ -135,7 +135,7 @@ func waitForSerialOutput(w *Workflow, project, zone, name string, so *SerialOutp
 				}
 				if so.SuccessMatch != "" {
 					if i := strings.Index(ln, so.SuccessMatch); i != -1 {
-						w.Logger.Printf("WaitForInstancesSignal: SuccessMatch found for %q: %q", name, strings.TrimSpace(ln[i:]))
+						w.Logger.StepInfo(w, "WaitForInstancesSignal", "SuccessMatch found for %q: %q", name, strings.TrimSpace(ln[i:]))
 						return nil
 					}
 				}

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -99,7 +98,7 @@ func testWorkflow() *Workflow {
 	w.ComputeClient, _ = newTestGCEClient()
 	w.StorageClient, _ = newTestGCSClient()
 	w.Cancel = make(chan struct{})
-	w.Logger = log.New(ioutil.Discard, "", 0)
+	w.Logger = &MockLogger{}
 	return w
 }
 

--- a/daisy/validate_test.go
+++ b/daisy/validate_test.go
@@ -16,8 +16,6 @@ package daisy
 
 import (
 	"context"
-	"io/ioutil"
-	"log"
 	"reflect"
 	"sync"
 	"testing"
@@ -79,7 +77,7 @@ func TestValidateWorkflow(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 
-	logger := log.New(ioutil.Discard, "", 0)
+	logger := &MockLogger{}
 	// Bad test cases.
 	tests := []struct {
 		desc string

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -384,7 +383,7 @@ func TestPopulate(t *testing.T) {
 	got.Zone = "wf-zone"
 	got.Project = "bar-project"
 	got.OAuthPath = tf
-	got.Logger = log.New(ioutil.Discard, "", 0)
+	got.Logger = &MockLogger{}
 	got.Vars = map[string]Var{
 		"bucket":    {Value: "wf-bucket", Required: true},
 		"step_name": {Value: "step1"},
@@ -403,7 +402,7 @@ func TestPopulate(t *testing.T) {
 		},
 	}
 	got.StorageClient = client
-	got.gcsLogging = true
+	got.externalLogging = true
 
 	if err := got.populate(ctx); err != nil {
 		t.Fatalf("error populating workflow: %v", err)
@@ -426,7 +425,7 @@ func TestPopulate(t *testing.T) {
 	want.Zone = "wf-zone"
 	want.Project = "bar-project"
 	want.OAuthPath = tf
-	want.gcsLogging = true
+	want.externalLogging = true
 	want.Sources = map[string]string{}
 	want.Vars = map[string]Var{
 		"bucket":    {Value: "wf-bucket", Required: true},
@@ -631,6 +630,8 @@ func TestPrint(t *testing.T) {
     }
   },
   "Dependencies": {},
+  "GcsLogging": false,
+  "StdoutLogging": false,
   "ComputeEndpoint": ""
 }
 `


### PR DESCRIPTION
Add Cloud Logging support to daisy.

- Cloud Logging is the default.
    - Logs will go to GCS when specified by the flag or when CloudLogging
      is unavailable.
- Removes stdout logging unless specified by a flag.
  - This was undesirable when running via gcloud.
- Cloud logs are structured JSON logs.
 - Stdout and GCS logs are still strings for compatibility. However, the timestamp now contains timezone.


Cloud Logs example
![screenshot from 2018-04-19 12-09-15](https://user-images.githubusercontent.com/10036644/39012878-8c441392-43ca-11e8-968b-ca7c9be77090.png)
