### PR TITLE
Resize buffer disk dynamically

### DIFF
--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -20,7 +20,7 @@
     },
     "buffer_disk_size": {
       "Value": "200",
-      "Description": "size of the export instances buffer disk, this disk starts from a larger size to increase PD read speed, and grows on demand"
+      "Description": "size of the export instances buffer disk, this disk starts from a fixed size which can guarantee a nice PD read speed, and grows on demand"
     },
     "export_network": {
       "Value": "global/networks/default",
@@ -41,12 +41,14 @@
         {
           "Name": "disk-${NAME}-os",
           "SourceImage": "${export_instance_disk_image}",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+	  "ExactName": true
         },
         {
-          "Name": "disk-${NAME}-buffer",
+          "Name": "disk-${NAME}-buffer-${ID}",
           "SizeGb": "${buffer_disk_size}",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+	  "ExactName": true
         }
       ]
     },
@@ -57,7 +59,7 @@
           "Disks": [
             {"Source": "disk-${NAME}-os"},
             {"Source": "${source_disk}", "Mode": "READ_ONLY"},
-            {"Source": "disk-${NAME}-buffer"}
+            {"Source": "disk-${NAME}-buffer-${ID}"}
           ],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
@@ -65,7 +67,7 @@
             "gcs-path": "${OUTSPATH}/${NAME}",
             "format": "${format}",
 	    "instance-name": "inst-${NAME}",
