### PR TITLE
Use latest FreeBSD 11.2 images on prow tests

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -140,7 +140,7 @@ periodics:
           projects/centos-cloud/global/images/family/centos-7,\
           projects/rhel-cloud/global/images/family/rhel-6,\
           projects/rhel-cloud/global/images/family/rhel-7,\
-          projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-2,\
+          projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-2-snap,\
           projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-0"
       - "-var:alias_ips=\
           10.128.3.128,\


### PR DESCRIPTION
The Google Compute Agent was updated on FreeBSD 11.2 but prow was only testing
the release image. Tests should be focusing on the latest builds.