### PR TITLE
Fix configuration test for centos/rhel

### DIFF
--- a/image_test/configuration/linux/redhat.py
+++ b/image_test/configuration/linux/redhat.py
@@ -38,7 +38,7 @@ class RedHatTests(generic_distro.GenericDistroTests):
 
   def IsPackageInstalled(self, package_name):
     # the following command returns zero if package is installed
-    command = ['yum', '--assumeno', 'install', package_name]
+    command = ['yum', 'list', 'installed', package_name]
     rc, output = utils.Execute(command, raise_errors=False)
     return rc == 0
 
@@ -56,7 +56,7 @@ class RedHatTests(generic_distro.GenericDistroTests):
 
   def TestAutomaticSecurityUpdates(self):
     # the following command returns zero if package is installed
-    utils.Execute(['yum', '--assumeno', 'install', 'yum-cron'])
+    utils.Execute(['yum', 'list', 'installed', 'yum-cron'])
 
     # service returns zero if service exists and is running
     utils.Execute(['service', 'yum-cron', 'status'])


### PR DESCRIPTION
When verifying if a package is installed or not, the command
'yum --assumeno install package_name' returns 1 insetad of 0 if there is an
update to the package available, even if the package is installed, causing the
test to fail.

This patch replaces this commad by 'yum list installed package_name'.