### PR TITLE
 oslogin-ssh test: Avoid empty ssh-keys inclusion 

### DIFF
--- a/daisy_workflows/image_test/oslogin-ssh/README.md
+++ b/daisy_workflows/image_test/oslogin-ssh/README.md
@@ -42,12 +42,12 @@ Create two service accounts with the following roles:
 You can use the following commands
 
     gcloud iam service-accounts create daisy-oslogin
-    gcloud projects add-iam-policy-binding main-nucleus-128012 --member='serviceAccount:daisy-oslogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/compute.osLogin'
-    gcloud projects add-iam-policy-binding main-nucleus-128012 --member='serviceAccount:daisy-oslogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/iam.serviceAccountUser'
-    gcloud projects add-iam-policy-binding main-nucleus-128012 --member='serviceAccount:daisy-oslogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/storage.objectViewer'
+    gcloud projects add-iam-policy-binding ${PROJECT} --member='serviceAccount:daisy-oslogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/compute.osLogin'
+    gcloud projects add-iam-policy-binding ${PROJECT} --member='serviceAccount:daisy-oslogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/iam.serviceAccountUser'
+    gcloud projects add-iam-policy-binding ${PROJECT} --member='serviceAccount:daisy-oslogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/storage.objectViewer'
 
     gcloud iam service-accounts create daisy-osadminlogin
-    gcloud projects add-iam-policy-binding main-nucleus-128012 --member='serviceAccount:daisy-osadminlogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/compute.osAdminLogin'
-    gcloud projects add-iam-policy-binding main-nucleus-128012 --member='serviceAccount:daisy-osadminlogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/iam.serviceAccountUser'
-    gcloud projects add-iam-policy-binding main-nucleus-128012 --member='serviceAccount:daisy-osadminlogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/storage.objectViewer'
+    gcloud projects add-iam-policy-binding ${PROJECT} --member='serviceAccount:daisy-osadminlogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/compute.osAdminLogin'
+    gcloud projects add-iam-policy-binding ${PROJECT} --member='serviceAccount:daisy-osadminlogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/iam.serviceAccountUser'
+    gcloud projects add-iam-policy-binding ${PROJECT} --member='serviceAccount:daisy-osadminlogin@${PROJECT}.iam.gserviceaccount.com' --role='roles/storage.objectViewer'
 

--- a/daisy_workflows/linux_common/utils.py
+++ b/daisy_workflows/linux_common/utils.py
@@ -562,7 +562,12 @@ class MetadataManager:
     if not level:
       level = self.INSTANCE_LEVEL
     md_item = self.ExtractKeyItem(md_key, level)
-    md_item['value'] = re.sub('.*%s.*\n?' % key, '', md_item['value'])
+    # Clear the key (whole line), empty keys (if any) and the last break line.
+    md_item['value'] = re.sub('\n$', '',
+        re.sub('\n\n', '\n',
+            re.sub('.*%s.*' % key, '', md_item['value'])
+        )
+    )
     if not md_item['value']:
       self.md_items[level].remove(md_item)
     if store:


### PR DESCRIPTION
The old method was stacking a '\n' at the ssh-keys metadata list when it
was removing the last key (it could clear a '\n' at the end at removal,
but only after removing, the new list had a '\n' at the end).

This fix will avoid the project metadata being overwhelmed by empty keys
after several runs and it will even clear them, if it happens again.