### PR TITLE
Reduce boot, disk and multi-nic test conflicts

### DIFF
--- a/daisy_workflows/image_test/boot/boot.sh
+++ b/daisy_workflows/image_test/boot/boot.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Wait for machine boot to avoid log race conditions
+sleep 10
+
 if ! ls /reboot.txt; then
   echo "REBOOT" > /reboot.txt
   logger -p daemon.info "BOOTED"

--- a/daisy_workflows/image_test/linux_images.test.gotmpl
+++ b/daisy_workflows/image_test/linux_images.test.gotmpl
@@ -48,7 +48,8 @@
         "Path": "./multi-nic/multi-nic.wf.json",
         "Vars": {
           "source_image": "{{$image}}"
-        }
+        },
+        "CustomProjectLock": "subnetworks"
       },
       "test-network [{{$image}}]": {
         "Path": "./network/network.wf.json",
@@ -62,7 +63,8 @@
         "Path": "./disk/disk.wf.json",
         "Vars": {
           "source_image": "{{$image}}"
-        }
+        },
+        "CustomProjectLock": "disks"
       }{{if lt (add $index 1) $length}},{{end}}
     {{end -}}
   }


### PR DESCRIPTION
Boot test could fail as the "BOOTED" message was overwritten by other
boot messages on rsyslog (race condition). Adding a 10s sleep should
avoid this kind of issue

Disk and multi-nic tests uses a lot of a project quota for testing
several images. As the bottle necks for completing the tests are the
oslogin tests, running disk/multi-nic tests one at a time will not
impact total time for the tests run, but will require a lower resource
quota.