### PR TITLE
osconfig_tests: increase timeout waiting for osconfig install

### DIFF
--- a/osconfig_tests/test_suites/inventory/inventory.go
+++ b/osconfig_tests/test_suites/inventory/inventory.go
@@ -274,7 +274,7 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 	defer inst.Cleanup()
 
 	testCase.Logf("Waiting for agent install to complete")
-	if err := inst.WaitForSerialOutput("osconfig install done", 1, 5*time.Second, 5*time.Minute); err != nil {
+	if err := inst.WaitForSerialOutput("osconfig install done", 1, 5*time.Second, 7*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return nil, false
 	}

--- a/osconfig_tests/test_suites/inventory/inventory.go
+++ b/osconfig_tests/test_suites/inventory/inventory.go
@@ -73,7 +73,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},
@@ -82,7 +82,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},
@@ -91,7 +91,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},
@@ -100,7 +100,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},
@@ -109,7 +109,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},
@@ -118,7 +118,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},
@@ -127,7 +127,34 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			packageType: []string{"googet", "wua", "qfe"},
 			shortName:   "windows",
 			startup: &api.MetadataItems{
-				Key:   "windows-startup-script-cmd",
+				Key:   "windows-startup-script-ps1",
+				Value: &utils.InstallOSConfigGooGet,
+			},
+		},
+		&inventoryTestSetup{
+			image:       "projects/windows-cloud/global/images/family/windows-1809-core",
+			packageType: []string{"googet", "wua", "qfe"},
+			shortName:   "windows",
+			startup: &api.MetadataItems{
+				Key:   "windows-startup-script-ps1",
+				Value: &utils.InstallOSConfigGooGet,
+			},
+		},
+		&inventoryTestSetup{
+			image:       "projects/windows-cloud/global/images/family/windows-2019-core",
+			packageType: []string{"googet", "wua", "qfe"},
+			shortName:   "windows",
+			startup: &api.MetadataItems{
+				Key:   "windows-startup-script-ps1",
+				Value: &utils.InstallOSConfigGooGet,
+			},
+		},
+		&inventoryTestSetup{
+			image:       "projects/windows-cloud/global/images/family/windows-2019",
+			packageType: []string{"googet", "wua", "qfe"},
+			shortName:   "windows",
+			startup: &api.MetadataItems{
+				Key:   "windows-startup-script-ps1",
 				Value: &utils.InstallOSConfigGooGet,
 			},
 		},

--- a/osconfig_tests/utils/utils.go
+++ b/osconfig_tests/utils/utils.go
@@ -29,8 +29,9 @@ apt-get install -y google-osconfig-agent
 echo 'osconfig install done'`
 
 	// InstallOSConfigGooGet installs the osconfig agent on googet based systems.
-	InstallOSConfigGooGet = `c:\programdata\googet\googet.exe -noconfirm install -sources https://packages.cloud.google.com/yuck/repos/google-osconfig-agent-unstable google-osconfig-agent
-echo 'osconfig install done'`
+	InstallOSConfigGooGet = `Start-Sleep 10
+c:\programdata\googet\googet.exe -noconfirm install -sources https://packages.cloud.google.com/yuck/repos/google-osconfig-agent-unstable google-osconfig-agent
+Write-Host 'osconfig install done'`
 
 	// InstallOSConfigYumEL7 installs the osconfig agent on el7 based systems.
 	InstallOSConfigYumEL7 = `cat > /etc/yum.repos.d/google-osconfig-agent.repo <<EOM


### PR DESCRIPTION
Add tests for new windows instances
Add sleep before install in an attempt to deflake 2012 tests