### PR TITLE
metadata-scripts: improve script download testing

### DIFF
--- a/daisy_workflows/image_test/metadata-script/metadata-script-integrity.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-integrity.subwf.json
@@ -1,25 +1,166 @@
 {
-  "Name": "metadata-script-integrity-test",
+  "Name": "integrity",
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "startup_msg": {"Required": true, "Description": "Hash of startup script"},
-    "shutdown_msg": {"Required": true, "Description": "Hash of shutdown script"}
+    "shutdown_msg": {"Required": true, "Description": "Hash of shutdown script"},
+    "startup_script_name": {"Required": true, "Description": "Startup script of the created instance"},
+    "shutdown_script_name": {"Required": true, "Description": "Shutdown script of the created instance"}
+  },
+  "Sources": {
+    "startup_file": "${startup_script_name}",
+    "shutdown_file": "${shutdown_script_name}"
   },
   "Steps": {
-    "test-metadata-script-integrity": {
-      "SubWorkflow": {
-        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+    "create-integrity-url": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "instance_tag": "integrity",
-            "startup-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/metadata-script-test-startup-hash.sh",
-            "shutdown-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/metadata-script-test-shutdown-hash.sh",
-            "windows-startup-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/metadata-script-test-startup-hash.ps1",
-            "windows-shutdown-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/metadata-script-test-shutdown-hash.ps1",
+            "instance": "inst-metadata-scripts-url",
+            "startup_script_meta_key": "startup-script-url",
+            "windows_startup_script_meta_key": "windows-startup-script-url",
+            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/${startup_script_name}",
+            "shutdown_script_meta_key": "shutdown-script-url",
+            "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
+            "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/${shutdown_script_name}"
+        }
+      }
+    },
+    "wait-integrity-url": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-url",
             "startup_msg": "${startup_msg}",
             "shutdown_msg": "${shutdown_msg}"
         }
       }
+    },
+
+    "create-integrity-gcs": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance.subwf.json",
+        "Vars": {
+            "source_image": "${source_image}",
+            "instance": "inst-metadata-scripts-gcs",
+            "startup_script_meta_key": "startup-script-url",
+            "windows_startup_script_meta_key": "windows-startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_file",
+            "shutdown_script_meta_key": "shutdown-script-url",
+            "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
+            "shutdown_script_meta": "${SOURCESPATH}/shutdown_file"
+        }
+      }
+    },
+    "wait-integrity-gcs": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-gcs",
+            "startup_msg": "${startup_msg}",
+            "shutdown_msg": "${shutdown_msg}"
+        }
+      }
+    },
+
+    "copy-scripts-to-public": {
+      "CopyGCSObjects": [
+        {
+          "Source": "${SOURCESPATH}/startup_file",
+          "Destination": "${SOURCESPATH}/startup_file_public",
+          "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
+        },
+        {
+          "Source": "${SOURCESPATH}/shutdown_file",
+          "Destination": "${SOURCESPATH}/shutdown_file_public",
+          "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
+        }
+      ]
+    },
+    "create-integrity-public-gcs": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance-no-scope.subwf.json",
+        "Vars": {
+            "source_image": "${source_image}",
+            "instance": "inst-metadata-scripts-public-gcs",
+            "startup_script_meta_key": "startup-script-url",
+            "windows_startup_script_meta_key": "windows-startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_file_public",
+            "shutdown_script_meta_key": "shutdown-script-url",
+            "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
+            "shutdown_script_meta": "${SOURCESPATH}/shutdown_file_public"
+        }
+      }
+    },
+    "wait-integrity-public-gcs": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-public-gcs",
+            "startup_msg": "${startup_msg}",
+            "shutdown_msg": "${shutdown_msg}"
+        }
+      }
+    },
+
+    "create-integrity-native": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance.subwf.json",
+        "Vars": {
+            "source_image": "${source_image}",
+            "instance": "inst-metadata-scripts-native",
+            "startup_script_meta_key": "startup-script",
+            "windows_startup_script_meta_key": "windows-startup-script-ps1",
+            "startup_script_meta": "${SOURCE:startup_file}",
+            "shutdown_script_meta_key": "shutdown-script",
+            "windows_shutdown_script_meta_key": "windows-shutdown-script-ps1",
+            "shutdown_script_meta": "${SOURCE:shutdown_file}"
+        }
+      }
+    },
+    "wait-integrity-native": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-native",
+            "startup_msg": "${startup_msg}",
+            "shutdown_msg": "${shutdown_msg}"
+        }
+      }
+    },
+
+    "create-integrity-startup-param": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance-no-metadata.subwf.json",
+        "Vars": {
+            "source_image": "${source_image}",
+            "instance": "inst-metadata-scripts-startup-param",
+            "startup_script": "${startup_script_name}"
+        }
+      }
+    },
+    "wait-integrity-startup-param": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-startup-param",
+            "startup_msg": "${startup_msg}",
+            "shutdown_msg": "shutdown-script"
+        }
+      }
     }
