### PR TITLE
When version is empty, don't append the dash in image name

### DIFF
--- a/cli_tools/gce_image_publish/publish/publish.go
+++ b/cli_tools/gce_image_publish/publish/publish.go
@@ -226,8 +226,14 @@ func publishImage(p *Publish, img *Image, pubImgs []*compute.Image, skipDuplicat
 	if skipDuplicates && rep {
 		return nil, nil, nil, errors.New("cannot set both skipDuplicates and replace")
 	}
-	publishName := fmt.Sprintf("%s-%s", img.Prefix, p.publishVersion)
-	sourceName := fmt.Sprintf("%s-%s", img.Prefix, p.sourceVersion)
+	publishName := img.Prefix
+	if p.publishVersion != "" {
+		publishName = fmt.Sprintf("%s-%s", publishName, p.publishVersion)
+	}
+	sourceName := img.Prefix
+	if p.sourceVersion != "" {
+		sourceName = fmt.Sprintf("%s-%s", sourceName, p.sourceVersion)
+	}
 
 	ci := daisy.Image{
 		Image: compute.Image{

--- a/cli_tools/gce_image_publish/publish/publish_test.go
+++ b/cli_tools/gce_image_publish/publish/publish_test.go
@@ -147,6 +147,21 @@ func TestPublishImage(t *testing.T) {
 			&daisy.DeprecateImages{{Image: "foo-2", Project: "foo-project", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED", Replacement: "https://www.googleapis.com/compute/v1/projects/foo-project/global/images/foo-3"}}},
 			false,
 		},
+		{
+			"new image from src, without version",
+			&Publish{SourceProject: "bar-project", PublishProject: "foo-project"},
+			&Image{Prefix: "foo-x", Family: "foo-family", GuestOsFeatures: []string{"foo-feature", "bar-feature"}},
+			[]*compute.Image{
+				{Name: "bar-x", Family: "bar-family"},
+			},
+			false,
+			false,
+			&daisy.CreateImages{{GuestOsFeatures: []string{"foo-feature", "bar-feature"}, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-x"}, Image: compute.Image{
+				Name: "foo-x", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-x"},
+			}},
+			nil,
+			false,
+		},
 	}
 	for _, tt := range tests {
 		dr, di, _, err := publishImage(tt.p, tt.img, tt.pubImgs, tt.skipDup, tt.replace)


### PR DESCRIPTION
Currently with prefix `image-foo` and empty version, the publish name will become `image-foo-` and fails daisy validation :-(

/assign @adjackura 