### PR TITLE
Fix scopes: set default value when empty

### DIFF
--- a/daisy/instance.go
+++ b/daisy/instance.go
@@ -88,7 +88,7 @@ type Instance struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// OAuth2 scopes to give the instance. If left unset
 	// https://www.googleapis.com/auth/devstorage.read_only will be added.
-	Scopes []string `json:",omitempty"`
+	Scopes *[]string `json:",omitempty"`
 	// StartupScript is the Sources path to a startup script to use in this step.
 	// This will be automatically mapped to the appropriate metadata key.
 	StartupScript string `json:",omitempty"`
@@ -225,10 +225,10 @@ func (i *Instance) populateNetworks() dErr {
 
 func (i *Instance) populateScopes() dErr {
 	if i.Scopes == nil {
-		i.Scopes = append(i.Scopes, "https://www.googleapis.com/auth/devstorage.read_only")
+		i.Scopes = &[]string{"https://www.googleapis.com/auth/devstorage.read_only"}
 	}
 	if i.ServiceAccounts == nil {
-		i.ServiceAccounts = []*compute.ServiceAccount{{Email: "default", Scopes: i.Scopes}}
+		i.ServiceAccounts = []*compute.ServiceAccount{{Email: "default", Scopes: *i.Scopes}}
 	}
 	return nil
 }

--- a/daisy/instance_test.go
+++ b/daisy/instance_test.go
@@ -280,13 +280,13 @@ func TestInstancePopulateScopes(t *testing.T) {
 	defaultScopes := []string{"https://www.googleapis.com/auth/devstorage.read_only"}
 	tests := []struct {
 		desc           string
-		input          []string
+		input          *[]string
 		inputSas, want []*compute.ServiceAccount
 		shouldErr      bool
 	}{
 		{"default case", nil, nil, []*compute.ServiceAccount{{Email: "default", Scopes: defaultScopes}}, false},
-		{"nondefault case", []string{"foo"}, nil, []*compute.ServiceAccount{{Email: "default", Scopes: []string{"foo"}}}, false},
-		{"service accounts override case", []string{"foo"}, []*compute.ServiceAccount{}, []*compute.ServiceAccount{}, false},
+		{"nondefault case", &[]string{"foo"}, nil, []*compute.ServiceAccount{{Email: "default", Scopes: []string{"foo"}}}, false},
+		{"service accounts override case", &[]string{"foo"}, []*compute.ServiceAccount{}, []*compute.ServiceAccount{}, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The way Scopes was declared, json populates it as an empty list (even if
it is not set in the json object), so Scopes is never set to nil, and
the if statement that sets the default value is never true.

Declare Scopes as a pointer instead.