### PR TITLE
image_test: catch metadata script runner failure

### DIFF
--- a/image_test/metadata-script/metadata-script-inc/wait-message.wf.json
+++ b/image_test/metadata-script/metadata-script-inc/wait-message.wf.json
@@ -23,7 +23,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "${exec_msg}",
-            "StatusMatch": "TestStatus:"
+            "StatusMatch": "TestStatus:",
+            "FailureMatch": "Failure:"
           }
         },
         {


### PR DESCRIPTION
Stop the test if we detect an error from the google_metadata_script_runner