### PR TITLE
Avoid rebooting on boot test without catching output

### DIFF
--- a/daisy_workflows/image_test/boot/boot.bat
+++ b/daisy_workflows/image_test/boot/boot.bat
@@ -16,11 +16,8 @@ REM limitations under the License.
 if EXIST reboot.txt goto REBOOT
 
 :BOOT
-    echo BOOTED
     echo REBOOT > reboot.txt
-
-    REM restart after 1 second
-    shutdown /r /t 1
+    echo BOOTED
     goto END
 
 :REBOOT

--- a/daisy_workflows/image_test/boot/boot.sh
+++ b/daisy_workflows/image_test/boot/boot.sh
@@ -14,11 +14,9 @@
 # limitations under the License.
 
 if ! ls /reboot.txt; then
-  logger -p daemon.info "BOOTED"
   echo "REBOOT" > /reboot.txt
-  # Wait a bit for logger
-  sleep 10
-  shutdown -r now
+  logger -p daemon.info "BOOTED"
 else
   cat /reboot.txt | logger -p daemon.info
 fi
+sync

--- a/daisy_workflows/image_test/boot/boot.wf.json
+++ b/daisy_workflows/image_test/boot/boot.wf.json
@@ -43,6 +43,16 @@
         }
       ]
     },
+    "stop-instance": {
+      "StopInstances": {
+        "Instances": ["inst-boot-test"]
+      }
+    },
+    "start-instance": {
+      "StartInstances": {
+        "Instances": ["inst-boot-test"]
+      }
+    },
     "wait-for-reboot-instance": {
       "Timeout": "5m",
       "WaitForInstancesSignal": [
@@ -59,6 +69,8 @@
   "Dependencies": {
     "create-test-instance": ["create-test-disk"],
     "wait-for-boot-instance": ["create-test-instance"],
-    "wait-for-reboot-instance": ["wait-for-boot-instance"]
+    "stop-instance": ["wait-for-boot-instance"],
+    "start-instance": ["stop-instance"],
+    "wait-for-reboot-instance": ["start-instance"]
   }
 }


### PR DESCRIPTION
Fast instances could manage to print the boot message and restart
without daisy noticing it. When that happend, only the "REBOOT" was
caught but before a "BOOT", which led to a test filure by timeout.

This patch used daisy to control the rebooting which should make this
behavior not happening anymore.