### PR TITLE
image_test: utils: wait setMetadata operation

### DIFF
--- a/daisy_workflows/linux_common/utils.py
+++ b/daisy_workflows/linux_common/utils.py
@@ -436,7 +436,8 @@ class MetadataManager:
       request = self.compute.instances().setMetadata(
           project=self.project, zone=self.zone, instance=self.instance,
           body=md_obj)
-    request.execute()
+    response = request.execute()
+    self.Wait(response)
 
   def ExtractKeyItem(self, md_key, level):
     """Extract a given key value from the metadata.


### PR DESCRIPTION
Wait setMetadata operation to finish and raise an exception in case of
an error in the result.

Some times the operation returns with an error and this was being
ignored. Using the Wait function throws an exception in case of an
error returned in the operation.

Closes #414