### PR TITLE
osconfig_agent: update build scripts, add version info

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -40,6 +40,8 @@ var (
 	zypperRepoFilePath = flag.String("zypper_repo_file", "/etc/zypp/repos.d/google_osconfig.repo", "zypper repo file location")
 	yumRepoFilePath    = flag.String("yum_repo_file", "/etc/yum/repos.d/google_osconfig.repo", "yum repo file location")
 	aptRepoFilePath    = flag.String("aptrepo_file", "/etc/apt/sources.list.d/google_osconfig.list", "apt repo file location")
+
+	version string
 )
 
 // SvcPollInterval returns the frequency to poll the service.
@@ -131,4 +133,14 @@ func Instance() (string, error) {
 // Project is the URI of the instance the agent is running on.
 func Project() (string, error) {
 	return metadata.ProjectID()
+}
+
+// Version is the agent version.
+func Version() string {
+	return version
+}
+
+// SetVersion sets the agent version.
+func SetVersion(v string) {
+	version = v
 }

--- a/cli_tools/google-osconfig-agent/logger/logger.go
+++ b/cli_tools/google-osconfig-agent/logger/logger.go
@@ -40,6 +40,9 @@ var (
 
 // Init instantiates the logger.
 func Init(ctx context.Context, project string) {
+	msg := fmt.Sprintf("OSConfig Agent (version %s) Init", config.Version())
+	Infof(msg)
+
 	var err error
 	cloudLoggingClient, err = logging.NewClient(ctx, project)
 	if err != nil {
@@ -49,7 +52,7 @@ func Init(ctx context.Context, project string) {
 
 	// This automatically detects and associates with a GCE resource.
 	cloudLogger = cloudLoggingClient.Logger("osconfig")
-	if err := cloudLogger.LogSync(ctx, logging.Entry{Severity: logging.Info, Payload: map[string]string{"localTimestamp": now(), "message": "OSConfig Agent Init"}}); err != nil {
+	if err := cloudLogger.LogSync(ctx, logging.Entry{Severity: logging.Info, Payload: map[string]string{"localTimestamp": now(), "message": msg}}); err != nil {
 		// This means cloud logging is not working, so don't continue to try to log.
 		cloudLogger = nil
 		Errorf(err.Error())

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -31,6 +31,8 @@ import (
 	"google.golang.org/api/option"
 )
 
+var version string
+
 type logWritter struct{}
 
 func (l *logWritter) Write(b []byte) (int, error) {

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -33,6 +33,11 @@ import (
 
 var version string
 
+func init() {
+	// We do this here so the -X value doesn't need the full path.
+	config.SetVersion(version)
+}
+
 type logWritter struct{}
 
 func (l *logWritter) Write(b []byte) (int, error) {

--- a/cli_tools/google-osconfig-agent/packaging/common.sh
+++ b/cli_tools/google-osconfig-agent/packaging/common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NAME="google-osconfig-agent"
+VERSION="0.4.2"
+GOLANG="go1.11.4.linux-amd64.tar.gz"
+GO=/tmp/go/bin/go
+GOPATH=/usr/share/gocode
+
+working_dir=${PWD}
+if [[ $(basename "$working_dir") != $NAME ]]; then
+  echo "Packaging scripts must be run from top of package dir."
+  exit 1
+fi
+
+# Golang setup
+[[ -d /tmp/go ]] && rm -rf /tmp/go
+mkdir -p /tmp/go/
+echo "Downloading Go"
+curl -s "https://dl.google.com/go/${GOLANG}" -o /tmp/go/go.tar.gz
+echo "Extracting Go"
+tar -C /tmp/go/ --strip-components=1 -xf /tmp/go/go.tar.gz
+
+echo "Pulling dependencies"
+sudo su -c "GOPATH=${GOPATH} ${GO} get -d ./..."
+sudo su -c "GOOS=windows GOPATH=${GOPATH} ${GO} get -d ./..."

--- a/cli_tools/google-osconfig-agent/packaging/common.sh
+++ b/cli_tools/google-osconfig-agent/packaging/common.sh
@@ -17,7 +17,7 @@ NAME="google-osconfig-agent"
 VERSION="0.4.2"
 GOLANG="go1.11.4.linux-amd64.tar.gz"
 GO=/tmp/go/bin/go
-GOPATH=/usr/share/gocode
+export GOPATH=/usr/share/gocode
 
 working_dir=${PWD}
 if [[ $(basename "$working_dir") != $NAME ]]; then

--- a/cli_tools/google-osconfig-agent/packaging/debian/changelog
+++ b/cli_tools/google-osconfig-agent/packaging/debian/changelog
@@ -1,5 +1,11 @@
 google-osconfig-agent (0.4.2-1) UNRELEASED; urgency=medium
 
-  * Initial release. (Closes: #XXXXXX)
+  * Add version info to binary.
+
+ -- Google Cloud Team <gc-team@google.com>  Mon, 07 Jan 2019 12:00:00 +0000
+
+google-osconfig-agent (0.4.1-1) UNRELEASED; urgency=medium
+
+  * Initial release.
 
  -- Google Cloud Team <gc-team@google.com>  Mon, 31 Dec 2018 12:00:00 +0000

--- a/cli_tools/google-osconfig-agent/packaging/debian/changelog
+++ b/cli_tools/google-osconfig-agent/packaging/debian/changelog
@@ -1,4 +1,4 @@
-google-osconfig-agent (0.4.1-1) UNRELEASED; urgency=medium
+google-osconfig-agent (0.4.2-1) UNRELEASED; urgency=medium
 
   * Initial release. (Closes: #XXXXXX)
 

--- a/cli_tools/google-osconfig-agent/packaging/debian/control
+++ b/cli_tools/google-osconfig-agent/packaging/debian/control
@@ -3,7 +3,7 @@ Maintainer: Google Cloud Team <gc-team@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9), dh-golang (>= 1.1), dh-systemd
+Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1)
 
 Package: google-osconfig-agent
 Architecture: any

--- a/cli_tools/google-osconfig-agent/packaging/debian/control
+++ b/cli_tools/google-osconfig-agent/packaging/debian/control
@@ -3,7 +3,7 @@ Maintainer: Google Cloud Team <gc-team@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1)
+Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1), golang-go
 
 Package: google-osconfig-agent
 Architecture: any

--- a/cli_tools/google-osconfig-agent/packaging/debian/google-osconfig-agent.lintian-overrides
+++ b/cli_tools/google-osconfig-agent/packaging/debian/google-osconfig-agent.lintian-overrides
@@ -1,0 +1,1 @@
+google-osconfig-agent binary: statically-linked-binary

--- a/cli_tools/google-osconfig-agent/packaging/debian/google-osconfig-agent.lintian-overrides
+++ b/cli_tools/google-osconfig-agent/packaging/debian/google-osconfig-agent.lintian-overrides
@@ -1,1 +1,0 @@
-google-osconfig-agent binary: statically-linked-binary

--- a/cli_tools/google-osconfig-agent/packaging/debian/rules
+++ b/cli_tools/google-osconfig-agent/packaging/debian/rules
@@ -5,6 +5,7 @@ export SHELL := env PATH=$(PATH) /bin/bash
 
 export DH_OPTIONS
 export DH_GOPKG := github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent
+export CGO_ENABLED := 0
 
 %:
 	dh $@  --buildsystem=golang --with=golang,systemd
@@ -16,6 +17,9 @@ override_dh_auto_install:
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.
+
+override_dh_auto_build:
+	dh_auto_build -O--buildsystem=golang -- -ldflags "-s -w -X main.version=$(VERSION)"
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/cli_tools/google-osconfig-agent/packaging/debian/rules
+++ b/cli_tools/google-osconfig-agent/packaging/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export PATH := /tmp/go11/bin:$(PATH)
+export PATH := /tmp/go/bin:$(PATH)
 export SHELL := env PATH=$(PATH) /bin/bash
 
 export DH_OPTIONS

--- a/cli_tools/google-osconfig-agent/packaging/googet/build.sh
+++ b/cli_tools/google-osconfig-agent/packaging/googet/build.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+version=$(cat google-osconfig-agent.goospec | sed -nE 's/.*"version":.*"(.+)".*/\1/p')
+if [[ $? -ne 0 ]]; then
+  echo "could not match version in goospec"
+  exit 1
+fi
+
+pushd ../../
+GOOS=windows /tmp/go/bin/go build -ldflags "-X main.version=${version}" -o google_osconfig_agent.exe
+popd

--- a/cli_tools/google-osconfig-agent/packaging/googet/build.sh
+++ b/cli_tools/google-osconfig-agent/packaging/googet/build.sh
@@ -1,10 +1,8 @@
 #! /bin/bash
-version=$(cat google-osconfig-agent.goospec | sed -nE 's/.*"version":.*"(.+)".*/\1/p')
+version=$(cat packaging/googet/google-osconfig-agent.goospec | sed -nE 's/.*"version":.*"(.+)".*/\1/p')
 if [[ $? -ne 0 ]]; then
   echo "could not match version in goospec"
   exit 1
 fi
 
-pushd ../../
 GOOS=windows /tmp/go/bin/go build -ldflags "-X main.version=${version}" -o google_osconfig_agent.exe
-popd

--- a/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
+++ b/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
@@ -26,6 +26,6 @@
       ]
   }],
   "build": {
-    "linux": "./agent_build.sh"
+    "linux": "./build.sh"
   }
 }

--- a/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
+++ b/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
@@ -9,6 +9,7 @@
     "google_osconfig_agent.exe": "<ProgramFiles>/Google/OSConfig/google_osconfig_agent.exe"
   },
   "releaseNotes": [
+    "0.4.2 - Add version info to binary",
     "0.3.0 - Merge inventory agent funtionality"
   ],
   "install": {

--- a/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
+++ b/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
@@ -24,5 +24,8 @@
         "packaging/googet/install.ps1",
         "packaging/googet/uninstall.ps1"
       ]
-  }]
+  }],
+  "build": {
+    "linux": "./agent_build.sh"
+  }
 }

