### PR TITLE
daisy_workflows: use logging instead of wrappers

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/build_installer.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer.py
@@ -23,6 +23,7 @@ rhel_byol: true if building a RHEL BYOL image.
 """
 
 import difflib
+import logging
 import os
 import re
 
@@ -43,9 +44,9 @@ def main():
   sap_apps = utils.GetMetadataParam('rhel_sap_apps', raise_on_not_found=False)
   sap_apps = sap_apps == 'true'
 
-  utils.LogStatus('EL Release: %s' % release)
-  utils.LogStatus('Google Cloud repo: %s' % repo)
-  utils.LogStatus('Build working directory: %s' % os.getcwd())
+  logging.info('EL Release: %s' % release)
+  logging.info('Google Cloud repo: %s' % repo)
+  logging.info('Build working directory: %s' % os.getcwd())
 
   iso_file = 'installer.iso'
 
@@ -59,7 +60,7 @@ def main():
 
   # Write the installer disk. Write extlinux MBR, create partition,
   # copy installer ISO and ISO boot files over.
-  utils.LogStatus('Writing installer disk.')
+  logging.info('Writing installer disk.')
   utils.Execute(['parted', '/dev/sdb', 'mklabel', 'msdos'])
   utils.Execute(['sync'])
   utils.Execute(['parted', '/dev/sdb', 'mkpart', 'primary', '1MB', '100%'])
@@ -105,7 +106,7 @@ def main():
 
     # Print out a the modifications.
     diff = difflib.Differ().compare(oldcfg.splitlines(1), cfg.splitlines(1))
-    utils.LogStatus('Modified extlinux.conf:\n%s' % '\n'.join(diff))
+    logging.info('Modified extlinux.conf:\n%s' % '\n'.join(diff))
 
     f.seek(0)
     f.write(cfg)
@@ -118,6 +119,6 @@ def main():
 if __name__ == '__main__':
   try:
     main()
-    utils.LogSuccess('EL Installer build successful!')
+    logging.success('EL Installer build successful!')
   except:
-    utils.LogFail('EL Installer build failed!')
+    logging.error('EL Installer build failed!')

--- a/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
+++ b/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
@@ -15,9 +15,9 @@
 
 """Kickstart helper functions used to build kickstart files."""
 
+import logging
 import os
 
-import utils
 
 class RepoString(object):
   """Creates a yum.conf repository section statement for a kickstart file.
@@ -184,11 +184,11 @@ def BuildKsConfig(release, google_cloud_repo, byol, sap_hana, sap_apps):
   ks_packages = FetchConfigPart('common-packages.cfg')
   # For BYOL RHEL, don't remove subscription-manager.
   if byol:
-    utils.LogStatus('Building RHEL BYOL image.')
+    logging.info('Building RHEL BYOL image.')
     rhel_byol_post = FetchConfigPart('rhel-byol-post.cfg')
 
   if release == 'rhel6':
-    utils.LogStatus('Building RHEL 6 image.')
+    logging.info('Building RHEL 6 image.')
     ks_options = FetchConfigPart('el6-options.cfg')
     custom_post = FetchConfigPart('el6-post.cfg')
     if byol:
@@ -196,45 +196,45 @@ def BuildKsConfig(release, google_cloud_repo, byol, sap_hana, sap_apps):
     cleanup = FetchConfigPart('el6-cleanup.cfg')
     repo_version = 'el6'
   elif release == "centos6":
-    utils.LogStatus('Building CentOS 6 image.')
+    logging.info('Building CentOS 6 image.')
     ks_options = FetchConfigPart('el6-options.cfg')
     custom_post = FetchConfigPart('co6-post.cfg')
     cleanup = FetchConfigPart('el6-cleanup.cfg')
     repo_version = 'el6'
   elif release == "rhel7":
-    utils.LogStatus('Building RHEL 7 image.')
+    logging.info('Building RHEL 7 image.')
     ks_options = FetchConfigPart('el7-options.cfg')
     custom_post = FetchConfigPart('el7-post.cfg')
     if byol:
       custom_post = '\n'.join([custom_post, rhel_byol_post])
     elif sap_hana:
-      utils.LogStatus('Building RHEL 7 for SAP Hana')
+      logging.info('Building RHEL 7 for SAP Hana')
       custom_post = FetchConfigPart('rhel7-sap-hana-post.cfg')
     elif sap_apps:
-      utils.LogStatus('Building RHEL 7 for SAP Apps')
+      logging.info('Building RHEL 7 for SAP Apps')
       custom_post = FetchConfigPart('rhel7-sap-apps-post.cfg')
     cleanup = FetchConfigPart('el7-cleanup.cfg')
     repo_version = 'el7'
   elif release == "centos7":
-    utils.LogStatus('Building CentOS 7 image.')
+    logging.info('Building CentOS 7 image.')
     ks_options = FetchConfigPart('el7-options.cfg')
     custom_post = FetchConfigPart('co7-post.cfg')
     cleanup = FetchConfigPart('el7-cleanup.cfg')
     repo_version = 'el7'
   elif release == "oraclelinux6":
-    utils.LogStatus('Building Oracle Linux 6 image.')
+    logging.info('Building Oracle Linux 6 image.')
     ks_options = FetchConfigPart('el6-options.cfg')
     custom_post = FetchConfigPart('ol6-post.cfg')
     cleanup = FetchConfigPart('el6-cleanup.cfg')
     repo_version = 'el6'
   elif release == "oraclelinux7":
-    utils.LogStatus('Building Oracle Linux 7 image.')
+    logging.info('Building Oracle Linux 7 image.')
     ks_options = FetchConfigPart('el7-options.cfg')
     custom_post = FetchConfigPart('ol7-post.cfg')
     cleanup = FetchConfigPart('el7-cleanup.cfg')
     repo_version = 'el7'
   else:
-    utils.LogFail('Unknown Image Name: %s' % release)
+    logging.error('Unknown Image Name: %s' % release)
 
   ks_post = BuildPost(custom_post, cleanup, repo_version, google_cloud_repo)
 

--- a/daisy_workflows/image_build/enterprise_linux/save_logs.py
+++ b/daisy_workflows/image_build/enterprise_linux/save_logs.py
@@ -15,6 +15,7 @@
 
 """Saves the build logs and synopsis files to GCS from an EL install."""
 
+import logging
 import os
 
 import utils
@@ -34,8 +35,8 @@ def main():
   # Mount the installer disk.
   utils.Execute(['mount', '-t', 'ext4', '/dev/sdb1', '/mnt'])
 
-  utils.LogStatus('Installer root: %s' % os.listdir('/mnt'))
-  utils.LogStatus('Build logs: %s' % os.listdir('/mnt/build-logs'))
+  logging.info('Installer root: %s' % os.listdir('/mnt'))
+  logging.info('Build logs: %s' % os.listdir('/mnt/build-logs'))
 
   utils.UploadFile('/mnt/ks.cfg', '%s/' % logs_path)
   directory = '/mnt/build-logs'
@@ -50,6 +51,6 @@ def main():
 if __name__ == '__main__':
   try:
     main()
-    utils.LogSuccess('Build logs successfully saved.')
+    logging.success('Build logs successfully saved.')
   except Exception:
-    utils.LogFail('Failed to save build logs.')
+    logging.error('Failed to save build logs.')

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -49,7 +49,7 @@ def DistroSpecific(g):
   deb_release = utils.GetMetadataParam('debian_release')
 
   if install_gce == 'true':
-    print 'Installing GCE packages.'
+    logging.info('Installing GCE packages.')
     g.command(
         ['wget', 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
         '-O', '/tmp/gce_key'])
@@ -89,7 +89,7 @@ def DistroSpecific(g):
   g.command(['update-grub2'])
 
   # Reset network for DHCP.
-  print 'Resetting network to DHCP for eth0.'
+  logging.info('Resetting network to DHCP for eth0.')
   g.write('/etc/network/interfaces', interfaces)
 
 

--- a/daisy_workflows/image_test/disk/disk-tester.py
+++ b/daisy_workflows/image_test/disk/disk-tester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import time
 
 from google import auth
@@ -38,7 +39,7 @@ def TestDiskAttach(testee, removable_disk):
 
   # should detect a second disk
   utils.ExecuteInSsh(KEY, MD.ssh_user, testee, CHECK_SDB_COMMAND)
-  print("DiskAttached")
+  logging.info('DiskAttached')
 
 
 def TestDiskDetach(testee, removable_disk):
@@ -49,7 +50,7 @@ def TestDiskDetach(testee, removable_disk):
   # second disk should not be available anymore
   utils.ExecuteInSsh(KEY, MD.ssh_user, testee, CHECK_SDB_COMMAND,
       expect_fail=True)
