### PR TITLE
Fix new project name for osconfig e2e tests

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -127,7 +127,7 @@ periodics:
     - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
       args:
       - "-out_dir=/artifacts"
-      - "-test_project_id=compute-image-osconfigagent"
+      - "-test_project_id=compute-image-osconfig-agent"
       - "-test_zone=us-central1-c"
       volumeMounts:
       - name: compute-image-tools-test-service-account


### PR DESCRIPTION
I first create the new project without the hyphen and then changed it since it was not readable.