--- a/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
+++ b/cli_tools/google-osconfig-agent/packaging/googet/google-osconfig-agent.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-osconfig-agent",
-  "version": "0.4.1@1",
+  "version": "0.4.2@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -20,14 +20,8 @@
   "sources": [{
       "include": [
         "google_osconfig_agent.exe",
-        "install.ps1",
-        "uninstall.ps1"
+        "packaging/googet/install.ps1",
+        "packaging/googet/uninstall.ps1"
       ]
-  }],
-  "build": {
-    "linux": "/bin/bash",
-    "linuxArgs": ["-c", "GOOS=windows go build -ldflags='-s -w' -o \
-    google_osconfig_agent.exe \
-    github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent"]
-  }
+  }]
 }

--- a/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
+++ b/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
@@ -33,7 +33,7 @@ Contains the OSConfig agent binary and startup scripts
 %autosetup
 
 %build
-GOPATH=%{gopath} go build -ldflags="-s -w -linkmode=external -X main.version=${VERSION}" -o google_osconfig_agent
+GOPATH=%{gopath} CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=%{_version}" -o google_osconfig_agent
 
 %install
 install -d %{buildroot}%{_bindir}

--- a/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
+++ b/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
@@ -33,7 +33,7 @@ Contains the OSConfig agent binary and startup scripts
 %autosetup
 
 %build
