### PR TITLE
Fix disk test on debian/ubuntu

### DIFF
--- a/daisy_workflows/image_test/disk/disk-local-ssd.sh
+++ b/daisy_workflows/image_test/disk/disk-local-ssd.sh
@@ -41,7 +41,12 @@ CHECK_FILENAME=file
 CHECK_STRING=DiskWorks
 
 # create a primary partition allocating the whole disk
-echo -e "n\n\n\n\n\nw" | fdisk $DEVICE
+echo "n
+
+
+
+
+w" | fdisk $DEVICE
 
 mkfs.ext4 $PARTITION
 mkdir $MOUNT_POINT
@@ -50,7 +55,7 @@ echo $CHECK_STRING > $MOUNT_POINT/$CHECK_FILENAME
 umount $MOUNT_POINT
 
 mount $PARTITION $MOUNT_POINT
-if [ $CHECK_STRING == $(cat $MOUNT_POINT/$CHECK_FILENAME) ]; then
+if [ $CHECK_STRING = $(cat $MOUNT_POINT/$CHECK_FILENAME) ]; then
   logger -p daemon.info "CheckSuccessful"
 else
   logger -p daemon.info "CheckFailed"

--- a/daisy_workflows/image_test/disk/disk-testee.sh
+++ b/daisy_workflows/image_test/disk/disk-testee.sh
@@ -22,6 +22,9 @@ if [ ! -e /booted ]; then
     # should power off now, but it's safer to wait for daisy to do that after
     # the BOOTED message was spotted.
 else
+    # Output the partition table
+    parted -l | grep "Partition Table:" | sed -e 's/^/DiskResize: /' | logger -p daemon.info
+
     # Verify if there is any relevant unallocated disk space
     parted /dev/sda unit GB print free \
       | grep "Free Space" \
@@ -29,5 +32,10 @@ else
       | grep -v "0\.00GB"
 
     # Output if there is any reasonable free partition
-    [ $? -ne 0 ] && logger -p daemon.info "DiskFull" || logger -p daemon.info "DiskFreePart"
+    [ $? -ne 0 ] && \
+      logger -p daemon.info "DiskResize: The root partition is occupying the whole disk now" || \
+      logger -p daemon.info "DiskResize: There is unallocated space on the disk after growing of root partition"
+
+    # Finish test
+    logger -p daemon.info "DiskTestFinished"
 fi

--- a/daisy_workflows/image_test/disk/disk.wf.json
+++ b/daisy_workflows/image_test/disk/disk.wf.json
@@ -111,8 +111,8 @@
           "Name": "inst-disk-testee",
           "SerialOutput": {
             "Port": 1,
-            "SuccessMatch": "DiskFreePart",
-            "FailureMatch": "DiskFull"
+            "SuccessMatch": "DiskTestFinished",
+            "StatusMatch": "DiskResize:"
           }
         }
       ]


### PR DESCRIPTION
Improve shell script code to debian/ubuntu default shell acceptance.

Change disk resize test as success/fail case to only reporting status:
Some distros are using GPT partition table so the 2048GB partition
maximum size is not an issue anymore (it could overflow to the beginning
of the disk).