### PR TITLE
OSConfig packaging rpm and init scripts

### DIFF
--- a/cli_tools/google-osconfig-agent/google-osconfig-agent.conf
+++ b/cli_tools/google-osconfig-agent/google-osconfig-agent.conf
@@ -1,0 +1,4 @@
+description "Google OSConfig Agent"
+expect fork
+respawn
+exec /usr/bin/google_osconfig_agent

--- a/cli_tools/google-osconfig-agent/google-osconfig-agent.service
+++ b/cli_tools/google-osconfig-agent/google-osconfig-agent.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Google OSConfig Agent
+
+[Service]
+ExecStart=/usr/bin/google_osconfig_agent
+Restart=always
+RestartSec=120

--- a/cli_tools/google-osconfig-agent/packaging/debian/control
+++ b/cli_tools/google-osconfig-agent/packaging/debian/control
@@ -3,7 +3,7 @@ Maintainer: Google Cloud Team <gc-team@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9), dh-golang (>= 1.1)
+Build-Depends: debhelper (>= 9), dh-golang (>= 1.1), dh-systemd
 
 Package: google-osconfig-agent
 Architecture: any

--- a/cli_tools/google-osconfig-agent/packaging/debian/rules
+++ b/cli_tools/google-osconfig-agent/packaging/debian/rules
@@ -12,6 +12,7 @@ export DH_GOPKG := github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/
 override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
+	mv debian/google-osconfig-agent/usr/bin/google-osconfig-agent debian/google-osconfig-agent/usr/bin/google_osconfig_agent
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.

--- a/cli_tools/google-osconfig-agent/packaging/debian/rules
+++ b/cli_tools/google-osconfig-agent/packaging/debian/rules
@@ -7,7 +7,7 @@ export DH_OPTIONS
 export DH_GOPKG := github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent
 
 %:
-	dh $@  --buildsystem=golang --with=golang
+	dh $@  --buildsystem=golang --with=golang,systemd
 
 override_dh_auto_install:
 	# Binary-only package.
@@ -16,3 +16,12 @@ override_dh_auto_install:
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.
+
+override_dh_installinit:
+	dh_installinit --noscripts
+
+override_dh_systemd_start:
+	dh_systemd_start --no-start
+
+override_dh_systemd_enable:
+	dh_systemd_enable --no-enable

--- a/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
+++ b/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
@@ -1,0 +1,56 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Name: google-osconfig-agent
+Version: %{_version}
+Release: 1%{?dist}
+Summary: Google Compute Engine guest environment.
+License: ASL 2.0
+Url: https://github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent
+Source0: %{name}_%{version}.orig.tar.gz
+
+ExclusiveArch: %{go_arches}
+%if 0%{?rhel} == 7
+BuildRequires: systemd
+%endif
+BuildRequires: golang >= 1.11
+
+%description
+Contains the OSConfig agent binary and startup scripts
+
+%prep
+%autosetup
+
+%build
+GOPATH=%{gopath} go build -ldflags="-linkmode=external" -o google_osconfig_agent
+
+%install
+install -d %{buildroot}%{_bindir}
+install -p -m 0755 google_osconfig_agent %{buildroot}%{_bindir}/google_osconfig_agent
+%if 0%{?rhel} == 7
+install -d %{buildroot}%{_unitdir}
+install -p -m 0644 %{name}.service %{buildroot}%{_unitdir}
+%else
+install -d %{buildroot}/etc/init
+install -p -m 0644 %{name}.conf %{buildroot}/etc/init
+%endif
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/google_osconfig_agent
+%if 0%{?rhel} == 7
+%{_unitdir}/%{name}.service
+%else
+/etc/init/%{name}.conf
+%endif

--- a/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
@@ -28,7 +28,7 @@ fi
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y install debhelper devscripts build-essential curl tar
 
 # Build dependencies.
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y install dh-golang
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y install dh-golang dh-systemd
 
 dpkg-checkbuilddeps packaging/debian/control
 
@@ -53,6 +53,7 @@ tar xzvf ${NAME}_${VERSION}.orig.tar.gz
 cd ${NAME}-${VERSION}
 
 cp -r ${working_dir}/packaging/debian ./
