### PR TITLE
image_test: disk: don't flood logger

### DIFF
--- a/image_test/disk/disk-testee.sh
+++ b/image_test/disk/disk-testee.sh
@@ -32,5 +32,6 @@ while [ 1 ]; do
     logger -p daemon.info "TotalDisksUnrecognized"
   fi
 
-  sleep 1
+  # Avoid flooding the logs, otherwise we might lose the BOOTED/REBOOT message
+  sleep 10
 done


### PR DESCRIPTION
Sending messages to logger might flood the buffer and make it drop some
messages.
Increase the delay before printing again.