### PR TITLE
Allow increase log verbosity through instance metadata

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -43,6 +43,7 @@ const (
 	osInventoryEnabledDefault = false
 	osPackageEnabledDefault   = false
 	osPatchEnabledDefault     = false
+	debugEnabledDefault       = false
 )
 
 var (
@@ -57,7 +58,7 @@ var (
 )
 
 type config struct {
-	osInventoryEnabled, osPackageEnabled, osPatchEnabled                     bool
+	osInventoryEnabled, osPackageEnabled, osPatchEnabled, debugEnabled       bool
 	googetRepoFilePath, zypperRepoFilePath, yumRepoFilePath, aptRepoFilePath string
 }
 
@@ -93,6 +94,7 @@ type attributesJSON struct {
 	OSInventoryEnabled string `json:"os-inventory-enabled"`
 	OSPatchEnabled     string `json:"os-patch-enabled"`
 	OSPackageEnabled   string `json:"os-package-enabled"`
+	DebugEnabled       string `json:"debug-enabled"`
 }
 
 func createConfigFromMetadata(md metadataJSON) *config {
@@ -100,6 +102,7 @@ func createConfigFromMetadata(md metadataJSON) *config {
 		osInventoryEnabled: osInventoryEnabledDefault,
 		osPackageEnabled:   osPackageEnabledDefault,
 		osPatchEnabled:     osPatchEnabledDefault,
+		debugEnabled:       debugEnabledDefault,
 		googetRepoFilePath: googetRepoFilePath,
 		zypperRepoFilePath: zypperRepoFilePath,
 		yumRepoFilePath:    yumRepoFilePath,
@@ -125,6 +128,9 @@ func createConfigFromMetadata(md metadataJSON) *config {
 	}
 	if md.Instance.Attributes.OSPackageEnabled != "" {
 		c.osPackageEnabled = parseBool(md.Instance.Attributes.OSPackageEnabled)
+	}
+	if md.Instance.Attributes.DebugEnabled != "" {
+		c.debugEnabled = parseBool(md.Instance.Attributes.DebugEnabled)
 	}
 
 	return c
@@ -204,7 +210,7 @@ func ResourceOverride() string {
 
 // Debug sets the debug log verbosity.
 func Debug() bool {
-	return *debug
+	return (*debug || getAgentConfig().debugEnabled)
 }
 
 // OAuthPath is the local location of the OAuth credentials file.

--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -43,7 +43,7 @@ const (
 	osInventoryEnabledDefault = false
 	osPackageEnabledDefault   = false
 	osPatchEnabledDefault     = false
-	debugEnabledDefault       = false
+	osDebugEnabledDefault     = false
 )
 
 var (
@@ -52,13 +52,13 @@ var (
 	oauth            = flag.String("oauth", "", "path to oauth json file")
 	debug            = flag.Bool("debug", false, "set debug log verbosity")
 
-	agentConfig   *config
+	agentConfig   = &config{}
 	agentConfigMx sync.RWMutex
 	version       string
 )
 
 type config struct {
-	osInventoryEnabled, osPackageEnabled, osPatchEnabled, debugEnabled       bool
+	osInventoryEnabled, osPackageEnabled, osPatchEnabled, osDebugEnabled     bool
 	googetRepoFilePath, zypperRepoFilePath, yumRepoFilePath, aptRepoFilePath string
 }
 
@@ -94,7 +94,7 @@ type attributesJSON struct {
 	OSInventoryEnabled string `json:"os-inventory-enabled"`
 	OSPatchEnabled     string `json:"os-patch-enabled"`
 	OSPackageEnabled   string `json:"os-package-enabled"`
-	DebugEnabled       string `json:"debug-enabled"`
+	OSDebugEnabled     string `json:"os-debug-enabled"`
 }
 
 func createConfigFromMetadata(md metadataJSON) *config {
@@ -102,7 +102,7 @@ func createConfigFromMetadata(md metadataJSON) *config {
 		osInventoryEnabled: osInventoryEnabledDefault,
 		osPackageEnabled:   osPackageEnabledDefault,
 		osPatchEnabled:     osPatchEnabledDefault,
-		debugEnabled:       debugEnabledDefault,
+		osDebugEnabled:     osDebugEnabledDefault,
 		googetRepoFilePath: googetRepoFilePath,
 		zypperRepoFilePath: zypperRepoFilePath,
 		yumRepoFilePath:    yumRepoFilePath,
@@ -129,8 +129,8 @@ func createConfigFromMetadata(md metadataJSON) *config {
 	if md.Instance.Attributes.OSPackageEnabled != "" {
 		c.osPackageEnabled = parseBool(md.Instance.Attributes.OSPackageEnabled)
 	}
-	if md.Instance.Attributes.DebugEnabled != "" {
-		c.debugEnabled = parseBool(md.Instance.Attributes.DebugEnabled)
+	if md.Instance.Attributes.OSDebugEnabled != "" {
+		c.osDebugEnabled = parseBool(md.Instance.Attributes.OSDebugEnabled)
 	}
 
 	return c
@@ -210,7 +210,7 @@ func ResourceOverride() string {
 
 // Debug sets the debug log verbosity.
 func Debug() bool {
-	return (*debug || getAgentConfig().debugEnabled)
+	return (*debug || getAgentConfig().osDebugEnabled)
 }
 
 // OAuthPath is the local location of the OAuth credentials file.

--- a/cli_tools/google-osconfig-agent/config/config_test.go
+++ b/cli_tools/google-osconfig-agent/config/config_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSetConfig(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"project":{"attributes":{"os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"attributes":{"os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo"}}}`)
+		fmt.Fprintln(w, `{"project":{"attributes":{"os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"attributes":{"os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo", "debug-enabled":"true"}}}`)
 	}))
 	defer ts.Close()
 
@@ -46,6 +46,7 @@ func TestSetConfig(t *testing.T) {
 		{"osinventory should be enabled (proj disabled, inst enabled)", OSInventoryEnabled, true},
 		{"ospatch should be disabled (proj enabled, inst disabled)", OSPatchEnabled, false},
 		{"ospackage should be disabled (proj enabled, inst bad value)", OSPackageEnabled, false},
+		{"debugenabled should be true (proj disabled, inst enabled)", Debug, true},
 	}
 	for _, tt := range tests {
 		if tt.op() != tt.want {

--- a/cli_tools/google-osconfig-agent/config/config_test.go
+++ b/cli_tools/google-osconfig-agent/config/config_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSetConfig(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"project":{"attributes":{"os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"attributes":{"os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo", "debug-enabled":"true"}}}`)
+		fmt.Fprintln(w, `{"project":{"attributes":{"os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"attributes":{"os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo", "os-debug-enabled":"true"}}}`)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
Currently, there is no way to increase verbosity of agent logging. Until now, for debugging purpose I had to restart the agent on the test vm with the debug flag. This was already a painful process, and with introduction of agent locking, even this option was no more feasible.