### PR TITLE
Fix windows sysprep metadata scripts test: wrong SOURCE

### DIFF
--- a/image_test/metadata-script/sysprep-script-integrity.wf.json
+++ b/image_test/metadata-script/sysprep-script-integrity.wf.json
@@ -62,8 +62,8 @@
     "copy-scripts-to-public": {
       "CopyGCSObjects": [
         {
-          "Source": "${SOURCESPATH}/shutdown_file.ps1",
-          "Destination": "${SOURCESPATH}/shutdown_file_public.ps1",
+          "Source": "${SOURCESPATH}/startup_file.ps1",
+          "Destination": "${SOURCESPATH}/startup_file_public.ps1",
           "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
         }
       ]


### PR DESCRIPTION
That led to:
googleapi: Error 404: No such object:
${PROJECT}/daisy-sysprep-script-windows-20180910-14:23:46-8qm77/sources/shutdown_file.ps1,
notFound