### PR TITLE
Import diskutils.py only where is needed

### DIFF
--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -24,6 +24,8 @@ install_gce_packages: True if GCE agent and SDK should be installed
 import logging
 
 import utils
+import utils.diskutils as diskutils
+
 
 google_cloud = '''
 deb http://packages.cloud.google.com/apt cloud-sdk-{deb_release} main
@@ -90,10 +92,10 @@ def DistroSpecific(g):
 
 
 def main():
-  g = utils.MountDisk('/dev/sdb')
+  g = diskutils.MountDisk('/dev/sdb')
   DistroSpecific(g)
   utils.CommonRoutines(g)
-  utils.UnmountDisk(g)
+  diskutils.UnmountDisk(g)
 
 
 if __name__ == '__main__':

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -26,6 +26,8 @@ import logging
 import os
 
 import utils
+import utils.diskutils as diskutils
+
 
 repo_compute = '''
 [google-cloud-compute]
@@ -182,10 +184,10 @@ def DistroSpecific(g):
 def main():
   utils.AptGetInstall(['libguestfs-tools'])
   disk = '/dev/sdb'
-  g = utils.MountDisk(disk)
+  g = diskutils.MountDisk(disk)
   DistroSpecific(g)
   utils.CommonRoutines(g)
-  utils.UnmountDisk(g)
+  diskutils.UnmountDisk(g)
   utils.Execute(['virt-customize', '-a', disk, '--selinux-relabel'])
 
 

--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -23,6 +23,7 @@ install_gce_packages: True if GCE agent and SDK should be installed
 import logging
 
 import utils
+import utils.diskutils as diskutils
 
 
 network = '''
@@ -80,10 +81,10 @@ def DistroSpecific(g):
 
 
 def main():
-  g = utils.MountDisk('/dev/sdb')
+  g = diskutils.MountDisk('/dev/sdb')
   DistroSpecific(g)
   utils.CommonRoutines(g)
-  utils.UnmountDisk(g)
+  diskutils.UnmountDisk(g)
 
 
 if __name__ == '__main__':

--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -24,6 +24,7 @@ install_gce_packages: True if GCE agent and SDK should be installed
 import logging
 
 import utils
+import utils.diskutils as diskutils
 
 
 tinyproxy_cfg = '''
@@ -161,10 +162,10 @@ def DistroSpecific(g):
 
 def main():
   utils.AptGetInstall(['tinyproxy'])
-  g = utils.MountDisk('/dev/sdb')
+  g = diskutils.MountDisk('/dev/sdb')
   DistroSpecific(g)
   utils.CommonRoutines(g)
-  utils.UnmountDisk(g)
+  diskutils.UnmountDisk(g)
 
 
 if __name__ == '__main__':

--- a/daisy_workflows/linux_common/utils/__init__.py
+++ b/daisy_workflows/linux_common/utils/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python2.7
 
 from common import *  # noqa: F401,F403
-from diskutils import *  # noqa: F401,F403


### PR DESCRIPTION
Fix a regression added by fef17d7d6ca556fbe20ca078f98bbcb2bd5f81e0

In configuration image tests we import utils.py and after this commit,
it also imports diskutils.py. This script is trying to install
python-guestfs using apt in all distributions even in non-Debian based
and leading it to a failure.

You can check these failures in [testgrid](https://k8s-testgrid.appspot.com/google-gce-compute-image-tools#linux-image-tests&width=20).