### PR TITLE
Fix StopInstances serial output log

### DIFF
--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -46,10 +46,13 @@ Loop:
 		case <-tick:
 			resp, err := w.ComputeClient.GetSerialPortOutput(path.Base(i.Project), path.Base(i.Zone), i.Name, port, start)
 			if err != nil {
-				// Instance is stopped.
-				stopped, sErr := w.ComputeClient.InstanceStopped(path.Base(i.Project), path.Base(i.Zone), i.Name)
-				if stopped && sErr == nil {
-					break Loop
+				// Instance is stopped or stopping.
+				status, sErr := w.ComputeClient.InstanceStatus(path.Base(i.Project), path.Base(i.Zone), i.Name)
+				switch status {
+				case "TERMINATED", "STOPPED", "STOPPING":
+					if sErr == nil {
+						break Loop
+					}
 				}
 				w.LogStepInfo(s.name, "CreateInstances", "Instance %q: error getting serial port: %v", i.Name, err)
 				break Loop


### PR DESCRIPTION
When a machine was on "STOPPING" status, the SerialOutput would
eventually throw the warning `googleapi: Error 503: TIMEOUT,
backendError`, which is not really helpful as it's expected that the
SerialOutput will be closed soon.

By considering the "STOPPING" instance status an expected reason for
having the serial output closed, this warning is suppressed.