### PR TITLE
Fix test grid ui for osconfig tests

### DIFF
--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -82,7 +82,7 @@ func main() {
 	}()
 
 	for ret := range tests {
-		testSuiteOutPath := filepath.Join(*outDir, fmt.Sprintf("%s_junit.xml", ret.Name))
+		testSuiteOutPath := filepath.Join(*outDir, fmt.Sprintf("junit_%s.xml", ret.Name))
 		if err := os.MkdirAll(filepath.Dir(testSuiteOutPath), 0770); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
As per gubernator documentation, the optional artifacts should be of the format junit_*.xml.
without this, the testgrid dashboard does not show the cells for individual tests.

manually tested in test-grid