### PR TITLE
Fix PackageManagement tests

### DIFF
--- a/osconfig_tests/osconfig_server/osconfig_client.go
+++ b/osconfig_tests/osconfig_server/osconfig_client.go
@@ -30,6 +30,10 @@ func GetOsConfigClient(ctx context.Context) (*osconfig.Client, error) {
 		return osconfigClient, nil
 	}
 
-	config.SetConfig() // Ensure the configs have been loaded.
+	// Ensure the configs have been loaded.
+	if err := config.SetConfig(); err != nil {
+		return nil, err
+	}
+
 	return osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
 }

--- a/osconfig_tests/osconfig_server/osconfig_client.go
+++ b/osconfig_tests/osconfig_server/osconfig_client.go
@@ -30,5 +30,6 @@ func GetOsConfigClient(ctx context.Context) (*osconfig.Client, error) {
 		return osconfigClient, nil
 	}
 
+	config.SetConfig() // Ensure the configs have been loaded.
 	return osconfig.NewClient(ctx, option.WithEndpoint(config.SvcEndpoint()), option.WithCredentialsFile(config.OAuthPath()))
 }


### PR DESCRIPTION
Ensure we load the configs before using them to create the client. This was broken the other day when we changed how we load the `SvcEndpoint`.
