### PR TITLE
 osconfig agent: read config options out of instance metadata

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -16,9 +16,12 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"runtime"
+	"strconv"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -27,8 +30,17 @@ import (
 const (
 	// InstanceMetadata is the instance metadata URL.
 	InstanceMetadata = "http://metadata.google.internal/computeMetadata/v1/instance"
-	// ReportURL is where OS configurations are written in guest attributes.
+	// ReportURL is the guest attributes endpoint.
 	ReportURL = InstanceMetadata + "/guest-attributes"
+
+	googetRepoFilePath = "C:/ProgramData/GooGet/repos/google_osconfig.repo"
+	zypperRepoFilePath = "/etc/zypp/repos.d/google_osconfig.repo"
+	yumRepoFilePath    = "/etc/yum/repos.d/google_osconfig.repo"
+	aptRepoFilePath    = "/etc/apt/sources.list.d/google_osconfig.list"
+
+	osInventoryEnabled = false
+	osPackageEnabled   = false
+	osPatchEnabled     = false
 )
 
 var (
@@ -37,19 +49,99 @@ var (
 	oauth            = flag.String("oauth", "", "path to oauth json file")
 	debug            = flag.Bool("debug", false, "set debug log verbosity")
 
-	googetRepoFilePath = flag.String("googet_repo_file", "C:/ProgramData/GooGet/repos/google_osconfig.repo", "googet repo file location")
-	zypperRepoFilePath = flag.String("zypper_repo_file", "/etc/zypp/repos.d/google_osconfig.repo", "zypper repo file location")
-	yumRepoFilePath    = flag.String("yum_repo_file", "/etc/yum/repos.d/google_osconfig.repo", "yum repo file location")
-	aptRepoFilePath    = flag.String("apt_repo_file", "/etc/apt/sources.list.d/google_osconfig.list", "apt repo file location")
-
-	osPackageEnabled bool
-	osPatchEnabled   bool
-
-	version string
+	agentConfig   *config
+	agentConfigMx sync.RWMutex
+	version       string
 )
 
-// ReadConfig reads and parses the osconfig config file.
-func ReadConfig() error {
+type config struct {
+	osInventoryEnabled, osPackageEnabled, osPatchEnabled                     bool
+	googetRepoFilePath, zypperRepoFilePath, yumRepoFilePath, aptRepoFilePath string
+}
+
+func getAgentConfig() config {
+	agentConfigMx.RLock()
+	defer agentConfigMx.RUnlock()
+	return *agentConfig
+}
+
+func enabled(s string) bool {
+	enabled, err := strconv.ParseBool(s)
+	if err != nil {
+		// Bad entry returns as not enabled.
+		return false
+	}
+	return enabled
+}
+
+type metadataJSON struct {
+	Instance instanceJSON
+	Project  projectJSON
+}
+
+type instanceJSON struct {
+	Attributes attributesJSON
+}
+
+type projectJSON struct {
+	Attributes attributesJSON
+}
+
+type attributesJSON struct {
+	OSInventoryEnabled string `json:"os-inventory-enabled"`
+	OSPatchEnabled     string `json:"os-patch-enabled"`
+	OSPackageEnabled   string `json:"os-package-enabled"`
+}
+
+func (c *config) setFromMetadata(md metadataJSON) {
+	// Check project first then instance as instance metadata overrides project.
+	if md.Project.Attributes.OSInventoryEnabled != "" {
+		c.osInventoryEnabled = enabled(md.Project.Attributes.OSInventoryEnabled)
+	}
+	if md.Project.Attributes.OSPatchEnabled != "" {
+		c.osPatchEnabled = enabled(md.Project.Attributes.OSPatchEnabled)
+	}
+	if md.Project.Attributes.OSPackageEnabled != "" {
+		c.osPackageEnabled = enabled(md.Project.Attributes.OSPackageEnabled)
+	}
+
+	if md.Instance.Attributes.OSInventoryEnabled != "" {
+		c.osInventoryEnabled = enabled(md.Instance.Attributes.OSInventoryEnabled)
+	}
+	if md.Instance.Attributes.OSPatchEnabled != "" {
+		c.osPatchEnabled = enabled(md.Instance.Attributes.OSPatchEnabled)
+	}
+	if md.Instance.Attributes.OSPackageEnabled != "" {
+		c.osPackageEnabled = enabled(md.Instance.Attributes.OSPackageEnabled)
+	}
+}
+
+// SetConfig sets the agent config.
+func SetConfig() error {
+	agentConfigMx.Lock()
+	defer agentConfigMx.Unlock()
+	agentConfig = &config{
+		osInventoryEnabled: osInventoryEnabled,
+		osPackageEnabled:   osPackageEnabled,
+		osPatchEnabled:     osPatchEnabled,
+		googetRepoFilePath: googetRepoFilePath,
+		zypperRepoFilePath: zypperRepoFilePath,
+		yumRepoFilePath:    yumRepoFilePath,
+		aptRepoFilePath:    aptRepoFilePath,
+	}
+
+	md, err := metadata.Get("?recursive=true&alt=json")
+	if err != nil {
+		return err
+	}
+
+	var metadata metadataJSON
+	if err := json.Unmarshal([]byte(md), &metadata); err != nil {
+		return err
+	}
+
+	agentConfig.setFromMetadata(metadata)
+
 	return nil
 }
 
@@ -98,32 +190,37 @@ func SvcEndpoint() string {
 
 // ZypperRepoFilePath is the location where the zypper repo file will be created.
 func ZypperRepoFilePath() string {
-	return *zypperRepoFilePath
+	return getAgentConfig().zypperRepoFilePath
 }
 
 // YumRepoFilePath is the location where the zypper repo file will be created.
 func YumRepoFilePath() string {
-	return *yumRepoFilePath
+	return getAgentConfig().yumRepoFilePath
 }
 
 // AptRepoFilePath is the location where the zypper repo file will be created.
 func AptRepoFilePath() string {
-	return *aptRepoFilePath
+	return getAgentConfig().aptRepoFilePath
 }
 
 // GoogetRepoFilePath is the location where the googet repo file will be created.
 func GoogetRepoFilePath() string {
-	return *googetRepoFilePath
+	return getAgentConfig().googetRepoFilePath
+}
+
+// OSInventoryEnabled indicates whether OSInventory should be enabled.
+func OSInventoryEnabled() bool {
+	return getAgentConfig().osInventoryEnabled
 }
 
 // OSPackageEnabled indicates whether OSPackage should be enabled.
 func OSPackageEnabled() bool {
-	return osPackageEnabled
+	return getAgentConfig().osPackageEnabled
 }
 
 // OSPatchEnabled indicates whether OSPatch should be enabled.
 func OSPatchEnabled() bool {
-	return osPatchEnabled
+	return getAgentConfig().osPatchEnabled
 }
 
 // Instance is the URI of the instance the agent is running on.

--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -130,7 +130,7 @@ func createConfigFromMetadata(md metadataJSON) *config {
 	return c
 }
 
-func handleError(err error) error {
+func formatError(err error) error {
 	if urlErr, ok := err.(*url.Error); ok {
 		if _, ok := urlErr.Err.(*net.DNSError); ok {
 			return fmt.Errorf("DNS error when requesting metadata, check DNS settings and ensure metadata.internal.google is setup in your hosts file")
@@ -155,7 +155,7 @@ func SetConfig() error {
 		// Try up to 3 times to wait for slow network initialization, after
 		// that resort to using defaults and returning the error.
 		if webErrorCount == 2 {
-			webError = handleError(webError)
+			webError = formatError(webError)
 			break
 		}
 		webErrorCount++

--- a/cli_tools/google-osconfig-agent/config/config_test.go
+++ b/cli_tools/google-osconfig-agent/config/config_test.go
@@ -1,0 +1,55 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package config stores and retrieves configuration settings for the OS Config agent.
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSetConfig(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"project":{"attributes":{"os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"attributes":{"os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo"}}}`)
+	}))
+	defer ts.Close()
+
+	if err := os.Setenv("GCE_METADATA_HOST", strings.Trim(ts.URL, "http://")); err != nil {
+		t.Fatalf("Error running os.Setenv: %v", err)
+	}
+
+	if err := SetConfig(); err != nil {
+		t.Fatalf("Error running SetConfig: %v", err)
+	}
+
+	tests := []struct {
+		desc string
+		op   func() bool
+		want bool
+	}{
+		{"osinventory should be enabled (proj disabled, inst enabled)", OSInventoryEnabled, true},
+		{"ospatch should be disabled (proj enabled, inst disabled)", OSPatchEnabled, false},
+		{"ospackage should be disabled (proj enabled, inst bad value)", OSPackageEnabled, false},
+	}
+	for _, tt := range tests {
+		if tt.op() != tt.want {
+			t.Errorf("%q: got(%t) != want(%t)", tt.desc, tt.op(), tt.want)
+		}
+	}
+}

--- a/cli_tools/google-osconfig-agent/inventory/inventory.go
+++ b/cli_tools/google-osconfig-agent/inventory/inventory.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/attributes"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/tasker"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/osinfo"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
 )
@@ -47,7 +48,7 @@ type InstanceInventory struct {
 	PackageUpdates       packages.Packages
 }
 
-func writeInventory(state *InstanceInventory, url string) {
+func write(state *InstanceInventory, url string) {
 	logger.Infof("Writing instance inventory.")
 
 	if err := attributes.PostAttribute(url+"/Timestamp", strings.NewReader(time.Now().UTC().Format(time.RFC3339))); err != nil {
@@ -73,8 +74,8 @@ func writeInventory(state *InstanceInventory, url string) {
 	}
 }
 
-// GetInventory generates inventory data.
-func GetInventory() *InstanceInventory {
+// Get generates inventory data.
+func Get() *InstanceInventory {
 	logger.Infof("Gathering instance inventory.")
 
 	hs := &InstanceInventory{}
@@ -112,7 +113,7 @@ func GetInventory() *InstanceInventory {
 	return hs
 }
 
-// RunInventory gets the current inventory and writes it to guest attributes.
-func RunInventory() {
-	writeInventory(GetInventory(), inventoryURL)
+// Run gathers and records inventory information using tasker.Enqueue.
+func Run() {
+	tasker.Enqueue("Run OSInventory", func() { write(Get(), inventoryURL) })
 }

--- a/cli_tools/google-osconfig-agent/inventory/inventory_test.go
+++ b/cli_tools/google-osconfig-agent/inventory/inventory_test.go
@@ -41,7 +41,7 @@ func decodePackages(str string) packages.Packages {
 	return pkgs
 }
 
-func TestWriteInventory(t *testing.T) {
+func TestWrite(t *testing.T) {
 	inv := &InstanceInventory{
 		Hostname:      "Hostname",
 		LongName:      "LongName",
@@ -128,7 +128,7 @@ func TestWriteInventory(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	writeInventory(inv, svr.URL)
+	write(inv, svr.URL)
 
 	for k, v := range want {
 		if v {

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -63,8 +63,10 @@ func run(ctx context.Context) {
 			}
 		}
 
-		// This should always run after ospackage.SetConfig.
-		tasker.Enqueue("Gather instance inventory", inventory.RunInventory)
+		if config.OSInventoryEnabled() {
+			// This should always run after ospackage.SetConfig.
+			tasker.Enqueue("Gather instance inventory", inventory.RunInventory)
+		}
 
 		select {
 		case <-ticker.C:

--- a/cli_tools/google-osconfig-agent/ospackage/apt.go
+++ b/cli_tools/google-osconfig-agent/ospackage/apt.go
@@ -57,7 +57,7 @@ func aptRepositories(repos []*osconfigpb.AptRepository, repoFile string) error {
 func aptChanges(packageInstalls, packageRemovals []*osconfigpb.Package) error {
 	var errs []string
 
-	inv := inventory.GetInventory()
+	inv := inventory.Get()
 	changes := getNecessaryChanges(inv.InstalledPackages.Apt, inv.PackageUpdates.Apt, packageInstalls, packageRemovals)
 
 	if changes.packagesToInstall != nil {

--- a/cli_tools/google-osconfig-agent/ospackage/googet.go
+++ b/cli_tools/google-osconfig-agent/ospackage/googet.go
@@ -48,7 +48,7 @@ func googetRepositories(repos []*osconfigpb.GooRepository, repoFile string) erro
 func googetChanges(packageInstalls, packageRemovals []*osconfigpb.Package) error {
 	var errs []string
 
-	inv := inventory.GetInventory()
+	inv := inventory.Get()
 	changes := getNecessaryChanges(inv.InstalledPackages.Apt, inv.PackageUpdates.Apt, packageInstalls, packageRemovals)
 
 	if changes.packagesToInstall != nil {

--- a/cli_tools/google-osconfig-agent/ospackage/yum.go
+++ b/cli_tools/google-osconfig-agent/ospackage/yum.go
@@ -69,7 +69,7 @@ func yumRepositories(repos []*osconfigpb.YumRepository, repoFile string) error {
 func yumChanges(packageInstalls, packageRemovals []*osconfigpb.Package) error {
 	var errs []string
 
-	inv := inventory.GetInventory()
+	inv := inventory.Get()
 	changes := getNecessaryChanges(inv.InstalledPackages.Yum, inv.PackageUpdates.Yum, packageInstalls, packageRemovals)
 
 	if changes.packagesToInstall != nil {

--- a/cli_tools/google-osconfig-agent/ospackage/zypper.go
+++ b/cli_tools/google-osconfig-agent/ospackage/zypper.go
@@ -69,7 +69,7 @@ func zypperRepositories(repos []*osconfigpb.ZypperRepository, repoFile string) e
 func zypperChanges(packageInstalls, packageRemovals []*osconfigpb.Package) error {
 	var errs []string
 
-	inv := inventory.GetInventory()
+	inv := inventory.Get()
 	changes := getNecessaryChanges(inv.InstalledPackages.Zypper, inv.PackageUpdates.Zypper, packageInstalls, packageRemovals)
 
 	if changes.packagesToInstall != nil {

--- a/cli_tools/google-osconfig-agent/ospatch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_run.go
@@ -90,6 +90,7 @@ func Configure(ctx context.Context) {
 		// This should never happen as nothing should be sending on this
 		// channel.
 		if ok && !config.OSPatchEnabled() {
+			logger.Errorf("Someone sent on the cancelC channel, this should not have happened")
 			close(cancelC)
 		}
 	default:
@@ -104,7 +105,7 @@ func Configure(ctx context.Context) {
 // Run runs patching as a single blocking agent, use cancel to cancel.
 func Run(ctx context.Context, cancel <-chan struct{}) {
 	savedPatchJobName := checkSavedState(ctx)
-	watcher(ctx, savedPatchJobName, cancel)
+	watcher(ctx, savedPatchJobName, cancel, ackPatch)
 }
 
 // Load current patch state off disk, schedule the patch if it isn't complete,

--- a/cli_tools/google-osconfig-agent/ospatch/watcher.go
+++ b/cli_tools/google-osconfig-agent/ospatch/watcher.go
@@ -16,6 +16,7 @@ package ospatch
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -23,14 +24,12 @@ import (
 	"strings"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
 )
 
 const (
-	defaultEtag      = ""
-	metadataURL      = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true&wait_for_change=true&last_etag="
-	metadataPatchKey = "osconfig-patch-notify"
+	defaultEtag = ""
+	metadataURL = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true&wait_for_change=true&last_etag="
 )
 
 var (
@@ -47,17 +46,32 @@ func updateEtag(resp *http.Response) bool {
 	return etag != oldEtag
 }
 
-func watchMetadata() (string, error) {
+type watchMetadataRet struct {
+	attr *attributesJSON
+	err  error
+}
+
+type attributesJSON struct {
+	PatchNotify string `json:"osconfig-patch-notify"`
+}
+
+func watchMetadata(c chan watchMetadataRet) {
 	client := &http.Client{}
 
 	req, err := http.NewRequest("GET", metadataURL+etag, nil)
 	if err != nil {
-		return "", err
+		c <- watchMetadataRet{
+			attr: nil,
+			err:  err,
+		}
 	}
 	req.Header.Add("Metadata-Flavor", "Google")
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		c <- watchMetadataRet{
+			attr: nil,
+			err:  err,
+		}
 	}
 
 	updateEtag(resp)
@@ -65,60 +79,67 @@ func watchMetadata() (string, error) {
 	md, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return "", err
+		c <- watchMetadataRet{
+			attr: nil,
+			err:  err,
+		}
 	}
 
-	return string(md), nil
+	var metadata attributesJSON
+	err = json.Unmarshal(md, &metadata)
+
+	c <- watchMetadataRet{
+		attr: &metadata,
+		err:  err,
+	}
 }
 
-func watcher(ctx context.Context, savedPatchJobName string) {
+func watcher(ctx context.Context, savedPatchJobName string, cancel <-chan struct{}) {
 	currentPatchJobName = savedPatchJobName
 	webError := 0
 	for {
-		_, err := watchMetadata()
-		if err != nil {
-			// Only log the second web error to avoid transient errors and
-			// not to spam the log on network failures.
-			if webError == 1 {
-				if urlErr, ok := err.(*url.Error); ok {
-					if _, ok := urlErr.Err.(*net.DNSError); ok {
-						logger.Errorf("DNS error when requesting metadata, check DNS settings and ensure metadata.internal.google is setup in your hosts file.")
+		c := make(chan watchMetadataRet)
+		go func(c chan watchMetadataRet) {
+			watchMetadata(c)
+		}(c)
+
+		select {
+		case <-cancel:
+			return
+		case ret := <-c:
+			if ret.err != nil {
+				// Only log the second web error to avoid transient errors and
+				// not to spam the log on network failures.
+				if webError == 1 {
+					if urlErr, ok := ret.err.(*url.Error); ok {
+						if _, ok := urlErr.Err.(*net.DNSError); ok {
+							logger.Errorf("DNS error when requesting metadata, check DNS settings and ensure metadata.internal.google is setup in your hosts file.")
+						}
+						if _, ok := urlErr.Err.(*net.OpError); ok {
+							logger.Errorf("Network error when requesting metadata, make sure your instance has an active network and can reach the metadata server.")
+						}
 					}
-					if _, ok := urlErr.Err.(*net.OpError); ok {
-						logger.Errorf("Network error when requesting metadata, make sure your instance has an active network and can reach the metadata server.")
-					}
+					logger.Errorf(ret.err.Error())
 				}
-				logger.Errorf(err.Error())
+				webError++
+				time.Sleep(5 * time.Second)
 			}
-			webError++
-			time.Sleep(5 * time.Second)
-			continue
-		}
 
-		patchNotification, err := metadata.InstanceAttributeValue(metadataPatchKey)
-		if err != nil {
-			switch err.(type) {
-			case metadata.NotDefinedError:
-				logger.Debugf("Metadata updated but key '%s' not set.", metadataPatchKey)
-				continue
-			default:
-				logger.Errorf("Error when requesting metadata, make sure your instance has an active network and can reach the metadata server. %v", err)
+			patchJobName := strings.Split(ret.attr.PatchNotify, ",")[0]
+			if patchJobName == "" {
 				continue
 			}
+			if currentPatchJobName == patchJobName {
+				logger.Debugf("Already ran patch '%s'. Ignoring notification.", patchJobName)
+				continue
+			}
+
+			currentPatchJobName = patchJobName
+			if patchJobName != "" {
+				ackPatch(ctx, patchJobName)
+			}
+
+			webError = 0
 		}
-
-		patchJobName := strings.Split(patchNotification, ",")[0]
-
-		if currentPatchJobName == patchJobName {
-			logger.Debugf("Already ran patch '%s'. Ignoring notification.", patchJobName)
-			continue
-		}
-
-		currentPatchJobName = patchJobName
-
-		if patchJobName != "" {
-			ackPatch(ctx, patchJobName)
-		}
-		webError = 0
 	}
 }

--- a/cli_tools/google-osconfig-agent/ospatch/watcher.go
+++ b/cli_tools/google-osconfig-agent/ospatch/watcher.go
@@ -65,7 +65,9 @@ func watchMetadata(c chan watchMetadataRet) {
 			attr: nil,
 			err:  err,
 		}
+		return
 	}
+
 	req.Header.Add("Metadata-Flavor", "Google")
 	resp, err := client.Do(req)
 	if err != nil {
@@ -73,6 +75,7 @@ func watchMetadata(c chan watchMetadataRet) {
 			attr: nil,
 			err:  err,
 		}
+		return
 	}
 
 	updateEtag(resp)
@@ -84,6 +87,7 @@ func watchMetadata(c chan watchMetadataRet) {
 			attr: nil,
 			err:  err,
 		}
+		return
 	}
 
 	var metadata attributesJSON
@@ -128,6 +132,7 @@ func watcher(ctx context.Context, savedPatchJobName string, cancel <-chan struct
 				}
 				webError++
 				time.Sleep(5 * time.Second)
+				continue
 			}
 
 			patchJobName := strings.Split(ret.attr.PatchNotify, ",")[0]

--- a/cli_tools/google-osconfig-agent/ospatch/watcher.go
+++ b/cli_tools/google-osconfig-agent/ospatch/watcher.go
@@ -99,7 +99,7 @@ func watchMetadata(c chan watchMetadataRet) {
 	}
 }
 
-func handleError(err error) string {
+func formatError(err error) string {
 	if urlErr, ok := err.(*url.Error); ok {
 		if _, ok := urlErr.Err.(*net.DNSError); ok {
 			return fmt.Sprintf("DNS error when requesting metadata, check DNS settings and ensure metadata.internal.google is setup in your hosts file.")
@@ -128,7 +128,7 @@ func watcher(ctx context.Context, savedPatchJobName string, cancel <-chan struct
 				// Only log the second web error to avoid transient errors and
 				// not to spam the log on network failures.
 				if webError == 1 {
-					logger.Errorf(handleError(ret.err))
+					logger.Errorf(formatError(ret.err))
 				}
 				webError++
 				time.Sleep(5 * time.Second)

--- a/cli_tools/google-osconfig-agent/ospatch/watcher_test.go
+++ b/cli_tools/google-osconfig-agent/ospatch/watcher_test.go
@@ -1,0 +1,94 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package config stores and retrieves configuration settings for the OS Config agent.
+package ospatch
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWatcher(t *testing.T) {
+	var c chan struct{}
+
+	var i int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close channel at second request.
+		if i == 1 {
+			close(c)
+		}
+		q := r.URL.Query()
+		if q.Get("name") == "cancel" {
+			close(c)
+		}
+		fmt.Fprintln(w, fmt.Sprintf(`{"osconfig-patch-notify":"%s"}`, q.Get("name")))
+
+		i++
+	}))
+	defer ts.Close()
+
+	var ran bool
+	action := func(_ context.Context, _ string) {
+		ran = true
+	}
+
+	ctx := context.Background()
+
+	var tests = []struct {
+		desc    string
+		url     string
+		name    string
+		wantRun bool
+	}{
+		{
+			"normal case",
+			ts.URL + "?name=foo",
+			"",
+			true,
+		},
+		{
+			"no metadata",
+			ts.URL,
+			"",
+			false,
+		},
+		{
+			"same patch run name",
+			ts.URL + "?name=foo",
+			"foo",
+			false,
+		},
+		{
+			"canceled case",
+			ts.URL + "?name=cancel",
+			"",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		metadataURL = tt.url
+		c = make(chan struct{})
+		i = 0
+		ran = false
+		watcher(ctx, tt.name, c, action)
+		if ran != tt.wantRun {
+			t.Errorf("%s: wantRun=%t, got=%t", tt.desc, tt.wantRun, ran)
+		}
+
+	}
+}

--- a/osconfig_tests/test_suites/inventory/inventory.go
+++ b/osconfig_tests/test_suites/inventory/inventory.go
@@ -278,6 +278,10 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 					Key:   "enable-guest-attributes",
 					Value: func() *string { v := "true"; return &v }(),
 				},
+				&api.MetadataItems{
+					Key:   "os-inventory-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
 			},
 		},
 		Disks: []*api.AttachedDisk{

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -146,6 +146,10 @@ func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, tes
 		Metadata: &api.Metadata{
 			Items: []*api.MetadataItems{
 				testSetup.startup,
+				&api.MetadataItems{
+					Key:   "os-package-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
 			},
 		},
 		Disks: []*api.AttachedDisk{
@@ -225,6 +229,10 @@ func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCa
 		Metadata: &api.Metadata{
 			Items: []*api.MetadataItems{
 				testSetup.startup,
+				&api.MetadataItems{
+					Key:   "os-package-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
 			},
 		},
 		Disks: []*api.AttachedDisk{
@@ -303,6 +311,10 @@ func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, tes
 		Metadata: &api.Metadata{
 			Items: []*api.MetadataItems{
 				testSetup.startup,
+				&api.MetadataItems{
+					Key:   "os-package-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
 			},
 		},
 		Disks: []*api.AttachedDisk{


### PR DESCRIPTION
Rework task logic, attempt to standardize the surface for each component
Patch watcher reworked to allow for cancellation logic. Right now this is just used for disabling of the patch system.