### PR TITLE
Add integration tests for installation from new repo

### DIFF
--- a/osconfig_tests/osconfig_server/osconfig_data_builder.go
+++ b/osconfig_tests/osconfig_server/osconfig_data_builder.go
@@ -79,6 +79,47 @@ func BuildZypperPackageConfig(installs, removes []*osconfigpb.Package, repos []*
 	}
 }
 
+func BuildAptRepository(archiveType osconfigpb.AptRepository_ArchiveType, uri, distribution, keyuri string, components []string) *osconfigpb.AptRepository {
+	return &osconfigpb.AptRepository{
+		ArchiveType:  archiveType,
+		Uri:          uri,
+		Distribution: distribution,
+		Components:   components,
+		KeyUri:       keyuri,
+	}
+}
+
+func BuildYumRepository(id, name, baseUrl string, gpgkeys []string) *osconfigpb.YumRepository {
+	return &osconfigpb.YumRepository{
+		Id:          id,
+		DisplayName: name,
+		BaseUrl:     baseUrl,
+		GpgKeys:     gpgkeys,
+	}
+}
+
+func BuildZypperRepository(id, name, baseUrl string, gpgkeys []string) *osconfigpb.ZypperRepository {
+	return &osconfigpb.ZypperRepository{
+		Id:          id,
+		DisplayName: name,
+		BaseUrl:     baseUrl,
+		GpgKeys:     gpgkeys,
+	}
+}
+
+func BuildGooRepository(name, url string) *osconfigpb.GooRepository {
+	return &osconfigpb.GooRepository{
+		Name: name,
+		Url:  url,
+	}
+}
+
+func BuildWindowsUpdateConfig(uri string) *osconfigpb.WindowsUpdateConfig {
+	return &osconfigpb.WindowsUpdateConfig{
+		WindowsUpdateServerUri: uri,
+	}
+}
+
 // BuildWUPackageConfig create a window update config
 func BuildWUPackageConfig(wusu string) *osconfigpb.WindowsUpdateConfig {
 	return &osconfigpb.WindowsUpdateConfig{

--- a/osconfig_tests/osconfig_server/osconfig_data_builder.go
+++ b/osconfig_tests/osconfig_server/osconfig_data_builder.go
@@ -79,6 +79,7 @@ func BuildZypperPackageConfig(installs, removes []*osconfigpb.Package, repos []*
 	}
 }
 
+// BuildAptRepository create an apt repository object
 func BuildAptRepository(archiveType osconfigpb.AptRepository_ArchiveType, uri, distribution, keyuri string, components []string) *osconfigpb.AptRepository {
 	return &osconfigpb.AptRepository{
 		ArchiveType:  archiveType,
@@ -89,24 +90,27 @@ func BuildAptRepository(archiveType osconfigpb.AptRepository_ArchiveType, uri, d
 	}
 }
 
-func BuildYumRepository(id, name, baseUrl string, gpgkeys []string) *osconfigpb.YumRepository {
+// BuildYumRepository create an yum repository object
+func BuildYumRepository(id, name, baseURL string, gpgkeys []string) *osconfigpb.YumRepository {
 	return &osconfigpb.YumRepository{
 		Id:          id,
 		DisplayName: name,
-		BaseUrl:     baseUrl,
+		BaseUrl:     baseURL,
 		GpgKeys:     gpgkeys,
 	}
 }
 
-func BuildZypperRepository(id, name, baseUrl string, gpgkeys []string) *osconfigpb.ZypperRepository {
+// BuildZypperRepository create an zypper repository object
+func BuildZypperRepository(id, name, baseURL string, gpgkeys []string) *osconfigpb.ZypperRepository {
 	return &osconfigpb.ZypperRepository{
 		Id:          id,
 		DisplayName: name,
-		BaseUrl:     baseUrl,
+		BaseUrl:     baseURL,
 		GpgKeys:     gpgkeys,
 	}
 }
 
+// BuildGooRepository create an googet repository object
 func BuildGooRepository(name, url string) *osconfigpb.GooRepository {
 	return &osconfigpb.GooRepository{
 		Name: name,
@@ -114,6 +118,7 @@ func BuildGooRepository(name, url string) *osconfigpb.GooRepository {
 	}
 }
 
+// BuildWindowsUpdateConfig create an windows update repository object
 func BuildWindowsUpdateConfig(uri string) *osconfigpb.WindowsUpdateConfig {
 	return &osconfigpb.WindowsUpdateConfig{
 		WindowsUpdateServerUri: uri,

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -357,6 +357,89 @@ func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	}
 }
 
+func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *packageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
+	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
+	if err != nil {
+		testCase.WriteFailure("error while creating osconfig: \n%s\n", utils.GetStatusFromError(err))
+		return
+	}
+	defer cleanupOsConfig(ctx, testCase, oc, testProjectConfig)
+
+	assign, err := osconfigserver.CreateAssignment(ctx, testSetup.assignment, parent)
+	if err != nil {
+		testCase.WriteFailure("error while creating assignment: \n%s\n", utils.GetStatusFromError(err))
+		return
+	}
+	defer cleanupAssignment(ctx, testCase, assign, testProjectConfig)
+
+	client, err := daisyCompute.NewClient(ctx)
+	if err != nil {
+		testCase.WriteFailure("error creating client: %v", err)
+		return
+	}
+
+	testCase.Logf("Creating instance with image %q", testSetup.image)
+	i := &api.Instance{
+		Name:        testSetup.name,
+		MachineType: fmt.Sprintf("projects/%s/zones/%s/machineTypes/n1-standard-1", testProjectConfig.TestProjectID, testProjectConfig.TestZone),
+		NetworkInterfaces: []*api.NetworkInterface{
+			&api.NetworkInterface{
+				Network: "global/networks/default",
+				AccessConfigs: []*api.AccessConfig{
+					&api.AccessConfig{
+						Type: "ONE_TO_ONE_NAT",
+					},
+				},
+			},
+		},
+		Metadata: &api.Metadata{
+			Items: []*api.MetadataItems{
+				testSetup.startup,
+				&api.MetadataItems{
+					Key:   "os-package-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
+			},
+		},
+		Disks: []*api.AttachedDisk{
+			&api.AttachedDisk{
+				AutoDelete: true,
+				Boot:       true,
+				InitializeParams: &api.AttachedDiskInitializeParams{
+					SourceImage: testSetup.image,
+				},
+			},
+		},
+		ServiceAccounts: []*api.ServiceAccount{
+			&api.ServiceAccount{
+				Email:  testProjectConfig.ServiceAccountEmail,
+				Scopes: testProjectConfig.ServiceAccountScopes,
+			},
+		},
+	}
+
+	inst, err := compute.CreateInstance(client, testProjectConfig.TestProjectID, testProjectConfig.TestZone, i)
+	if err != nil {
+		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
+		return
+	}
+	defer inst.Cleanup()
+
+	testCase.Logf("Waiting for agent install to complete")
+	if err := inst.WaitForSerialOutput("osconfig install done", 1, 5*time.Second, 5*time.Minute); err != nil {
+		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
+		return
+	}
+
+	testCase.Logf("Agent installed successfully")
+
+	// read the serial console once
+	if err = testSetup.vf(inst, testSetup.vstring, 1, 10*time.Second, 60*time.Second); err != nil {
+		testCase.WriteFailure("error while asserting: %v", err)
+	}
+}
+
 func packageManagementTestCase(ctx context.Context, testSetup *packageManagementTestSetup, tests chan *junitxml.TestCase, wg *sync.WaitGroup, logger *log.Logger, regex *regexp.Regexp, testProjectConfig *testconfig.Project) {
 	defer wg.Done()
 
@@ -364,12 +447,14 @@ func packageManagementTestCase(ctx context.Context, testSetup *packageManagement
 	packageInstallTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/PackageInstall] Package installation", testSetup.image))
 	packageRemovalTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/PackageRemoval] Package removal", testSetup.image))
 	packageInstallRemovalTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/PackageInstallRemoval] Package no change", testSetup.image))
+	packageInstallFromNewRepoTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/PackageInstallFromNewRepo] Add a new package from new repository", testSetup.image))
 
 	for tc, f := range map[*junitxml.TestCase]func(context.Context, *junitxml.TestCase, *packageManagementTestSetup, *log.Logger, *testconfig.Project){
-		createOsConfigTest:        runCreateOsConfigTest,
-		packageInstallTest:        runPackageInstallTest,
-		packageRemovalTest:        runPackageRemovalTest,
-		packageInstallRemovalTest: runPackageInstallRemovalTest,
+		createOsConfigTest:            runCreateOsConfigTest,
+		packageInstallTest:            runPackageInstallTest,
+		packageRemovalTest:            runPackageRemovalTest,
+		packageInstallRemovalTest:     runPackageInstallRemovalTest,
+		packageInstallFromNewRepoTest: runPackageInstallFromNewRepoTest,
 	} {
 		tfname := strings.ToLower(strings.Replace(testSetup.fname, "test", "", 1))
 		ttc := strings.ToLower(getTestNameFromTestCase(tc.Name))

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	osconfigpb "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/logger"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/compute"
 	osconfigserver "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/osconfig_server"
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
@@ -35,6 +36,7 @@ type platformPkgManagerTuple struct {
 const (
 	packageInstalledString    = "package is installed"
 	packageNotInstalledString = "package is not installed"
+	osconfigTestRepo          = "osconfig-agent-test-repository"
 )
 
 var (
@@ -69,7 +71,8 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
 		default:
-			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			continue
 		}
 		setup := packageManagementTestSetup{
 			image:      image,
@@ -109,7 +112,8 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
 			vs = fmt.Sprintf(packageInstalledString)
 		default:
-			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			continue
 		}
 
 		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
@@ -159,7 +163,8 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(nil, removePkg, nil), nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		default:
-			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			continue
 		}
 
 		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
@@ -203,21 +208,64 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 			image = centosImage
 			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, removePkg, nil), nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		case "rhel":
 			image = rhelImage
 			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, removePkg, nil), nil, nil, nil)
 			vs = fmt.Sprintf(packageNotInstalledString)
 		default:
-			panic(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			continue
 		}
 
 		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
 		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 		ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
+		setup := packageManagementTestSetup{
+			image:      image,
+			name:       instanceName,
+			osconfig:   oc,
+			assignment: assign,
+			fname:      testName,
+			vf:         vf,
+			vstring:    vs,
+			startup: &api.MetadataItems{
+				Key:   "startup-script",
+				Value: &ss,
+			},
+		}
+		pkgTestSetup = append(pkgTestSetup, &setup)
+	}
+	return pkgTestSetup
+}
+
+func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+	testName := "packageinstallfromnewrepotest"
+	desc := "test package installation from new package"
+	packageName := "osconfig-agent-test"
+	for _, tuple := range tuples {
+		var oc *osconfigpb.OsConfig
+		var image, vs string
+		uniqueSuffix := utils.RandString(5)
+
+		switch tuple.platform {
+		case "debian":
+			image = debianImage
+			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+			repos := []*osconfigpb.AptRepository{osconfigserver.BuildAptRepository(osconfigpb.AptRepository_DEB, "http://packages.cloud.google.com/apt", osconfigTestRepo, "https://packages.cloud.google.com/apt/doc/apt-key.gpg", []string{"main"})}
+			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, nil, repos), nil, nil, nil, nil)
+			vs = fmt.Sprintf(packageInstalledString)
+		default:
+			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
+			continue
+		}
+
+		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+		ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
 		setup := packageManagementTestSetup{
 			image:      image,
 			name:       instanceName,
@@ -242,5 +290,6 @@ func generateAllTestSetup(testProjectConfig *testconfig.Project) []*packageManag
 	pkgTestSetup = addPackageInstallTest(pkgTestSetup, testProjectConfig)
 	pkgTestSetup = addPackageRemovalTest(pkgTestSetup, testProjectConfig)
 	pkgTestSetup = addPackageInstallRemovalTest(pkgTestSetup, testProjectConfig)
+	pkgTestSetup = addPackageInstallFromNewRepoTest(pkgTestSetup, testProjectConfig)
 	return pkgTestSetup
 }

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	tuples = []platformPkgManagerTuple{{"debian", "apt"}, {"centos", "yum"}, {"rhel", "yum"}}
+	platformPkgManagers = []platformPkgManagerTuple{{"debian", "apt"}, {"centos", "yum"}, {"rhel", "yum"}}
 )
 
 // vf is the the vertificationFunction that is used in each testSetup during assertion of test case.
