### PR TITLE
Add e2e test structure for package management

### DIFF
--- a/cli_tools/google-osconfig-agent/service/service.go
+++ b/cli_tools/google-osconfig-agent/service/service.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
+	osconfig "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/inventory"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"

--- a/cli_tools/google-osconfig-agent/service/service.go
+++ b/cli_tools/google-osconfig-agent/service/service.go
@@ -84,6 +84,7 @@ func run(ctx context.Context) {
 }
 
 // LookupConfigs looks up osconfigs.
+// TODO: move to osconfig_service wrapper
 func LookupConfigs(ctx context.Context, client *osconfig.Client, resource string) (*osconfigpb.LookupConfigsResponse, error) {
 	info, err := osinfo.GetDistributionInfo()
 	if err != nil {

--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -29,16 +29,17 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/junitxml"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/inventory"
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/package_management"
 )
 
 var (
-	oauth           = flag.String("oauth", "", "path to oauth json file")
 	testSuiteFilter = flag.String("test_suite_filter", "", "test suite filter")
 	testCaseFilter  = flag.String("test_case_filter", "", "test case filter")
 	outPath         = flag.String("out_path", "junit.xml", "junit xml path")
 )
 
 var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp){
+	package_management.TestSuite,
 	inventory.TestSuite,
 }
 
@@ -70,7 +71,7 @@ func main() {
 		}
 	}
 
-	logger := log.New(os.Stdout, "[OSConfigTests] ", 0)
+	logger := log.New(os.Stdout, "[OsConfigTests] ", 0)
 	logger.Println("Starting...")
 
 	tests := make(chan *junitxml.TestSuite)

--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/junitxml"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/inventory"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/package_management"
+	packagemanagement "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/package_management"
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 )
 
 var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp){
-	package_management.TestSuite,
+	packagemanagement.TestSuite,
 	inventory.TestSuite,
 }
 

