### PR TITLE
prow: increase the number of alias ip for network test

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -171,6 +171,18 @@ periodics:
           projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-0-snap,\
           projects/freebsd-org-cloud-dev/global/images/family/freebsd-13-0-snap"
       - "-var:alias_ips=\
+          10.128.3.80,\
+          10.128.3.84,\
+          10.128.3.88,\
+          10.128.3.92,\
+          10.128.3.96,\
+          10.128.3.100,\
+          10.128.3.104,\
+          10.128.3.108,\
+          10.128.3.112,\
+          10.128.3.116,\
+          10.128.3.120,\
+          10.128.3.124,\
           10.128.3.128,\
           10.128.3.132,\
           10.128.3.136,\
@@ -225,7 +237,11 @@ periodics:
           10.128.3.168,\
           10.128.3.172,\
           10.128.3.176,\
-          10.128.3.180"
+          10.128.3.180,\
+          10.128.3.184,\
+          10.128.3.188,\
+          10.128.3.192,\
+          10.128.3.196"
       - "image_test/windows_images.test.gotmpl"
       env:
       - name: REPO_OWNER


### PR DESCRIPTION
There are less IPs compared to the number of network tests being run in
parallel.
Increate the number of IPs and fix the following errors:
Code: IP_IN_USE_BY_ANOTHER_RESOURCE, Message: IP '10.128.3.140/31' is already being used by another resource.