### PR TITLE
Fix test runner execution

### DIFF
--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -52,7 +52,7 @@ func main() {
 		var err error
 		testSuiteRegex, err = regexp.Compile(*testSuiteFilter)
 		if err != nil {
-			fmt.Println("-testCaseFilter flag not valid:", err)
+			fmt.Println("-testSuiteFilter flag not valid:", err)
 			os.Exit(1)
 		}
 	}
@@ -81,7 +81,9 @@ func main() {
 		close(tests)
 	}()
 
+	var testSuites []*junitxml.TestSuite
 	for ret := range tests {
+		testSuites = append(testSuites, ret)
 		testSuiteOutPath := filepath.Join(*outDir, fmt.Sprintf("junit_%s.xml", ret.Name))
 		if err := os.MkdirAll(filepath.Dir(testSuiteOutPath), 0770); err != nil {
 			log.Fatal(err)
@@ -99,7 +101,7 @@ func main() {
 	}
 
 	var buf bytes.Buffer
-	for ts := range tests {
+	for _, ts := range testSuites {
 		if ts.Failures > 0 {
 			buf.WriteString(fmt.Sprintf("TestSuite %q has errors:\n", ts.Name))
 			for _, tc := range ts.TestCase {


### PR DESCRIPTION
we first read the testsuites from the channel to create the junit files
and the we again try to iterate over the channel to check for failures.
During the second loop, the channel is already empty and so the execution never fails.