### PR TITLE
Daisy Cloud Logging integration tests

### DIFF
--- a/daisy_workflows/e2e_tests/scripts/run_daisy_and_check_logs.sh
+++ b/daisy_workflows/e2e_tests/scripts/run_daisy_and_check_logs.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+URL="http://metadata/computeMetadata/v1/instance"
+BRANCH="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/github_branch)"
+GIT_REPO="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/github_repo)"
+INSTANCE_ID="$(curl -f -H Metadata-Flavor:Google ${URL}/id)"
+SHOULD_HAVE_LOGS="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/should_have_logs)"
+
+# Install build dependencies.
+apt-get update
+apt-get -y install git golang
+if [ $? -ne 0 ]; then
+  echo "BuildFailed: Unable to install build dependencies."
+  exit 1
+fi
+
+# Setup GOPATH
+mkdir -p go/src/github.com/GoogleCloudPlatform
+export GOPATH=$HOME/go
+
+# Clone the github repo.
+pushd $GOPATH/src/github.com/GoogleCloudPlatform
+git clone ${GIT_REPO} -b ${BRANCH}
+if [ $? -ne 0 ]; then
+  echo "BuildFailed: Unable to clone github repo ${GIT_REPO} and branch ${BRANCH}"
+  exit 1
+fi
+popd
+
+# Build daisy
+pushd $GOPATH/src/github.com/GoogleCloudPlatform/compute-image-tools/daisy
+go get ./...
+popd
+
+pushd $GOPATH/src/github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisy
+go build
+popd
+
+# Run daisy
+pushd $GOPATH/src/github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisy
+
+./daisy ../../daisy_workflows/e2e_tests/attach_disks.wf.json
+if [ $? -ne 0 ]; then
+  echo "BuildFailed: Error executing Daisy."
+  exit 1
+fi
+popd
+
+# Verify logs were sent to Cloud Logging
+LOGS=$(gcloud logging read "resource.labels.instance_id=$INSTANCE_ID jsonPayload.workflow=attach-disks-test")
+if [ $SHOULD_HAVE_LOGS = "true" ]; then
+  if [ -z "$LOGS" ]; then
+    echo "BuildFailed: Expected Cloud Logs."
+    exit 1
+  else
+    echo "Pass: Found expected Cloud Logs."
+  fi
+else
+  if [ -n "$LOGS" ]; then
+    echo "BuildFailed: Expected no Cloud Logs."
+    exit 1
+  else
+    echo "Pass: Cloud Logs were not written."
+  fi
+fi
+
+echo "BuildSuccess: Daisy completed."

--- a/daisy_workflows/e2e_tests/validate_cloud_logging.wf.json
+++ b/daisy_workflows/e2e_tests/validate_cloud_logging.wf.json
@@ -1,0 +1,99 @@
+{
+  "Name": "daisy-cloud-logs-test",
+  "Vars": {
+    "github_repo": {
+      "Value": "https://github.com/GoogleCloudPlatform/compute-image-tools.git",
+      "Description": "Github repo to build packages from."
+    },
+    "github_branch": {
+      "Value": "master",
+      "Description": "Github branch to build packages from."
+    }
+  },
+  "Sources": {
+    "run_daisy_and_check_logs.sh": "./scripts/run_daisy_and_check_logs.sh"
+  },
+  "Steps": {
+    "setup-disk": {
+      "CreateDisks": [
+        {
+          "Name": "disk1",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SizeGb": "10",
+          "Type": "pd-ssd"
+        },
+        {
+          "Name": "disk2",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SizeGb": "10",
+          "Type": "pd-ssd"
+        }
+      ]
+    },
+    "daisy-build-and-run": {
+      "CreateInstances": [
+        {
+          "Name": "inst-daisy-log-test-logs",
+          "Disks": [
+            {"Source": "disk1"}
+          ],
+          "MachineType": "n1-standard-2",
+          "Metadata": {
+            "github_branch": "${github_branch}",
+            "github_repo": "${github_repo}",
+            "should_have_logs": "true"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/logging.read",
+            "https://www.googleapis.com/auth/compute"
+          ],
+          "StartupScript": "run_daisy_and_check_logs.sh"
+        },
+        {
+          "Name": "inst-daisy-log-test-nologs",
+          "Disks": [
+            {"Source": "disk2"}
+          ],
+          "MachineType": "n1-standard-2",
+          "Metadata": {
+            "github_branch": "${github_branch}",
+            "github_repo": "${github_repo}",
+            "should_have_logs": "false"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write",
+            "https://www.googleapis.com/auth/logging.read",
+            "https://www.googleapis.com/auth/compute"
+          ],
+          "StartupScript": "run_daisy_and_check_logs.sh"
+        }
+      ]
+    },
+    "wait-for-build": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-daisy-log-test-logs",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "BuildSuccess:",
+            "FailureMatch": "BuildFailed:"
+          }
+        },
+        {
+          "Name": "inst-daisy-log-test-nologs",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "BuildSuccess:",
+            "FailureMatch": "BuildFailed:"
+          }
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "daisy-build-and-run": ["setup-disk"],
+    "wait-for-build": ["daisy-build-and-run"]
+  }
+}

--- a/test-infra/prowjobs/daisy-e2e/run/__main__.py
+++ b/test-infra/prowjobs/daisy-e2e/run/__main__.py
@@ -149,7 +149,12 @@ def run_subsuite(suite, wfs_tgz_name: str, res: result.Periodic) -> Tuple[int, L
 
 def run_wf(wf: str, wfs_tgz_name: str, res: result.Periodic) -> Tuple[int, Optional[str]]:
     """Runs a single workflow."""
-    args = OTHER_ARGS + ['-var:test-id=%s' % TEST_ID, wf]
+    args = OTHER_ARGS + ['-var:test-id=%s' % TEST_ID]
+    if REPO_URL:
+        args += ['-var:github_repo=%s' % REPO_URL]
+    if PULL_REFS:
+        args += ['-var:github_branch=%s' % PULL_REFS]
+    args += [wf]
     logging.info('Running test %s with args %s', wf, args)
 
     artifacts_path = common.urljoin(res.base_path, 'artifacts')

--- a/test-infra/prowjobs/daisy-e2e/run/__main__.py
+++ b/test-infra/prowjobs/daisy-e2e/run/__main__.py
@@ -149,12 +149,7 @@ def run_subsuite(suite, wfs_tgz_name: str, res: result.Periodic) -> Tuple[int, L
 
 def run_wf(wf: str, wfs_tgz_name: str, res: result.Periodic) -> Tuple[int, Optional[str]]:
     """Runs a single workflow."""
-    args = OTHER_ARGS + ['-var:test-id=%s' % TEST_ID]
-    if REPO_URL:
-        args += ['-var:github_repo=%s' % REPO_URL]
-    if PULL_REFS:
-        args += ['-var:github_branch=%s' % PULL_REFS]
-    args += [wf]
+    args = OTHER_ARGS + ['-var:test-id=%s' % TEST_ID, wf]
     logging.info('Running test %s with args %s', wf, args)
 
     artifacts_path = common.urljoin(res.base_path, 'artifacts')


### PR DESCRIPTION
These tests are a new workflow tat checks that logs work when enabled and don't when there is no permission.

The tests work by creating instances with a startup script. The startup script downloads Daisy from Github, compiles it, and executes against `attach_disks.wf.json` which is a simple workflow. One instance service account has logWrite permission and the other does not.

Prow test execution includes Github repo args for the PR to include in the WF so the WF tests the version of Daisy in the PR and not the version in `master`