### PR TITLE
Perform regex matching instead of plain string matching

### DIFF
--- a/osconfig_tests/compute/instance.go
+++ b/osconfig_tests/compute/instance.go
@@ -40,10 +40,16 @@ func (i *Instance) Cleanup() {
 }
 
 // WaitForSerialOutput waits for a match with regular expression regex on a serial port.
+// if you are using regular expression make sure to check the err
 func (i *Instance) WaitForSerialOutput(regex string, port int64, interval, timeout time.Duration) error {
 	var start int64
 	var errs int
-	var validMatch = regexp.MustCompile(regex)
+	validMatch, err := regexp.Compile(regex)
+
+	if err != nil {
+		return fmt.Errorf("error compiling regex: %v", err)
+	}
+
 	tick := time.Tick(interval)
 	timedout := time.Tick(timeout)
 	for {

--- a/osconfig_tests/compute/instance.go
+++ b/osconfig_tests/compute/instance.go
@@ -49,7 +49,7 @@ func (i *Instance) WaitForSerialOutput(regex string, port int64, interval, timeo
 	for {
 		select {
 		case <-timedout:
-			return fmt.Errorf("timed out waiting to match regular expression:", regex)
+			return fmt.Errorf("timed out waiting to match regular expression: %s", regex)
 		case <-tick:
 			resp, err := i.client.GetSerialPortOutput(i.Project, i.Zone, i.Name, port, start)
 			if err != nil {


### PR DESCRIPTION
In some cases, assertion on an output in serial console becomes tricky
with plain strings.
For example:
to check if a package is installed with rpmquery on centos, i am using
rpmquery -a {packagename}
The result is {packageName}-{version}-{arch}.
Assertion on packagename is ok but this might introduce a bug where
packge is not installed and output is
"package {packagename} is not installed".