### PR TITLE
image_test: Fix metadata-script with empty ServiceAccount

### DIFF
--- a/image_test/metadata-script/metadata-script-inc/create-instance-no-scope.wf.json
+++ b/image_test/metadata-script/metadata-script-inc/create-instance-no-scope.wf.json
@@ -19,6 +19,7 @@
           "Name": "${instance}",
           "Disks": [{"InitializeParams": {"SourceImage": "${source_image}"}, "AutoDelete": true}],
           "Scopes": [],
+          "ServiceAccounts": [],
           "Metadata": {
             "${startup_script_meta_key}": "${startup_script_meta}",
             "${windows_startup_script_meta_key}": "${startup_script_meta}",


### PR DESCRIPTION
Daisy adds default service account which doesn't seem to work well when
no scopes are set.
If no scopes are set but a service account is set, the instance can't
read public gcs files.

Fixes #622