### PR TITLE
 osconfig agent: hide features behind build tags

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -132,7 +132,11 @@ func Instance() (string, error) {
 
 // Project is the URI of the instance the agent is running on.
 func Project() (string, error) {
-	return metadata.ProjectID()
+	proj, err := metadata.ProjectID()
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve project, are you running in GCE? error: %v", err)
+	}
+	return proj, nil
 }
 
 // Version is the agent version.

--- a/cli_tools/google-osconfig-agent/logger/logger.go
+++ b/cli_tools/google-osconfig-agent/logger/logger.go
@@ -69,7 +69,9 @@ func Init(ctx context.Context, project string) {
 
 // Close closes the logger.
 func Close() {
-	cloudLoggingClient.Close()
+	if cloudLoggingClient != nil {
+		cloudLoggingClient.Close()
+	}
 }
 
 type serialPort struct {
@@ -120,8 +122,7 @@ func now() string {
 }
 
 func caller(depth int) *logpb.LogEntrySourceLocation {
-	// Add 2 to depth to account for this function and the imediate caller.
-	depth = depth + 2
+	depth = depth + 1
 	pc, file, line, ok := runtime.Caller(depth)
 	if !ok {
 		file = "???"

--- a/cli_tools/google-osconfig-agent/ospackage/apt.go
+++ b/cli_tools/google-osconfig-agent/ospackage/apt.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/apt_test.go
+++ b/cli_tools/google-osconfig-agent/ospackage/apt_test.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/changes.go
+++ b/cli_tools/google-osconfig-agent/ospackage/changes.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/changes_test.go
+++ b/cli_tools/google-osconfig-agent/ospackage/changes_test.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/googet.go
+++ b/cli_tools/google-osconfig-agent/ospackage/googet.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/googet_test.go
+++ b/cli_tools/google-osconfig-agent/ospackage/googet_test.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/public_stub.go
+++ b/cli_tools/google-osconfig-agent/ospackage/public_stub.go
@@ -1,0 +1,12 @@
+// +build public
+
+package ospackage
+
+import (
+	"context"
+)
+
+// RunOSConfig does nothing.
+func RunOsConfig(_ context.Context, _ string, _ bool) error {
+	return nil
+}

--- a/cli_tools/google-osconfig-agent/ospackage/yum.go
+++ b/cli_tools/google-osconfig-agent/ospackage/yum.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/yum_test.go
+++ b/cli_tools/google-osconfig-agent/ospackage/yum_test.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/zypper.go
+++ b/cli_tools/google-osconfig-agent/ospackage/zypper.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/ospackage/zypper_test.go
+++ b/cli_tools/google-osconfig-agent/ospackage/zypper_test.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package ospackage
 
 import (

--- a/cli_tools/google-osconfig-agent/packaging/debian/rules
+++ b/cli_tools/google-osconfig-agent/packaging/debian/rules
@@ -19,7 +19,7 @@ override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.
 
 override_dh_auto_build:
-	dh_auto_build -O--buildsystem=golang -- -ldflags "-s -w -X main.version=$(VERSION)"
+	dh_auto_build -O--buildsystem=golang -- -ldflags "-s -w -X main.version=$(VERSION)" -tags public
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/cli_tools/google-osconfig-agent/packaging/googet/build.sh
+++ b/cli_tools/google-osconfig-agent/packaging/googet/build.sh
@@ -5,4 +5,4 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-GOOS=windows /tmp/go/bin/go build -ldflags "-X main.version=${version}" -o google_osconfig_agent.exe
+GOOS=windows /tmp/go/bin/go build -ldflags "-X main.version=${version}" -o google_osconfig_agent.exe -tags public

--- a/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
+++ b/cli_tools/google-osconfig-agent/packaging/google-osconfig-agent.spec
@@ -32,7 +32,7 @@ Contains the OSConfig agent binary and startup scripts
 %autosetup
 
 %build
-GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -o google_osconfig_agent
+GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -o google_osconfig_agent -tags public
 
 %install
 install -d %{buildroot}%{_bindir}

--- a/cli_tools/google-osconfig-agent/patch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_run.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/patch_run_test.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_run_test.go
@@ -12,4 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch

--- a/cli_tools/google-osconfig-agent/patch/patch_state.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_state.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/patch_state_test.go
+++ b/cli_tools/google-osconfig-agent/patch/patch_state_test.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/public_stub.go
+++ b/cli_tools/google-osconfig-agent/patch/public_stub.go
@@ -1,0 +1,11 @@
+// +build public
+
+package patch
+
+import "context"
+
+// Init does nothing.
+func Init(_ context.Context) {}
+
+// RunPatchAgent does nothing.
+func RunPatchAgent(_ context.Context) {}

--- a/cli_tools/google-osconfig-agent/patch/system_linux.go
+++ b/cli_tools/google-osconfig-agent/patch/system_linux.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/system_windows.go
+++ b/cli_tools/google-osconfig-agent/patch/system_windows.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/updates_linux.go
+++ b/cli_tools/google-osconfig-agent/patch/updates_linux.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/updates_windows.go
+++ b/cli_tools/google-osconfig-agent/patch/updates_windows.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/patch/watcher.go
+++ b/cli_tools/google-osconfig-agent/patch/watcher.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !public
+
 package patch
 
 import (

--- a/cli_tools/google-osconfig-agent/service/service.go
+++ b/cli_tools/google-osconfig-agent/service/service.go
@@ -20,39 +20,14 @@ import (
 	"fmt"
 	"time"
 
-	osconfig "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/inventory"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/ospackage"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/patch"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/tasker"
-	"github.com/GoogleCloudPlatform/compute-image-tools/go/osinfo"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/service"
-	"github.com/kylelemons/godebug/pretty"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc/status"
-
-	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
 )
-
-var dump = &pretty.Config{IncludeUnexported: true}
-
-func runOsConfig(ctx context.Context, res string) error {
-	client, err := osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
-	if err != nil {
-		return fmt.Errorf("osconfig.NewClient Error: %v", err)
-	}
-
-	resp, err := LookupConfigs(ctx, client, res)
-	if err != nil {
-		return fmt.Errorf("LookupConfigs error: %v", err)
-	}
-
-	// We don't check the error from ospackage.SetConfig as all errors are already logged.
-	tasker.Enqueue("Set package config", func() { ospackage.SetConfig(resp) })
-	return nil
-}
 
 func run(ctx context.Context) {
 	patch.Init(ctx)
@@ -63,16 +38,9 @@ func run(ctx context.Context) {
 	}
 
 	ticker := time.NewTicker(config.SvcPollInterval())
-	configError := false
 	for {
-		err := runOsConfig(ctx, res)
-		// Only log osconfig error on the first error so as not to spam the logs.
-		// TODO: Remove once the API is in beta.
-		if err != nil && !configError {
+		if err := ospackage.RunOsConfig(ctx, res, true); err != nil {
 			logger.Errorf(err.Error())
-			configError = true
-		} else {
-			configError = false
 		}
 
 		// This should always run after ospackage.SetConfig.
@@ -86,45 +54,6 @@ func run(ctx context.Context) {
 			return
 		}
 	}
-}
-
-// LookupConfigs looks up osconfigs.
-// TODO: move to osconfig_service wrapper
-func LookupConfigs(ctx context.Context, client *osconfig.Client, resource string) (*osconfigpb.LookupConfigsResponse, error) {
-	info, err := osinfo.GetDistributionInfo()
-	if err != nil {
-		return nil, err
-	}
-
-	req := &osconfigpb.LookupConfigsRequest{
-		Resource: resource,
-		OsInfo: &osconfigpb.LookupConfigsRequest_OsInfo{
-			OsLongName:     info.LongName,
-			OsShortName:    info.ShortName,
-			OsVersion:      info.Version,
-			OsKernel:       info.Kernel,
-			OsArchitecture: info.Architecture,
-		},
-		ConfigTypes: []osconfigpb.LookupConfigsRequest_ConfigType{
-			osconfigpb.LookupConfigsRequest_GOO,
-			osconfigpb.LookupConfigsRequest_WINDOWS_UPDATE,
-			osconfigpb.LookupConfigsRequest_APT,
-			osconfigpb.LookupConfigsRequest_YUM,
-			osconfigpb.LookupConfigsRequest_ZYPPER,
-		},
-	}
-	logger.Debugf("LookupConfigs request:\n%s\n\n", dump.Sprint(req))
-
-	res, err := client.LookupConfigs(ctx, req)
-	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return nil, fmt.Errorf("code: %q, message: %q, details: %q", s.Code(), s.Message(), s.Details())
-		}
-		return nil, err
-	}
-	logger.Debugf("LookupConfigs response:\n%s\n\n", dump.Sprint(res))
-
-	return res, nil
 }
 
 // Run registers a service to periodically call the osconfig enpoint to pull


### PR DESCRIPTION
This adds a build tag of public for agent builds with only the inventory feature. This allows us to build packages with just the inventory features but still continue developing and testing the other unreleased features.

go build -tags public > creates an agent that should not have any ospackage or patch code or functionality.