### PR TITLE
Expose qemu error for export workflow

### DIFF
--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -37,11 +37,11 @@ SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | 
 SIZE_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000)+ 1)}")
 
 echo "GCEExport: Exporting disk of size ${SIZE_GB}GB and format ${FORMAT}."
-qemu-img convert /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT &> qemu_output.txt
-QEMU_ERR=$?
-if [ ${QEMU_ERR} -ne 0 ]; then
-	echo "ExportFailed: Failed to export disk source to ${GS_PATH} due to qemu-img error code '${QEMU_ERR}', error info: $(cat qemu_output.txt)"
+
+if ! out=$(qemu-img convert /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT 2>&1); then
+  echo "ExportFailed: Failed to export disk source to ${GS_PATH} due to qemu-img error: ${out}"
 fi
 
+echo ${out}
 echo "export success"
 sync

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -37,7 +37,7 @@ SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | 
 SIZE_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000)+ 1)}")
 
 echo "GCEExport: Exporting disk of size ${SIZE_GB}GB and format ${FORMAT}."
-qemu-img convertiii /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT &> qemu_output.txt
+qemu-img convert /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT &> qemu_output.txt
 QEMU_ERR=$?
 if [ ${QEMU_ERR} -ne 0 ]; then
 	echo "ExportFailed: Failed to export disk source to ${GS_PATH} due to qemu-img error code '${QEMU_ERR}', error info: $(cat qemu_output.txt)"

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -37,9 +37,10 @@ SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | 
 SIZE_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000)+ 1)}")
 
 echo "GCEExport: Exporting disk of size ${SIZE_GB}GB and format ${FORMAT}."
-qemu-img convert /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT
-if [ $? -ne 0 ]; then
-  echo "ExportFailed: Failed to export disk source to ${GS_PATH}."
+qemu-img convertiii /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT &> qemu_output.txt
+QEMU_ERR=$?
+if [ ${QEMU_ERR} -ne 0 ]; then
+	echo "ExportFailed: Failed to export disk source to ${GS_PATH} due to qemu-img error code '${QEMU_ERR}', error info: $(cat qemu_output.txt)"
 fi
 
 echo "export success"


### PR DESCRIPTION
Currently, qemu error details are not shown in daisy log and console. Let's output it there so user/dev can figure out the root cause easily.

It's tested manually since there isn't fancy new feature added.