### PR TITLE
Add missing comma in shutdown-script.wf.json

### DIFF
--- a/image_test/metadata-script/shutdown-script.wf.json
+++ b/image_test/metadata-script/shutdown-script.wf.json
@@ -6,7 +6,7 @@
     "shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script exists"},
     "no_shutdown_msg": {"Required": true, "Description": "Shutdown script message to be verified when script is missing"},
     "wait_msg": {"Required": true, "Description": "Startup script message to be verified to stop instance"},
-    "shutdown_script_name": {"Required": true, "Description": "Shutdown script of the created instance"}
+    "shutdown_script_name": {"Required": true, "Description": "Shutdown script of the created instance"},
     "startup_script_name": {"Required": true, "Description": "Startup script of the created instance"}
   },
   "Steps": {


### PR DESCRIPTION
Sorry, the tests are failing in testgrid because of a missing comma in my last PR.