### PR TITLE
image_test: fix race condition on /dev/console

### DIFF
--- a/daisy_workflows/image_test/boot/boot.sh
+++ b/daisy_workflows/image_test/boot/boot.sh
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! cat /reboot.txt > /dev/console; then
-  echo "BOOTED" > /dev/console
-  echo "REBOOTED" > /reboot.txt
+if ! ls /reboot.txt; then
+  logger -p daemon.info "BOOTED"
+  echo "REBOOT" > /reboot.txt
+  # Wait a bit for logger
+  sleep 10
   shutdown -r now
+else
+  cat /reboot.txt | logger -p daemon.info
 fi

--- a/daisy_workflows/image_test/boot/boot.wf.json
+++ b/daisy_workflows/image_test/boot/boot.wf.json
@@ -48,7 +48,7 @@
           "Name": "inst-boot-test",
           "SerialOutput": {
             "Port": 1,
-            "SuccessMatch": "REBOOTED"
+            "SuccessMatch": "REBOOT"
           }
         }
       ]

--- a/daisy_workflows/image_test/metadata-ssh/metadata-ssh.wf.json
+++ b/daisy_workflows/image_test/metadata-ssh/metadata-ssh.wf.json
@@ -56,7 +56,7 @@
           "RealName": "inst-metadata-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
-            "startup-script": "service sshguard stop; echo BOOTED > /dev/console"
+            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED"
           }
         }
       ]

--- a/daisy_workflows/image_test/multi-nic/multi_nic.wf.json
+++ b/daisy_workflows/image_test/multi-nic/multi_nic.wf.json
@@ -33,7 +33,7 @@
           "RealName": "inst-multi-nic-slave-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-slave-img"}],
           "Metadata": {
-            "startup-script": "echo BOOTED > /dev/console"
+            "startup-script": "logger -p daemon.info BOOTED"
           },
           "NetworkInterfaces": [
             {
@@ -56,7 +56,7 @@
           "Name": "inst-multi-nic-master",
           "Disks": [{"Source": "disk-master-img"}],
           "Metadata": {
-            "startup-script": "sleep 10; ping -c 1 inst-multi-nic-slave-${DATETIME}-${ID} && echo 'MultiNICSuccess' > /dev/console || echo 'MultiNICFailed' > /dev/console"
+            "startup-script": "sleep 10; ping -c 1 inst-multi-nic-slave-${DATETIME}-${ID} && logger -p daemon.info 'MultiNICSuccess' || logger -p daemon.info 'MultiNICFailed'"
             },
           "NetworkInterfaces": [
             {

--- a/daisy_workflows/image_test/network/network-testee.sh
+++ b/daisy_workflows/image_test/network/network-testee.sh
@@ -22,7 +22,7 @@
 [ -n "$INSTANCE" ] && getent hosts www.google.com
 
 # Signalize wait-for-instance that instance is ready or error occurred
-[ $? -ne 0 ] && [ -n "$INSTANCE" ] && echo "DNS_Failed" > /dev/console || echo "BOOTED" > /dev/console
+[ $? -ne 0 ] && [ -n "$INSTANCE" ] && logger -p daemon.info "DNS_Failed" || logger -p daemon.info "BOOTED"
 
 # Serve a file server that prints the hostname when requesting "/hostname"
 mkdir /server

--- a/daisy_workflows/image_test/network/network.wf.json
+++ b/daisy_workflows/image_test/network/network.wf.json
@@ -8,9 +8,9 @@
   "Sources": {
     "testee.sh": "./network-testee.sh",
     "test_files/test.py": "./network-tester.py",
-    "test_files/utils.py": "../linux_common/utils.py",
+    "test_files/utils.py": "../../linux_common/utils.py",
     "test_files/genips.py": "./genips.py",
-    "startup_master_tester": "../linux_common/bootstrap.py"
+    "startup_master_tester": "../../linux_common/bootstrap.py"
   },
   "Steps": {
     "create-testee-disk": {

--- a/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh.wf.json
+++ b/daisy_workflows/image_test/oslogin-ssh/oslogin-ssh.wf.json
@@ -122,7 +122,7 @@
           "RealName": "inst-oslogin-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
-            "startup-script": "service sshguard stop; echo BOOTED > /dev/console"
+            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED"
           }
         }
       ]


### PR DESCRIPTION
Use logger instead of writting to /dev/console directly
Also, in the boot test, wait a bit before restarting so logger can flush
the messages.