### PR TITLE
Clarify API authentication error, fixes #368

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -208,7 +208,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (Client, error)
 	opts = append(o, opts...)
 	hc, ep, err := transport.NewHTTPClient(ctx, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("dialing: %v", err)
+		return nil, fmt.Errorf("error creating HTTP API client: %v", err)
 	}
 	rawService, err := compute.New(hc)
 	if err != nil {


### PR DESCRIPTION
Error message is passed from utility method which creates a secure connection to
a Google API [doc link](https://godoc.org/google.golang.org/api/transport#NewHTTPClient)