### PR TITLE
Update logic of patch run to report / check status as it goes

### DIFF
--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/inventory"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/ospackage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/patch"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/service"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
 	"google.golang.org/api/option"
@@ -87,6 +88,11 @@ func main() {
 		if err := ospackage.SetConfig(resp); err != nil {
 			log.Fatalf(err.Error())
 		}
+		os.Exit(0)
+	}
+
+	if action == "ospatch" {
+		patch.RunPatchAgent(ctx)
 		os.Exit(0)
 	}
 

--- a/cli_tools/google-osconfig-agent/patch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_run.go
@@ -16,16 +16,22 @@ package patch
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
-	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
+	"cloud.google.com/go/compute/metadata"
+	osconfig "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
+	api "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/tasker"
 	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/api/option"
+)
+
+const (
+	identityTokenPath = "instance/service-accounts/default/identity?audience=osconfig.googleapis.com&format=full"
 )
 
 // Init starts the patch system.
@@ -56,10 +62,11 @@ type patchRun struct {
 	StartedAt, EndedAt time.Time `json:",omitempty"`
 	Complete           bool
 	Errors             []string `json:",omitempty"`
+	// TODO add Attempts and track number of retries with backoff, jitter, etc.
 }
 
 type patchJob struct {
-	*osconfigpb.ReportPatchJobInstanceDetailsResponse
+	*api.ReportPatchJobInstanceDetailsResponse
 }
 
 // MarshalJSON marshals a patchConfig using jsonpb.
@@ -77,89 +84,195 @@ func (j *patchJob) UnmarshalJSON(b []byte) error {
 	return jsonpb.UnmarshalString(string(b), j)
 }
 
