### PR TITLE
Fix broken and flaky tests

### DIFF
--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -381,7 +381,6 @@ func cleanupOsConfig(ctx context.Context, testCase *junitxml.TestCase, oc *oscon
 }
 
 func cleanupAssignment(ctx context.Context, testCase *junitxml.TestCase, assignment *osconfigserver.Assignment, testProjectConfig *testconfig.Project) {
-	fmt.Printf("deleting assignment: %s\n\n", assignment.Name)
 	err := assignment.Cleanup(ctx, testProjectConfig.TestProjectID)
 	if err != nil {
 		testCase.WriteFailure(fmt.Sprintf("error while deleting assignment: %s", utils.GetStatusFromError(err)))

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -381,6 +381,7 @@ func cleanupOsConfig(ctx context.Context, testCase *junitxml.TestCase, oc *oscon
 }
 
 func cleanupAssignment(ctx context.Context, testCase *junitxml.TestCase, assignment *osconfigserver.Assignment, testProjectConfig *testconfig.Project) {
+	fmt.Printf("deleting assignment: %s\n\n", assignment.Name)
 	err := assignment.Cleanup(ctx, testProjectConfig.TestProjectID)
 	if err != nil {
 		testCase.WriteFailure(fmt.Sprintf("error while deleting assignment: %s", utils.GetStatusFromError(err)))


### PR DESCRIPTION
the package removal tests are flaky because soon after the test package is installed, the startup script tries to access package manager database but it is locked by some other process.
I only saw this happening frequently with debian hosts