### PR TITLE
image_test/metadata-script: update the expected messages

### DIFF
--- a/image_test/metadata-script/shutdown-script-linux.wf.json
+++ b/image_test/metadata-script/shutdown-script-linux.wf.json
@@ -11,8 +11,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "shutdown_hash": "e3de3cd247bbe7c8b3a6f496f55a80f1",
-            "shutdown_msg": "shutdown-script: INFO Found shutdown-script-url in metadata.",
-            "no_shutdown_msg": "shutdown-script: INFO No shutdown scripts found in metadata.",
+            "shutdown_msg": "INFO Found shutdown-script-url in metadata.",
+            "no_shutdown_msg": "INFO No shutdown scripts found in metadata.",
             "wait_msg": "Ready to stop instance.",
             "shutdown_script_name": "metadata-script-test-shutdown-hash.sh",
             "startup_script_name": "startup-script-for-shutdown-tests.sh"

--- a/image_test/metadata-script/startup-script-linux.wf.json
+++ b/image_test/metadata-script/startup-script-linux.wf.json
@@ -11,8 +11,8 @@
         "Vars": {
             "source_image": "${source_image}",
             "startup_hash": "7d954ca9f2786bef7f3c69c6d6661a75",
-            "startup_msg": "startup-script: INFO Found startup-script-url in metadata.",
-            "no_startup_msg": "startup-script: INFO No startup scripts found in metadata.",
+            "startup_msg": "INFO Found startup-script-url in metadata.",
+            "no_startup_msg": "INFO No startup scripts found in metadata.",
             "startup_script_name": "metadata-script-test-startup-hash.sh"
         }
       }


### PR DESCRIPTION
Using journald a number is added to the log message after the name of
the daemon, and this number varies depending on the order of daemons
execution. So the daemon name was removed from the expected message.