### PR TITLE
image_test: remove SizeGb from workflows

### DIFF
--- a/daisy_workflows/image_test/boot/boot.wf.json
+++ b/daisy_workflows/image_test/boot/boot.wf.json
@@ -13,7 +13,6 @@
         {
           "Name": "disk-test-img",
           "SourceImage": "${source_image}",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]

--- a/daisy_workflows/image_test/metadata-ssh/metadata-ssh.wf.json
+++ b/daisy_workflows/image_test/metadata-ssh/metadata-ssh.wf.json
@@ -14,7 +14,6 @@
         {
           "Name": "disk-tester",
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]
@@ -24,7 +23,6 @@
         {
           "Name": "disk-testee",
           "SourceImage": "${source_image}",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]

--- a/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh.wf.json
+++ b/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh.wf.json
@@ -26,7 +26,6 @@
         {
           "Name": "disk-master-tester",
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]
@@ -36,7 +35,6 @@
         {
           "Name": "disk-oslogin-ssh-tester",
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]
@@ -46,7 +44,6 @@
         {
           "Name": "disk-osadminlogin-ssh-tester",
           "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]
@@ -56,7 +53,6 @@
         {
           "Name": "disk-testee",
           "SourceImage": "${source_image}",
-          "SizeGb": "10",
           "Type": "pd-ssd"
         }
       ]


### PR DESCRIPTION
Use default image size instead.
Fix issue when testing FreeBSD images that use a size of 32Gb instead of
10Gb.