### PR TITLE
Refactor shutdown image tests

### DIFF
--- a/image_test/metadata-script/metadata-script-inc/shutdown-check.wf.json
+++ b/image_test/metadata-script/metadata-script-inc/shutdown-check.wf.json
@@ -2,16 +2,29 @@
   "Name": "shutdown-check",
   "Vars": {
     "instance": {"Required": true, "Description": "Instance name to be tested"},
-    "shutdown_msg": {"Required": true, "Description": "The message to wait when the instance shuts down"}
+    "shutdown_msg": {"Required": true, "Description": "The message to wait when the instance shuts down"},
+    "wait_msg": {"Required": true, "Description": "The message to wait to shut down the instance"}
   },
   "Steps": {
+    "test-wait-to-stop-instance": {
+      "Timeout": "5m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "${instance}",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "${wait_msg}"
+          }
+        }
+      ]
+    },
     "test-stop-instance": {
       "StopInstances": {
         "Instances":["${instance}"]
       }
     },
     "test-shutdown-check-log": {
-      "Timeout": "140s",
+      "Timeout": "3m",
       "IncludeWorkflow": {
         "Path": "./wait-message.wf.json",
         "Vars": {
@@ -28,6 +41,7 @@
     }
   },
   "Dependencies": {
+    "test-stop-instance": ["test-wait-to-stop-instance"],
     "cleanup-instance": ["test-stop-instance", "test-shutdown-check-log"]
   }
 }

--- a/image_test/metadata-script/metadata-script-test-shutdown-hash.sh
+++ b/image_test/metadata-script/metadata-script-test-shutdown-hash.sh
@@ -204,5 +204,13 @@ EOF
 chmod +x shutdown_tester.sh
 ./shutdown_tester.sh
 
+# In FreeBSD the default utility to calculate md5 checksum for a file is 'md5'
+# and for Linux based systems is 'md5sum'.
+if [ "$(uname)" = 'FreeBSD' ]; then
+    md5bin=md5
+else
+    md5bin=md5sum
+fi
+
 # Finish the script by outputing the hash which is the SuccessMatch
-md5sum ./shutdown_tester.sh | logger -p daemon.info
+$md5bin ./shutdown_tester.sh | logger -p daemon.info

--- a/image_test/metadata-script/shutdown-script-integrity.wf.json
+++ b/image_test/metadata-script/shutdown-script-integrity.wf.json
@@ -3,14 +3,17 @@
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "shutdown_msg": {"Required": true, "Description": "Hash of shutdown script"},
+    "wait_msg": {"Required": true, "Description": "Message to stop instance"},
     "shutdown_script_name": {"Required": true, "Description": "Shutdown script of the created instance"},
+    "startup_script_name": {"Required": true, "Description": "Startup script of the created instance"},
     "instance_url": "integrity-url",
     "instance_gcs": "integrity-gcs",
     "instance_public_gcs": "integrity-public-gcs",
     "instance_metadata": "integrity-metadata"
   },
   "Sources": {
-    "shutdown_file.ps1": "${shutdown_script_name}"
+    "shutdown_file.ps1": "${shutdown_script_name}",
+    "startup_script.ps1": "${startup_script_name}"
   },
   "Steps": {
     "create-integrity-url": {
@@ -19,6 +22,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "instance": "${instance_url}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/${shutdown_script_name}"
@@ -31,7 +36,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance_url}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     },
@@ -42,6 +48,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "instance":  "${instance_gcs}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "${SOURCESPATH}/shutdown_file.ps1"
@@ -54,7 +62,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance_gcs}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     },
@@ -65,6 +74,11 @@
           "Source": "${SOURCESPATH}/shutdown_file.ps1",
           "Destination": "${SOURCESPATH}/shutdown_file_public.ps1",
           "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
+        },
+        {
+          "Source": "${SOURCESPATH}/startup_script.ps1",
+          "Destination": "${SOURCESPATH}/startup_script_public.ps1",
+          "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
         }
       ]
     },
@@ -74,6 +88,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "instance": "${instance_public_gcs}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script_public.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "${SOURCESPATH}/shutdown_file_public.ps1"
@@ -86,7 +102,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance_public_gcs}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     },
@@ -97,6 +114,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "instance": "${instance_metadata}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
             "shutdown_script_meta_key": "shutdown-script",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-ps1",
             "shutdown_script_meta": "${SOURCE:shutdown_file.ps1}"
@@ -109,7 +128,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance_metadata}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     }

--- a/image_test/metadata-script/shutdown-script-junk.wf.json
+++ b/image_test/metadata-script/shutdown-script-junk.wf.json
@@ -4,11 +4,14 @@
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified"},
+    "startup_script_name": {"Required": true, "Description": "Startup script of the created instance"},
+    "wait_msg": {"Required": true, "Description": "Message to stop instance"},
     "instance_url": "junk-url",
     "instance_gcs": "junk-gcs"
   },
   "Sources": {
-    "junk_file.ps1": "./junk.ps1"
+    "junk_file.ps1": "./junk.ps1",
+    "startup_script.ps1": "${startup_script_name}"
   },
   "Steps": {
     "create-junk-url": {
@@ -17,6 +20,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "instance": "${instance_url}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/junk.ps1"
@@ -29,7 +34,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance_url}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     },
@@ -40,6 +46,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "instance": "${instance_gcs}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "${SOURCESPATH}/junk_file.ps1"
@@ -52,7 +60,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance_gcs}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     }

