### PR TITLE
daisy: fix uploading sources from subworkflows

### DIFF
--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -205,13 +205,11 @@ func (w *Workflow) Run(ctx context.Context) error {
 	defer w.cleanup()
 	w.Logger.WorkflowInfo(w, "Daisy scratch path: https://console.cloud.google.com/storage/browser/%s", path.Join(w.bucket, w.scratchPath))
 
-	if len(w.Sources) != 0 {
-		w.Logger.WorkflowInfo(w, "Uploading sources")
-		if err := w.uploadSources(ctx); err != nil {
-			w.Logger.WorkflowInfo(w, "Error uploading sources: %v", err)
-			close(w.Cancel)
-			return err
-		}
+	w.Logger.WorkflowInfo(w, "Uploading sources")
+	if err := w.uploadSources(ctx); err != nil {
+		w.Logger.WorkflowInfo(w, "Error uploading sources: %v", err)
+		close(w.Cancel)
+		return err
 	}
 	w.Logger.WorkflowInfo(w, "Running workflow")
 	if err := w.run(ctx); err != nil {


### PR DESCRIPTION
Fix regressing introduced by #403
Don't check w.Sources before calling uploadSources, this funcions
already deals with empty sources and also upload sources from
subworkflows