+  },
+  "Dependencies": {
+    "wait-integrity-url": ["create-integrity-url"],
+
+    "wait-integrity-gcs": ["create-integrity-gcs"],
+
+    "create-integrity-public-gcs": ["copy-scripts-to-public"],
+    "wait-integrity-public-gcs": ["create-integrity-public-gcs"],
+
+    "wait-integrity-native": ["create-integrity-native"],
+
+    "wait-integrity-startup-param": ["create-integrity-startup-param"]
   }
 }

--- a/daisy_workflows/image_test/metadata-script/metadata-script-junk.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-junk.subwf.json
@@ -1,25 +1,65 @@
 {
   "Name": "metadata-script-junk-test",
+  "Description": "Like integrity test but could not add the native test because daisy checks the garbage and it can't pass that stage",
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "startup_msg": {"Required": true, "Description": "Startup script message to be verified"},
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified"}
   },
+  "Sources": {
+    "junk_file": "./junk"
+  },
   "Steps": {
-    "test-metadata-script-junk": {
-      "SubWorkflow": {
-        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+    "create-junk-url": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "instance_tag": "junk",
-            "startup-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk",
-            "shutdown-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk",
-            "windows-startup-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk",
-            "windows-shutdown-script-url": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk",
+            "instance": "inst-metadata-scripts-junk-url",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk",
+            "shutdown_script_meta_key": "shutdown-script-url",
+            "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk"
+        }
+      }
+    },
+    "wait-junk-url": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-junk-url",
+            "startup_msg": "${startup_msg}",
+            "shutdown_msg": "${shutdown_msg}"
+        }
+      }
+    },
+
+    "create-junk-gcs": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance.subwf.json",
+        "Vars": {
+            "source_image": "${source_image}",
+            "instance": "inst-metadata-scripts-junk-gcs",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/junk_file",
+            "shutdown_script_meta_key": "shutdown-script-url",
+            "shutdown_script_meta": "${SOURCESPATH}/junk_file"
+        }
+      }
+    },
+    "wait-junk-gcs": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-junk-gcs",
             "startup_msg": "${startup_msg}",
             "shutdown_msg": "${shutdown_msg}"
         }
       }
     }
+  },
+  "Dependencies": {
+    "wait-junk-url": ["create-junk-url"],
+    "wait-junk-gcs": ["create-junk-gcs"]
   }
 }

--- a/daisy_workflows/image_test/metadata-script/metadata-script-linux.wf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-linux.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "metadata-script-test",
+  "Name": "metadata-script-linux",
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"}
   },
@@ -9,12 +9,15 @@
         "Path": "./metadata-script.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "startup_hash": "631efd12afdf1460ad5f236fe272dccb",
-            "shutdown_hash": "452bc222517c6f77dc1040da134eb9b7",
+            "startup_hash": "7d954ca9f2786bef7f3c69c6d6661a75",
+            "shutdown_hash": "e3de3cd247bbe7c8b3a6f496f55a80f1",
             "startup_msg": "startup-script: INFO Found startup-script-url in metadata.",
             "shutdown_msg": "shutdown-script: INFO Found shutdown-script-url in metadata.",
             "no_startup_msg": "startup-script: INFO No startup scripts found in metadata.",