-            "buffer-disk": "disk-${NAME}-buffer"
+            "buffer-disk": "disk-${NAME}-buffer-${ID}"
           },
           "networkInterfaces": [
             {

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -18,9 +18,9 @@
       "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "image to use for the exporter instance"
     },
-    "export_instance_disk_size": {
+    "buffer_disk_size": {
       "Value": "200",
-      "Description": "size of the export instances disk, this disk is unused for the export but a larger size increase PD read speed"
+      "Description": "size of the export instances buffer disk, this disk starts from a larger size to increase PD read speed, and grows on demand"
     },
     "export_network": {
       "Value": "global/networks/default",
@@ -32,15 +32,20 @@
     }
   },
   "Sources": {
-    "${NAME}_export_disk_ext.sh": "./export_disk_ext.sh"
+    "${NAME}_export_disk_ext.sh": "./export_disk_ext.sh",
+    "disk_resizing_mon.sh": "./disk_resizing_mon.sh"
   },
   "Steps": {
     "setup-disks": {
       "CreateDisks": [
         {
-          "Name": "disk-${NAME}",
+          "Name": "disk-${NAME}-os",
           "SourceImage": "${export_instance_disk_image}",
-          "SizeGb": "${export_instance_disk_size}",
+          "Type": "pd-ssd"
+        },
+        {
+          "Name": "disk-${NAME}-buffer",
+          "SizeGb": "${buffer_disk_size}",
           "Type": "pd-ssd"
         }
       ]
@@ -49,12 +54,18 @@
       "CreateInstances": [
         {
           "Name": "inst-${NAME}",
-          "Disks": [{"Source": "disk-${NAME}"}, {"Source": "${source_disk}", "Mode": "READ_ONLY"}],
+          "Disks": [
+            {"Source": "disk-${NAME}-os"},
+            {"Source": "${source_disk}", "Mode": "READ_ONLY"},
+            {"Source": "disk-${NAME}-buffer"}
+          ],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
             "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}",
-            "format": "${format}"
+            "format": "${format}",
+	    "instance-name": "inst-${NAME}",
+            "buffer-disk": "disk-${NAME}-buffer"
           },
           "networkInterfaces": [
             {
@@ -62,7 +73,7 @@
               "subnetwork": "${export_subnet}"
             }
           ],
-          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],
+          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/cloud-platform"],
           "StartupScript": "${NAME}_export_disk_ext.sh"
         }
       ]

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -39,7 +39,7 @@
     "setup-disks": {
       "CreateDisks": [
         {
-          "Name": "disk-${NAME}-os",
+          "Name": "disk-${NAME}-os-${ID}",
           "SourceImage": "${export_instance_disk_image}",
           "Type": "pd-ssd",
 	  "ExactName": true
@@ -57,7 +57,7 @@
         {
           "Name": "inst-${NAME}",
           "Disks": [
-            {"Source": "disk-${NAME}-os"},
+            {"Source": "disk-${NAME}-os-${ID}"},
             {"Source": "${source_disk}", "Mode": "READ_ONLY"},
             {"Source": "disk-${NAME}-buffer-${ID}"}
           ],

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -18,9 +18,9 @@
       "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "image to use for the exporter instance"
     },
-    "buffer_disk_size": {
+    "export_instance_disk_size": {
       "Value": "200",
-      "Description": "size of the export instances buffer disk, this disk starts from a fixed size which can guarantee a nice PD read speed, and grows on demand"
+      "Description": "size of the export instances buffer disk, this disk starts from a fixed size which can guarantee an acceptable PD read speed, and grows on demand"
     },
     "export_network": {
       "Value": "global/networks/default",
@@ -33,20 +33,19 @@
   },
   "Sources": {
     "${NAME}_export_disk_ext.sh": "./export_disk_ext.sh",
-    "disk_resizing_mon.sh": "./disk_resizing_mon.sh"
+    "${NAME}_disk_resizing_mon.sh": "./disk_resizing_mon.sh"
   },
   "Steps": {
     "setup-disks": {
       "CreateDisks": [
         {
-          "Name": "disk-${NAME}-os-${ID}",
+          "Name": "disk-${NAME}-os",
           "SourceImage": "${export_instance_disk_image}",
-          "Type": "pd-ssd",
-	  "ExactName": true
+          "Type": "pd-ssd"
         },
         {
           "Name": "disk-${NAME}-buffer-${ID}",
-          "SizeGb": "${buffer_disk_size}",
+          "SizeGb": "${export_instance_disk_size}",
           "Type": "pd-ssd",
 	  "ExactName": true
         }
@@ -57,7 +56,7 @@
         {
           "Name": "inst-${NAME}",
           "Disks": [
-            {"Source": "disk-${NAME}-os-${ID}"},
+            {"Source": "disk-${NAME}-os"},
             {"Source": "${source_disk}", "Mode": "READ_ONLY"},
             {"Source": "disk-${NAME}-buffer-${ID}"}
           ],
@@ -66,8 +65,8 @@
             "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}",
             "format": "${format}",
-	    "instance-name": "inst-${NAME}",
-            "buffer-disk": "disk-${NAME}-buffer-${ID}"
+            "buffer-disk": "disk-${NAME}-buffer-${ID}",
+	    "resizing-script-name": "${NAME}_disk_resizing_mon.sh"
           },
           "networkInterfaces": [
             {
@@ -75,7 +74,7 @@
               "subnetwork": "${export_subnet}"
             }
           ],
-          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/cloud-platform"],
+          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/compute"],
           "StartupScript": "${NAME}_export_disk_ext.sh"
         }
       ]

--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -3,53 +3,36 @@
 METADATA_URL="http://metadata/computeMetadata/v1/instance"
 
 MAX_SIZE=$1
+BUFFER_MIN_SIZE=10
 BUFFER_SIZE=25
 INTERVAL=10
 
-echo "Max disk size ${MAX_SIZE}GB, buffer size ${BUFFER_SIZE}GB, starting monitoring available disk buffer every ${INTERVAL}s..."
-while [ 1 ]
-do
-  sleep ${INTERVAL}
+# Prepare parameters for resizing
+ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
+if [ $? -ne 0 ]; then
+  echo "GCEExport: Failed to get metadata from ${METADATA_URL}/zone, will try again later."
+  continue
+fi
+BUFFER_DISK=$(curl "${METADATA_URL}/attributes/buffer-disk" -H "Metadata-Flavor: Google")
 
+echo "Max disk size ${MAX_SIZE}GB, min buffer size ${BUFFER_SIZE}GB, starting monitoring available disk buffer every ${INTERVAL}s..."
+while sleep ${INTERVAL};
+do
   # Check whether available buffer space is lower than threshold.
   AVAILABLE_BUFFER=$(df -BG /dev/sdc --output=avail | sed -n 2p)
   AVAILABLE_BUFFER=${AVAILABLE_BUFFER%?}
-  if [ ${AVAILABLE_BUFFER} -ge ${BUFFER_SIZE} ]; then
+  if [ ${AVAILABLE_BUFFER} -ge ${BUFFER_MIN_SIZE} ]; then
+    echo "ge!!!! ${AVAILABLE_BUFFER} vs ${BUFFER_MIN_SIZE}  "
     continue
   fi
+  echo "not ge!!!! ${AVAILABLE_BUFFER} vs ${BUFFER_MIN_SIZE}  "
 
-  # Decide the new size, which won't be higher than max size.
-  CURRENT_SIZE=$(lsblk /dev/sdc --output=SIZE | sed -n 2p)
-  CURRENT_SIZE=${CURRENT_SIZE%?}
-  NEXT_SIZE=$(awk "BEGIN {print int(${CURRENT_SIZE} + ${BUFFER_SIZE})}")
-  if [ ${NEXT_SIZE} -gt ${MAX_SIZE} ]; then
-    NEXT_SIZE=${MAX_SIZE}
-  fi
+  # Decide the new size of the device.
+  CURRENT_DEVICE_SIZE_BYTES=$(lsblk /dev/sdc --output=size -b | sed -n 2p)
+  CURRENT_DEVICE_SIZE=$(awk "BEGIN {print int(((${CURRENT_DEVICE_SIZE_BYTES}-1)/1073741824) + 1)}")
+  NEXT_SIZE=$(awk "BEGIN {print int(${CURRENT_DEVICE_SIZE} + ${BUFFER_SIZE})}")
 
-  # Prepare parameters for resizing
-  ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
-  if [ $? -ne 0 ]; then
-    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/zone, will try again later."
-    continue
-  fi
-  INSTANCE_NAME_PREFIX=$(curl "${METADATA_URL}/attributes/instance-name" -H "Metadata-Flavor: Google")
-  if [ $? -ne 0 ]; then
-    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/attributes/instance-name, will try again later."
-    continue
-  fi
-  HOST_NAME=$(curl "${METADATA_URL}/hostname" -H "Metadata-Flavor: Google"| cut -d'.' -f1)
-  if [ $? -ne 0 ]; then
-    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/hostname, will try again later."
-    continue
-  fi
-  BUFFER_DISK_PREFIX=$(curl "${METADATA_URL}/attributes/buffer-disk" -H "Metadata-Flavor: Google")
-  if [ $? -ne 0 ]; then
-    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/attributes/buffer-disk, will try again later."
-    continue
-  fi
-  BUFFER_DISK=${BUFFER_DISK_PREFIX}-$(echo ${HOST_NAME} | awk -F"${INSTANCE_NAME_PREFIX}-" '{ print $2}')
-
-  echo "GCEExport: Resizing buffer disk from ${CURRENT_SIZE}GB to ${NEXT_SIZE}GB..."
+  echo "GCEExport: Resizing buffer disk from ${CURRENT_DEVICE_SIZE}GB to ${NEXT_SIZE}GB..."
   if ! out=$(gcloud compute disks resize ${BUFFER_DISK} --size=${NEXT_SIZE}GB --quiet --zone "${ZONE}" 2>&1); then
     echo "ExportFailed: Failed to resize buffer disk. Error: ${out}"
     continue
@@ -61,7 +44,12 @@ do
   fi
   echo ${out}
 
-  if [ ${NEXT_SIZE} -eq ${MAX_SIZE} ]; then
+  # If current file system has reached or exceeded max size, then stop resizing.
+  # We need to know the size of the available file system other than the size of
+  # the partition, so "df" is used instead of "lsblk" here.
+  CURRENT_FILESYSTEM_SIZE=$(df -BG /dev/sdc --output=size | sed -n 2p)
+  CURRENT_FILESYSTEM_SIZE=${CURRENT_FILESYSTEM_SIZE%?}
+  if [ ${CURRENT_FILESYSTEM_SIZE} -ge ${MAX_SIZE} ]; then
     echo "Buffer disk reaches max size."
     exit
   fi

--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+METADATA_URL="http://metadata/computeMetadata/v1/instance"
+
+MAX_SIZE=$1
+BUFFER_SIZE=25
+INTERVAL=10
+
+echo "Max disk size ${MAX_SIZE}GB, buffer size ${BUFFER_SIZE}GB, starting monitoring available disk buffer every ${INTERVAL}s..."
+while [ 1 ]
+do
+  sleep ${INTERVAL}
+
+  # Check whether available buffer space is lower than threshold.
+  AVAILABLE_BUFFER=$(df -BG /dev/sdc --output=avail | sed -n 2p)
+  AVAILABLE_BUFFER=${AVAILABLE_BUFFER%?}
+  if [ ${AVAILABLE_BUFFER} -ge ${BUFFER_SIZE} ]; then
+    continue
+  fi
+
+  # Decide the new size, which won't be higher than max size.
+  CURRENT_SIZE=$(lsblk /dev/sdc --output=SIZE | sed -n 2p)
+  CURRENT_SIZE=${CURRENT_SIZE%?}
+  NEXT_SIZE=$(awk "BEGIN {print int(${CURRENT_SIZE} + ${BUFFER_SIZE})}")
+  if [ ${NEXT_SIZE} -gt ${MAX_SIZE} ]; then
+    NEXT_SIZE=${MAX_SIZE}
+  fi
+
+  # Prepare parameters for resizing
+  ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
+  if [ $? -ne 0 ]; then
+    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/zone, will try again later."
+    continue
+  fi
+  INSTANCE_NAME_PREFIX=$(curl "${METADATA_URL}/attributes/instance-name" -H "Metadata-Flavor: Google")
+  if [ $? -ne 0 ]; then
+    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/attributes/instance-name, will try again later."
+    continue
+  fi
+  HOST_NAME=$(curl "${METADATA_URL}/hostname" -H "Metadata-Flavor: Google"| cut -d'.' -f1)
+  if [ $? -ne 0 ]; then
+    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/hostname, will try again later."
+    continue
+  fi
+  BUFFER_DISK_PREFIX=$(curl "${METADATA_URL}/attributes/buffer-disk" -H "Metadata-Flavor: Google")
+  if [ $? -ne 0 ]; then
+    echo "GCEExport: Failed to get metadata from ${METADATA_URL}/attributes/buffer-disk, will try again later."
+    continue
+  fi
+  BUFFER_DISK=${BUFFER_DISK_PREFIX}-$(echo ${HOST_NAME} | awk -F"${INSTANCE_NAME_PREFIX}-" '{ print $2}')
+
+  echo "GCEExport: Resizing buffer disk from ${CURRENT_SIZE}GB to ${NEXT_SIZE}GB..."
+  if ! out=$(gcloud compute disks resize ${BUFFER_DISK} --size=${NEXT_SIZE}GB --quiet --zone "${ZONE}" 2>&1); then
+    echo "ExportFailed: Failed to resize buffer disk. Error: ${out}"
+    continue
+  fi
+  echo ${out}
+  if ! out=$(sudo resize2fs /dev/sdc 2>&1); then
+    echo "ExportFailed: Failed to resize partition of buffer disk. Error: ${out}"
+    continue
+  fi
+  echo ${out}
+
+  if [ ${NEXT_SIZE} -eq ${MAX_SIZE} ]; then
+    echo "Buffer disk reaches max size."
+    exit
+  fi
+done

--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+BYTES_1GB=1073741824
 METADATA_URL="http://metadata/computeMetadata/v1/instance"
 
 MAX_SIZE=$1
@@ -12,8 +13,7 @@ ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
 BUFFER_DISK=$(curl "${METADATA_URL}/attributes/buffer-disk" -H "Metadata-Flavor: Google")
 
 echo "Max disk size ${MAX_SIZE}GB, min buffer size ${BUFFER_SIZE}GB, starting monitoring available disk buffer every ${INTERVAL}s..."
-while sleep ${INTERVAL};
-do
+while sleep ${INTERVAL}; do
   # Check whether available buffer space is lower than threshold.
   AVAILABLE_BUFFER=$(df -BG /dev/sdc --output=avail | sed -n 2p)
   AVAILABLE_BUFFER=${AVAILABLE_BUFFER%?}
@@ -23,7 +23,7 @@ do
 
   # Decide the new size of the device.
   CURRENT_DEVICE_SIZE_BYTES=$(lsblk /dev/sdc --output=size -b | sed -n 2p)
-  CURRENT_DEVICE_SIZE=$(awk "BEGIN {print int(((${CURRENT_DEVICE_SIZE_BYTES}-1)/1073741824) + 1)}")
+  CURRENT_DEVICE_SIZE=$(awk "BEGIN {print int(((${CURRENT_DEVICE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
   NEXT_SIZE=$(awk "BEGIN {print int(${CURRENT_DEVICE_SIZE} + ${BUFFER_SIZE})}")
 
   echo "GCEExport: Resizing buffer disk from ${CURRENT_DEVICE_SIZE}GB to ${NEXT_SIZE}GB..."

--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -9,10 +9,6 @@ INTERVAL=10
 
 # Prepare parameters for resizing
 ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
-if [[ $? -ne 0 ]]; then
-  echo "GCEExport: Failed to get metadata from ${METADATA_URL}/zone, will try again later."
-  continue
-fi
 BUFFER_DISK=$(curl "${METADATA_URL}/attributes/buffer-disk" -H "Metadata-Flavor: Google")
 
 echo "Max disk size ${MAX_SIZE}GB, min buffer size ${BUFFER_SIZE}GB, starting monitoring available disk buffer every ${INTERVAL}s..."

--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -9,7 +9,7 @@ INTERVAL=10
 
 # Prepare parameters for resizing
 ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
   echo "GCEExport: Failed to get metadata from ${METADATA_URL}/zone, will try again later."
   continue
 fi
@@ -21,7 +21,7 @@ do
   # Check whether available buffer space is lower than threshold.
   AVAILABLE_BUFFER=$(df -BG /dev/sdc --output=avail | sed -n 2p)
   AVAILABLE_BUFFER=${AVAILABLE_BUFFER%?}
-  if [ ${AVAILABLE_BUFFER} -ge ${BUFFER_MIN_SIZE} ]; then
+  if [[ ${AVAILABLE_BUFFER} -ge ${BUFFER_MIN_SIZE} ]]; then
     echo "ge!!!! ${AVAILABLE_BUFFER} vs ${BUFFER_MIN_SIZE}  "
     continue
   fi
@@ -49,7 +49,7 @@ do
   # the partition, so "df" is used instead of "lsblk" here.
   CURRENT_FILESYSTEM_SIZE=$(df -BG /dev/sdc --output=size | sed -n 2p)
   CURRENT_FILESYSTEM_SIZE=${CURRENT_FILESYSTEM_SIZE%?}
-  if [ ${CURRENT_FILESYSTEM_SIZE} -ge ${MAX_SIZE} ]; then
+  if [[ ${CURRENT_FILESYSTEM_SIZE} -ge ${MAX_SIZE} ]]; then
     echo "Buffer disk reaches max size."
     exit
   fi

--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -22,10 +22,8 @@ do
   AVAILABLE_BUFFER=$(df -BG /dev/sdc --output=avail | sed -n 2p)
   AVAILABLE_BUFFER=${AVAILABLE_BUFFER%?}
   if [[ ${AVAILABLE_BUFFER} -ge ${BUFFER_MIN_SIZE} ]]; then
-    echo "ge!!!! ${AVAILABLE_BUFFER} vs ${BUFFER_MIN_SIZE}  "
     continue
   fi
-  echo "not ge!!!! ${AVAILABLE_BUFFER} vs ${BUFFER_MIN_SIZE}  "
 
   # Decide the new size of the device.
   CURRENT_DEVICE_SIZE_BYTES=$(lsblk /dev/sdc --output=size -b | sed -n 2p)

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -14,11 +14,10 @@
 # limitations under the License.
 set -x
 
-DISK_RESIZING_MON=disk_resizing_mon.sh
-
 URL="http://metadata/computeMetadata/v1/instance/attributes"
 GS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 FORMAT=$(curl -f -H Metadata-Flavor:Google ${URL}/format)
+DISK_RESIZING_MON=$(curl -f -H Metadata-Flavor:Google ${URL}/resizing-script-name)
 
 # Strip gs://
 IMAGE_OUTPUT_PATH=${GS_PATH##*//}

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -51,7 +51,7 @@ fi
 echo ${out}
 
 echo "GCEExport: Launching disk size monitor in background..."
-${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
+bash ${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
 
 echo "GCEExport: Exporting disk of size ${SIZE_OUTPUT_GB}GB and format ${FORMAT}."
 if ! out=$(qemu-img convert /dev/sdb "/gs/${IMAGE_OUTPUT_PATH}" -p -O $FORMAT 2>&1); then

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -51,7 +51,7 @@ fi
 echo ${out}
 
 echo "GCEExport: Launching disk size monitor in background..."
-sh ${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
+bash ${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
 
 echo "GCEExport: Exporting disk of size ${SIZE_OUTPUT_GB}GB and format ${FORMAT}."
 if ! out=$(qemu-img convert /dev/sdb "/gs/${IMAGE_OUTPUT_PATH}" -p -O $FORMAT 2>&1); then

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -28,16 +28,15 @@ mkdir -p "/gs/${OUTS_PATH}"
 
 # Prepare disk size info.
 # 1. Disk image size info.
-SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | grep -o '[0-9]\+')
+SIZE_BYTES=$(lsblk /dev/sdb --output=size -b | sed -n 2p)
 # 2. Round up to the next GB.
-SIZE_OUTPUT_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000) + 1)}")
+SIZE_OUTPUT_GB=$(awk "BEGIN {print int(((${SIZE_BYTES}-1)/1073741824) + 1)}")
 # 3. Add 5GB of additional space to max size to prevent the corner case that output
 # file is slightly larger than source disk.
 MAX_BUFFER_DISK_SIZE_GB=$(awk "BEGIN {print int(${SIZE_OUTPUT_GB} + 5)}")
 
 # Prepare buffer disk
 echo "GCEExport: Initializing buffer disk for qemu-img output..."
-sudo arted -a optimal /dev/sdc mklabel gpt
 sudo mkfs.ext4 /dev/sdc
 sudo mount /dev/sdc "/gs/${OUTS_PATH}"
 

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -14,31 +14,56 @@
 # limitations under the License.
 set -x
 
+DISK_RESIZING_MON=disk_resizing_mon.sh
+
 URL="http://metadata/computeMetadata/v1/instance/attributes"
 GS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 FORMAT=$(curl -f -H Metadata-Flavor:Google ${URL}/format)
 
 # Strip gs://
-LOCAL_PATH=${GS_PATH##*//}
+IMAGE_OUTPUT_PATH=${GS_PATH##*//}
 # Create dir for output
-OUTS_PATH=${LOCAL_PATH%/*}
+OUTS_PATH=${IMAGE_OUTPUT_PATH%/*}
 mkdir -p "/gs/${OUTS_PATH}"
 
-# Disk image size info.
+# Prepare disk size info.
+# 1. Disk image size info.
 SIZE_BYTES=$(qemu-img info --output "json" /dev/sdb | grep -m1 "virtual-size" | grep -o '[0-9]\+')
- # Round up to the next GB.
-SIZE_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000)+ 1)}")
+# 2. Round up to the next GB.
+SIZE_OUTPUT_GB=$(awk "BEGIN {print int((${SIZE_BYTES}/1000000000) + 1)}")
+# 3. Add 5GB of additional space to max size to prevent the corner case that output
+# file is slightly larger than source disk.
+MAX_BUFFER_DISK_SIZE_GB=$(awk "BEGIN {print int(${SIZE_OUTPUT_GB} + 5)}")
 
-echo "GCEExport: Exporting disk of size ${SIZE_GB}GB and format ${FORMAT}."
+# Prepare buffer disk
+echo "GCEExport: Initializing buffer disk for qemu-img output..."
+sudo arted -a optimal /dev/sdc mklabel gpt
+sudo mkfs.ext4 /dev/sdc
+sudo mount /dev/sdc "/gs/${OUTS_PATH}"
 
-if ! out=$(qemu-img convert /dev/sdb "/gs/${LOCAL_PATH}" -p -O $FORMAT 2>&1); then
+# Fetch disk size monitor script from GCS1
+DISK_RESIZING_MON_GCS_PATH=gs://${OUTS_PATH%/*}/sources/${DISK_RESIZING_MON}
+DISK_RESIZING_MON_LOCAL_PATH=/gs/${DISK_RESIZING_MON}
+echo "GCEExport: Copying disk size monitor script..."
+if ! out=$(gsutil cp "${DISK_RESIZING_MON_GCS_PATH}" "${DISK_RESIZING_MON_LOCAL_PATH}" 2>&1); then
+  echo "ExportFailed: Failed to copy disk size monitor script. Error: ${out}"
+  exit
+fi
+echo ${out}
+
+echo "GCEExport: Launching disk size monitor in background..."
+sh ${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
+
+echo "GCEExport: Exporting disk of size ${SIZE_OUTPUT_GB}GB and format ${FORMAT}."
+if ! out=$(qemu-img convert /dev/sdb "/gs/${IMAGE_OUTPUT_PATH}" -p -O $FORMAT 2>&1); then
   echo "ExportFailed: Failed to export disk source to ${GS_PATH} due to qemu-img error: ${out}"
   exit
 fi
 echo ${out}
 
-if ! out=$(gsutil cp "/gs/${LOCAL_PATH}" "${GS_PATH}" 2>&1); then
-  echo "ExportFiled: Failed to copy output image to ${GS_PATH}, error: ${out}"
+echo "GCEExport: Copying output image to target GCS path..."
+if ! out=$(gsutil cp "/gs/${IMAGE_OUTPUT_PATH}" "${GS_PATH}" 2>&1); then
+  echo "ExportFailed: Failed to copy output image to ${GS_PATH}, error: ${out}"
   exit
 fi
 echo ${out}

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -20,7 +20,7 @@
     },
     "buffer_disk_size": {
       "Value": "200",
-      "Description": "size of the export instances buffer disk, this disk starts from a larger size to increase PD read speed, and grows on demand"
+      "Description": "size of the export instances buffer disk, this disk starts from a fixed size which can guarantee a nice PD read speed, and grows on demand"
     },
     "export_network": {
       "Value": "global/networks/default",

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -18,9 +18,9 @@
       "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "image to use for the exporter instance"
     },
-    "export_instance_disk_size": {
+    "buffer_disk_size": {
       "Value": "200",
-      "Description": "size of the export instances disk, this disk is unused for the export but a larger size increase PD read speed"
+      "Description": "size of the export instances buffer disk, this disk starts from a larger size to increase PD read speed, and grows on demand"
     },
     "export_network": {
       "Value": "global/networks/default",
@@ -49,7 +49,7 @@
           "destination": "${destination}",
           "format": "${format}",
           "export_instance_disk_image": "${export_instance_disk_image}",
-          "export_instance_disk_size": "${export_instance_disk_size}",
+          "buffer_disk_size": "${buffer_disk_size}",
           "export_network": "${export_network}",
           "export_subnet": "${export_subnet}"
         }

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -18,9 +18,9 @@
       "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "image to use for the exporter instance"
     },
-    "buffer_disk_size": {
+    "export_instance_disk_size": {
       "Value": "200",
-      "Description": "size of the export instances buffer disk, this disk starts from a fixed size which can guarantee a nice PD read speed, and grows on demand"
+      "Description": "size of the export instances buffer disk, this disk starts from a fixed size which can guarantee an acceptable PD read speed, and grows on demand"
     },
     "export_network": {
       "Value": "global/networks/default",
@@ -49,7 +49,7 @@
           "destination": "${destination}",
           "format": "${format}",
           "export_instance_disk_image": "${export_instance_disk_image}",
-          "buffer_disk_size": "${buffer_disk_size}",
+          "export_instance_disk_size": "${export_instance_disk_size}",
           "export_network": "${export_network}",
           "export_subnet": "${export_subnet}"
         }


### PR DESCRIPTION
Today, a large-enough disk (which means, more than 200GB after compression) can't be exported with format converting. This CL fixed the problem.

Originally: Worker instance use a 200GB for both buffering and OS. Now: It creates a separate buffer disk starting from 200GB and will increase 25GB when there is not enough space during the exporing process.
Detail of the resizing logic:
200GB as initial size.
Check available space every 10s.
If available space is less than 25GB, then add 25GB more.
Unless it has reached the max size. Max size is source disk + 5GB.
Resizing logic is host in a separate shell script "disk_resizing_mon.sh", which runs in background.
OS is hosted in a default size disk, which is 10GB now. It helps to isolate buffer size from OS, because OS size can be different in the future.
This design won't cost too much space - it applies new space only when it's required.
It unblocks >200GB scenario for customers. Ideally it can support the max disk size of google cloud - 64TB. We need test to verify how big it can actually handle. Manual test for 400GB+ works well.

Test result 1: perf regression test. Disk size 198GB.
Originally: 88min Now: 78min. Basically the same level.

Test result 2: large disk (700GB before compression, 493GB after compression) test.
Originally: 100% fail. Now: 100% pass