### PR TITLE
Compare current state with desired state

### DIFF
--- a/cli_tools/google-osconfig-agent/inventory/changes.go
+++ b/cli_tools/google-osconfig-agent/inventory/changes.go
@@ -22,6 +22,7 @@ import (
 	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
 )
 
+// Changes represents the delta between the actual and the desired package installation state.
 type Changes struct {
 	PackagesToInstall []string
 	PackagesToUpgrade []string

--- a/cli_tools/google-osconfig-agent/inventory/changes.go
+++ b/cli_tools/google-osconfig-agent/inventory/changes.go
@@ -1,0 +1,73 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package inventory scans the current inventory (patches and package installed and available)
+// and writes them to Guest Attributes.
+package inventory
+
+import (
+	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
+
+	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
+)
+
+type Changes struct {
+	PackagesToInstall []string
+	PackagesToUpgrade []string
+	PackagesToRemove  []string
+}
+
+// GetNecessaryChanges compares the current state and the desired state to determine which packages
+// need to be installed, upgraded, or removed.
+func GetNecessaryChanges(installedPkgs []packages.PkgInfo, upgradablePkgs []packages.PkgInfo, packageInstalls []*osconfigpb.Package, packageRemovals []*osconfigpb.Package) Changes {
+
+	installedPkgMap := make(map[string]bool)
+	for _, pkg := range installedPkgs {
+		installedPkgMap[pkg.Name] = true
+	}
+
+	upgradeablePkgMap := make(map[string]bool)
+	for _, pkg := range upgradablePkgs {
+		upgradeablePkgMap[pkg.Name] = true
+	}
+
+	var pkgsToInstall []string
+	var pkgsToUpgrade []string
+
+	for _, pkg := range packageInstalls {
+		_, isInstalled := installedPkgMap[pkg.Name]
+		_, isUpgradable := upgradeablePkgMap[pkg.Name]
+
+		if !isInstalled {
+			pkgsToInstall = append(pkgsToInstall, pkg.Name)
+		} else if isInstalled && isUpgradable {
+			pkgsToUpgrade = append(pkgsToUpgrade, pkg.Name)
+		}
+	}
+
+	var pkgsToRemove []string
+	for _, pkg := range packageRemovals {
+		_, isInstalled := installedPkgMap[pkg.Name]
+
+		if isInstalled {
+			pkgsToRemove = append(pkgsToRemove, pkg.Name)
+		}
+	}
+
+	return Changes{
+		PackagesToInstall: pkgsToInstall,
+		PackagesToUpgrade: pkgsToUpgrade,
+		PackagesToRemove:  pkgsToRemove,
+	}
+}

--- a/cli_tools/google-osconfig-agent/inventory/changes_test.go
+++ b/cli_tools/google-osconfig-agent/inventory/changes_test.go
@@ -1,0 +1,119 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package inventory
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
+
+	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
+)
+
+func TestGetNecessaryChanges(t *testing.T) {
+
+	tests := [...]struct {
+		name            string
+		installedPkgs   []packages.PkgInfo
+		upgradablePkgs  []packages.PkgInfo
+		packageInstalls []*osconfigpb.Package
+		packageRemovals []*osconfigpb.Package
+		want            Changes
+	}{
+		{
+			name:            "install from empty",
+			installedPkgs:   createPkgInfos(),
+			upgradablePkgs:  createPkgInfos(),
+			packageInstalls: createPackages("foo"),
+			packageRemovals: createPackages(),
+			want: Changes{
+				PackagesToInstall: []string{"foo"},
+				PackagesToUpgrade: []string{},
+				PackagesToRemove:  []string{},
+			},
+		}, {
+			name:            "single upgrade",
+			installedPkgs:   createPkgInfos("foo"),
+			upgradablePkgs:  createPkgInfos("foo"),
+			packageInstalls: createPackages("foo"),
+			packageRemovals: createPackages(),
+			want: Changes{
+				PackagesToInstall: []string{},
+				PackagesToUpgrade: []string{"foo"},
+				PackagesToRemove:  []string{},
+			},
+		}, {
+			name:            "remove",
+			installedPkgs:   createPkgInfos("foo"),
+			upgradablePkgs:  createPkgInfos("foo"),
+			packageInstalls: createPackages(),
+			packageRemovals: createPackages("foo"),
+			want: Changes{
+				PackagesToInstall: []string{},
+				PackagesToUpgrade: []string{},
+				PackagesToRemove:  []string{"foo"},
+			},
+		}, {
+			name:            "mixed",
+			installedPkgs:   createPkgInfos("foo", "bar", "buz"),
+			upgradablePkgs:  createPkgInfos("bar"),
+			packageInstalls: createPackages("foo", "baz"),
+			packageRemovals: createPackages("buz"),
+			want: Changes{
+				PackagesToInstall: []string{"baz"},
+				PackagesToUpgrade: []string{},
+				PackagesToRemove:  []string{"buz"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		got := GetNecessaryChanges(tt.installedPkgs, tt.upgradablePkgs, tt.packageInstalls, tt.packageRemovals)
+
+		if !equalChanges(&got, &tt.want) {
+			t.Errorf("Did not get expected changes for '%s', got: %v, want: %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func equalChanges(got *Changes, want *Changes) bool {
+	return equalSlices(got.PackagesToInstall, want.PackagesToInstall) &&
+		equalSlices(got.PackagesToRemove, want.PackagesToRemove) &&
+		equalSlices(got.PackagesToUpgrade, want.PackagesToUpgrade)
+}
+
+func equalSlices(got []string, want []string) bool {
+	if len(got) == 0 && len(want) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(got, want)
+}
+
+func createPkgInfos(names ...string) []packages.PkgInfo {
+	var res []packages.PkgInfo
+	for _, n := range names {
+		res = append(res, packages.PkgInfo{Name: n})
+	}
+	return res
+}
+
+func createPackages(names ...string) []*osconfigpb.Package {
+	var res []*osconfigpb.Package
+	for _, n := range names {
+		res = append(res, &osconfigpb.Package{Name: n})
+	}
+	return res
+}


### PR DESCRIPTION
This is not yet tied into the actual inventory or package management code. It is just the logic that will be used to determine what updates are needed given the caller already has the `instanceInventory` and the `LookupConfigsResponse`.

The caller is expected to know which package managers they care about and pass the package info for just those packages.