### PR TITLE
prow: Test most recent FreeBSD-12-0 images

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -141,7 +141,7 @@ periodics:
           projects/rhel-cloud/global/images/family/rhel-6,\
           projects/rhel-cloud/global/images/family/rhel-7,\
           projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-2,\
-          projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-0-snap"
+          projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-0"
       - "-var:alias_ips=\
           10.128.3.128,\
           10.128.3.132,\


### PR DESCRIPTION
FreeBSD 12.0 is on its release cycle and their alpha releases are being
released under freebsd-12-0 image-family and the freebsd-12-0-snap is
deprecated until the release comes up.