### PR TITLE
Fix source name conflicts in shutdown image tests

### DIFF
--- a/image_test/metadata-script/shutdown-script-integrity.wf.json
+++ b/image_test/metadata-script/shutdown-script-integrity.wf.json
@@ -13,7 +13,7 @@
   },
   "Sources": {
     "shutdown_file.ps1": "${shutdown_script_name}",
-    "startup_script.ps1": "${startup_script_name}"
+    "startup_script_integrity.ps1": "${startup_script_name}"
   },
   "Steps": {
     "create-integrity-url": {
@@ -23,7 +23,7 @@
             "source_image": "${source_image}",
             "instance": "${instance_url}",
             "startup_script_meta_key": "startup-script-url",
-            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
+            "startup_script_meta": "${SOURCESPATH}/startup_script_integrity.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/${shutdown_script_name}"
@@ -49,7 +49,7 @@
             "source_image": "${source_image}",
             "instance":  "${instance_gcs}",
             "startup_script_meta_key": "startup-script-url",
-            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
+            "startup_script_meta": "${SOURCESPATH}/startup_script_integrity.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "${SOURCESPATH}/shutdown_file.ps1"
@@ -76,7 +76,7 @@
           "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
         },
         {
-          "Source": "${SOURCESPATH}/startup_script.ps1",
+          "Source": "${SOURCESPATH}/startup_script_integrity.ps1",
           "Destination": "${SOURCESPATH}/startup_script_public.ps1",
           "AclRules": [{"Entity": "allUsers", "Role": "READER"}]
         }
@@ -115,7 +115,7 @@
             "source_image": "${source_image}",
             "instance": "${instance_metadata}",
             "startup_script_meta_key": "startup-script-url",
-            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
+            "startup_script_meta": "${SOURCESPATH}/startup_script_integrity.ps1",
             "shutdown_script_meta_key": "shutdown-script",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-ps1",
             "shutdown_script_meta": "${SOURCE:shutdown_file.ps1}"

--- a/image_test/metadata-script/shutdown-script-junk.wf.json
+++ b/image_test/metadata-script/shutdown-script-junk.wf.json
@@ -11,7 +11,7 @@
   },
   "Sources": {
     "junk_file.ps1": "./junk.ps1",
-    "startup_script.ps1": "${startup_script_name}"
+    "startup_script_junk.ps1": "${startup_script_name}"
   },
   "Steps": {
     "create-junk-url": {
@@ -21,7 +21,7 @@
             "source_image": "${source_image}",
             "instance": "${instance_url}",
             "startup_script_meta_key": "startup-script-url",
-            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
+            "startup_script_meta": "${SOURCESPATH}/startup_script_junk.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "https://raw.githubusercontent.com/GoogleCloudPlatform/compute-image-tools/master/image_test/metadata-script/junk.ps1"
@@ -47,7 +47,7 @@
             "source_image": "${source_image}",
             "instance": "${instance_gcs}",
             "startup_script_meta_key": "startup-script-url",
-            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1",
+            "startup_script_meta": "${SOURCESPATH}/startup_script_junk.ps1",
             "shutdown_script_meta_key": "shutdown-script-url",
             "windows_shutdown_script_meta_key": "windows-shutdown-script-url",
             "shutdown_script_meta": "${SOURCESPATH}/junk_file.ps1"

--- a/image_test/metadata-script/shutdown-script-noscript.wf.json
+++ b/image_test/metadata-script/shutdown-script-noscript.wf.json
@@ -8,7 +8,7 @@
     "instance": "noscript"
   },
   "Sources": {
-    "startup_script.ps1": "${startup_script_name}"
+    "startup_script_no_script.ps1": "${startup_script_name}"
   },
   "Steps": {
     "create-noscript": {
@@ -18,7 +18,7 @@
             "source_image": "${source_image}",
             "instance": "${instance}",
             "startup_script_meta_key": "startup-script-url",
-            "startup_script_meta": "${SOURCESPATH}/startup_script.ps1"
+            "startup_script_meta": "${SOURCESPATH}/startup_script_no_script.ps1"
         }
       }
     },


### PR DESCRIPTION
The startup scripts have the same name in all shutdown tests,
and when they are included in the same workflow we got an error
trying to populate it.