### PR TITLE
daisy: upload sources from IncludeWorkflow

### DIFF
--- a/daisy/sources.go
+++ b/daisy/sources.go
@@ -180,6 +180,11 @@ func (w *Workflow) uploadSources(ctx context.Context) dErr {
 				return err
 			}
 		}
+		if step.IncludeWorkflow != nil {
+			if err := step.IncludeWorkflow.Workflow.uploadSources(ctx); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The uploadSources function uploads files from the SubWorkflow step but
IncludeWorkflow step was missing.