### PR TITLE
Added missing network/subnet variable forwarding to the included translate workflow

### DIFF
--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -52,7 +52,9 @@
           "image_name": "${image_name}",
           "install_gce_packages": "${install_gce_packages}",
           "family": "${family}",
-          "description": "${description}"
+          "description": "${description}",
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "1h"


### PR DESCRIPTION
Import from image now works without default VPC networks.