--- a/osconfig_tests/osconfig_server/osconfig_service_wrapper.go
+++ b/osconfig_tests/osconfig_server/osconfig_service_wrapper.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package compute contains wrappers around the GCE compute API.
+// Package contains wrapper around osconfig service APIs and helper methods
 package osconfig_server
 
 import (
@@ -28,11 +28,21 @@ import (
 
 var dump = &pretty.Config{IncludeUnexported: true}
 
-func CreateOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.CreateOsConfigRequest) (*osconfigpb.OsConfig, error) {
+func getOsConfigClient(ctx context.Context, logger *log.Logger) (*osconfig.Client, error) {
 	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
 
 	if err != nil {
 		logger.Printf("error while creating osconfig client: %s\n", err)
+	}
+	return client, err
+
+}
+
+func CreateOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.CreateOsConfigRequest) (*osconfigpb.OsConfig, error) {
+	client, err := getOsConfigClient(ctx, logger)
+
+	if err != nil {
+		return nil, err
 	}
 
 	logger.Printf("create osconfig request:\n%s\n\n", dump.Sprint(req))
@@ -48,10 +58,10 @@ func CreateOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.Cre
 }
 
 func ListOsConfigs(ctx context.Context, logger *log.Logger, req *osconfigpb.ListOsConfigsRequest) *osconfig.OsConfigIterator {
-	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
+	client, err := getOsConfigClient(ctx, logger)
 
 	if err != nil {
-		logger.Printf("error while creating osconfig client: %s\n", err)
+		return nil
 	}
 
 	logger.Printf("List osconfig request:\n%s\n\n", dump.Sprint(req))
@@ -66,10 +76,10 @@ func ListOsConfigs(ctx context.Context, logger *log.Logger, req *osconfigpb.List
 }
 
 func DeleteOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.DeleteOsConfigRequest) error {
-	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
+	client, err := getOsConfigClient(ctx, logger)
 
 	if err != nil {
-		logger.Printf("error while creating osconfig client: %s\n", err)
+		return err
 	}
 
 	logger.Printf("Delete osconfig request:\n%s\n\n", dump.Sprint(req))

--- a/osconfig_tests/osconfig_server/osconfig_service_wrapper.go
+++ b/osconfig_tests/osconfig_server/osconfig_service_wrapper.go
@@ -12,8 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package contains wrapper around osconfig service APIs and helper methods
-package osconfig_server
+// Package osconfigserver contains wrapper around osconfig service APIs and helper methods
+package osconfigserver
 
 import (
 	"context"
@@ -46,6 +46,7 @@ func getOsConfigClient(ctx context.Context, logger *log.Logger) (*osconfig.Clien
 	return client, err
 }
 
+// CreateOsConfig is a wrapper around createOsConfig API
 func CreateOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.CreateOsConfigRequest) (*osconfigpb.OsConfig, error) {
 	client, err := getOsConfigClient(ctx, logger)
 
@@ -65,6 +66,7 @@ func CreateOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.Cre
 	return res, nil
 }
 
+// ListOsConfigs is a wrapper around listOsConfigs API
 func ListOsConfigs(ctx context.Context, logger *log.Logger, req *osconfigpb.ListOsConfigsRequest) *osconfig.OsConfigIterator {
 	client, err := getOsConfigClient(ctx, logger)
 
@@ -76,13 +78,14 @@ func ListOsConfigs(ctx context.Context, logger *log.Logger, req *osconfigpb.List
 
 	resp := client.ListOsConfigs(ctx, req)
 	if resp == nil {
-		logger.Printf("error while listing osconfig:\n%s\n\n", *resp)
+		logger.Printf("error while listing osconfig:\n%v\n\n", resp)
 		return nil
 	}
 
 	return resp
 }
 
+// DeleteOsConfig is a wrapper around deleteOsConfig API
 func DeleteOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.DeleteOsConfigRequest) error {
 	client, err := getOsConfigClient(ctx, logger)
 
@@ -100,8 +103,7 @@ func DeleteOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.Del
 	return ok
 }
 
-// This function will cleanup all the osconfig created under project
-// Assumption is that this project is only used by this test application
+// CleanupOsConfig function will cleanup the osconfig created under project
 func CleanupOsConfig(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger, osConfig *osconfigpb.OsConfig) {
 
 	logger.Printf("Starting OsConfig cleanup...")

--- a/osconfig_tests/osconfig_server/osconfig_service_wrapper.go
+++ b/osconfig_tests/osconfig_server/osconfig_service_wrapper.go
@@ -1,0 +1,83 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package compute contains wrappers around the GCE compute API.
+package osconfig_server
+
+import (
+	"context"
+	"log"
+
+	osconfig "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
+	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/config"
+	"github.com/kylelemons/godebug/pretty"
+	"google.golang.org/api/option"
+)
+
+var dump = &pretty.Config{IncludeUnexported: true}
+
+func CreateOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.CreateOsConfigRequest) (*osconfigpb.OsConfig, error) {
+	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
+
+	if err != nil {
+		logger.Printf("error while creating osconfig client: %s\n", err)
+	}
+
+	logger.Printf("create osconfig request:\n%s\n\n", dump.Sprint(req))
+
+	res, err := client.CreateOsConfig(ctx, req)
+	if err != nil {
+		logger.Printf("error while creating osconfig:\n%s\n\n", err)
+		return nil, err
+	}
+	logger.Printf("create osconfig response:\n%s\n\n", dump.Sprint(res))
+
+	return res, nil
+}
+
+func ListOsConfigs(ctx context.Context, logger *log.Logger, req *osconfigpb.ListOsConfigsRequest) *osconfig.OsConfigIterator {
+	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
+
+	if err != nil {
+		logger.Printf("error while creating osconfig client: %s\n", err)
+	}
+
+	logger.Printf("List osconfig request:\n%s\n\n", dump.Sprint(req))
+
+	resp := client.ListOsConfigs(ctx, req)
+	if resp == nil {
+		logger.Printf("error while deleting osconfig:\n%s\n\n", *resp)
+		return nil
+	}
+
+	return resp
+}
+
+func DeleteOsConfig(ctx context.Context, logger *log.Logger, req *osconfigpb.DeleteOsConfigRequest) error {
+	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
+
+	if err != nil {
+		logger.Printf("error while creating osconfig client: %s\n", err)
+	}
+
+	logger.Printf("Delete osconfig request:\n%s\n\n", dump.Sprint(req))
+
+	ok := client.DeleteOsConfig(ctx, req)
+	if ok != nil {
+		logger.Printf("error while deleting osconfig:\n%s\n\n", ok)
+		return nil
+	}
+	return ok
+}

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -132,6 +132,8 @@ func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, log
 	logger.Printf("CreateOsConfig response:\n%s\n\n", dump.Sprint(res))
 }
 
+// This function will cleanup all the osconfig created under project
+// Assumption is that this project is only used by this test application
 func cleanupOsConfig(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger) {
 
 	logger.Printf("Starting OsConfig cleanup...")

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -1,0 +1,185 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package package_management
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/junitxml"
+	"github.com/kylelemons/godebug/pretty"
+	api "google.golang.org/api/compute/v1"
+
+	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
+
+	osconfig_server "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/osconfig_server"
+)
+
+const testSuiteName = "PackageManagementTests"
+
+// TODO: Should these be configurable via flags?
+const testProject = "compute-image-test-pool-001"
+const testZone = "us-central1-c"
+
+var dump = &pretty.Config{IncludeUnexported: true}
+
+// TODO: Move to the new combined osconfig package, also make this easily available to other tests.
+var installOsConfigAgentDeb = `echo 'deb http://packages.cloud.google.com/apt google-osconfig-agent-stretch-unstable main' >> /etc/apt/sources.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+apt-get update
+apt-get install -y google-osconfig-agent
+echo 'osconfig agent install done'`
+var installOsConfigAgentGooGet = `c:\programdata\googet\googet.exe -noconfirm install -sources https://packages.cloud.google.com/yuck/repos/google-osconfig-agent-unstable google-osconfig-agent
+echo 'osconfig agent install done'`
+var installOsConfigAgentYumEL7 = `cat > /etc/yum.repos.d/google-osconfig-agent.repo <<EOM
+[google-osconfig-agent]
+name=Google OSConfig Agent Repository
+baseurl=https://packages.cloud.google.com/yum/repos/google-osconfig-agent-el7-unstable
+enabled=1
+gpgcheck=0
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+yum -y install google-osconfig-agent
+echo 'osconfig agent install done'`
+
+type packageManagementTestSetup struct {
+	image       string
+	name        string
+	packageType []string
+	shortName   string
+	startup     *api.MetadataItems
+}
+
+// TestSuite is a PackageManagementTests test suite.
+func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junitxml.TestSuite, logger *log.Logger, testSuiteRegex, testCaseRegex *regexp.Regexp) {
+	defer tswg.Done()
+
+	if testSuiteRegex != nil && testSuiteRegex.MatchString(testSuiteName) {
+		return
+	}
+
+	testSuite := junitxml.NewTestSuite(testSuiteName)
+	defer testSuite.Finish(testSuites)
+
+	logger.Printf("Running TestSuite %q", testSuite.Name)
+
+	testSetup := []*packageManagementTestSetup{
+		// Debian images.
+		&packageManagementTestSetup{
+			image:       "projects/debian-cloud/global/images/family/debian-9",
+			packageType: []string{"deb"},
+			shortName:   "debian",
+			startup: &api.MetadataItems{
+				Key:   "startup-script",
+				Value: &installOsConfigAgentDeb,
+			},
+		},
+	}
+
+	var wg sync.WaitGroup
+	tests := make(chan *junitxml.TestCase)
+	for _, setup := range testSetup {
+		wg.Add(1)
+		go packageManagementTestCase(ctx, setup, tests, &wg, logger, testCaseRegex)
+	}
+
+	go func() {
+		wg.Wait()
+		close(tests)
+	}()
+
+	for ret := range tests {
+		testSuite.TestCase = append(testSuite.TestCase, ret)
+	}
+
+	logger.Printf("Finished TestSuite %q", testSuite.Name)
+}
+
+func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger) {
+	defer cleanupOsConfig(ctx, testCase, logger)
+
+	req := &osconfigpb.CreateOsConfigRequest{
+		Parent: "projects/compute-image-test-pool-001",
+		OsConfig: &osconfigpb.OsConfig{
+			Name: "foo",
+		},
+	}
+
+	logger.Printf("create osconfig request:\n%s\n\n", dump.Sprint(req))
+
+	res, err := osconfig_server.CreateOsConfig(ctx, logger, req)
+	if err != nil {
+		testCase.WriteFailure("error while creating osconfig:\n%s\n\n", err)
+	}
+
+	logger.Printf("CreateOsConfig response:\n%s\n\n", dump.Sprint(res))
+}
+
+func cleanupOsConfig(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger) {
+
+	logger.Printf("Starting OsConfig cleanup...")
+
+	req := &osconfigpb.ListOsConfigsRequest{
+		Parent: "projects/compute-image-test-pool-001",
+	}
+
+	logger.Printf("List all osconfig under project [compute-image-test-pool-001] for cleanup: \n%s\n\n", dump.Sprint(req))
+
+	resp := osconfig_server.ListOsConfigs(ctx, logger, req)
+	if resp == nil {
+		testCase.WriteFailure("error while listing osconfig")
+	}
+
+	for item, ok := resp.Next(); ; item, ok = resp.Next() {
+		if ok != nil {
+			break
+		}
+		logger.Printf("deleting osconfig\n%s", item.Name)
+		deleteReq := &osconfigpb.DeleteOsConfigRequest{
+			Name: fmt.Sprintf("projects/compute-image-test-pool-001/osConfigs/%s", item.Name),
+		}
+		ok := osconfig_server.DeleteOsConfig(ctx, logger, deleteReq)
+		if ok != nil {
+			testCase.WriteFailure("error while cleaning up")
+			return
+		}
+	}
+	logger.Printf("OsConfig cleanup done.")
+
+}
+
+func packageManagementTestCase(ctx context.Context, testSetup *packageManagementTestSetup, tests chan *junitxml.TestCase, wg *sync.WaitGroup, logger *log.Logger, regex *regexp.Regexp) {
+	defer wg.Done()
+
+	createOsConfigTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[CreateOsConfig] Create OsConfig"))
+
+	for tc, f := range map[*junitxml.TestCase]func(context.Context, *junitxml.TestCase, *log.Logger){
+		createOsConfigTest: runCreateOsConfigTest,
+	} {
+		if tc.FilterTestCase(regex) {
+			tc.Finish(tests)
+		} else {
+			logger.Printf("Running TestCase %s.%q", tc.Classname, tc.Name)
+			f(ctx, tc, logger)
+			tc.Finish(tests)
+			logger.Printf("TestCase %s.%q finished in %fs", tc.Classname, tc.Name, tc.Time)
+		}
+	}
+}

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package package_management
+package packagemanagement
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 	api "google.golang.org/api/compute/v1"
 
 	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
