### PR TITLE
Export: Change "qemu-img" to use disk as buffer, and then copy output to GCS gssutil

### DIFF
--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -21,8 +21,8 @@ FORMAT=$(curl -f -H Metadata-Flavor:Google ${URL}/format)
 # Strip gs://
 LOCAL_PATH=${GS_PATH##*//}
 # Create dir for output
-OUTS=${LOCAL_PATH%/*}
-mkdir -p "/gs/${OUTS}"
+OUTS_PATH=${LOCAL_PATH%/*}
+mkdir -p "/gs/${OUTS_PATH}"
 
 # Disk image size info.
 SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | grep -o '[0-9]\+')
@@ -38,7 +38,7 @@ fi
 echo ${out}
 
 if ! out=$(gsutil cp "/gs/${LOCAL_PATH}" "${GS_PATH}"); then
-  echo "ExportFiled: Failed to copy output image to ${GS_PATH}"
+  echo "ExportFiled: Failed to copy output image to ${GS_PATH}, error: ${out}"
   exit
 fi
 echo ${out}

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -37,7 +37,7 @@ if ! out=$(qemu-img convert /dev/sdb "/gs/${LOCAL_PATH}" -p -O $FORMAT 2>&1); th
 fi
 echo ${out}
 
-if ! out=$(gsutil cp "/gs/${LOCAL_PATH}" "${GS_PATH}"); then
+if ! out=$(gsutil cp "/gs/${LOCAL_PATH}" "${GS_PATH}" 2>&1); then
   echo "ExportFiled: Failed to copy output image to ${GS_PATH}, error: ${out}"
   exit
 fi

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -19,17 +19,10 @@ GS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 FORMAT=$(curl -f -H Metadata-Flavor:Google ${URL}/format)
 
 # Strip gs://
-GCS_PATH=${GS_PATH##*//}
-# Grab only the bucket
-GCS_BUCKET=${GCS_PATH%%/*}
-# Mount GCS bucket containing the disk image.
-mkdir -p "/gcs/${GCS_BUCKET}"
-gcsfuse ${GCS_BUCKET} /gcs/${GCS_BUCKET}
-if [ $? -ne 0 ]; then
-  echo "ExportFailed: Failed to mount ${GCS_BUCKET}."
-fi
-OUTS=${GCS_PATH%/*}
-mkdir -p "/gcs/${OUTS}"
+LOCAL_PATH=${GS_PATH##*//}
+# Create dir for output
+OUTS=${LOCAL_PATH%/*}
+mkdir -p "/gs/${OUTS}"
 
 # Disk image size info.
 SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | grep -o '[0-9]\+')
@@ -38,10 +31,17 @@ SIZE_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000)+ 1)}")
 
 echo "GCEExport: Exporting disk of size ${SIZE_GB}GB and format ${FORMAT}."
 
-if ! out=$(qemu-img convert /dev/sdb "/gcs/${GCS_PATH}" -p -O $FORMAT 2>&1); then
+if ! out=$(qemu-img convert /dev/sdb "/gs/${LOCAL_PATH}" -p -O $FORMAT 2>&1); then
   echo "ExportFailed: Failed to export disk source to ${GS_PATH} due to qemu-img error: ${out}"
+  exit
 fi
-
 echo ${out}
+
+if ! out=$(gsutil cp "/gs/${LOCAL_PATH}" "${GS_PATH}"); then
+  echo "ExportFiled: Failed to copy output image to ${GS_PATH}"
+  exit
+fi
+echo ${out}
+
 echo "export success"
 sync


### PR DESCRIPTION
This CL changes the way of using qemu-img:
Original: qemu-img output file to GCS by gcsfuse
Now: qemu-img output file to disk, then copy to GCS by gsutil

It achieves 3 purposes:
1. When qemu-img failed due to disk space or network issue, the workflow will fail. Previously it failed silently and the workflow got a success, and thus output a corrupt image.
2. Much higher success rate for large-size image, due that gsutil is much more reliable than gcsfuse, especially when network is not very stable. For a 198GB image, old method success rate is 29% while new method is 100% per my testing.
3. It made the code ready for next improvement: dynamically enlarge disk space to export >200GB image.

Conclusion: this CL resolved problems for <200GB image export, and technically prepared for >200GB improvement.

Concern of time efficiency: there was a concern that new method may double the time consuming. Below test result shows the concern is invalid:
![test](https://user-images.githubusercontent.com/33922283/53453491-14bb0c80-39d9-11e9-936a-ed5daf1cb652.png)