-            "no_shutdown_msg": "shutdown-script: INFO No shutdown scripts found in metadata."
+            "no_shutdown_msg": "shutdown-script: INFO No shutdown scripts found in metadata.",
+
+            "startup_script_name": "metadata-script-test-startup-hash.sh",
+            "shutdown_script_name": "metadata-script-test-shutdown-hash.sh"
         }
       }
     }

--- a/daisy_workflows/image_test/metadata-script/metadata-script-noscript.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-noscript.subwf.json
@@ -1,21 +1,32 @@
 {
-  "Name": "metadata-script-noscript-test",
+  "Name": "noscript",
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "startup_msg": {"Required": true, "Description": "Startup script message to be verified"},
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified"}
   },
   "Steps": {
-    "test-metadata-script-noscript": {
-      "SubWorkflow": {
-        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+    "create-noscript": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-create-instance.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "instance_tag": "noscript",
+            "instance": "inst-metadata-scripts-noscript"
+        }
+      }
+    },
+    "wait-noscript": {
+      "IncludeWorkflow": {
+        "Path": "./metadata-script-subwf/sub-startup-shutdown-check.subwf.json",
+        "Vars": {
+            "instance": "inst-metadata-scripts-noscript",
             "startup_msg": "${startup_msg}",
             "shutdown_msg": "${shutdown_msg}"
         }
       }
     }
+  },
+  "Dependencies": {
+    "wait-noscript": ["create-noscript"]
   }
 }

--- a/daisy_workflows/image_test/metadata-script/metadata-script-subwf/sub-create-instance-no-metadata.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-subwf/sub-create-instance-no-metadata.subwf.json
@@ -1,0 +1,37 @@
+{
+  "Name": "sub-create-instance-no-metadata",
+  "Vars": {
+    "instance": {"Required": true, "Description": "The name of the instance to be created"},
+    "source_image": {"Required": true, "Description": "Image to be tested"},
+    "startup_script": {"Value": "", "Description": "Startup script of the created instance"}
+  },
+  "Sources": {
+    "metadata-script-test-startup-hash.sh": "../metadata-script-test-startup-hash.sh",
+    "metadata-script-test-startup-hash.ps1": "../metadata-script-test-startup-hash.ps1"
+  },
+  "Steps": {
+    "create-disk": {
+      "CreateDisks": [
+        {
+          "Name": "disk-${instance}",
+          "SourceImage": "${source_image}"
+        }
+      ]
+    },
+    "create-instance": {
+      "CreateInstances": [
+        {
+          "Name": "${instance}",
+          "Disks": [{"Source": "disk-${instance}"}],
+          "StartupScript": "${startup_script}",
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only"
+          ]
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-instance": ["create-disk"]
+  }
+}

--- a/daisy_workflows/image_test/metadata-script/metadata-script-subwf/sub-create-instance-no-scope.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-subwf/sub-create-instance-no-scope.subwf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "sub-create-instance",
+  "Name": "sub-create-instance-no-scope",
   "Vars": {
     "instance": {"Required": true, "Description": "The name of the instance to be created"},
     "source_image": {"Required": true, "Description": "Image to be tested"},
@@ -32,10 +32,7 @@
 
             "${shutdown_script_meta_key}": "${shutdown_script_meta}",
             "${windows_shutdown_script_meta_key}": "${shutdown_script_meta}"
-          },
-          "Scopes": [
-            "https://www.googleapis.com/auth/devstorage.read_only"
-          ]
+          }
         }
       ]
     }

