### PR TITLE
image_test: replace FULLNAME by RealName

### DIFF
--- a/daisy_workflows/image_test/configuration/configuration.wf.json
+++ b/daisy_workflows/image_test/configuration/configuration.wf.json
@@ -30,10 +30,11 @@
       "CreateInstances": [
         {
           "Name": "inst-configuration",
+          "RealName": "inst-configuration-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk"}],
           "StartupScript": "bootstrap",
           "Metadata": {
-            "instance_name": "inst-configuration-${FULLNAME}",
+            "instance_name": "inst-configuration-${DATETIME}-${ID}",
             "test_files_gcs_dir": "${SOURCESPATH}/test_files",
             "test_script": "test.py",
             "zone": "${ZONE}",
@@ -62,7 +63,7 @@
           "Name": "inst-configuration",
           "SerialOutput": {
             "Port": 1,
-            "SuccessMatch": "inst-configuration-${FULLNAME}"
+            "SuccessMatch": "inst-configuration-${DATETIME}-${ID}"
           }
         }
       ]

--- a/daisy_workflows/image_test/metadata-ssh/metadata-ssh.wf.json
+++ b/daisy_workflows/image_test/metadata-ssh/metadata-ssh.wf.json
@@ -36,7 +36,7 @@
           "metadata": {
             "test_files_gcs_dir": "${SOURCESPATH}/test_files",
             "test_script": "test.py",
-            "testee": "inst-metadata-ssh-testee-${FULLNAME}",
+            "testee": "inst-metadata-ssh-testee-${DATETIME}-${ID}",
             "zone": "${ZONE}",
             "project": "${PROJECT}"
           },
@@ -51,6 +51,7 @@
       "CreateInstances": [
         {
           "Name": "inst-metadata-ssh-testee",
+          "RealName": "inst-metadata-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
             "startup-script": "service sshguard stop; echo BOOTED > /dev/console"

--- a/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh.wf.json
+++ b/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh.wf.json
@@ -66,9 +66,9 @@
           "metadata": {
             "test_files_gcs_dir": "${SOURCESPATH}/test_files",
             "test_script": "test.py",
-            "testee": "inst-oslogin-ssh-testee-${FULLNAME}",
-            "osLoginTester": "inst-oslogin-ssh-tester-${FULLNAME}",
-            "osAdminLoginTester": "inst-osadminlogin-ssh-tester-${FULLNAME}",
+            "testee": "inst-oslogin-ssh-testee-${DATETIME}-${ID}",
+            "osLoginTester": "inst-oslogin-ssh-tester-${DATETIME}-${ID}",
+            "osAdminLoginTester": "inst-osadminlogin-ssh-tester-${DATETIME}-${ID}",
             "zone": "${ZONE}",
             "project": "${PROJECT}"
           },
@@ -83,6 +83,7 @@
       "CreateInstances": [
         {
           "Name": "inst-oslogin-ssh-tester",
+          "RealName": "inst-oslogin-ssh-tester-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-oslogin-ssh-tester"}],
           "StartupScript": "startup_slave_tester",
           "ServiceAccounts": [{
@@ -99,6 +100,7 @@
       "CreateInstances": [
         {
           "Name": "inst-osadminlogin-ssh-tester",
+          "RealName": "inst-osadminlogin-ssh-tester-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-osadminlogin-ssh-tester"}],
           "StartupScript": "startup_slave_tester",
           "ServiceAccounts": [{
@@ -115,6 +117,7 @@
       "CreateInstances": [
         {
           "Name": "inst-oslogin-ssh-testee",
+          "RealName": "inst-oslogin-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
             "startup-script": "service sshguard stop; echo BOOTED > /dev/console"


### PR DESCRIPTION
The RealName of a resource is composed by the name of the parent
workflows, but the genName function truncates it if too big, and it
can do a different truncation per resource, which means that using
FULLNAME variable is not reliable to deduce the RealName of the
resources.

It becomes a problem when we have several subworkflows where the
RealName of the resources are bigger, which breaks usages like the
oslogin test, where we need to pass the RealName of an instance
to another using metadata.