### PR TITLE
Fix bug in sending serial logs to Cloud and refactor

### DIFF
--- a/daisy/logger_test.go
+++ b/daisy/logger_test.go
@@ -130,7 +130,7 @@ func (cl *MockCloudLogWriter) Flush() error {
 func TestSendSerialPortLogsToCloud(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.createLogger(context.Background())
+	w.Logger = &daisyLog{}
 	cl := &MockCloudLogWriter{}
 	w.Logger.(*daisyLog).cloudLogger = cl
 	var buf bytes.Buffer
@@ -148,8 +148,7 @@ func TestSendSerialPortLogsToCloud(t *testing.T) {
 func TestSendSerialPortLogsToCloudDisabled(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.createLogger(context.Background())
-	w.Logger.(*daisyLog).cloudLogger = nil
+	w.Logger = &daisyLog{}
 	var buf bytes.Buffer
 	buf.WriteString("Serial output\n")
 

--- a/daisy/logger_test.go
+++ b/daisy/logger_test.go
@@ -17,7 +17,6 @@ package daisy
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"regexp"
 	"sync"
@@ -74,7 +73,7 @@ func (l *MockLogger) getEntries() []*logEntry {
 func TestWriteWorkflowInfo(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.createLogger(context.Background())
+	w.Logger = &daisyLog{}
 
 	var b bytes.Buffer
 	w.Logger.(*daisyLog).gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&b)}
@@ -96,7 +95,7 @@ func TestWriteWorkflowInfo(t *testing.T) {
 func TestWriteStepInfo(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.createLogger(context.Background())
+	w.Logger = &daisyLog{}
 
 	var b bytes.Buffer
 	w.Logger.(*daisyLog).gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&b)}

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -79,7 +79,7 @@ Loop:
 	// Type assertion check is needed for tests not to panic.
 	// Split if output is too long for log entry (100K max, we leave a 2K buffer).
 	dl, ok := w.Logger.(*daisyLog)
-	if ok {
+	if ok && !w.cloudLoggingDisabled {
 		ss := strings.SplitAfter(buf.String(), "\n")
 		var str string
 		cl := func(str string) {

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -19,11 +19,8 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"strings"
 	"sync"
 	"time"
-
-	"cloud.google.com/go/logging"
 )
 
 // CreateInstances is a Daisy CreateInstances workflow step.
@@ -75,34 +72,7 @@ Loop:
 		}
 	}
 
-	// Write the output to cloud logging only after instance has stopped.
-	// Type assertion check is needed for tests not to panic.
-	// Split if output is too long for log entry (100K max, we leave a 2K buffer).
-	dl, ok := w.Logger.(*daisyLog)
-	if ok && !w.cloudLoggingDisabled {
-		ss := strings.SplitAfter(buf.String(), "\n")
-		var str string
-		cl := func(str string) {
-			dl.cloudLogger.Log(logging.Entry{
-				Payload: map[string]string{
-					"localTimestamp": time.Now().String(),
-					"workflowName":   getAbsoluteName(w),
-					"message":        fmt.Sprintf("Serial port output for instance %q", name),
-					"serialPort1":    str,
-					"type":           "Daisy",
-				},
-			})
-		}
-		for _, s := range ss {
-			if len(str)+len(s) > 98*1024 {
-				cl(str)
-				str = s
-			} else {
-				str += s
-			}
-		}
-		cl(str)
-	}
+	w.Logger.SendSerialPortLogsToCloud(w, name, buf)
 }
 
 // populate preprocesses fields: Name, Project, Zone, Description, MachineType, NetworkInterfaces, Scopes, ServiceAccounts, and daisyName.


### PR DESCRIPTION
- Fixes bug where we would try to send serial logs to the cloud when cloud logging is disabled (985dd16)
- Refactor to move serial logging logic into logger and add basic sanity tests (395b1dc).
