### PR TITLE
Fix metadata-scripts URLs

### DIFF
--- a/image_test/metadata-script/shutdown-script-integrity.wf.json
+++ b/image_test/metadata-script/shutdown-script-integrity.wf.json
@@ -21,7 +21,7 @@
             "instance": "${instance_url}",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
-            "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/${shutdown_script_name}"
+            "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/${shutdown_script_name}"
         }
       }
     },

--- a/image_test/metadata-script/shutdown-script-junk.wf.json
+++ b/image_test/metadata-script/shutdown-script-junk.wf.json
@@ -19,7 +19,7 @@
             "instance": "${instance_url}",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
-            "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk.ps1"
+            "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/junk.ps1"
         }
       }
     },

--- a/image_test/metadata-script/startup-script-integrity.wf.json
+++ b/image_test/metadata-script/startup-script-integrity.wf.json
@@ -21,7 +21,7 @@
             "instance": "${instance_url}",
             "startup_script_meta_key": "startup-script-url",
             "windows_startup_script_meta_key": "windows-startup-script-url",
-            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/${startup_script_name}"
+            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/${startup_script_name}"
         }
       }
     },

--- a/image_test/metadata-script/startup-script-junk.wf.json
+++ b/image_test/metadata-script/startup-script-junk.wf.json
@@ -19,7 +19,7 @@
             "instance": "${instance_url}",
             "startup_script_meta_key": "startup-script-url",
             "windows_startup_script_meta_key": "windows-startup-script-url",
-            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk.ps1"
+            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/junk.ps1"
         }
       }
     },

--- a/image_test/metadata-script/sysprep-script-integrity.wf.json
+++ b/image_test/metadata-script/sysprep-script-integrity.wf.json
@@ -20,7 +20,7 @@
             "source_image": "${source_image}",
             "instance": "${instance_url}",
             "windows_startup_script_meta_key": "sysprep-specialize-script-url",
-            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/${sysprep_script_name}"
+            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/${sysprep_script_name}"
         }
       }
     },

--- a/image_test/metadata-script/sysprep-script-junk.wf.json
+++ b/image_test/metadata-script/sysprep-script-junk.wf.json
@@ -18,7 +18,7 @@
             "source_image": "${source_image}",
             "instance": "${instance_url}",
             "windows_startup_script_meta_key": "sysprep-specialize-script-url",
-            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/daisy_workflows/image_test/metadata-script/junk.ps1"
+            "startup_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/junk.ps1"
         }
       }
     },


### PR DESCRIPTION
After moving image_test out of daisy_workflow directory, this URLs
should have been updated.