-GOPATH=%{gopath} CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=%{_version}" -o google_osconfig_agent
+GOPATH=%{gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -o google_osconfig_agent
 
 %install
 install -d %{buildroot}%{_bindir}

--- a/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
+++ b/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
@@ -33,7 +33,7 @@ Contains the OSConfig agent binary and startup scripts
 %autosetup
 
 %build
-GOPATH=%{gopath} go build -ldflags="-linkmode=external" -o google_osconfig_agent
+GOPATH=%{gopath} go build -ldflags="-s -w -linkmode=external -X main.version=${VERSION}" -o google_osconfig_agent
 
 %install
 install -d %{buildroot}%{_bindir}

--- a/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
@@ -12,18 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-set -e
 
-NAME="google-osconfig-agent"
-VERSION="0.4.1"
-GOLANG="go1.11.4.linux-amd64.tar.gz"
+source packaging/common.sh 
 
 working_dir=${PWD}
-if [[ $(basename "$working_dir") != $NAME ]]; then
-  echo "Packaging scripts must be run from top of package dir."
-  exit 1
-fi
+
+sudo apt-get update
 
 # DEB creation tools.
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y install debhelper devscripts build-essential curl tar
@@ -33,20 +27,9 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get -y install dh-golang dh-systemd
 
 dpkg-checkbuilddeps packaging/debian/control
 
-# Golang setup
-[[ -d /tmp/go ]] && rm -rf /tmp/go
-mkdir -p /tmp/go/
-echo "Downloading Go"
-curl -s "https://dl.google.com/go/${GOLANG}" -o /tmp/go/go.tar.gz
-echo "Extracting Go"
-tar -C /tmp/go/ --strip-components=1 -xf /tmp/go/go.tar.gz
-
-# Go Build dependencies
-GOPATH=/usr/share/gocode /tmp/go/bin/go get -d ./...
-
 [[ -d /tmp/debpackage ]] && rm -rf /tmp/debpackage
 mkdir /tmp/debpackage
-tar czvf /tmp/debpackage/${NAME}_${VERSION}.orig.tar.gz  --exclude .git --exclude packaging --transform "s/^\./${NAME}-${VERSION}/" .
+tar czvf /tmp/debpackage/${NAME}_${VERSION}.orig.tar.gz --exclude .git --exclude packaging --transform "s/^\./${NAME}-${VERSION}/" .
 
 pushd /tmp/debpackage
 tar xzvf ${NAME}_${VERSION}.orig.tar.gz

--- a/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
@@ -23,7 +23,7 @@ sudo apt-get update
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y install debhelper devscripts build-essential curl tar
 
 # Build dependencies.
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y install dh-golang dh-systemd
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y install dh-golang dh-systemd golang-go
 
 dpkg-checkbuilddeps packaging/debian/control
 

--- a/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
@@ -39,6 +39,6 @@ cd ${NAME}-${VERSION}
 cp -r ${working_dir}/packaging/debian ./
 cp -r ${working_dir}/*.service ./debian/
 
-debuild -us -uc -e "VERSION=${VERSION}"
+debuild -e "VERSION=${VERSION}" -us -uc
 
 popd

--- a/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_deb.sh
@@ -39,6 +39,6 @@ cd ${NAME}-${VERSION}
 cp -r ${working_dir}/packaging/debian ./
 cp -r ${working_dir}/*.service ./debian/
 
-debuild -us -uc
+debuild -us -uc -e "VERSION=${VERSION}"
 
 popd

--- a/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
@@ -15,6 +15,8 @@
 
 source packaging/common.sh 
 
+sudo cp * ${GOPATH}/src/github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/
+
 echo "Building package"
-$GO get github.com/google/googet/goopack
+sudo su -c "GOPATH=${GOPATH} ${GO} get -d github.com/google/googet/goopack"
 $GO run github.com/google/googet/goopack packaging/googet/google-osconfig-agent.goospec

--- a/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
@@ -17,4 +17,4 @@ source packaging/common.sh
 
 echo "Building package"
 $GO get github.com/google/googet/goopack
-~/go/bin/goopack packaging/googet/google-osconfig-agent.goospec
+$GO run github.com/google/googet/goopack packaging/googet/google-osconfig-agent.goospec

--- a/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
@@ -13,29 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+source packaging/common.sh 
 
-NAME="google-osconfig-agent"
-VERSION="0.4.1"
-GOLANG="go1.11.4.linux-amd64.tar.gz"
-
-working_dir=${PWD}
-if [[ $(basename "$working_dir") != $NAME ]]; then
-  echo "Packaging scripts must be run from top of package dir."
-  exit 1
-fi
-
-# Golang setup
-[[ -d /tmp/go ]] && rm -rf /tmp/go
-mkdir -p /tmp/go/
-echo "Downloading Go"
-curl -s "https://dl.google.com/go/${GOLANG}" -o /tmp/go/go.tar.gz
-echo "Extracting Go"
-tar -C /tmp/go/ --strip-components=1 -xf /tmp/go/go.tar.gz
-
-# Go Build dependencies
-GOOS=windows /tmp/go/bin/go get -d ./...
-
-/tmp/go/bin/go get -d github.com/google/googet
-
-GOOS=windows /tmp/go/bin/go run github.com/google/googet/goopack/goopack.go packaging/googet/google-osconfig-agent.goospec
+echo "Building package"
+$GO get github.com/google/googet/goopack
+GOOS=windows $GO build -ldflags="-s -w -X main.version=${VERSION}" -o google_osconfig_agent.exe 
+~/go/bin/goopack packaging/googet/google-osconfig-agent.goospec

--- a/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_goo.sh
@@ -17,5 +17,4 @@ source packaging/common.sh
 
 echo "Building package"
 $GO get github.com/google/googet/goopack
-GOOS=windows $GO build -ldflags="-s -w -X main.version=${VERSION}" -o google_osconfig_agent.exe 
 ~/go/bin/goopack packaging/googet/google-osconfig-agent.goospec

--- a/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This downloads a go version we don't use for rpmbuild.
 source packaging/common.sh 
 
 rpm_working_dir=/tmp/rpmpackage/

--- a/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
@@ -13,23 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
-NAME="google-osconfig-agent"
-VERSION="0.4.1"
+# This downloads a go version we don't use for rpmbuild.
+source packaging/common.sh 
 
 rpm_working_dir=/tmp/rpmpackage/
-working_dir=${PWD}
-if [[ $(basename "$working_dir") != $NAME ]]; then
-  echo "Packaging scripts must be run from top of package dir."
-  exit 1
-fi
 
 # RPM creation tools.
 sudo yum -y install rpmdevtools go-srpm-macros
-
-# Go build dependencies.
-sudo su -c 'GOPATH=/usr/share/gocode go get -d ./...'
 
 rm -rf /tmp/rpmpackage
 mkdir -p ${rpm_working_dir}/{SOURCES,SPECS}

--- a/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 NAME="google-osconfig-agent"
-VERSION="0.4.11"
+VERSION="0.4.1"
 
 rpm_working_dir=/tmp/rpmpackage/
 working_dir=${PWD}

--- a/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
+++ b/cli_tools/google-osconfig-agent/packaging/setup_rpm.sh
@@ -30,4 +30,4 @@ tar czvf ${rpm_working_dir}/SOURCES/${NAME}_${VERSION}.orig.tar.gz \
   --exclude .git --exclude packaging --transform "s/^\./${NAME}-${VERSION}/" .
 
 rpmbuild --define "_topdir ${rpm_working_dir}/" --define "_version ${VERSION}" \
-  -ba ${rpm_working_dir}/SPECS/${NAME}.spec
+  --define "_go ${GO}" -ba ${rpm_working_dir}/SPECS/${NAME}.spec


### PR DESCRIPTION
Add windows build script
Add version info to build
Don't use cgo (use Go resolver, not cgo)
Move common build commands to common function