### PR TITLE
linux_common/bootstrap.py: add Ubuntu 18.x support

### DIFF
--- a/daisy_workflows/image_build/debian/debian.wf.json
+++ b/daisy_workflows/image_build/debian/debian.wf.json
@@ -17,7 +17,7 @@
     "build_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "build_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
     "build_files/google_cloud_test_repos": "./google_cloud_test_repos/",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup": {

--- a/daisy_workflows/image_build/debian/debian_fai.wf.json
+++ b/daisy_workflows/image_build/debian/debian_fai.wf.json
@@ -17,7 +17,7 @@
     "build_files/utils/common.py": "../../linux_common/utils/common.py",
     "build_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "build_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup": {

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
@@ -48,7 +48,7 @@
     "build_files/kickstart": "./kickstart/",
     "build_files/ks_helpers.py": "./ks_helpers.py",
     "build_files/save_logs.py": "./save_logs.py",
-    "installerprep_startup_script": "../../linux_common/bootstrap.py"
+    "installerprep_startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disks": {

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux_uefi.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux_uefi.wf.json
@@ -48,7 +48,7 @@
     "build_files/kickstart": "./kickstart/",
     "build_files/ks_helpers.py": "./ks_helpers.py",
     "build_files/save_logs.py": "./save_logs.py",
-    "installerprep_startup_script": "../../linux_common/bootstrap.py"
+    "installerprep_startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disks": {

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -27,7 +27,7 @@
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disk": {

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -35,7 +35,7 @@
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "translate-disk-inst": {

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -35,7 +35,7 @@
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disk": {

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -35,7 +35,7 @@
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disk": {

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -27,7 +27,7 @@
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
-    "startup_script": "../../linux_common/bootstrap.py"
+    "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disk": {

--- a/daisy_workflows/linux_common/bootstrap.sh
+++ b/daisy_workflows/linux_common/bootstrap.sh
@@ -1,3 +1,17 @@
+#!/bin/sh
+
+# Ubuntu 18.x does not ship python2 installed by default.
+if [  -n "$(uname -a | grep Ubuntu)" ]; then
+    ubuntu_release=$(lsb_release -rs)
+    if [ "$ubuntu_release" = "18.04" -o "$ubuntu_release" = "18.10" ]; then
+        apt-get update && apt-get install -y python
+    fi
+fi
+
+bootstrap_script="$(dirname $0)/bootstrap.py"
+
+echo "Creating $bootstrap_script"
+cat > $bootstrap_script <<EOF
 #!/usr/bin/env python2
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
@@ -148,3 +162,8 @@ def Bootstrap():
 
 if __name__ == '__main__':
   Bootstrap()
+EOF
+
+echo "Calling $bootstrap_script"
+chmod +x $bootstrap_script
+$bootstrap_script

--- a/image_test/configuration/linux-configuration.wf.json
+++ b/image_test/configuration/linux-configuration.wf.json
@@ -4,7 +4,7 @@
     "source_image": {"Required": true, "Description": "Image to be tested"}
   },
   "Sources": {
-    "bootstrap": "../../daisy_workflows/linux_common/bootstrap.py",
+    "bootstrap": "../../daisy_workflows/linux_common/bootstrap.sh",
     "test_files/": "./linux/",
     "test_files/test.py": "./linux/configuration-test.py",
     "test_files/utils/common.py": "../../daisy_workflows/linux_common/utils/common.py",

--- a/image_test/metadata-ssh/metadata-ssh.wf.json
+++ b/image_test/metadata-ssh/metadata-ssh.wf.json
@@ -8,7 +8,7 @@
     "test_files/utils/common.py": "../../daisy_workflows/linux_common/utils/common.py",
     "test_files/utils/diskutils.py": "../../daisy_workflows/linux_common/utils/diskutils.py",
     "test_files/utils/__init__.py": "../../daisy_workflows/linux_common/utils/__init__.py",
-    "startup_tester": "../../daisy_workflows/linux_common/bootstrap.py"
+    "startup_tester": "../../daisy_workflows/linux_common/bootstrap.sh"
   },
   "Steps": {
     "create-firewall-rule": {

--- a/image_test/network/network.wf.json
+++ b/image_test/network/network.wf.json
@@ -16,7 +16,7 @@
     "test_files/utils/diskutils.py": "../../daisy_workflows/linux_common/utils/diskutils.py",
     "test_files/utils/__init__.py": "../../daisy_workflows/linux_common/utils/__init__.py",
     "test_files/genips.py": "./genips.py",
-    "startup_master_tester": "../../daisy_workflows/linux_common/bootstrap.py"
+    "startup_master_tester": "../../daisy_workflows/linux_common/bootstrap.sh"
   },
   "Steps": {
     "create-testee-disk": {

--- a/image_test/oslogin-ssh/oslogin-ssh.wf.json
+++ b/image_test/oslogin-ssh/oslogin-ssh.wf.json
@@ -18,7 +18,7 @@
     "test_files/utils/common.py": "../../daisy_workflows/linux_common/utils/common.py",
     "test_files/utils/diskutils.py": "../../daisy_workflows/linux_common/utils/diskutils.py",
     "test_files/utils/__init__.py": "../../daisy_workflows/linux_common/utils/__init__.py",
-    "startup_master_tester": "../../daisy_workflows/linux_common/bootstrap.py",
+    "startup_master_tester": "../../daisy_workflows/linux_common/bootstrap.sh",
     "slave_tester.sh": "./oslogin_slave_tester.sh"
   },
   "Steps": {


### PR DESCRIPTION
Python 2 is not installed by default in Ubuntu 18.x and bootstrap.py
depends on it.

Ubuntu configuration tests are failing in [test grid](https://k8s-testgrid.appspot.com/google-gce-compute-image-tools#linux-image-tests&width=20) because python2 is not available in those images.