### PR TITLE
image_test/multi-nic: install ping in Ubuntu minimal images

### DIFF
--- a/image_test/multi-nic/multi-nic-master.sh
+++ b/image_test/multi-nic/multi-nic-master.sh
@@ -16,4 +16,11 @@
 # Wait for network initialization
 sleep 10
 
+# Ubuntu minimal images do not have ping installed by default.
+if [  -n "$(uname -a | grep Ubuntu)" ]; then
+    if ! type ping > /dev/null; then
+        apt-get update && apt-get install -y iputils-ping
+    fi
+fi
+
 ping -c 5 ${HOST} && logger -p daemon.info 'MultiNICSuccess' || logger -p daemon.info 'MultiNICFailed'


### PR DESCRIPTION
This will fix some test failures in the test grid.