### PR TITLE
image_test: fix python shebang for FreeBSD

### DIFF
--- a/daisy_workflows/image_test/linux_common/bootstrap.py
+++ b/daisy_workflows/image_test/linux_common/bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/daisy_workflows/image_test/linux_common/utils.py
+++ b/daisy_workflows/image_test/linux_common/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/daisy_workflows/image_test/metadata-ssh/metadata-ssh-tester.py
+++ b/daisy_workflows/image_test/metadata-ssh/metadata-ssh-tester.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh-master-tester.py
+++ b/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh-master-tester.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
There is no /usr/bin/python in FreeBSD,
Without this fix, the configuration test is not executed