-  print("DiskDetached")
+  logging.info('DiskDetached')
 
 
 def TestDiskResize(testee, testee_disk):
@@ -61,7 +62,7 @@ def TestDiskResize(testee, testee_disk):
     time.sleep(5)
 
   MD.Wait(MD.ResizeDiskGb(testee_disk, 2049))
-  print("DiskResized")
+  logging.info('DiskResized')
 
 
 def main():

--- a/daisy_workflows/image_test/network/network-tester.py
+++ b/daisy_workflows/image_test/network/network-tester.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import urllib2
 
 
@@ -35,7 +36,7 @@ class RequestError(Exception):
 
 def GetHostname(addr, timeout=10):
   URL = "http://%s/hostname" % addr
-  print("Retrieving: %s" % URL)
+  logging.info('Retrieving: %s' % URL)
   return urllib2.urlopen(URL, None, timeout).read()
 
 

--- a/daisy_workflows/linux_common/bootstrap.py
+++ b/daisy_workflows/linux_common/bootstrap.py
@@ -50,7 +50,7 @@ def GetBucketContent(bucket, prefix):
       'bucket_name': bucket,
       'prefix': prefix,
   }
-  print ("Bucket listing with %s prefix: %s" % (prefix, url))
+  logging.info('Status: Bucket listing with %s prefix: %s' % (prefix, url))
   request = urllib2.Request(url)
   request.add_unredirected_header('Metadata-Flavor', 'Google')
   request.add_unredirected_header('Authorization', TOKEN)
@@ -60,7 +60,7 @@ def GetBucketContent(bucket, prefix):
 
 def SaveBucketFile(bucket, bucket_file, dest_filepath):
   url = 'https://storage.googleapis.com/%s/%s' % (bucket, bucket_file)
-  print ("Bucket save: %s => %s" % (url, dest_filepath))
+  logging.info('Status: Bucket save: %s => %s' % (url, dest_filepath))
   request = urllib2.Request(url)
   request.add_unredirected_header('Metadata-Flavor', 'Google')
   request.add_unredirected_header('Authorization', TOKEN)
@@ -93,8 +93,8 @@ def GetMetadataAttribute(attribute):
   return urllib2.urlopen(request).read()
 
 
-def DebianInstallGoogleApiPythonClient(prefix):
-  logging.info('%sStatus: Installing google-api-python-client', prefix)
+def DebianInstallGoogleApiPythonClient():
+  logging.info('Status: Installing google-api-python-client')
   subprocess.check_call(['apt-get', 'update'])
   env = os.environ.copy()
   env['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -110,13 +110,13 @@ def Bootstrap():
   try:
     global TOKEN
     prefix = GetMetadataAttribute('prefix')
-    status = prefix + 'Status'
-    logging.info('%s: Starting bootstrap.py.', status)
-
+    fmt = '%s%s%s' % ('%(levelname)s:', prefix, '%(message)s')
+    logging.basicConfig(level=logging.DEBUG, format=fmt)
+    logging.info('Status: Starting bootstrap.py.')
     # Optional flag
     try:
       if GetMetadataAttribute('debian_install_google_api_python_client'):
-        DebianInstallGoogleApiPythonClient(prefix)
+        DebianInstallGoogleApiPythonClient()
     except urllib2.HTTPError:
       pass
 
@@ -137,15 +137,13 @@ def Bootstrap():
       dest_filepath = f.replace(bucket_dir, DIR)
       SaveBucketFile(bucket, f, dest_filepath)
 
-    logging.info('%s: Making script %s executable.', status, full_script)
+    logging.info('Status: Making script %s executable.', full_script)
     subprocess.check_call(['chmod', '+x', script], cwd=DIR)
-    logging.info('%s: Running %s.', status, full_script)
+    logging.info('Status: Running %s.', full_script)
     subprocess.check_call([full_script], cwd=DIR)
   except Exception as e:
-    fail = prefix + 'Failed'
-    print('%s: error: %s' % (fail, str(e)))
+    logging.error('Failed: error: %s' % str(e))
 
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logging.DEBUG)
   Bootstrap()


### PR DESCRIPTION
Standarize logs by setting the formats for every logging level in the
root logger.

As a consequance, this fixes the following bug when calling the
wrappers:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file utils.py, line 51
```