-func (r *patchRun) in() bool {
-	return true
-}
-
-func (r *patchRun) run() (reboot bool) {
-	logger.Debugf("run %s", r.Job.PatchJobName)
-
-	r.StartedAt = time.Now()
-
-	if r.Complete {
-		return false
-	}
-
-	defer func() {
-		if err := saveState(state, r); err != nil {
-			logger.Errorf("saveState error: %v", err)
-		}
-	}()
-
-	// TODO: Change this to be calls to ReportPatchJobInstanceDetails.
-	if !r.in() {
-		return false
-	}
-
+func (r *patchRun) saveState() (shouldStop bool) {
 	if err := saveState(state, r); err != nil {
 		logger.Errorf("saveState error: %v", err)
-		r.Errors = append(r.Errors, err.Error())
+		return true
 	}
-
-	reboot, err := runUpdates(r.Job.PatchConfig)
-	if err != nil {
-		// TODO: implement retries
-		logger.Errorf("runUpdates error: %v", err)
-		r.Errors = append(r.Errors, err.Error())
-		return false
-	}
-
-	// TODO: Change this to be calls to ReportPatchJobInstanceDetails.
-	if !r.in() {
-		return false
-	}
-
-	if !reboot {
-		r.Complete = true
-		r.EndedAt = time.Now()
-	}
-	return reboot
+	return false
 }
 
-func patchRunner(ctx context.Context, client *osconfig.Client, pr *patchRun) {
-	logger.Debugf("patchrunner running %s", pr.Job.PatchJobName)
-	reboot := pr.run()
-	if pr.Job.PatchConfig.RebootConfig == osconfigpb.PatchConfig_NEVER {
+func (r *patchRun) finishAndReportError(ctx context.Context, msg string, err error) {
+	r.Complete = true
+	r.EndedAt = time.Now()
+	errMsg := fmt.Sprintf(msg, err)
+	logger.Errorf(errMsg)
+	_, rptErr := reportPatchDetails(ctx, r.Job.PatchJobName, api.Instance_FAILED, 0, errMsg)
+	if rptErr != nil {
+		logger.Errorf("Failed to report patch failure. Error: %v", rptErr)
 		return
 	}
-	if (pr.Job.PatchConfig.RebootConfig == osconfigpb.PatchConfig_ALWAYS) ||
-		(((pr.Job.PatchConfig.RebootConfig == osconfigpb.PatchConfig_DEFAULT) ||
-			(pr.Job.PatchConfig.RebootConfig == osconfigpb.PatchConfig_REBOOT_CONFIG_UNSPECIFIED)) &&
-			reboot) {
-		logger.Debugf("reboot requested %s", pr.Job.PatchJobName)
-		if err := rebootSystem(); err != nil {
-			logger.Errorf("error running reboot: %s", err)
-		} else {
-			// Reboot can take a bit, shutdown the agent so other activities don't start.
-			os.Exit(0)
-		}
-	}
-	logger.Debugf("finished patch window %s", pr.Job.PatchJobName)
+	r.saveState()
 }
 
-func ackPatch(ctx context.Context, id string) {
+func (r *patchRun) finishJobComplete() {
+	r.Complete = true
+	r.EndedAt = time.Now()
+	logger.Infof("PatchJob %s is complete. Canceling patch execution.", r.Job.PatchJobName)
+	r.saveState()
+}
+
+func (r *patchRun) reportState(ctx context.Context, patchState api.Instance_PatchState) (shouldStop bool) {
+	patchJob, err := reportPatchDetails(ctx, r.Job.PatchJobName, patchState, 0, "")
+	if err != nil {
+		// If we fail to report state, we can't report that we failed.
+		logger.Errorf("Failed to report state %s. Error: %v", patchState, err)
+		return true
+	}
+	r.Job.ReportPatchJobInstanceDetailsResponse = patchJob
+	if patchJob.PatchJobState == api.ReportPatchJobInstanceDetailsResponse_COMPLETED {
+		r.finishJobComplete()
+		return true
+	}
+	r.saveState()
+	return false
+}
+
+func (r *patchRun) rebootIfNeeded(ctx context.Context, postUpdate bool) (shouldStop bool) {
+	if r.Job.PatchConfig.RebootConfig == api.PatchConfig_NEVER {
+		return true
+	}
+
+	var reboot bool
+	var err error
+	if r.Job.PatchConfig.RebootConfig == api.PatchConfig_ALWAYS && postUpdate {
+		reboot = true
+	} else {
+		reboot, err = systemRebootRequired()
+		if err != nil {
+			r.finishAndReportError(ctx, "Unable to check if reboot is required: %v", err)
+			return true
+		}
+	}
+
+	if reboot {
+		if r.reportState(ctx, api.Instance_REBOOTING) {
+			return true
+		}
+
+		err := rebootSystem()
+		if err != nil {
+			r.finishAndReportError(ctx, "Failed to reboot system: %v", err)
+			return true
+		}
+		// Reboot can take a bit, shutdown the agent so other activities don't start.
+		os.Exit(0)
+		return true
+	}
+	return false
+}
+
+func (r *patchRun) reportSucceeded(ctx context.Context) {
+	isFinalRebootRequired, err := systemRebootRequired()
+	if err != nil {
+		r.finishAndReportError(ctx, "Unable to check if reboot is required: %v", err)
+		return
+	}
+
+	r.Complete = true
+	r.EndedAt = time.Now()
+
+	finalState := api.Instance_SUCCEEDED
+	if isFinalRebootRequired {
+		finalState = api.Instance_REBOOT_REQUIRED
+	}
+
+	if r.reportState(ctx, finalState) {
+		return
+	}
+}
+
+func (r *patchRun) runPatch(ctx context.Context) {
+
+	savedPatchState, err := loadState(state)
+	if err != nil {
+		logger.Errorf("loadState error: %v", err)
+		return
+	} else if savedPatchState != nil && savedPatchState.Complete {
+		logger.Infof("PatchJob already complete. %s", savedPatchState.Job.PatchJobName)
+		return
+	}
+
+	logger.Debugf("Running patchJob %s", r.Job)
+	r.StartedAt = time.Now()
+
+	if r.reportState(ctx, api.Instance_STARTED) {
+		return
+	}
+
+	// check if we need to reboot
+	if r.rebootIfNeeded(ctx, false) {
+		return
+	}
+
+	if r.reportState(ctx, api.Instance_APPLYING_PATCHES) {
+		return
+	}
+
+	err = runUpdates(r.Job.PatchConfig)
+	if err != nil {
+		r.finishAndReportError(ctx, "Failed to apply patches: %v", err)
+		return
+	}
+
+	// check if we need to reboot
+	if r.rebootIfNeeded(ctx, true) {
+		return
+	}
+
+	r.reportSucceeded(ctx)
+}
+
+func patchRunner(ctx context.Context, pr *patchRun) {
+	logger.Debugf("Running patch job %s", pr.Job.PatchJobName)
+	pr.runPatch(ctx)
+	logger.Debugf("Finished patch job %s", pr.Job.PatchJobName)
+}
+
+func ackPatch(ctx context.Context, patchJobName string) {
+	res, err := reportPatchDetails(ctx, patchJobName, api.Instance_STARTED, 0, "")
+	if err != nil {
+		logger.Errorf("reportPatchDetails Error: %v", err)
+		return
+	}
+
+	tasker.Enqueue("Run patch", func() { patchRunner(ctx, &patchRun{Job: &patchJob{res}}) })
+}
+
+func reportPatchDetails(ctx context.Context, patchJobName string, patchState api.Instance_PatchState, attemptCount int64, failureReason string) (*api.ReportPatchJobInstanceDetailsResponse, error) {
+	// TODO: add retries. Patching shouldn't continue if we can't talk to the server.
+
 	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
 	if err != nil {
 		logger.Errorf("osconfig.NewClient Error: %v", err)
-		return
+		return nil, err
 	}
 
-	// TODO: Add all necessary bits into the API.
-	res, err := client.ReportPatchJobInstanceDetails(ctx, &osconfigpb.ReportPatchJobInstanceDetailsRequest{PatchJobName: id, State: osconfigpb.Instance_NOTIFIED})
+	identityToken, err := metadata.Get(identityTokenPath)
 	if err != nil {
-		logger.Errorf("osconfig.ReportPatchJobInstanceDetails Error: %v", err)
-		return
+		return nil, err
 	}
 
-	tasker.Enqueue("Run patch", func() { patchRunner(ctx, client, &patchRun{Job: &patchJob{res}}) })
+	fullInstanceName, err := config.Instance()
+	if err != nil {
+		return nil, err
+	}
+
+	instanceID, err := metadata.InstanceID()
+	if err != nil {
+		return nil, err
+	}
+
+	request := api.ReportPatchJobInstanceDetailsRequest{
+		Resource:         fullInstanceName,
+		InstanceSystemId: instanceID,
+		PatchJobName:     patchJobName,
+		InstanceIdToken:  identityToken,
+		State:            patchState,
+		AttemptCount:     attemptCount,
+		FailureReason:    failureReason,
+	}
+
+	res, err := client.ReportPatchJobInstanceDetails(ctx, &request)
+	return res, err
 }

--- a/cli_tools/google-osconfig-agent/patch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_run.go
@@ -34,26 +34,50 @@ const (
 	identityTokenPath = "instance/service-accounts/default/identity?audience=osconfig.googleapis.com&format=full"
 )
 
+type patchStep int
+
+// These patch steps are ordered to allow us to skip steps that have already been completed. Progress should
+// always move forward, even if we need to retry a step.
+const (
+	unknown patchStep = iota
+	notified
+	started
+	preScript
+	prePatchReboot
+	downloadPatch
+	applyPatch
+	postPatchReboot
+	postPatchRebooted // even if we fail, we don't want to force reboot more than once.
+	postPatchScript
+	completeSuccess
+	completeFailed
+	completeJobCompleted
+)
+
 // Init starts the patch system.
 func Init(ctx context.Context) {
-	savedPatchName := ""
-	// Load current patch state off disk.
+	savedPatchJobName := checkSavedState(ctx)
+	go watcher(ctx, savedPatchJobName)
+}
+
+// RunPatchAgent runs patching as a single blocking agent.
+func RunPatchAgent(ctx context.Context) {
+	savedPatchJobName := checkSavedState(ctx)
+	watcher(ctx, savedPatchJobName)
+}
+
+// Load current patch state off disk and return its name.
+func checkSavedState(ctx context.Context) string {
+	savedPatchJobName := ""
 	pr, err := loadState(state)
 	if err != nil {
 		logger.Errorf("loadState error: %v", err)
-	} else if pr != nil {
-		savedPatchName = pr.Job.PatchJobName
-		if !pr.Complete {
-			client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
-			if err != nil {
-				logger.Errorf("osconfig.NewClient Error: %v", err)
-			} else {
-				tasker.Enqueue("Run patch", func() { patchRunner(ctx, client, pr) })
-			}
-		}
+	} else if pr != nil && !pr.Complete {
+		savedPatchJobName = pr.Job.PatchJobName
+		logger.Infof("Loaded State, running patch: '%s'...", savedPatchJobName)
+		tasker.Enqueue("Run patch", func() { patchRunner(ctx, pr) })
 	}
-
-	go watcher(ctx, savedPatchName)
+	return savedPatchJobName
 }
 
 type patchRun struct {
@@ -62,6 +86,7 @@ type patchRun struct {
 	StartedAt, EndedAt time.Time `json:",omitempty"`
 	Complete           bool
 	Errors             []string `json:",omitempty"`
+	PatchStep          patchStep
 	// TODO add Attempts and track number of retries with backoff, jitter, etc.
 }
 
@@ -95,6 +120,7 @@ func (r *patchRun) saveState() (shouldStop bool) {
 func (r *patchRun) finishAndReportError(ctx context.Context, msg string, err error) {
 	r.Complete = true
 	r.EndedAt = time.Now()
+	r.PatchStep = completeFailed
 	errMsg := fmt.Sprintf(msg, err)
 	logger.Errorf(errMsg)
 	_, rptErr := reportPatchDetails(ctx, r.Job.PatchJobName, api.Instance_FAILED, 0, errMsg)
@@ -108,6 +134,7 @@ func (r *patchRun) finishAndReportError(ctx context.Context, msg string, err err
 func (r *patchRun) finishJobComplete() {
 	r.Complete = true
 	r.EndedAt = time.Now()
+	r.PatchStep = completeJobCompleted
 	logger.Infof("PatchJob %s is complete. Canceling patch execution.", r.Job.PatchJobName)
 	r.saveState()
 }
@@ -150,14 +177,23 @@ func (r *patchRun) rebootIfNeeded(ctx context.Context, postUpdate bool) (shouldS
 			return true
 		}
 
-		err := rebootSystem()
-		if err != nil {
-			r.finishAndReportError(ctx, "Failed to reboot system: %v", err)
+		if r.Job.DryRun {
+			logger.Infof("Dry run - not rebooting for patch job '%s'", r.Job.PatchJobName)
+		} else {
+			err := rebootSystem()
+			if err != nil {
+				r.finishAndReportError(ctx, "Failed to reboot system: %v", err)
+				return true
+			}
+		}
+		r.PatchStep = postPatchRebooted
+		r.saveState()
+
+		if !r.Job.DryRun {
+			// Reboot can take a bit, shutdown the agent so other activities don't start.
+			os.Exit(0)
 			return true
 		}
-		// Reboot can take a bit, shutdown the agent so other activities don't start.
-		os.Exit(0)
-		return true
 	}
 	return false
 }
@@ -182,45 +218,73 @@ func (r *patchRun) reportSucceeded(ctx context.Context) {
 	}
 }
 
+/**
+ * Runs a patch from start to finish. Sometimes this happens in a single invocation. Other times
+ * we need to handle the following edge cases:
+ * - The watcher has initiated this multiple times for the same patch job.
+ * - We have a saved state and are continuing after a reboot.
+ * - An error occurred and we do another attempt starting where we last failed.
+ * - The process was unexpectedly restarted and we are continuing from where we left off.
+ */
 func (r *patchRun) runPatch(ctx context.Context) {
-
 	savedPatchState, err := loadState(state)
 	if err != nil {
 		logger.Errorf("loadState error: %v", err)
 		return
-	} else if savedPatchState != nil && savedPatchState.Complete {
-		logger.Infof("PatchJob already complete. %s", savedPatchState.Job.PatchJobName)
-		return
 	}
 
-	logger.Debugf("Running patchJob %s", r.Job)
-	r.StartedAt = time.Now()
-
-	if r.reportState(ctx, api.Instance_STARTED) {
-		return
+	if savedPatchState != nil && savedPatchState.Job.PatchJobName == r.Job.PatchJobName {
+		// continue from previous patch step
+		r.PatchStep = savedPatchState.PatchStep
+	} else {
+		// We have no saved state for this patch.
+		r.PatchStep = started
 	}
 
-	// check if we need to reboot
-	if r.rebootIfNeeded(ctx, false) {
-		return
+	if r.PatchStep <= started {
+		logger.Debugf("Starting patchJob %s", r.Job)
+		r.StartedAt = time.Now()
+
+		if r.reportState(ctx, api.Instance_STARTED) {
+			return
+		}
 	}
 
-	if r.reportState(ctx, api.Instance_APPLYING_PATCHES) {
-		return
+	if r.PatchStep <= prePatchReboot {
+		// check if we need to reboot
+		if r.rebootIfNeeded(ctx, false) {
+			return
+		}
 	}
 
-	err = runUpdates(r.Job.PatchConfig)
-	if err != nil {
-		r.finishAndReportError(ctx, "Failed to apply patches: %v", err)
-		return
+	if r.PatchStep <= applyPatch {
+		if r.reportState(ctx, api.Instance_APPLYING_PATCHES) {
+			return
+		}
+
+		if r.Job.DryRun {
+			logger.Infof("Dry run - No updates applied for patch job '%s'", r.Job.PatchJobName)
+		} else {
+			err = runUpdates(r.Job.PatchConfig)
+			if err != nil {
+				r.finishAndReportError(ctx, "Failed to apply patches: %v", err)
+				return
+			}
+		}
 	}
 
-	// check if we need to reboot
-	if r.rebootIfNeeded(ctx, true) {
-		return
+	if r.PatchStep <= postPatchReboot {
+		// check if we need to reboot
+		if r.rebootIfNeeded(ctx, true) {
+			return
+		}
 	}
 
-	r.reportSucceeded(ctx)
+	if r.PatchStep <= completeSuccess {
+		r.PatchStep = completeSuccess
+		r.reportSucceeded(ctx)
+	}
+	logger.Debugf("Completed patchJob %s", r.Job)
 }
 
 func patchRunner(ctx context.Context, pr *patchRun) {
@@ -230,17 +294,34 @@ func patchRunner(ctx context.Context, pr *patchRun) {
 }
 
 func ackPatch(ctx context.Context, patchJobName string) {
-	res, err := reportPatchDetails(ctx, patchJobName, api.Instance_STARTED, 0, "")
+	currentPatchJob, err := loadState(state)
 	if err != nil {
-		logger.Errorf("reportPatchDetails Error: %v", err)
+		logger.Errorf("Unable to load state to ack notification. Error: %v", err)
 		return
 	}
 
-	tasker.Enqueue("Run patch", func() { patchRunner(ctx, &patchRun{Job: &patchJob{res}}) })
+	// Notify the server if we haven't yet
+	if currentPatchJob == nil || currentPatchJob.Job.PatchJobName != patchJobName {
+		res, err := reportPatchDetails(ctx, patchJobName, api.Instance_NOTIFIED, 0, "")
+		if err != nil {
+			logger.Errorf("reportPatchDetails Error: %v", err)
+			return
+		}
+		tasker.Enqueue("Run patch", func() {
+			patchRunner(ctx, &patchRun{Job: &patchJob{res}})
+		})
+		return
+	}
+
+	tasker.Enqueue("Run patch", func() {
+		patchRunner(ctx, &patchRun{Job: &patchJob{currentPatchJob.Job.ReportPatchJobInstanceDetailsResponse}})
+	})
 }
 
 func reportPatchDetails(ctx context.Context, patchJobName string, patchState api.Instance_PatchState, attemptCount int64, failureReason string) (*api.ReportPatchJobInstanceDetailsResponse, error) {
 	// TODO: add retries. Patching shouldn't continue if we can't talk to the server.
+
+	logger.Infof("Reporting patch details name:'%s', state:'%s', failReason:'%s'", patchJobName, patchState, failureReason)
 
 	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
 	if err != nil {

--- a/cli_tools/google-osconfig-agent/patch/patch_state.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_state.go
@@ -50,8 +50,9 @@ func saveState(state string, w *patchRun) error {
 		return err
 	}
 
+	// This sends state to guest attributes and isn't required for patching to work.
 	if err := attributes.PostAttribute(config.ReportURL+"/osConfig/patchRunner", bytes.NewReader(d)); err != nil {
-		logger.Errorf("postAttribute error: %v", err)
+		logger.Debugf("postAttribute error: %v", err)
 	}
 
 	// TODO: Once we are storing more state consider atomic state save

--- a/cli_tools/google-osconfig-agent/patch/patch_state_test.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_state_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	testPatchRunJSON = "{\"Job\":{\"ReportPatchJobInstanceDetailsResponse\":{\"patchJobName\":\"flipyflappy\",\"patchConfig\":{\"rebootConfig\":\"ALWAYS\"}}},\"StartedAt\":\"0001-01-01T00:00:00Z\",\"EndedAt\":\"0001-01-01T00:00:00Z\",\"Complete\":false}"
+	testPatchRunJSON = "{\"Job\":{\"ReportPatchJobInstanceDetailsResponse\":{\"patchJobName\":\"flipyflappy\",\"patchConfig\":{\"rebootConfig\":\"ALWAYS\"}}},\"StartedAt\":\"0001-01-01T00:00:00Z\",\"EndedAt\":\"0001-01-01T00:00:00Z\",\"Complete\":false,\"PatchStep\":0}"
 	testPatchRun     = &patchRun{
 		Job: &patchJob{
 			&osconfigpb.ReportPatchJobInstanceDetailsResponse{

--- a/cli_tools/google-osconfig-agent/patch/updates_linux.go
+++ b/cli_tools/google-osconfig-agent/patch/updates_linux.go
@@ -21,30 +21,13 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
 )
 
-func rebootRequired() (bool, error) {
+func systemRebootRequired() (bool, error) {
 	// TODO: actually check for distro specific reboot file.
 	return false, nil
 }
 
-func runUpdates(pc *osconfigpb.PatchConfig) (bool, error) {
-	if pc.RebootConfig != osconfigpb.PatchConfig_NEVER {
-		reboot, err := rebootRequired()
-		if err != nil {
-			return false, err
-		}
-		if reboot {
-			return true, nil
-		}
-	}
-
-	if err := packages.UpdatePackages(); err != nil {
-		return false, err
-	}
-
-	if pc.RebootConfig != osconfigpb.PatchConfig_NEVER {
-		return rebootRequired()
-	}
-	return false, nil
+func runUpdates(pc *osconfigpb.PatchConfig) error {
+	return packages.UpdatePackages()
 }
 
 func rebootSystem() error {

--- a/cli_tools/google-osconfig-agent/service/service.go
+++ b/cli_tools/google-osconfig-agent/service/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/inventory"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/ospackage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/patch"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/tasker"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/osinfo"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/service"
@@ -51,7 +52,7 @@ func runOsConfig(ctx context.Context, res string) error {
 }
 
 func run(ctx context.Context) {
-	//patch.Init(ctx)
+	patch.Init(ctx)
 
 	res, err := config.Instance()
 	if err != nil {


### PR DESCRIPTION
- Patching reports status and stops if the patch job is not active
- Handles restarts across crashes and reboots
- Handles dryruns
- Handles stopping on failure
- Supports running the agent as `ospatch` to facilitate testing.
- Does not *yet* handle retry attempts (that'll be another PR)
- I did a lot of manual testing but this code doesn't lend itself well to unit testing. I need to think more about how to do that in a subsequent PR.
