### PR TITLE
Update container image workflow for Windows Server 2019 and 1809.

### DIFF
--- a/daisy_workflows/image_build/windows_for_containers/container_image_install.ps1
+++ b/daisy_workflows/image_build/windows_for_containers/container_image_install.ps1
@@ -146,10 +146,6 @@ function Run-FirstBootSteps {
   $docker_version = "18.09"
   Write-Host "Installing Docker EE ${docker_version}"
   Install-Package -Name docker -ProviderName DockerMsftProvider -Force -RequiredVersion ${docker_version}
-
-  Write-Host 'Enabling IPv6'
-  $ipv_path = 'HKLM:\SYSTEM\CurrentControlSet\services\TCPIP6\Parameters'
-  Set-ItemProperty -Path $ipv_path -Name 'DisabledComponents' -Value 0x0
 }
 
 function Run-SecondBootSteps {

--- a/daisy_workflows/image_build/windows_for_containers/container_image_install.ps1
+++ b/daisy_workflows/image_build/windows_for_containers/container_image_install.ps1
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script prepares a Windows Server version 1803 image to run Windows
-# Server containers by following the steps in Microsoft's documentation:
-# https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server.
+# This script prepares a Windows Server image to run Windows Server containers.
+# It works on Windows Server version 1709 and later.
+#
 # These steps use the DockerMsftProvider OneGet module
 # (https://github.com/OneGet/MicrosoftDockerProvider), which installs Docker
 # Enterprise Edition (not "Docker for Windows", which is a distribution of
@@ -47,61 +47,163 @@ function Get-MetadataValue {
   }
 }
 
