### PR TITLE
Enable cumulative updates install, SQL on Server 2019

### DIFF
--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2016-enterprise-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2016.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2016-enterprise-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-ent-2016-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2016-standard-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2016.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2016-standard-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2016-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-std-2016-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2016-web-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2016.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2016-web-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2016-web"
+          ],
+          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-web-2016-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2017-enterprise-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2017.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2017-enterprise-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2017-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-ent-2017-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2017-express-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2017.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2017-express-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2017-express"
+          ],
+          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-exp-2017-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2017-standard-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2017.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2017-standard-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2017-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-std-2017-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2017-web-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2017.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2017-web-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2017-web"
+          ],
+          "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Family": "sql-web-2017-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql_install.ps1
+++ b/daisy_workflows/image_build/sqlserver/sql_install.ps1
@@ -233,6 +233,11 @@ function Install-SSMS {
   Write-Host 'Finished installing SSMS'
 }
 
+function Enable-MicrosoftUpdate {
+  $service_manager = New-Object -ComObject 'Microsoft.Update.ServiceManager'
+  $service_manager.AddService2("7971f918-a847-4430-9279-4a52d1efe18d",7,"")
+}
+
 try {
   if (!(Test-Path 'D:\')) {
     $sysprep = 'c:\Windows\System32\Sysprep'
@@ -241,6 +246,7 @@ try {
     Format-ScratchDisk
     Install-SqlServer
     Install-SSMS
+    Enable-MicrosoftUpdate
   }
 
   $reboot_required = Install-WindowsUpdates


### PR DESCRIPTION
* If Microsoft Update is not enabled, the latest cumulative update(s)
for SQL Server are not installed via automatic updates. Service packs
ARE installed regardless of the setting.
* MSSQL 2016 and 2017 now offered on Windows Server 2019.