--- a/image_test/metadata-script/shutdown-script-linux.wf.json
+++ b/image_test/metadata-script/shutdown-script-linux.wf.json
@@ -13,7 +13,9 @@
             "shutdown_hash": "e3de3cd247bbe7c8b3a6f496f55a80f1",
             "shutdown_msg": "shutdown-script: INFO Found shutdown-script-url in metadata.",
             "no_shutdown_msg": "shutdown-script: INFO No shutdown scripts found in metadata.",
-            "shutdown_script_name": "metadata-script-test-shutdown-hash.sh"
+            "wait_msg": "Ready to stop instance.",
+            "shutdown_script_name": "metadata-script-test-shutdown-hash.sh",
+            "startup_script_name": "startup-script-for-shutdown-tests.sh"
         }
       }
     }

--- a/image_test/metadata-script/shutdown-script-noscript.wf.json
+++ b/image_test/metadata-script/shutdown-script-noscript.wf.json
@@ -3,7 +3,12 @@
   "Vars": {
     "source_image": {"Required": true, "Description": "Image to be tested"},
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified"},
+    "startup_script_name": {"Required": true, "Description": "Startup script of the created instance"},
+    "wait_msg": {"Required": true, "Description": "Message to stop instance"},
     "instance": "noscript"
+  },
+  "Sources": {
+    "startup_script.ps1": "${startup_script_name}"
   },
   "Steps": {
     "create-noscript": {
@@ -11,7 +16,9 @@
         "Path": "./metadata-script-inc/create-instance.wf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "instance": "${instance}"
+            "instance": "${instance}",
+            "startup_script_meta_key": "startup-script-url",
+            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1"
         }
       }
     },
@@ -21,7 +28,8 @@
         "Path": "./metadata-script-inc/shutdown-check.wf.json",
         "Vars": {
             "instance": "${instance}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "wait_msg": "${wait_msg}"
         }
       }
     }

--- a/image_test/metadata-script/shutdown-script-windows.wf.json
+++ b/image_test/metadata-script/shutdown-script-windows.wf.json
@@ -13,7 +13,8 @@
             "shutdown_hash": "BFDE8004A9C0B59CC530DD9DFFFDBF8D",
             "shutdown_msg": "GCEMetadataScripts: Starting shutdown scripts",
             "no_shutdown_msg": "GCEMetadataScripts: No shutdown scripts to run.",
-            "shutdown_script_name": "metadata-script-test-shutdown-hash.ps1"
+            "shutdown_script_name": "metadata-script-test-shutdown-hash.ps1",
+            "startup_script_name": "startup-script-for-shutdown-tests.ps1"
         }
       }
     }

--- a/image_test/metadata-script/shutdown-script.wf.json
+++ b/image_test/metadata-script/shutdown-script.wf.json
@@ -5,7 +5,9 @@
     "shutdown_hash": {"Required": true, "Description": "Hash of shutdown script"},
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script exists"},
     "no_shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script is missing"},
+    "wait_msg": {"Required": true, "Description": "Startup script message to be verified to stop instance"},
     "shutdown_script_name": {"Required": true, "Description": "Shutdown script of the created instance"}
+    "startup_script_name": {"Required": true, "Description": "Startup script of the created instance"}
   },
   "Steps": {
     "test-shutdown-script-noscript": {
@@ -14,7 +16,9 @@
         "Path": "./shutdown-script-noscript.wf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "shutdown_msg": "${no_shutdown_msg}"
+            "shutdown_msg": "${no_shutdown_msg}",
+            "startup_script_name": "${startup_script_name}",
+            "wait_msg": "${wait_msg}"
         }
       }
     },
@@ -24,7 +28,9 @@
         "Path": "./shutdown-script-junk.wf.json",
         "Vars": {
             "source_image": "${source_image}",
-            "shutdown_msg": "${shutdown_msg}"
+            "shutdown_msg": "${shutdown_msg}",
+            "startup_script_name": "${startup_script_name}",
+            "wait_msg": "${wait_msg}"
         }
       }
     },
@@ -35,7 +41,9 @@
         "Vars": {
             "source_image": "${source_image}",
             "shutdown_msg": "${shutdown_hash}",
-            "shutdown_script_name": "${shutdown_script_name}"
+            "wait_msg": "${wait_msg}",
+            "shutdown_script_name": "${shutdown_script_name}",
+            "startup_script_name": "${startup_script_name}"
         }
       }
     }

--- a/image_test/metadata-script/startup-script-for-shutdown-tests.ps1
+++ b/image_test/metadata-script/startup-script-for-shutdown-tests.ps1
@@ -1,0 +1,1 @@
+Write-Host "Ready to stop instance."

--- a/image_test/metadata-script/startup-script-for-shutdown-tests.sh
+++ b/image_test/metadata-script/startup-script-for-shutdown-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# FreeBSD's kernel aborts if the shutdown process takes more than 90 seconds,
+# and for some tests we need more than that.
+if [ "$(uname)" = 'FreeBSD' ]; then
+    sysctl kern.init_shutdown_timeout=180
+    sysrc rcshutdown_timeout="180"
+fi
+
+echo "Ready to stop instance."


### PR DESCRIPTION
These tests were not reliable because some times the instance powered off
before the logs had been processed. Now, we delayed a bit the instance
shutdown and the tests start to watch the serial output before the
shutdown process starts.

Besides that we add some small fixes related to FreeBSD.