-	osconfig_server "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/osconfig_server"
+	osconfigserver "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/osconfig_server"
 )
 
 const testSuiteName = "PackageManagementTests"
@@ -115,10 +115,10 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger) {
 
 	osConfig := &osconfigpb.OsConfig{
-		Name: "foo",
+		Name: "CreateOsConfig-test-osconfig",
 	}
 
-	defer osconfig_server.CleanupOsConfig(ctx, testCase, logger, osConfig)
+	defer osconfigserver.CleanupOsConfig(ctx, testCase, logger, osConfig)
 
 	req := &osconfigpb.CreateOsConfigRequest{
 		Parent:   "projects/compute-image-test-pool-001",
@@ -127,7 +127,7 @@ func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, log
 
 	logger.Printf("create osconfig request:\n%s\n\n", dump.Sprint(req))
 
-	res, err := osconfig_server.CreateOsConfig(ctx, logger, req)
+	res, err := osconfigserver.CreateOsConfig(ctx, logger, req)
 	if err != nil {
 		testCase.WriteFailure("error while creating osconfig:\n%s\n\n", err)
 	}


### PR DESCRIPTION
* Add a wrapper for osconfig service
* added a test case to create OsConfig, list and then delete the osconfig. This is just a sample test case to test the setup and osconfig service APIs. Tests around actual customer use cases to follow