### PR TITLE
osconfig agent: use a lock file

### DIFF
--- a/cli_tools/google-osconfig-agent/lock_linux.go
+++ b/cli_tools/google-osconfig-agent/lock_linux.go
@@ -1,4 +1,4 @@
-//  Copyright 2018 Google Inc. All Rights Reserved.
+//  Copyright 2019 Google Inc. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/cli_tools/google-osconfig-agent/lock_linux.go
+++ b/cli_tools/google-osconfig-agent/lock_linux.go
@@ -43,7 +43,7 @@ func obtainLock() {
 	select {
 	case err := <-c:
 		if err != nil {
-			logger.Fatalf("OSConfig agent lock already held, is the agent already running? Error: %v", err)
+			logger.Fatalf("Cannot obtain agent lock, is the agent already running? Error: %v", err)
 		}
 	case <-time.After(time.Second):
 		logger.Fatalf("OSConfig agent lock already held, is the agent already running?")

--- a/cli_tools/google-osconfig-agent/lock_linux.go
+++ b/cli_tools/google-osconfig-agent/lock_linux.go
@@ -1,0 +1,53 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
+)
+
+func obtainLock() {
+	lockFile := "/run/lock/osconfig_agent.lock"
+
+	err := os.MkdirAll(filepath.Dir(lockFile), 0755)
+	if err != nil && !os.IsExist(err) {
+		logger.Fatalf("Cannot obtain agent lock: %v", err)
+	}
+
+	f, err := os.OpenFile(lockFile, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil && !os.IsExist(err) {
+		logger.Fatalf("Cannot obtain agent lock: %v", err)
+	}
+
+	c := make(chan error)
+	go func() {
+		c <- syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+	}()
+	select {
+	case err := <-c:
+		if err != nil {
+			logger.Fatalf("OSConfig agent lock already held, is the agent already running? Error: %v", err)
+		}
+	case <-time.After(time.Second):
+		logger.Fatalf("OSConfig agent lock already held, is the agent already running?")
+	}
+
+	deferredFuncs = append(deferredFuncs, func() { syscall.Flock(int(f.Fd()), syscall.LOCK_UN); f.Close(); os.Remove(lockFile) })
+}

--- a/cli_tools/google-osconfig-agent/lock_windows.go
+++ b/cli_tools/google-osconfig-agent/lock_windows.go
@@ -1,4 +1,4 @@
-//  Copyright 2018 Google Inc. All Rights Reserved.
+//  Copyright 2019 Google Inc. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -48,7 +48,7 @@ func lockFileEx(hFile uintptr, dwFlags, nNumberOfBytesToLockLow, nNumberOfBytesT
 	)
 	// If the function succeeds, the return value is nonzero.
 	if ret == 0 {
-		return fmt.Errorf("nonzero return code from LockFileEx: %d", ret)
+		return errors.New("LockFileEx unable to obtain lock")
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func unlockFileEx(hFile uintptr, nNumberOfBytesToLockLow, nNumberOfBytesToLockHi
 	)
 	// If the function succeeds, the return value is nonzero.
 	if ret == 0 {
-		return fmt.Errorf("nonzero return code from UnlockFileEx: %d", ret)
+		return errors.New("UnlockFileEx unable to unlock")
 	}
 	return nil
 }

--- a/cli_tools/google-osconfig-agent/lock_windows.go
+++ b/cli_tools/google-osconfig-agent/lock_windows.go
@@ -1,0 +1,88 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	kernel32         = windows.NewLazySystemDLL("kernel32.dll")
+	procLockFileEx   = kernel32.NewProc("LockFileEx")
+	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	// https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-lockfileex
+	LOCKFILE_EXCLUSIVE_LOCK   = 2
+	LOCKFILE_FAIL_IMMEDIATELY = 1
+)
+
+func lockFileEx(hFile uintptr, dwFlags, nNumberOfBytesToLockLow, nNumberOfBytesToLockHigh uint32, lpOverlapped *syscall.Overlapped) (err error) {
+	ret, _, _ := procLockFileEx.Call(
+		hFile,
+		uintptr(dwFlags),
+		0,
+		uintptr(nNumberOfBytesToLockLow),
+		uintptr(nNumberOfBytesToLockHigh),
+		uintptr(unsafe.Pointer(lpOverlapped)),
+	)
+	// If the function succeeds, the return value is nonzero.
+	if ret == 0 {
+		return fmt.Errorf("nonzero return code from LockFileEx: %d", ret)
+	}
+	return nil
+}
+
+func unlockFileEx(hFile uintptr, nNumberOfBytesToLockLow, nNumberOfBytesToLockHigh uint32, lpOverlapped *syscall.Overlapped) (err error) {
+	ret, _, _ := procUnlockFileEx.Call(
+		hFile,
+		0,
+		uintptr(nNumberOfBytesToLockLow),
+		uintptr(nNumberOfBytesToLockHigh),
+		uintptr(unsafe.Pointer(lpOverlapped)),
+	)
+	// If the function succeeds, the return value is nonzero.
+	if ret == 0 {
+		return fmt.Errorf("nonzero return code from UnlockFileEx: %d", ret)
+	}
+	return nil
+}
+
+func obtainLock() {
+	lockFile := `C:\Program Files\Google\OSConfig\lock`
+
+	err := os.MkdirAll(filepath.Dir(lockFile), 0755)
+	if err != nil && !os.IsExist(err) {
+		logger.Fatalf("Cannot obtain agent lock: %v", err)
+	}
+	f, err := os.OpenFile(lockFile, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil && !os.IsExist(err) {
+		logger.Fatalf("Cannot obtain agent lock: %v", err)
+	}
+
+	if err := lockFileEx(f.Fd(), LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY, 1, 0, &syscall.Overlapped{}); err != nil {
+		logger.Fatalf("OSConfig agent lock already held, is the agent already running?")
+	}
+
+	deferredFuncs = append(deferredFuncs, func() { unlockFileEx(f.Fd(), 1, 0, &syscall.Overlapped{}); f.Close(); os.Remove(lockFile) })
+}

--- a/cli_tools/google-osconfig-agent/logger/logger.go
+++ b/cli_tools/google-osconfig-agent/logger/logger.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	// DeferedFatalFuncs is a slice of functions that will be called prior to os.Exit in Fatal.
-	DeferedFatalFuncs []func()
+	// DeferredFatalFuncs is a slice of functions that will be called prior to os.Exit in Fatal.
+	DeferredFatalFuncs []func()
 
 	port               = &serialPort{config.SerialLogPort()}
 	cloudLoggingClient *logging.Client
@@ -187,7 +187,7 @@ func Errorf(format string, v ...interface{}) {
 func Fatal(e LogEntry) {
 	le := &logEntry{LocalTimestamp: now(), LogEntry: e, severity: logging.Critical, source: caller(e.CallDepth)}
 	log(le, io.MultiWriter(os.Stderr, port))
-	for _, f := range DeferedFatalFuncs {
+	for _, f := range DeferredFatalFuncs {
 		f()
 	}
 	Close()

--- a/cli_tools/google-osconfig-agent/logger/logger.go
+++ b/cli_tools/google-osconfig-agent/logger/logger.go
@@ -33,6 +33,9 @@ import (
 )
 
 var (
+	// DeferedFatalFuncs is a slice of functions that will be called prior to os.Exit in Fatal.
+	DeferedFatalFuncs []func()
+
 	port               = &serialPort{config.SerialLogPort()}
 	cloudLoggingClient *logging.Client
 	cloudLogger        *logging.Logger
@@ -184,6 +187,9 @@ func Errorf(format string, v ...interface{}) {
 func Fatal(e LogEntry) {
 	le := &logEntry{LocalTimestamp: now(), LogEntry: e, severity: logging.Critical, source: caller(e.CallDepth)}
 	log(le, io.MultiWriter(os.Stderr, port))
+	for _, f := range DeferedFatalFuncs {
+		f()
+	}
 	Close()
 	os.Exit(1)
 }

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -40,12 +40,6 @@ func init() {
 	config.SetVersion(version)
 
 	obtainLock()
-	logger.DeferredFatalFuncs = append(logger.DeferredFatalFuncs, deferredFuncs...)
-	defer func() {
-		for _, f := range deferredFuncs {
-			f()
-		}
-	}()
 }
 
 type logWritter struct{}
@@ -94,6 +88,13 @@ var deferredFuncs []func()
 func main() {
 	flag.Parse()
 	ctx := context.Background()
+
+	logger.DeferredFatalFuncs = append(logger.DeferredFatalFuncs, deferredFuncs...)
+	defer func() {
+		for _, f := range deferredFuncs {
+			f()
+		}
+	}()
 
 	if err := config.SetConfig(); err != nil {
 		logger.Errorf(err.Error())

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -40,6 +40,12 @@ func init() {
 	config.SetVersion(version)
 
 	obtainLock()
+	logger.DeferredFatalFuncs = append(logger.DeferredFatalFuncs, deferredFuncs...)
+	defer func() {
+		for _, f := range deferredFuncs {
+			f()
+		}
+	}()
 }
 
 type logWritter struct{}
@@ -88,13 +94,6 @@ var deferredFuncs []func()
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-
-	logger.DeferredFatalFuncs = append(logger.DeferredFatalFuncs, deferredFuncs...)
-	defer func() {
-		for _, f := range deferredFuncs {
-			f()
-		}
-	}()
 
 	if err := config.SetConfig(); err != nil {
 		logger.Errorf(err.Error())

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -103,6 +103,7 @@ func main() {
 	ctx := context.Background()
 
 	// TODO: move to a different locking system or move lockFile definition to config.
+	// This type of simple file locking can cause issues if the process crashes without cleanup.
 	lockFile := "/etc/osconfig/lock"
 	if runtime.GOOS == "windows" {
 		lockFile = `C:\Program Files\Google\OSConfig\lock`
@@ -110,7 +111,7 @@ func main() {
 
 	obtainLock(lockFile)
 	// Remove the lock file at the end of main or if logger.Fatal is called.
-	logger.DeferedFatalFuncs = append(logger.DeferedFatalFuncs, func() { os.Remove(lockFile) })
+	logger.DeferredFatalFuncs = append(logger.DeferredFatalFuncs, func() { os.Remove(lockFile) })
 	defer os.Remove(lockFile)
 
 	if err := config.SetConfig(); err != nil {

--- a/cli_tools/google-osconfig-agent/ospatch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_run.go
@@ -69,7 +69,7 @@ var (
 		completeJobCompleted: 9,
 	}
 
-	cancelC chan struct{}
+	cancelC = make(chan struct{})
 )
 
 func initPatch(ctx context.Context) {

--- a/cli_tools/google-osconfig-agent/packaging/googet/install.ps1
+++ b/cli_tools/google-osconfig-agent/packaging/googet/install.ps1
@@ -18,7 +18,7 @@ try {
   if (-not (Get-Service 'google_osconfig_agent' -ErrorAction SilentlyContinue)) {
     New-Service -DisplayName 'Google OSConfig Agent' `
                 -Name 'google_osconfig_agent' `
-                -BinaryPathName '"C:\Program Files\Google\OSConfig\google_osconfig_agent.exe" run' `
+                -BinaryPathName '"C:\Program Files\Google\OSConfig\google_osconfig_agent.exe"' `
                 -StartupType Automatic `
                 -Description 'Google OSConfig service agent'
   }


### PR DESCRIPTION
Use a lock file to ensure only one osconfig process is running at any one time. This is a simple solution to this issue and should be expanded upon or replaced later with a more robust solution.