### PR TITLE
image_test: boot: improve portability

### DIFF
--- a/daisy_workflows/image_test/boot/boot.sh
+++ b/daisy_workflows/image_test/boot/boot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ -f ~/reboot.txt ]]; then
-  cat ~/reboot.txt
-else
+if ! cat /reboot.txt > /dev/console; then
   echo "BOOTED" > /dev/console
-  echo "REBOOTED" > ~/reboot.txt
+  echo "REBOOTED" > /reboot.txt
   shutdown -r now
 fi

--- a/daisy_workflows/image_test/boot/boot.wf.json
+++ b/daisy_workflows/image_test/boot/boot.wf.json
@@ -24,7 +24,9 @@
           "Name": "inst-boot-test",
           "Disks": [{"Source": "disk-test-img"}],
           "MachineType": "${machine_type}",
-          "StartupScript": "boot.sh"
+          "Metadata": {
+            "startup-script": "${SOURCE:boot.sh}"
+          }
         }
       ]
     },


### PR DESCRIPTION
image_test: boot: remove gsutil dependency

Use SOURCE to copy the script to startup-script parameter instead of
relying in gsutil to download the script

image_test: boot: improve portability

Use /bin/sh instead of bash
Remove the use of [[ -f file ]] (it is not supported by csh, causing
problems to FreeBSD)
Use a fix path for the reboot file instead of using relative home path