### PR TITLE
Make Windows container workflow names consistent

### DIFF
--- a/daisy_workflows/image_build/windows_for_containers/windows-1709-core-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-1709-core-for-containers.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-1803-for-containers-image-build",
+  "Name": "windows-1709-core-for-containers-image-build",
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
@@ -19,7 +19,7 @@
         },
         {
           "Name": "${install_disk}",
-          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1803-core",
+          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1709-core",
           "Type": "pd-ssd"
         }
       ]
@@ -31,7 +31,7 @@
           "Disks": [{"Source": "${install_disk}"}, {"Source": "disk-scratch"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "version": "1803"
+            "version": "1709"
           },
           "StartupScript": "container_image_install.ps1"
         }
@@ -57,12 +57,12 @@
     "create-image": {
       "CreateImages": [
         {
-          "Name": "windows-server-1803-dc-core-for-containers-v${build_date}",
+          "Name": "windows-server-1709-dc-core-for-containers-v${build_date}",
           "SourceDisk": "${install_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-for-containers"],
-          "Description": "Microsoft, Windows Server, version 1803 Core for Containers, Server Core, x64 built on ${build_date}",
+          "Description": "Microsoft, Windows Server, version 1709 Core for Containers, Server Core, x64 built on ${build_date}",
           "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
-          "Family": "windows-1803-core-for-containers",
+          "Family": "windows-1709-core-for-containers",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/windows_for_containers/windows-1803-core-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-1803-core-for-containers.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-1809-for-containers-image-build",
+  "Name": "windows-1803-core-for-containers-image-build",
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
@@ -19,7 +19,7 @@
         },
         {
           "Name": "${install_disk}",
-          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1809-core",
+          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1803-core",
           "Type": "pd-ssd"
         }
       ]
@@ -31,7 +31,7 @@
           "Disks": [{"Source": "${install_disk}"}, {"Source": "disk-scratch"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "version": "1809"
+            "version": "1803"
           },
           "StartupScript": "container_image_install.ps1"
         }
@@ -57,12 +57,12 @@
     "create-image": {
       "CreateImages": [
         {
-          "Name": "windows-server-1809-dc-core-for-containers-v${build_date}",
+          "Name": "windows-server-1803-dc-core-for-containers-v${build_date}",
           "SourceDisk": "${install_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-for-containers"],
-          "Description": "Microsoft, Windows Server, version 1809 Core for Containers, Server Core, x64 built on ${build_date}",
+          "Description": "Microsoft, Windows Server, version 1803 Core for Containers, Server Core, x64 built on ${build_date}",
           "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
-          "Family": "windows-1809-core-for-containers",
+          "Family": "windows-1803-core-for-containers",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/windows_for_containers/windows-1809-core-for-containers.wf.json
+++ b/daisy_workflows/image_build/windows_for_containers/windows-1809-core-for-containers.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-1709-for-containers-image-build",
+  "Name": "windows-1809-core-for-containers-image-build",
   "Vars": {
     "build_date": "${TIMESTAMP}",
     "publish_project": "${PROJECT}",
@@ -19,7 +19,7 @@
         },
         {
           "Name": "${install_disk}",
-          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1709-core",
+          "SourceImage": "projects/${source_image_project}/global/images/family/windows-1809-core",
           "Type": "pd-ssd"
         }
       ]
@@ -31,7 +31,7 @@
           "Disks": [{"Source": "${install_disk}"}, {"Source": "disk-scratch"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "version": "1709"
+            "version": "1809"
           },
           "StartupScript": "container_image_install.ps1"
         }
@@ -57,12 +57,12 @@
     "create-image": {
       "CreateImages": [
         {
-          "Name": "windows-server-1709-dc-core-for-containers-v${build_date}",
+          "Name": "windows-server-1809-dc-core-for-containers-v${build_date}",
           "SourceDisk": "${install_disk}",
           "Licenses": ["projects/windows-cloud/global/licenses/windows-for-containers"],
-          "Description": "Microsoft, Windows Server, version 1709 Core for Containers, Server Core, x64 built on ${build_date}",
+          "Description": "Microsoft, Windows Server, version 1809 Core for Containers, Server Core, x64 built on ${build_date}",
           "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
-          "Family": "windows-1709-core-for-containers",
+          "Family": "windows-1809-core-for-containers",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true


### PR DESCRIPTION
* windows-2019-for-containers workflow is based off windows-2019 (server desktop) base
image
* ensure all container images using server core as a base image contain 'core' in
the workflow name