### PR TITLE
Configuration test: retry apt/yum network operations

### DIFF
--- a/daisy_workflows/image_test/configuration/debian.py
+++ b/daisy_workflows/image_test/configuration/debian.py
@@ -25,7 +25,12 @@ class DebianTests(generic_distro.GenericDistroTests):
   """
   __metaclass__ = abc.ABCMeta
 
+  @utils.RetryOnFailure
   def TestPackageInstallation(self):
+    """
+    Network instabilities can lead to errors when fetching the apt repository.
+    It worths to try if that happens
+    """
     utils.Execute(['apt-get', 'update'])
     utils.Execute(['apt-get', 'install', '--reinstall', '-y', 'tree'])
 

--- a/daisy_workflows/image_test/configuration/redhat.py
+++ b/daisy_workflows/image_test/configuration/redhat.py
@@ -25,7 +25,12 @@ class RedHatTests(generic_distro.GenericDistroTests):
   """
   __metaclass__ = abc.ABCMeta
 
+  @utils.RetryOnFailure
   def TestPackageInstallation(self):
+    """
+    Network instabilities can lead to errors when fetching the yum repository.
+    It worths to try if that happens
+    """
     # install something to test repository sanity
     utils.Execute(['yum', '-y', 'install', 'tree'])
     # in case it was already installed, ask for reinstall just to be sure


### PR DESCRIPTION
The repository server is not as reliable as one can assume. For that
reason it worths to retry connecting to it when it doesn't work at the
first time.