@@ -52,7 +52,7 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	testName := "createosconfigtest"
 	desc := "test osconfig creation"
 	packageName := "cowsay"
-	for _, tuple := range tuples {
+	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
 		var image string
 		uniqueSuffix := utils.RandString(5)
@@ -90,7 +90,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	testName := "packageinstalltest"
 	desc := "test package installation"
 	packageName := "cowsay"
-	for _, tuple := range tuples {
+	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
 		uniqueSuffix := utils.RandString(5)
@@ -141,7 +141,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	testName := "packageremovaltest"
 	desc := "test package removal"
 	packageName := "cowsay"
-	for _, tuple := range tuples {
+	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
 		uniqueSuffix := utils.RandString(5)
@@ -192,7 +192,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 	testName := "packageinstallremovaltest"
 	desc := "test package removal takes precedence over package installation"
 	packageName := "cowsay"
-	for _, tuple := range tuples {
+	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
 		uniqueSuffix := utils.RandString(5)
@@ -246,7 +246,7 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 	testName := "packageinstallfromnewrepotest"
 	desc := "test package installation from new package"
 	packageName := "osconfig-agent-test"
-	for _, tuple := range tuples {
+	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
 		var image, vs string
 		uniqueSuffix := utils.RandString(5)

--- a/osconfig_tests/test_suites/package_management/package_management_utils.go
+++ b/osconfig_tests/test_suites/package_management/package_management_utils.go
@@ -173,7 +173,7 @@ func getPackageInstallFromNewRepoTestStartupScript(pkgManager, packageName strin
 
 	case "apt":
 		ss = "%s\n" +
-			"sleep 10;\n" +
+			"sleep 10;\n" + // allow time for the test runner create the osconfigs, assignments
 			"systemctl restart google-osconfig-agent\n" +
 			"while true;\n" +
 			"do\n" +

--- a/osconfig_tests/test_suites/package_management/package_management_utils.go
+++ b/osconfig_tests/test_suites/package_management/package_management_utils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
+	"github.com/google/logger"
 )
 
 func getPackageInstallStartupScript(pkgManager, packageName string) string {
@@ -56,7 +57,7 @@ func getPackageInstallStartupScript(pkgManager, packageName string) string {
 		ss = fmt.Sprintf(ss, utils.InstallOSConfigYumEL7, packageName, packageInstalledString, packageNotInstalledString)
 
 	default:
-		panic(fmt.Sprintf("invalid package manager: %s", pkgManager))
+		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
 	return ss
@@ -119,7 +120,7 @@ func getPackageRemovalStartupScript(pkgManager, packageName string) string {
 		ss = fmt.Sprintf(ss, utils.InstallOSConfigYumEL7, packageName, packageName, packageName, packageInstalledString, packageNotInstalledString)
 
 	default:
-		panic(fmt.Sprintf("invalid package manager: %s", pkgManager))
+		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
 	return ss
@@ -159,7 +160,53 @@ func getPackageInstallRemovalStartupScript(pkgManager, packageName string) strin
 		ss = fmt.Sprintf(ss, utils.InstallOSConfigYumEL7, packageName, packageInstalledString, packageNotInstalledString)
 
 	default:
-		panic(fmt.Sprintf("invalid package manager: %s", pkgManager))
+		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
+	}
+
+	return ss
+}
+
+func getPackageInstallFromNewRepoTestStartupScript(pkgManager, packageName string) string {
+	var ss string
+
+	switch pkgManager {
+
+	case "apt":
+		ss = "%s\n" +
+			"sleep 10;\n" +
+			"systemctl restart google-osconfig-agent\n" +
+			"while true;\n" +
+			"do\n" +
+			"isinstalled=`/usr/bin/dpkg-query -s %s`\n" +
+			"if [[ $isinstalled =~ \"Status: install ok installed\" ]]; then\n" +
+			"echo \"%s\"\n" +
+			"else\n" +
+			"echo \"%s\"\n" +
+			"fi\n" +
+			"sleep 5;\n" +
+			"done;\n"
+
+		ss = fmt.Sprintf(ss, utils.InstallOSConfigDeb, packageName, packageInstalledString, packageNotInstalledString)
+
+	case "yum":
+		ss = "%s\n" +
+			"n=0\n" +
+			"while [[ n -lt 10 ]];\n" +
+			"do\n" +
+			"isinstalled=`/usr/bin/rpmquery -a %s`\n" +
+			"if [[ $isinstalled =~ ^cowsay-* ]]; then\n" +
+			"echo \"%s\"\n" +
+			"break\n" +
+			"else\n" +
+			"n=$[$n+1]\n" +
+			"sleep 5\n" +
+			"fi\n" +
+			"done\n" +
+			"echo \"%s\"\n"
+		ss = fmt.Sprintf(ss, utils.InstallOSConfigYumEL7, packageName, packageInstalledString, packageNotInstalledString)
+
+	default:
+		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
 	return ss


### PR DESCRIPTION
- As a osconfig user, user should be able to add a new repository
and install packages from the new one. For our case, we have create
new rapture repository 'osconfig-agent-test-repository'.
I have only added test for debian based system. Tests for yum based systems
are yet to follow.
- Removed the panics since it does not make sense to crash the test runner as
these configurations are owned by the test runner itself. There will be no situation
where the a package-manager is missing unknowingly