### PR TITLE
Revert "Add driver package installation steps."

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -257,9 +257,6 @@ function Install-Packages {
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-windows
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-auto-updater
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-vss -ErrorAction SilentlyContinue
-    Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-vioscsi
-    Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-netkvm
-    Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-pvpanic
   }
 }
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/compute-image-tools#675

This PR is breaking two tests:
https://gubernator.k8s.io/build/compute-image-tools-test/logs/ci-daisy-e2e/1095834234284675072
daisy-e2e-tests 2008R2 vmware image translate
daisy-e2e-tests 7 image translate

It appears to be related to the installation of vioscsi googet package.
```
2019/02/14 12:05:12 windows-startup-script-url: Running C:\ProgramData\GooGet\googet.exe with arguments -root C:\ProgramData\Go
2019/02/14 12:05:12 windows-startup-script-url: oGet -noconfirm install google-compute-engine-driver-vioscsi.
2019/02/14 12:05:12 windows-startup-script-url: Exception caught in script:
2019/02/14 12:05:12 windows-startup-script-url: 
2019/02/14 12:05:12 windows-startup-script-url: At C:\Windows\TEMP\metadata-scripts620956315\windows-startup-script-url.ps1:30 
2019/02/14 12:05:12 windows-startup-script-url: char:11
2019/02/14 12:05:12 windows-startup-script-url: +   $out = & <<<< $executable $arguments 2>&1 | Out-String
2019/02/14 12:05:12 windows-startup-script-url: TranslateFailed: Unexpected token '.' in expression or statement.
```