### PR TITLE
daisy_integration_tests: 7 translate import

### DIFF
--- a/daisy_integration_tests/7_translate.wf.json
+++ b/daisy_integration_tests/7_translate.wf.json
@@ -39,6 +39,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+              "byol": "true"
+          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.ps1"
         }


### PR DESCRIPTION
* Test VM did not have BYOL set in metadata, test failed b/c 7 was not
activated

OBSERVED:
 -  7 image translate: step "wait-for-test-instance" run error: WaitForInstancesSignal FailureMatch found for "inst-import-test-windows-7-translate-test-sslvj": "Test Failed: Windows is not activated"

EXPECTED:
Test passes.