### PR TITLE
Add random suffix to resource names

### DIFF
--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -71,6 +71,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 
 	logger.Printf("Running TestSuite %q", testSuite.Name)
 	testSetup := generateAllTestSetup(testProjectConfig)
+	fmt.Sprintf("%s\n", dump.Sprint(testSetup))
 	var wg sync.WaitGroup
 	tests := make(chan *junitxml.TestCase)
 	for _, setup := range testSetup {
@@ -198,6 +199,7 @@ func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCa
 	assign, err := osconfigserver.CreateAssignment(ctx, testSetup.assignment, parent)
 	if err != nil {
 		testCase.WriteFailure("error while creating assignment: \n%s\n", utils.GetStatusFromError(err))
+		return
 	}
 
 	defer cleanupAssignment(ctx, testCase, assign, testProjectConfig)

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -71,7 +71,6 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 
 	logger.Printf("Running TestSuite %q", testSuite.Name)
 	testSetup := generateAllTestSetup(testProjectConfig)
-	fmt.Sprintf("%s\n", dump.Sprint(testSetup))
 	var wg sync.WaitGroup
 	tests := make(chan *junitxml.TestCase)
 	for _, setup := range testSetup {

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -53,7 +53,7 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image string
-		uuid := utils.RandString(8)
+		uuid := utils.RandString(5)
 
 		switch tuple.platform {
 		case "debian":
@@ -90,7 +90,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
-		uuid := utils.RandString(8)
+		uuid := utils.RandString(5)
 
 		switch tuple.platform {
 		case "debian":
@@ -140,7 +140,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
-		uuid := utils.RandString(8)
+		uuid := utils.RandString(5)
 
 		switch tuple.platform {
 		case "debian":
@@ -190,7 +190,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
-		uuid := utils.RandString(8)
+		uuid := utils.RandString(5)
 
 		switch tuple.platform {
 		case "debian":

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/compute"
 	osconfigserver "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/osconfig_server"
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
 	api "google.golang.org/api/compute/v1"
 )
 
@@ -52,20 +53,21 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image string
+		uuid := utils.RandString(8)
 
 		switch tuple.platform {
 		case "debian":
 			image = debianImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
 		case "centos":
 			image = centosImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
 		case "rhel":
 			image = rhelImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
 		default:
 			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
 		}
@@ -88,29 +90,30 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
+		uuid := utils.RandString(8)
 
 		switch tuple.platform {
 		case "debian":
 			image = debianImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
 			vs = fmt.Sprintf(packageInstalledString)
 		case "centos":
 			image = centosImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
 			vs = fmt.Sprintf(packageInstalledString)
 		case "rhel":
 			image = rhelImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
 			vs = fmt.Sprintf(packageInstalledString)
 		default:
 			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
 		}
 
-		instanceName := fmt.Sprintf("%s-%s", path.Base(image), testName)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid)
+		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 		ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
 		setup := packageManagementTestSetup{
 			image:      image,
@@ -137,12 +140,13 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
+		uuid := utils.RandString(8)
 
 		switch tuple.platform {
 		case "debian":
 			image = debianImage
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildAptPackageConfig(nil, pkgs, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildAptPackageConfig(nil, pkgs, nil), nil, nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		case "centos":
 			image = centosImage
@@ -158,8 +162,8 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
 		}
 
-		instanceName := fmt.Sprintf("%s-%s", path.Base(image), testName)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid)
+		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 		ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
 		setup := packageManagementTestSetup{
 			image:      image,
@@ -186,32 +190,33 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 	for _, tuple := range tuples {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
+		uuid := utils.RandString(8)
 
 		switch tuple.platform {
 		case "debian":
 			image = debianImage
 			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		case "centos":
 			image = centosImage
 			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		case "rhel":
 			image = rhelImage
 			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		default:
 			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
 		}
 
-		instanceName := fmt.Sprintf("%s-%s", path.Base(image), testName)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s", path.Base(image), testName), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid)
+		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uuid), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 		ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
 		setup := packageManagementTestSetup{
 			image:      image,


### PR DESCRIPTION
Without this, the tests from the subsequent test run fails if the resources
from previous tests are not clean'd up.
