### PR TITLE
osconfig-agent: Fix initialization of global values

### DIFF
--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -54,7 +54,7 @@ func run(ctx context.Context) {
 	ticker := time.NewTicker(config.SvcPollInterval())
 	for {
 		if err := config.SetConfig(); err != nil {
-			logger.Errorf(err.Error())
+			logger.Fatalf(err.Error())
 		}
 
 		// This sets up the patching system to run in the background.
@@ -82,6 +82,10 @@ func run(ctx context.Context) {
 func main() {
 	flag.Parse()
 	ctx := context.Background()
+
+	if err := config.SetConfig(); err != nil {
+		logger.Errorf(err.Error())
+	}
 
 	if config.Debug() {
 		packages.DebugLogger = log.New(&logWritter{}, "", 0)

--- a/cli_tools/google-osconfig-agent/main.go
+++ b/cli_tools/google-osconfig-agent/main.go
@@ -54,7 +54,7 @@ func run(ctx context.Context) {
 	ticker := time.NewTicker(config.SvcPollInterval())
 	for {
 		if err := config.SetConfig(); err != nil {
-			logger.Fatalf(err.Error())
+			logger.Errorf(err.Error())
 		}
 
 		// This sets up the patching system to run in the background.

--- a/cli_tools/google-osconfig-agent/ospackage/ospackage.go
+++ b/cli_tools/google-osconfig-agent/ospackage/ospackage.go
@@ -24,6 +24,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	osconfig "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
@@ -101,8 +102,14 @@ func lookupConfigs(ctx context.Context, client *osconfig.Client, resource string
 
 func setConfig(res *osconfigpb.LookupConfigsResponse) error {
 	var errs []string
-
 	if res.Goo != nil && packages.GooGetExists {
+		if _, err := os.Stat(config.GoogetRepoFilePath()); os.IsNotExist(err) {
+			logger.Debugf("Repo file does not exist, will create one...")
+			if err := os.MkdirAll(filepath.Dir(config.GoogetRepoFilePath()), 07550); err != nil {
+				logger.Errorf("Error creating repo file: %v", err)
+				errs = append(errs, fmt.Sprintf("error creating googet repo file: %v", err))
+			}
+		}
 		if err := googetRepositories(res.Goo.Repositories, config.GoogetRepoFilePath()); err != nil {
 			logger.Errorf("Error writing googet repo file: %v", err)
 			errs = append(errs, fmt.Sprintf("error writing googet repo file: %v", err))
@@ -113,6 +120,13 @@ func setConfig(res *osconfigpb.LookupConfigsResponse) error {
 	}
 
 	if res.Apt != nil && packages.AptExists {
+		if _, err := os.Stat(config.AptRepoFilePath()); os.IsNotExist(err) {
+			logger.Debugf("Repo file does not exist, will create one...")
+			if err := os.MkdirAll(filepath.Dir(config.AptRepoFilePath()), 07550); err != nil {
+				logger.Errorf("Error creating repo file: %v", err)
+				errs = append(errs, fmt.Sprintf("error creating apt repo file: %v", err))
+			}
+		}
 		if err := aptRepositories(res.Apt.Repositories, config.AptRepoFilePath()); err != nil {
 			logger.Errorf("Error writing apt repo file: %v", err)
 			errs = append(errs, fmt.Sprintf("error writing apt repo file: %v", err))
@@ -123,6 +137,13 @@ func setConfig(res *osconfigpb.LookupConfigsResponse) error {
 	}
 
 	if res.Yum != nil && packages.YumExists {
+		if _, err := os.Stat(config.YumRepoFilePath()); os.IsNotExist(err) {
+			logger.Debugf("Repo file does not exist, will create one...")
+			if err := os.MkdirAll(filepath.Dir(config.YumRepoFilePath()), 07550); err != nil {
+				logger.Errorf("Error creating repo file: %v", err)
+				errs = append(errs, fmt.Sprintf("error creating yum repo file: %v", err))
+			}
+		}
 		if err := yumRepositories(res.Yum.Repositories, config.YumRepoFilePath()); err != nil {
 			logger.Errorf("Error writing yum repo file: %v", err)
 			errs = append(errs, fmt.Sprintf("error writing yum repo file: %v", err))
@@ -133,6 +154,13 @@ func setConfig(res *osconfigpb.LookupConfigsResponse) error {
 	}
 
 	if res.Zypper != nil && packages.ZypperExists {
+		if _, err := os.Stat(config.ZypperRepoFilePath()); os.IsNotExist(err) {
+			logger.Debugf("Repo file does not exist, will create one...")
+			if err := os.MkdirAll(filepath.Dir(config.ZypperRepoFilePath()), 07550); err != nil {
+				logger.Errorf("Error creating repo file: %v", err)
+				errs = append(errs, fmt.Sprintf("error creating zypper repo file: %v", err))
+			}
+		}
 		if err := zypperRepositories(res.Zypper.Repositories, config.ZypperRepoFilePath()); err != nil {
 			logger.Errorf("Error writing zypper repo file: %v", err)
 			errs = append(errs, fmt.Sprintf("error writing zypper repo file: %v", err))

--- a/go/packages/apt_deb.go
+++ b/go/packages/apt_deb.go
@@ -41,6 +41,7 @@ func init() {
 		dpkgquery = "/usr/bin/dpkg-query"
 		aptGet = "/usr/bin/apt-get"
 	}
+	AptExists = exists(aptGet)
 }
 
 // InstallAptPackages installs apt packages.

--- a/go/packages/gem.go
+++ b/go/packages/gem.go
@@ -31,6 +31,7 @@ func init() {
 	if runtime.GOOS != "windows" {
 		gem = "/usr/bin/gem"
 	}
+	GemExists = exists(gem)
 }
 
 func gemUpdates(run runFunc) ([]PkgInfo, error) {

--- a/go/packages/googet.go
+++ b/go/packages/googet.go
@@ -37,6 +37,7 @@ func init() {
 	if runtime.GOOS == "windows" {
 		googet = filepath.Join(os.Getenv("GooGetRoot"), "googet.exe")
 	}
+	GooGetExists = exists(googet)
 }
 
 func googetUpdates() ([]PkgInfo, error) {

--- a/go/packages/packages_linux.go
+++ b/go/packages/packages_linux.go
@@ -19,14 +19,6 @@ import (
 	"strings"
 )
 
-func init() {
-	AptExists = exists(aptGet)
-	YumExists = exists(yum)
-	ZypperExists = exists(zypper)
-	GemExists = exists(gem)
-	PipExists = exists(pip)
-}
-
 // UpdatePackages installs all available package updates for all known system
 // package managers.
 func UpdatePackages() error {

--- a/go/packages/packages_windows.go
+++ b/go/packages/packages_windows.go
@@ -21,10 +21,6 @@ import (
 	"github.com/go-ole/go-ole/oleutil"
 )
 
-func init() {
-	GooGetExists = exists(googet)
-}
-
 // GetPackageUpdates gets available package updates GooGet as well as any
 // available updates from Windows Update Agent.
 func GetPackageUpdates() (Packages, []string) {

--- a/go/packages/pip.go
+++ b/go/packages/pip.go
@@ -32,6 +32,7 @@ func init() {
 	if runtime.GOOS != "windows" {
 		pip = "/usr/bin/pip"
 	}
+	PipExists = exists(pip)
 }
 
 func pipUpdates(run runFunc) ([]PkgInfo, error) {

--- a/go/packages/yum.go
+++ b/go/packages/yum.go
@@ -37,6 +37,7 @@ func init() {
 	if runtime.GOOS != "windows" {
 		yum = "/usr/bin/yum"
 	}
+	YumExists = exists(yum)
 }
 
 // InstallYumPackages installs yum packages.

--- a/go/packages/zypper.go
+++ b/go/packages/zypper.go
@@ -37,6 +37,7 @@ func init() {
 	if runtime.GOOS != "windows" {
 		zypper = "/usr/bin/zypper"
 	}
+	ZypperExists = exists(zypper)
 }
 
 // InstallZypperPackages Installs zypper packages


### PR DESCRIPTION
This commit fixes 3 issues
1) 	As per Golang specs, the init functions from different files
	in a single package are called in lexicographical order of
	the file names.
	Because of such order of initialization, some of the values
	are not initialized before they are used.

2)	The agentconfig is not initialized for cases where the
	users want to only execute a single feature

3)	In ospackage feature, the repo directory might not exist.