### PR TITLE
Correct CentOS7 GSetup path

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
+++ b/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
@@ -254,7 +254,8 @@ def BuildKsConfig(release, google_cloud_repo, byol, sap, sap_hana, sap_apps,
       ks_options = FetchConfigPart('el7-options.cfg')
     custom_post = FetchConfigPart('el7-post.cfg')
     if uefi:
-      el7_uefi_post = FetchConfigPart('el7-uefi-post.cfg')
+      el7_uefi_post = FetchConfigPart('el7-uefi-post.cfg').replace("redhat",
+                                                                   "centos")
       custom_post = '\n'.join([custom_post, el7_uefi_post])
     cleanup = FetchConfigPart('el7-cleanup.cfg')
     repo_version = 'el7'


### PR DESCRIPTION
Turns out CentOS ships their UEFI boot shim in a different path than redhat, and this can cause boot failures in some scenarios. This PR simply amends the path in the kickstart script that generates GSetup/boot.