### PR TITLE
image_import: 7 does not support disabling hibernate

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -208,7 +208,12 @@ function Change-InstanceProperties {
   # Change time zone to Coordinated Universal Time.
   Run-Command tzutil /s 'UTC'
 
-  Run-Command powercfg /hibernate off
+  # Not supported on 6.1 client, but is supported on 6.1 server
+  $pn_path = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
+  $pn = (Get-ItemProperty -Path $pn_path -Name ProductName).ProductName
+  if ($pn -notlike '*Windows 7*') {
+    Run-Command powercfg /hibernate off
+  }
 }
 
 function Configure-RDPSecurity {


### PR DESCRIPTION
OBSERVED
Windows 7 image translate (import) fails, providing the error:

At C:\Windows\TEMP\metadata-scripts128481719\windows-startup-script-url.ps1:30 
char:11
+   $out = & <<<< $executable $arguments 2>&1 | Out-String
TranslateFailed: Hibernation failed with the following error: The request is not supported.

EXPECTED
Translate completes with no errors.