+function Get-ContainerRepo {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+
+  # The canonical source for Windows base container images used to be Docker
+  # Hub ('microsoft/...'), now it is Microsoft Container Registry
+  # ('mcr.microsoft.com/windows/...'). See:
+  # https://azure.microsoft.com/en-us/blog/microsoft-syndicates-container-catalog/
+  # https://blogs.technet.microsoft.com/virtualization/2018/11/13/windows-server-2019-now-available/
+  if ($windows_version -eq '1709' -or $windows_version -eq '1803') {
+    return 'microsoft'
+  }
+  return 'mcr.microsoft.com/windows'
+}
+
+function Get-ContainerVersionLabel {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+
+  # For more information about Windows container version labels see:
+  # https://hub.docker.com/r/microsoft/windowsservercore/
+  # https://blogs.technet.microsoft.com/virtualization/2017/10/18/container-images-are-now-out-for-windows-server-version-1709/
+  # https://azure.microsoft.com/en-us/blog/microsoft-syndicates-container-catalog/
+  # https://blogs.technet.microsoft.com/virtualization/2018/11/13/windows-server-2019-now-available/
+  if ($windows_version -eq '2019') {
+    return 'ltsc2019'
+  }
+  # '1709', '1803', '1809':
+  return $windows_version
+}
+
+function Supports-NanoserverContainerImage {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+
+  # Windows Server 2019 does not support the nanoserver container image, only
+  # Servercore:
+  # https://blogs.technet.microsoft.com/virtualization/2018/11/13/windows-server-2019-now-available/.
+  if ($windows_version -eq '2019') {
+    return $false
+  }
+  return $true
+}
+
+function Get-ServerCoreImageName {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+
+  $repo = Get-ContainerRepo $windows_version
+  if ($windows_version -eq '1709' -or $windows_version -eq '1803') {
+    $image = 'windowsservercore'
+  } else {
+    $image = 'servercore'
+  }
+  $label = Get-ContainerVersionLabel $windows_version
+  return "${repo}/${image}:${label}"
+}
+
+function Get-NanoserverImageName {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+  $repo = Get-ContainerRepo $windows_version
+  $image = 'nanoserver'
+  $label = Get-ContainerVersionLabel $windows_version
+  return "${repo}/${image}:${label}"
+}
+
+function Get-BaseContainerImageNames {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+  $images = @(Get-ServerCoreImageName $windows_version)
+  if (Supports-NanoserverContainerImage $windows_version) {
+    $images += (Get-NanoserverImageName $windows_version)
+  }
+  return $images
+}
+
+function Run-FirstBootSteps {
+  Write-Host 'Installing NuGet module'
+  Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+
+  Write-Host 'Installing DockerMsftProvider module'
+  Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
+
+  $docker_version = "18.09"
+  Write-Host "Installing Docker EE ${docker_version}"
+  Install-Package -Name docker -ProviderName DockerMsftProvider -Force -RequiredVersion ${docker_version}
+
+  Write-Host 'Enabling IPv6'
+  $ipv_path = 'HKLM:\SYSTEM\CurrentControlSet\services\TCPIP6\Parameters'
+  Set-ItemProperty -Path $ipv_path -Name 'DisabledComponents' -Value 0x0
+}
+
+function Run-SecondBootSteps {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$windows_version
+  )
+
+  # For some reason the docker service may not be started automatically on the
+  # first reboot, although it seems to work fine on subsequent reboots. The
+  # docker service must be running or else the vEthernet interface may not be
+  # present.
+  Restart-Service docker
+
+  Write-Host 'Setting host vEthernet MTU to 1460'
+  Get-NetAdapter | Where-Object {$_.Name -like 'vEthernet*'} | ForEach-Object {
+    & netsh interface ipv4 set subinterface $_.InterfaceIndex mtu=1460 store=persistent
+  }
+
+  # As most if not all Windows containers are based on one of the base images
+  # provided by Microsoft, we pull them here so that running a container using
+  # this image is quick.
+  $container_images = Get-BaseContainerImageNames $windows_version
+  ForEach ($image in $container_images) {
+    Write-Host "Pulling container image: $image"
+    & docker pull $image
+    if (!$?) {
+      throw "Error running 'docker pull $image'"
+    }
+  }
+
+  Write-Host 'Setting container vEthernet MTU to 1460'
+  $servercore_image = Get-ServerCoreImageName $windows_version
+  & docker run --rm "$servercore_image" powershell.exe "Get-NetAdapter | Where-Object {`$_.Name -like 'vEthernet*'} | ForEach-Object { & netsh interface ipv4 set subinterface `$_.InterfaceIndex mtu=1460 store=persistent }"
+  if (!$?) {
+    throw "Error running 'docker run $servercore_image'"
+  }
+}
+
 & googet -noconfirm update
 try {
   $windows_version = Get-MetadataValue 'version'
+  Write-Host "Windows version: $windows_version"
   if (-not $windows_version) {
     throw 'Error retrieving "version" from metadata'
   }
 
   if (!(Get-Package -ProviderName DockerMsftProvider -ErrorAction SilentlyContinue| Where-Object {$_.Name -eq 'docker'})) {
-    Write-Host 'Installing NuGet module'
-    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-
-    Write-Host 'Installing DockerMsftProvider module'
-    Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
-
-    $docker_version = "18.09"
-    Write-Host "Installing Docker EE ${docker_version}"
-    Install-Package -Name docker -ProviderName DockerMsftProvider -Force -RequiredVersion ${docker_version}
-
-    Write-Host 'Enabling IPv6'
-    $ipv_path = 'HKLM:\SYSTEM\CurrentControlSet\services\TCPIP6\Parameters'
-    Set-ItemProperty -Path $ipv_path -Name 'DisabledComponents' -Value 0x0
-
+    Run-FirstBootSteps
     Write-Host 'Restarting computer to finish install'
     Restart-Computer -Force
   }
   else {
-    # For some reason the docker service may not be started automatically on the
-    # first reboot, although it seems to work fine on subsequent reboots. The
-    # docker service must be running or else the vEthernet interface may not be
-    # present.
-    Restart-Service docker
-
-    Write-Host 'Setting host vEthernet MTU to 1460'
-    Get-NetAdapter | Where-Object {$_.Name -like 'vEthernet*'} | ForEach-Object {
-      & netsh interface ipv4 set subinterface $_.InterfaceIndex mtu=1460 store=persistent
-    }
-
-    # As most if not all Windows containers are based on one of these images
-    # we pull it here so that running a container using this image is quick.
-    Write-Host 'Pulling latest Windows containers'
-    & docker pull "microsoft/windowsservercore:${windows_version}"
-    if (!$?) {
-      throw "Error running 'docker pull microsoft/windowsservercore:${windows_version}'"
-    }
-    & docker pull "microsoft/nanoserver:${windows_version}"
-    if (!$?) {
-      throw "Error running 'docker pull microsoft/nanoserver:${windows_version}'"
-    }
-
-    Write-Host 'Setting container vEthernet MTU to 1460'
-    & docker run --rm "microsoft/windowsservercore:${windows_version}" powershell.exe "Get-NetAdapter | Where-Object {`$_.Name -like 'vEthernet*'} | ForEach-Object { & netsh interface ipv4 set subinterface `$_.InterfaceIndex mtu=1460 store=persistent }"
-    if (!$?) {
-      throw "Error running 'docker run microsoft/windowsservercore:${windows_version}'"
-    }
-
+    Run-SecondBootSteps $windows_version
     Write-Host 'Launching sysprep.'
     & 'C:\Program Files\Google\Compute Engine\sysprep\gcesysprep.bat'
   }

--- a/daisy_workflows/image_build/windows_for_containers/windows-1803-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-1803-for-containers.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
-    "install_disk": {"Value": "disk-install", "Description": "Name of the GCE disk to use for the SQL install"},
+    "install_disk": {"Value": "disk-install", "Description": "Name of the GCE disk to use for the installation"},
     "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
   },
   "Sources": {

--- a/daisy_workflows/image_build/windows_for_containers/windows-1809-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-1809-for-containers.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-1709-for-containers-image-build",
+  "Name": "windows-1809-for-containers-image-build",
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
@@ -19,7 +19,7 @@
         },
         {
           "Name": "${install_disk}",
-          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1709-core",
+          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1809-core",
           "Type": "pd-ssd"
         }
       ]
