### PR TITLE
Added subnet variable to image and disk export workflows

### DIFF
--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -24,10 +24,6 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
-    },
-    "export_subnet": {
-      "Value": "",
-      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Sources": {
@@ -51,13 +47,13 @@
           "Disks": [{"Source": "disk-${NAME}"}, {"Source": "${source_disk}", "Mode": "READ_ONLY"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
+            "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}.tar.gz",
             "licenses": "${licenses}"
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-	      "subnetwork": "${export_subnet}"
+              "network": "${export_network}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -24,6 +24,10 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Sources": {
@@ -53,7 +57,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}"
+              "network": "${export_network}",
+	      "subnetwork": "${export_subnet}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -24,6 +24,10 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Sources": {
@@ -47,13 +51,13 @@
           "Disks": [{"Source": "disk-${NAME}"}, {"Source": "${source_disk}", "Mode": "READ_ONLY"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}.tar.gz",
             "licenses": "${licenses}"
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}"
+              "network": "${export_network}",
+	      "subnetwork": "${export_subnet}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -58,7 +58,7 @@
           "networkInterfaces": [
             {
               "network": "${export_network}",
-	      "subnetwork": "${export_subnet}"
+              "subnetwork": "${export_subnet}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -25,6 +25,10 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Sources": {
@@ -54,7 +58,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}"
+              "network": "${export_network}",
+	      "subnetwork": "${export_subnet}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -59,7 +59,7 @@
           "networkInterfaces": [
             {
               "network": "${export_network}",
-	      "subnetwork": "${export_subnet}"
+              "subnetwork": "${export_subnet}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -25,10 +25,6 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
-    },
-    "export_subnet": {
-      "Value": "",
-      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Sources": {
@@ -52,13 +48,13 @@
           "Disks": [{"Source": "disk-${NAME}"}, {"Source": "${source_disk}", "Mode": "READ_ONLY"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
+            "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}",
             "format": "${format}"
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-	      "subnetwork": "${export_subnet}"
+              "network": "${export_network}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -25,6 +25,10 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Sources": {
@@ -48,13 +52,13 @@
           "Disks": [{"Source": "disk-${NAME}"}, {"Source": "${source_disk}", "Mode": "READ_ONLY"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}",
             "format": "${format}"
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}"
+              "network": "${export_network}",
+	      "subnetwork": "${export_subnet}"
             }
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],

--- a/daisy_workflows/export/image_export.wf.json
+++ b/daisy_workflows/export/image_export.wf.json
@@ -24,10 +24,6 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
-    },
-    "export_subnet": {
-      "Value": "",
-      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Steps": {
@@ -49,8 +45,7 @@
           "export_instance_disk_image": "${export_instance_disk_image}",
           "export_instance_disk_size": "${export_instance_disk_size}",
           "licenses": "${licenses}",
-          "export_network": "${export_network}",
-	  "export_subnet": "${export_subnet}"
+          "export_network": "${export_network}"
         }
       }
     }

--- a/daisy_workflows/export/image_export.wf.json
+++ b/daisy_workflows/export/image_export.wf.json
@@ -50,7 +50,7 @@
           "export_instance_disk_size": "${export_instance_disk_size}",
           "licenses": "${licenses}",
           "export_network": "${export_network}",
-	  "export_subnet": "${export_subnet}"
+          "export_subnet": "${export_subnet}"
         }
       }
     }

--- a/daisy_workflows/export/image_export.wf.json
+++ b/daisy_workflows/export/image_export.wf.json
@@ -24,6 +24,10 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Steps": {
@@ -45,7 +49,8 @@
           "export_instance_disk_image": "${export_instance_disk_image}",
           "export_instance_disk_size": "${export_instance_disk_size}",
           "licenses": "${licenses}",
-          "export_network": "${export_network}"
+          "export_network": "${export_network}",
+	  "export_subnet": "${export_subnet}"
         }
       }
     }

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -51,7 +51,7 @@
           "export_instance_disk_image": "${export_instance_disk_image}",
           "export_instance_disk_size": "${export_instance_disk_size}",
           "export_network": "${export_network}",
-	  "export_subnet": "${export_subnet}"
+          "export_subnet": "${export_subnet}"
         }
       }
     }

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -25,6 +25,10 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
     }
   },
   "Steps": {
@@ -46,7 +50,8 @@
           "format": "${format}",
           "export_instance_disk_image": "${export_instance_disk_image}",
           "export_instance_disk_size": "${export_instance_disk_size}",
-          "export_network": "${export_network}"
+          "export_network": "${export_network}",
+	  "export_subnet": "${export_subnet}"
         }
       }
     }

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -25,7 +25,11 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
-    }
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
+   }
   },
   "Steps": {
     "setup-disks": {
@@ -46,7 +50,8 @@
           "format": "${format}",
           "export_instance_disk_image": "${export_instance_disk_image}",
           "export_instance_disk_size": "${export_instance_disk_size}",
-          "export_network": "${export_network}"
+          "export_network": "${export_network}",
+          "export_subnet": "${export_subnet}"
         }
       }
     }

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -25,11 +25,7 @@
     "export_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the export instance"
-    },
-    "export_subnet": {
-      "Value": "",
-      "Description": "SubNetwork to use for the export instance"
-   }
+    }
   },
   "Steps": {
     "setup-disks": {
@@ -50,8 +46,7 @@
           "format": "${format}",
           "export_instance_disk_image": "${export_instance_disk_image}",
           "export_instance_disk_size": "${export_instance_disk_size}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "export_network": "${export_network}"
         }
       }
     }


### PR DESCRIPTION
Added subnet variable to image and disk export workflows. Passing this variable to CreateInstance step. 

Specifying subnet is necessary when a GCP project has custom network setup.