+cp -r ${working_dir}/*.service ./debian/
 
 debuild -us -uc
 

--- a/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NAME="google-osconfig-agent"
+VERSION="0.4.11"
+
+rpm_working_dir=/tmp/rpmpackage/
+working_dir=${PWD}
+if [[ $(basename "$working_dir") != $NAME ]]; then
+  echo "Packaging scripts must be run from top of package dir."
+  exit 1
+fi
+
+# RPM creation tools.
+sudo yum -y install rpmdevtools go-srpm-macros
+
+# Go build dependencies.
+sudo su -c 'GOPATH=/usr/share/gocode go get -d ./...'
+
+rm -rf /tmp/rpmpackage
+mkdir -p ${rpm_working_dir}/{SOURCES,SPECS}
+
+cp packaging/${NAME}.spec ${rpm_working_dir}/SPECS/
+
+tar czvf ${rpm_working_dir}/SOURCES/${NAME}_${VERSION}.orig.tar.gz \
+  --exclude .git --exclude packaging --transform "s/^\./${NAME}-${VERSION}/" .
+
+rpmbuild --define "_topdir ${rpm_working_dir}/" --define "_version ${VERSION}" \
+  -ba ${rpm_working_dir}/SPECS/${NAME}.spec


### PR DESCRIPTION
OSConfig changes:

* Build RPM packages for CentOS/RHEL 6/7
* Include upstart (CentOS/RHEL 6) and systemd scripts
* Don't enable or start service by default

Debian contents:
```
find /tmp/debpackage/ -iname '*.deb' -ls -exec dpkg-deb -I '{}' \; -exec dpkg-deb -c '{}' \;
     2158   2840 -rw-r--r--   1 liamh    liamh     2905346 Jan  3 00:23 /tmp/debpackage/google-osconfig-agent_0.4.1-1_amd64.deb
 new debian package, version 2.0.
 size 2905346 bytes: control archive=681 bytes.
     330 bytes,    11 lines      control              
     317 bytes,     4 lines      md5sums              
     185 bytes,     7 lines   *  postrm               #!/bin/sh
 Package: google-osconfig-agent
 Version: 0.4.1-1
 Architecture: amd64
 Maintainer: Google Cloud Team <gc-team@google.com>
 Installed-Size: 10415
 Depends: libc6 (>= 2.3.2)
 Section: misc
 Priority: optional
 Description: Google Compute Engine OSConfig Agent
  Contains the OSConfig agent service binary as well as systemd
  startup scripts
drwxr-xr-x root/root         0 2018-12-31 12:00 ./
drwxr-xr-x root/root         0 2018-12-31 12:00 ./lib/
drwxr-xr-x root/root         0 2018-12-31 12:00 ./lib/systemd/
drwxr-xr-x root/root         0 2018-12-31 12:00 ./lib/systemd/system/
-rw-r--r-- root/root       123 2018-12-31 12:00 ./lib/systemd/system/google-osconfig-agent.service
drwxr-xr-x root/root         0 2018-12-31 12:00 ./usr/
drwxr-xr-x root/root         0 2018-12-31 12:00 ./usr/bin/
-rwxr-xr-x root/root  10650096 2018-12-31 12:00 ./usr/bin/google_osconfig_agent
drwxr-xr-x root/root         0 2018-12-31 12:00 ./usr/share/
drwxr-xr-x root/root         0 2018-12-31 12:00 ./usr/share/doc/
drwxr-xr-x root/root         0 2018-12-31 12:00 ./usr/share/doc/google-osconfig-agent/
-rw-r--r-- root/root       169 2018-12-31 12:00 ./usr/share/doc/google-osconfig-agent/changelog.Debian.gz
-rw-r--r-- root/root       982 2018-12-31 12:00 ./usr/share/doc/google-osconfig-agent/copyright
```

RHEL7 contents:
```
find /tmp/rpmpackage/RPMS -iname '*.rpm' -ls -exec rpm -qpil '{}' \;
11282910 3272 -rw-rw-r--   1 liamh    liamh     3349236 Jan  2 21:51 /tmp/rpmpackage/RPMS/x86_64/google-osconfig-agent-0.4.11-1.el7.x86_64.rpm
Name        : google-osconfig-agent
Version     : 0.4.11
Release     : 1.el7
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 10755321
License     : ASL 2.0
Signature   : (none)
Source RPM  : google-osconfig-agent-0.4.11-1.el7.src.rpm
Build Date  : Wed 02 Jan 2019 09:51:32 PM UTC
Build Host  : rhel-7.c.liamh-testing.internal
Relocations : (not relocatable)
URL         : https://github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent
Summary     : Google Compute Engine guest environment.
Description :
Contains the OSConfig agent binary and startup scripts

/usr/bin/google-osconfig-agent
/usr/lib/systemd/system/google-osconfig-agent.service
```
RHEL6 contents:
```
find /tmp/rpmpackage/RPMS -iname '*.rpm' -ls -exec rpm -qpil '{}' \;
269262 3196 -rw-rw-r--   1 liamh    liamh     3272244 Jan  3 00:50 /tmp/rpmpackage/RPMS/x86_64/google-osconfig-agent-0.4.11-1.el6.x86_64.rpm
Name        : google-osconfig-agent        Relocations: (not relocatable)
Version     : 0.4.11                            Vendor: (none)
Release     : 1.el6                         Build Date: Thu 03 Jan 2019 12:50:33 AM UTC
Install Date: (not installed)               Build Host: rhel-6.c.liamh-testing.internal
Group       : Unspecified                   Source RPM: google-osconfig-agent-0.4.11-1.el6.src.rpm
Size        : 10642916                         License: ASL 2.0
Signature   : (none)
URL         : https://github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent
Summary     : Google Compute Engine guest environment.
Description :
Contains the OSConfig agent binary and startup scripts
/etc/init/google-osconfig-agent.conf
/usr/bin/google_osconfig_agent
```