@@ -31,7 +31,7 @@
           "Disks": [{"Source": "${install_disk}"}, {"Source": "disk-scratch"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "version": "1709"
+            "version": "1809"
           },
           "StartupScript": "container_image_install.ps1"
         }
@@ -57,12 +57,12 @@
     "create-image": {
       "CreateImages": [
         {
-          "Name": "windows-server-1709-dc-core-for-containers-v${build_date}",
+          "Name": "windows-server-1809-dc-core-for-containers-v${build_date}",
           "SourceDisk": "${install_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-for-containers"],
-          "Description": "Microsoft, Windows Server, version 1709 Core for Containers, Server Core, x64 built on ${build_date}",
+          "Description": "Microsoft, Windows Server, version 1809 Core for Containers, Server Core, x64 built on ${build_date}",
           "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
-          "Family": "windows-1709-core-for-containers",
+          "Family": "windows-1809-core-for-containers",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/windows_for_containers/windows-2019-core-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-2019-core-for-containers.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-1709-for-containers-image-build",
+  "Name": "windows-2019-core-for-containers-image-build",
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
@@ -19,7 +19,7 @@
         },
         {
           "Name": "${install_disk}",
-          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1709-core",
+          "SourceImage": "projects/${source_image_project}/global/images/family/windows-2019-core",
           "Type": "pd-ssd"
         }
       ]
@@ -31,7 +31,7 @@
           "Disks": [{"Source": "${install_disk}"}, {"Source": "disk-scratch"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "version": "1709"
+            "version": "2019"
           },
           "StartupScript": "container_image_install.ps1"
         }
@@ -57,12 +57,12 @@
     "create-image": {
       "CreateImages": [
         {
-          "Name": "windows-server-1709-dc-core-for-containers-v${build_date}",
+          "Name": "windows-server-2019-dc-core-for-containers-v${build_date}",
           "SourceDisk": "${install_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-for-containers"],
-          "Description": "Microsoft, Windows Server, version 1709 Core for Containers, Server Core, x64 built on ${build_date}",
+          "Description": "Microsoft, Windows Server, 2019 Datacenter Core for Containers, Server Core, x64 built on ${build_date}",
           "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
-          "Family": "windows-1709-core-for-containers",
+          "Family": "windows-2019-core-for-containers",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/windows_for_containers/windows-2019-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-2019-for-containers.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-1709-for-containers-image-build",
+  "Name": "windows-2019-for-containers-image-build",
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
@@ -19,7 +19,7 @@
         },
         {
           "Name": "${install_disk}",
-          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1709-core",
+          "SourceImage": "projects/${source_image_project}/global/images/family/windows-2019",
           "Type": "pd-ssd"
         }
       ]
@@ -31,7 +31,7 @@
           "Disks": [{"Source": "${install_disk}"}, {"Source": "disk-scratch"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "version": "1709"
+            "version": "2019"
           },
           "StartupScript": "container_image_install.ps1"
         }
@@ -57,12 +57,12 @@
     "create-image": {
       "CreateImages": [
         {
-          "Name": "windows-server-1709-dc-core-for-containers-v${build_date}",
+          "Name": "windows-server-2019-dc-for-containers-v${build_date}",
           "SourceDisk": "${install_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-for-containers"],
-          "Description": "Microsoft, Windows Server, version 1709 Core for Containers, Server Core, x64 built on ${build_date}",
+          "Description": "Microsoft, Windows Server, 2019 Datacenter for Containers, x64 built on ${build_date}",
           "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
-          "Family": "windows-1709-core-for-containers",
+          "Family": "windows-2019-for-containers",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true


### PR DESCRIPTION
Microsoft made several changes to the naming and location of their base
Windows containers with the release of Windows Server 2019 and 1809.
This change adds workflow files for Windows Server 2019 and 1809 and
updates the container image installation script to accommodate the
version differences.

====Tested:====
time ~/go/bin/daisy -project PROJECT -zone us-west1-b daisy_workflows/image_build/windows_for_containers/windows-1709-for-containers.wf.json
time ~/go/bin/daisy -project PROJECT -zone us-west1-b daisy_workflows/image_build/windows_for_containers/windows-1803-for-containers.wf.json
time ~/go/bin/daisy -project PROJECT -zone us-west1-b daisy_workflows/image_build/windows_for_containers/windows-1809-for-containers.wf.json
time ~/go/bin/daisy -project PROJECT -zone us-west1-b daisy_workflows/image_build/windows_for_containers/windows-2019-for-containers.wf.json
time ~/go/bin/daisy -project PROJECT -zone us-west1-b daisy_workflows/image_build/windows_for_containers/windows-2019-core-for-containers.wf.json