### PR TITLE
metadata-ssh: test root privileges after re-add ssh key

### DIFF
--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -520,14 +520,20 @@ class MetadataManager:
       self.StoreMetadata(level)
 
   @RetryOnFailure
-  def TestSshLogin(self, key, expect_fail=False):
+  def TestSshLogin(self, key, as_root=False, expect_fail=False):
     """Try to login to self.instance using key.
 
     Args:
       key: string, the private key to be used in the ssh connection.
+      as_root: bool, indicates if the test is executed with root privileges.
+      expect_fail: bool, indicates if the failure in the execution is expected.
     """
+
+    command = ['echo', 'Logged']
+    if as_root:
+        command.insert(0, 'sudo')
     ExecuteInSsh(
-        key, self.ssh_user, self.instance, ['echo', 'Logged'],
+        key, self.ssh_user, self.instance, command,
         expect_fail=expect_fail)
 
   @classmethod

--- a/image_test/metadata-ssh/metadata-ssh-tester.py
+++ b/image_test/metadata-ssh/metadata-ssh-tester.py
@@ -81,6 +81,18 @@ def TestBlockProjectSshKeysIgnoresProjectLevelKeys():
   MD.TestSshLogin(instance_key, expect_fail=True)
 
 
+def TestAdminLoginSshKeys(level):
+  key = MD.AddSshKey(MM.SSH_KEYS, level)
+  MD.TestSshLogin(key, as_root=True)
+  MD.RemoveSshKey(key, MM.SSH_KEYS, level)
+  MD.TestSshLogin(key, as_root=True, expect_fail=True)
+  # Re-add a new ssh key and check if it still has root privileges.
+  new_key = MD.AddSshKey(MM.SSH_KEYS, level)
+  MD.TestSshLogin(new_key, as_root=True)
+  MD.RemoveSshKey(new_key, MM.SSH_KEYS, level)
+  MD.TestSshLogin(new_key, as_root=True, expect_fail=True)
+
+
 def main():
   global MD
 
@@ -93,6 +105,8 @@ def main():
 
   TestLoginSshKeys(MM.INSTANCE_LEVEL)
   TestLoginSshKeys(MM.PROJECT_LEVEL)
+  TestAdminLoginSshKeys(MM.INSTANCE_LEVEL)
+  TestAdminLoginSshKeys(MM.PROJECT_LEVEL)
   TestSshKeysWithSshKeys(MM.INSTANCE_LEVEL)
   TestSshKeysWithSshKeys(MM.PROJECT_LEVEL)
   TestSshKeysMixedProjectInstanceLevel()


### PR DESCRIPTION
Add a new test case for metadata-ssh, seems that this was an issue in the past.