--- a/daisy_workflows/image_test/metadata-script/metadata-script-subwf/sub-startup-shutdown-check.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-subwf/sub-startup-shutdown-check.subwf.json
@@ -1,34 +1,16 @@
 {
   "Name": "sub-startup-shutdown-check",
   "Vars": {
-    "source_image": {"Required": true, "Description": "Image to be tested"},
-    "instance_tag": {"Required": true, "Description": "Tag name to be used on instance name"},
+    "instance": {"Required": true, "Description": "Instance name to be tested"},
     "startup_msg": {"Required": true, "Description": "The message to wait when the instance starts up"},
-    "shutdown_msg": {"Required": true, "Description": "The message to wait when the instance shuts down"},
-    "startup-script-url": {"Description": "Linux startup script to create the instance (URL)"},
-    "shutdown-script-url": {"Description": "Linux shutdown script to create the instance (URL)"},
-    "windows-startup-script-url": {"Description": "Windows startup script to create the instance (URL)"},
-    "windows-shutdown-script-url": {"Description": "Windows shutdown script to create the instance (URL)"}
+    "shutdown_msg": {"Required": true, "Description": "The message to wait when the instance shuts down"}
   },
   "Steps": {
-    "test-create-instance": {
-      "IncludeWorkflow": {
-        "Path": "./sub-create-instance.subwf.json",
-        "Vars": {
-            "source_image": "${source_image}",
-            "instance": "inst-metadata-scripts-${instance_tag}",
-            "startup-script-url": "${startup-script-url}",
-            "shutdown-script-url": "${shutdown-script-url}",
-            "windows-startup-script-url": "${windows-startup-script-url}",
-            "windows-shutdown-script-url": "${windows-shutdown-script-url}"
-        }
-      }
-    },
     "test-startup-check-log": {
       "IncludeWorkflow": {
         "Path": "./sub-wait-message.subwf.json",
         "Vars": {
-            "instance": "inst-metadata-scripts-${instance_tag}",
+            "instance": "${instance}",
             "script_type": "startup",
             "exec_msg": "${startup_msg}"
         }
@@ -36,14 +18,14 @@
     },
     "test-stop-instance": {
       "StopInstances": {
-        "Instances":["inst-metadata-scripts-${instance_tag}"]
+        "Instances":["${instance}"]
       }
     },
     "test-shutdown-check-log": {
       "IncludeWorkflow": {
         "Path": "./sub-wait-message.subwf.json",
         "Vars": {
-            "instance": "inst-metadata-scripts-${instance_tag}",
+            "instance": "${instance}",
             "script_type": "shutdown",
             "exec_msg": "${shutdown_msg}"
         }
@@ -51,7 +33,6 @@
     }
   },
   "Dependencies": {
-    "test-startup-check-log": ["test-create-instance"],
     "test-stop-instance": ["test-startup-check-log"],
     "test-shutdown-check-log": ["test-startup-check-log"]
   }

--- a/daisy_workflows/image_test/metadata-script/metadata-script-test-shutdown-hash.sh
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-test-shutdown-hash.sh
@@ -1,3 +1,4 @@
+cat > shutdown_tester.sh <<'EOF'
 #!/bin/sh
 
 # Test that a shutdown script can run for at least 100 seconds
@@ -14,9 +15,6 @@ echo "TestStatus: waiting 10 seconds (70/100)"  | logger -p $PRIO; sleep 10
 echo "TestStatus: waiting 10 seconds (80/100)"  | logger -p $PRIO; sleep 10
 echo "TestStatus: waiting 10 seconds (90/100)"  | logger -p $PRIO; sleep 10
 echo "TestStatus: waiting 10 seconds (100/100)" | logger -p $PRIO
-
-# Finish the script by outputing it's hash, which is the SuccessMatch
-md5sum "${0}" | logger -p daemon.info
 
 # Below, some random data only to increase entropy in case this file gets
 # corrupted.
@@ -201,3 +199,10 @@ md5sum "${0}" | logger -p daemon.info
 # PhjxoxKKfSvpfTOH1Ofi450SyGIz497dm0CncRcFP+cARc+FatNT48ABy1RLHpJMJg0ae5+VKEli
 # 6txosGOmsciVWXjn1m3tlZLrKtRW4b8E7qzCsvuHGkcp8PSo4jDlWrLueNRvzWmTr7CzvDXroFHY
 # gZFvZIyZIO1TA4mXJY8nEh10yU5MmoqMv4Gu7KbSS6dtGdd/qg==
+EOF
+
+chmod +x shutdown_tester.sh
+./shutdown_tester.sh
+
+# Finish the script by outputing the hash which is the SuccessMatch
+md5sum ./shutdown_tester.sh | logger -p daemon.info

--- a/daisy_workflows/image_test/metadata-script/metadata-script-test-startup-hash.sh
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-test-startup-hash.sh
@@ -1,7 +1,6 @@
+cat > startup_tester.sh <<EOF
 # avoiding shebang on purpose: testing if the script execution is using the
 # image's default shell
-
-md5sum "${0}" | logger -p daemon.info
 
 # Below, some random data only to increase entropy in case this file gets
 # corrupted.
@@ -186,3 +185,8 @@ md5sum "${0}" | logger -p daemon.info
 # fPcvQb+M/PlcNHTPdCufIClIO6tZHxGlL8LllMMOSIMN2PLfodLwpj+uSr62UllMi43VQEhmmq5o
 # P89IKaa7YU5JtyVF3R1cvWrjKFvH3+lao0dPgZT8AfvwAAJX05plBUnDO4FhDfT3fSF0pbHlkNI9
 # eZ5iEj2Jwyfxr8nmCUV7NfJfZN0KJDu/HHY99/iNZrB8G912+A==
+EOF
+
+chmod +x startup_tester.sh
+./startup_tester.sh
+md5sum ./startup_tester.sh | logger -p daemon.info

--- a/daisy_workflows/image_test/metadata-script/metadata-script-windows.wf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script-windows.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "metadata-script-test",
+  "Name": "metadata-script-windows",
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"}
   },
@@ -14,7 +14,10 @@
             "startup_msg": "GCEMetadataScripts: Starting startup scripts",
             "shutdown_msg": "GCEMetadataScripts: Starting shutdown scripts",
             "no_startup_msg": "GCEMetadataScripts: No startup scripts to run.",
-            "no_shutdown_msg": "GCEMetadataScripts: No shutdown scripts to run."
+            "no_shutdown_msg": "GCEMetadataScripts: No shutdown scripts to run.",
+
+            "startup_script_name": "metadata-script-test-startup-hash.ps1",
+            "shutdown_script_name": "metadata-script-test-shutdown-hash.ps1"
         }
       }
     }

