### PR TITLE
OVF importer Dockerfile

### DIFF
--- a/Dockerfile.gce_ovf_import
+++ b/Dockerfile.gce_ovf_import
@@ -1,0 +1,21 @@
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/distroless/base
+
+COPY linux/gce_ovf_import /gce_ovf_import
+COPY daisy_workflows/ /daisy_workflows/
+
+WORKDIR /
+ENTRYPOINT ["/gce_ovf_import"]


### PR DESCRIPTION
Adding missing OVF importer Dockerfile which should have been part of the big OVF importer pull request