--- a/daisy_workflows/image_test/metadata-script/metadata-script.subwf.json
+++ b/daisy_workflows/image_test/metadata-script/metadata-script.subwf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "metadata-script-test",
+  "Name": "test",
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "startup_hash": {"Required": true, "Description": "Hash of startup script"},
@@ -7,11 +7,13 @@
     "startup_msg": {"Required": true, "Description": "Startup script message to be verified when script exists"},
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script exists"},
     "no_startup_msg": {"Required": true, "Description": "Startup script message to be verified when script is missing"},
-    "no_shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script is missing"}
+    "no_shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script is missing"},
+    "startup_script_name": {"Description": "Startup script of the created instance"},
+    "shutdown_script_name": {"Description": "Shutdown script of the created instance"}
   },
   "Steps": {
     "test-metadata-script-noscript": {
-      "SubWorkflow": {
+      "IncludeWorkflow": {
         "Path": "./metadata-script-noscript.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
@@ -21,7 +23,7 @@
       }
     },
     "test-metadata-script-junk": {
-      "SubWorkflow": {
+      "IncludeWorkflow": {
         "Path": "./metadata-script-junk.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
@@ -31,12 +33,14 @@
       }
     },
     "test-metadata-script-integrity": {
-      "SubWorkflow": {
+      "IncludeWorkflow": {
         "Path": "./metadata-script-integrity.subwf.json",
         "Vars": {
             "source_image": "${source_image}",
             "startup_msg": "${startup_hash}",
-            "shutdown_msg": "${shutdown_hash}"
+            "shutdown_msg": "${shutdown_hash}",
+            "startup_script_name": "${startup_script_name}",
+            "shutdown_script_name": "${shutdown_script_name}"
         }
       }
     }


### PR DESCRIPTION
I improved the architecture in order to allow several startup-script
flavors: GCS download (authenticated and unauthenticated), URL download
and directly from metadata.

Note: Sometimes the shutdown-script messages are not printed. I noticed
it specially when there is no shutdown-script to execute (on this case,
it should print something like "shutdown-script: INFO No shutdown
scripts found in metadata.").