### PR TITLE
[OsConfig Agent] Add other supported images for different platforms

### DIFF
--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -36,12 +36,12 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
 )
 
-const (
+var (
 	testSuiteName = "PackageManagementTests"
-	debianImage   = "projects/debian-cloud/global/images/family/debian-9"
-	centosImage   = "projects/centos-cloud/global/images/family/centos-7"
-	rhelImage     = "projects/rhel-cloud/global/images/family/rhel-7"
-	windowsImage  = "projects/windows-cloud/global/images/family/windows-2016"
+	debianImages  = []string{"projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts", "projects/debian-cloud/global/images/family/debian-9"}
+	centosImages  = []string{"projects/centos-cloud/global/images/family/centos-6", "projects/centos-cloud/global/images/family/centos-7"}
+	rhelImages    = []string{"projects/rhel-cloud/global/images/family/rhel-6", "projects/rhel-cloud/global/images/family/rhel-7"}
+	windowsImages = []string{"projects/windows-cloud/global/images/family/windows-2016"}
 )
 
 var (
@@ -58,6 +58,19 @@ type packageManagementTestSetup struct {
 	vstring       string
 	assertTimeout time.Duration
 	vf            func(*compute.Instance, string, int64, time.Duration, time.Duration) error
+}
+
+func NewPackageManagementTestSetup(image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) *packageManagementTestSetup {
+	return &packageManagementTestSetup{
+		image:      image,
+		name:       name,
+		osconfig:   oc,
+		assignment: assignment,
+		fname:      fname,
+		vf:         vf,
+		vstring: 		vs,
+		startup: startup,
+	}
 }
 
 // TestSuite is a PackageManagementTests test suite.

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -60,16 +60,17 @@ type packageManagementTestSetup struct {
 	vf            func(*compute.Instance, string, int64, time.Duration, time.Duration) error
 }
 
-func newPackageManagementTestSetup(setup **packageManagementTestSetup, image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) {
+func newPackageManagementTestSetup(setup **packageManagementTestSetup, image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, assertTimeout time.Duration, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) {
 	*setup = &packageManagementTestSetup{
-		image:      image,
-		name:       name,
-		osconfig:   oc,
-		assignment: assignment,
-		fname:      fname,
-		vf:         vf,
-		vstring:    vs,
-		startup:    startup,
+		image:         image,
+		name:          name,
+		osconfig:      oc,
+		assignment:    assignment,
+		fname:         fname,
+		vf:            vf,
+		vstring:       vs,
+		assertTimeout: assertTimeout,
+		startup:       startup,
 	}
 }
 

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -60,16 +60,17 @@ type packageManagementTestSetup struct {
 	vf            func(*compute.Instance, string, int64, time.Duration, time.Duration) error
 }
 
-func NewPackageManagementTestSetup(image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) *packageManagementTestSetup {
-	return &packageManagementTestSetup{
+// NewPackageManagementTestSetup returns a new PackageManagementTestSetup object
+func NewPackageManagementTestSetup(image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) *PackageManagementTestSetup {
+	return &PackageManagementTestSetup{
 		image:      image,
 		name:       name,
 		osconfig:   oc,
 		assignment: assignment,
 		fname:      fname,
 		vf:         vf,
-		vstring: 		vs,
-		startup: startup,
+		vstring:    vs,
+		startup:    startup,
 	}
 }
 
@@ -105,7 +106,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 	logger.Printf("Finished TestSuite %q", testSuite.Name)
 }
 
-func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *packageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *PackageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
 
 	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
 	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
@@ -117,7 +118,7 @@ func runCreateOsConfigTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	defer cleanupOsConfig(ctx, testCase, oc, testProjectConfig)
 }
 
-func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *packageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *PackageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
 
 	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
 	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
@@ -209,7 +210,7 @@ func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	}
 }
 
-func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *packageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *PackageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
 	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
 	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
 	if err != nil {
@@ -295,95 +296,7 @@ func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCa
 	}
 }
 
-func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *packageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
-	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
-	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
-	if err != nil {
-		testCase.WriteFailure("error while creating osconfig: \n%s\n", utils.GetStatusFromError(err))
-		return
-	}
-	defer cleanupOsConfig(ctx, testCase, oc, testProjectConfig)
-
-	assign, err := osconfigserver.CreateAssignment(ctx, testSetup.assignment, parent)
-	if err != nil {
-		testCase.WriteFailure("error while creating assignment: \n%s\n", utils.GetStatusFromError(err))
-		return
-	}
-	defer cleanupAssignment(ctx, testCase, assign, testProjectConfig)
-
-	client, err := daisyCompute.NewClient(ctx)
-	if err != nil {
-		testCase.WriteFailure("error creating client: %v", err)
-		return
-	}
-
-	testCase.Logf("Creating instance with image %q", testSetup.image)
-	i := &api.Instance{
-		Name:        testSetup.name,
-		MachineType: fmt.Sprintf("projects/%s/zones/%s/machineTypes/n1-standard-4", testProjectConfig.TestProjectID, testProjectConfig.TestZone),
-		NetworkInterfaces: []*api.NetworkInterface{
-			&api.NetworkInterface{
-				Network: "global/networks/default",
-				AccessConfigs: []*api.AccessConfig{
-					&api.AccessConfig{
-						Type: "ONE_TO_ONE_NAT",
-					},
-				},
-			},
-		},
-		Metadata: &api.Metadata{
-			Items: []*api.MetadataItems{
-				testSetup.startup,
-				&api.MetadataItems{
-					Key:   "os-package-enabled",
-					Value: func() *string { v := "true"; return &v }(),
-				},
-				&api.MetadataItems{
-					Key:   "os-debug-enabled",
-					Value: func() *string { v := "true"; return &v }(),
-				},
-			},
-		},
-		Disks: []*api.AttachedDisk{
-			&api.AttachedDisk{
-				AutoDelete: true,
-				Boot:       true,
-				InitializeParams: &api.AttachedDiskInitializeParams{
-					SourceImage: testSetup.image,
-					DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-ssd", testProjectConfig.TestProjectID, testProjectConfig.TestZone),
-				},
-			},
-		},
-		ServiceAccounts: []*api.ServiceAccount{
-			&api.ServiceAccount{
-				Email:  testProjectConfig.ServiceAccountEmail,
-				Scopes: testProjectConfig.ServiceAccountScopes,
-			},
-		},
-	}
-
-	inst, err := compute.CreateInstance(client, testProjectConfig.TestProjectID, testProjectConfig.TestZone, i)
-	if err != nil {
-		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
-		return
-	}
-	defer inst.Cleanup()
-
-	testCase.Logf("Waiting for agent install to complete")
-	if err := inst.WaitForSerialOutput("osconfig install done", 1, 5*time.Second, 5*time.Minute); err != nil {
-		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
-		return
-	}
-
-	testCase.Logf("Agent installed successfully")
-
-	// read the serial console once
-	if err = testSetup.vf(inst, testSetup.vstring, 1, 10*time.Second, testSetup.assertTimeout); err != nil {
-		testCase.WriteFailure("error while asserting: %v", err)
-	}
-}
-
-func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *packageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *PackageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
 	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
 	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
 	if err != nil {
@@ -471,7 +384,95 @@ func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.Te
 	}
 }
 
-func packageManagementTestCase(ctx context.Context, testSetup *packageManagementTestSetup, tests chan *junitxml.TestCase, wg *sync.WaitGroup, logger *log.Logger, regex *regexp.Regexp, testProjectConfig *testconfig.Project) {
+func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *PackageManagementTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+	parent := fmt.Sprintf("projects/%s", testProjectConfig.TestProjectID)
+	oc, err := osconfigserver.CreateOsConfig(ctx, testSetup.osconfig, parent)
+	if err != nil {
+		testCase.WriteFailure("error while creating osconfig: \n%s\n", utils.GetStatusFromError(err))
+		return
+	}
+	defer cleanupOsConfig(ctx, testCase, oc, testProjectConfig)
+
+	assign, err := osconfigserver.CreateAssignment(ctx, testSetup.assignment, parent)
+	if err != nil {
+		testCase.WriteFailure("error while creating assignment: \n%s\n", utils.GetStatusFromError(err))
+		return
+	}
+	defer cleanupAssignment(ctx, testCase, assign, testProjectConfig)
+
+	client, err := daisyCompute.NewClient(ctx)
+	if err != nil {
+		testCase.WriteFailure("error creating client: %v", err)
+		return
+	}
+
+	testCase.Logf("Creating instance with image %q", testSetup.image)
+	i := &api.Instance{
+		Name:        testSetup.name,
+		MachineType: fmt.Sprintf("projects/%s/zones/%s/machineTypes/n1-standard-4", testProjectConfig.TestProjectID, testProjectConfig.TestZone),
+		NetworkInterfaces: []*api.NetworkInterface{
+			&api.NetworkInterface{
+				Network: "global/networks/default",
+				AccessConfigs: []*api.AccessConfig{
+					&api.AccessConfig{
+						Type: "ONE_TO_ONE_NAT",
+					},
+				},
+			},
+		},
+		Metadata: &api.Metadata{
+			Items: []*api.MetadataItems{
+				testSetup.startup,
+				&api.MetadataItems{
+					Key:   "os-package-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
+				&api.MetadataItems{
+					Key:   "os-debug-enabled",
+					Value: func() *string { v := "true"; return &v }(),
+				},
+			},
+		},
+		Disks: []*api.AttachedDisk{
+			&api.AttachedDisk{
+				AutoDelete: true,
+				Boot:       true,
+				InitializeParams: &api.AttachedDiskInitializeParams{
+					SourceImage: testSetup.image,
+					DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-ssd", testProjectConfig.TestProjectID, testProjectConfig.TestZone),
+				},
+			},
+		},
+		ServiceAccounts: []*api.ServiceAccount{
+			&api.ServiceAccount{
+				Email:  testProjectConfig.ServiceAccountEmail,
+				Scopes: testProjectConfig.ServiceAccountScopes,
+			},
+		},
+	}
+
+	inst, err := compute.CreateInstance(client, testProjectConfig.TestProjectID, testProjectConfig.TestZone, i)
+	if err != nil {
+		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
+		return
+	}
+	defer inst.Cleanup()
+
+	testCase.Logf("Waiting for agent install to complete")
+	if err := inst.WaitForSerialOutput("osconfig install done", 1, 5*time.Second, 5*time.Minute); err != nil {
+		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
+		return
+	}
+
+	testCase.Logf("Agent installed successfully")
+
+	// read the serial console once
+	if err = testSetup.vf(inst, testSetup.vstring, 1, 10*time.Second, testSetup.assertTimeout); err != nil {
+		testCase.WriteFailure("error while asserting: %v", err)
+	}
+}
+
+func packageManagementTestCase(ctx context.Context, testSetup *PackageManagementTestSetup, tests chan *junitxml.TestCase, wg *sync.WaitGroup, logger *log.Logger, regex *regexp.Regexp, testProjectConfig *testconfig.Project) {
 	defer wg.Done()
 
 	createOsConfigTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/CreateOsConfig] Create OsConfig", testSetup.image))
@@ -480,7 +481,7 @@ func packageManagementTestCase(ctx context.Context, testSetup *packageManagement
 	packageInstallRemovalTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/PackageInstallRemoval] Package no change", testSetup.image))
 	packageInstallFromNewRepoTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[%s/PackageInstallFromNewRepo] Add a new package from new repository", testSetup.image))
 
-	for tc, f := range map[*junitxml.TestCase]func(context.Context, *junitxml.TestCase, *packageManagementTestSetup, *log.Logger, *testconfig.Project){
+	for tc, f := range map[*junitxml.TestCase]func(context.Context, *junitxml.TestCase, *PackageManagementTestSetup, *log.Logger, *testconfig.Project){
 		createOsConfigTest:            runCreateOsConfigTest,
 		packageInstallTest:            runPackageInstallTest,
 		packageRemovalTest:            runPackageRemovalTest,

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -58,39 +58,41 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	packageName := "cowsay"
 	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
-		var image string
 		uniqueSuffix := utils.RandString(5)
 
 		switch tuple.platform {
 		case "debian":
-			image = debianImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
+			for _, image := range debianImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
+				setup := NewPackageManagementTestSetup(image, fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), testName, "", oc, nil, nil, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "centos":
-			image = centosImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+			for _, image := range centosImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+				setup := NewPackageManagementTestSetup(image, fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), testName, "", oc, nil, nil, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "rhel":
-			image = rhelImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+			for _, image := range rhelImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+				setup := NewPackageManagementTestSetup(image, fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), testName, "", oc, nil, nil, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "windows":
-			image = windowsImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(pkgs, nil, nil), nil, nil)
+			for _, image := range windowsImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(pkgs, nil, nil), nil, nil)
+				setup := NewPackageManagementTestSetup(image, fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), testName, "", oc, nil, nil, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
 			continue
 		}
-		setup := packageManagementTestSetup{
-			image:      image,
-			name:       fmt.Sprintf("%s-%s", path.Base(image), testName),
-			osconfig:   oc,
-			assignment: nil,
-			fname:      testName,
-			vf:         vf,
-		}
-		pkgTestSetup = append(pkgTestSetup, &setup)
 	}
 	return pkgTestSetup
 }
@@ -100,51 +102,59 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	packageName := "cowsay"
 	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
-		var image, vs string
+		var vs string
 		uniqueSuffix := utils.RandString(5)
 		assertTimeout := 60 * time.Second
 
 		switch tuple.platform {
 		case "debian":
-			image = debianImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
+			for _, image := range debianImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "centos":
-			image = centosImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
+			for _, image := range centosImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "rhel":
-			image = rhelImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
+			for _, image := range rhelImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "windows":
-			image = windowsImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(pkgs, nil, nil), nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
-			assertTimeout = 1200 * time.Second
+			for _, image := range windowsImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(pkgs, nil, nil), nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
 			continue
 		}
-
-		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
-		ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
-		setup := packageManagementTestSetup{
-			image:      image,
-			name:       instanceName,
-			osconfig:   oc,
-			assignment: assign,
-			fname:      testName,
-			vf:         vf,
-			vstring:    vs,
-			startup:    ss,
-		}
-		pkgTestSetup = append(pkgTestSetup, &setup)
 	}
 	return pkgTestSetup
 }
@@ -155,51 +165,59 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	packageName := "cowsay"
 	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
-		var image, vs string
+		var vs string
 		uniqueSuffix := utils.RandString(5)
 		assertTimeout := 600 * time.Second
 
 		switch tuple.platform {
 		case "debian":
-			image = debianImage
-			pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(nil, pkgs, nil), nil, nil, nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range debianImages {
+				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(nil, pkgs, nil), nil, nil, nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "centos":
-			image = centosImage
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(nil, removePkg, nil), nil, nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range centosImages {
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(nil, removePkg, nil), nil, nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "rhel":
-			image = rhelImage
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(nil, removePkg, nil), nil, nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range rhelImages {
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(nil, removePkg, nil), nil, nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "windows":
-			image = windowsImage
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(nil, removePkg, nil), nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range windowsImages {
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(nil, removePkg, nil), nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
 			continue
 		}
-
-		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
-		ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
-		setup := packageManagementTestSetup{
-			image:         image,
-			name:          instanceName,
-			osconfig:      oc,
-			assignment:    assign,
-			fname:         testName,
-			vf:            vf,
-			assertTimeout: assertTimeout,
-			vstring:       vs,
-			startup:       ss,
-		}
-		pkgTestSetup = append(pkgTestSetup, &setup)
 	}
 	return pkgTestSetup
 }
@@ -210,55 +228,64 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 	packageName := "cowsay"
 	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
-		var image, vs string
+		var vs string
 		uniqueSuffix := utils.RandString(5)
 		assertTimeout := 60 * time.Second
 
 		switch tuple.platform {
 		case "debian":
-			image = debianImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range debianImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, removePkg, nil), nil, nil, nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "centos":
-			image = centosImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, removePkg, nil), nil, nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range centosImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, removePkg, nil), nil, nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "rhel":
-			image = rhelImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, removePkg, nil), nil, nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range rhelImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, removePkg, nil), nil, nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "windows":
-			image = windowsImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(installPkg, removePkg, nil), nil, nil)
-			vs = fmt.Sprintf(packageNotInstalledString)
+			for _, image := range windowsImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				removePkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(installPkg, removePkg, nil), nil, nil)
+				vs = fmt.Sprintf(packageNotInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
 			continue
 		}
-
-		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
-		ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
-		setup := packageManagementTestSetup{
-			image:      image,
-			name:       instanceName,
-			osconfig:   oc,
-			assignment: assign,
-			fname:      testName,
-			vf:         vf,
-			vstring:    vs,
-			startup:    ss,
-		}
-		pkgTestSetup = append(pkgTestSetup, &setup)
 	}
 	return pkgTestSetup
 }
@@ -269,56 +296,63 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 	packageName := "osconfig-agent-test"
 	for _, tuple := range platformPkgManagers {
 		var oc *osconfigpb.OsConfig
-		var image, vs string
+		var vs string
 		uniqueSuffix := utils.RandString(5)
 		assertTimeout := 60 * time.Second
 
 		switch tuple.platform {
 		case "debian":
-			image = debianImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			repos := []*osconfigpb.AptRepository{osconfigserver.BuildAptRepository(osconfigpb.AptRepository_DEB, aptTestRepoBaseURL, osconfigTestRepo, aptRaptureGpgKey, []string{"main"})}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, nil, repos), nil, nil, nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
+			for _, image := range debianImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				repos := []*osconfigpb.AptRepository{osconfigserver.BuildAptRepository(osconfigpb.AptRepository_DEB, aptTestRepoBaseURL, osconfigTestRepo, aptRaptureGpgKey, []string{"main"})}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildAptPackageConfig(installPkg, nil, repos), nil, nil, nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "centos":
-			image = centosImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			repos := []*osconfigpb.YumRepository{osconfigserver.BuildYumRepository(osconfigTestRepo, "Google OSConfig Agent Test Repository", yumTestRepoBaseURL, yumRaptureGpgKeys)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, nil, repos), nil, nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
+			for _, image := range centosImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				repos := []*osconfigpb.YumRepository{osconfigserver.BuildYumRepository(osconfigTestRepo, "Google OSConfig Agent Test Repository", yumTestRepoBaseURL, yumRaptureGpgKeys)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, nil, repos), nil, nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "rhel":
-			image = rhelImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			repos := []*osconfigpb.YumRepository{osconfigserver.BuildYumRepository(osconfigTestRepo, "Google OSConfig Agent Test Repository", yumTestRepoBaseURL, yumRaptureGpgKeys)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, nil, repos), nil, nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
+			for _, image := range rhelImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				repos := []*osconfigpb.YumRepository{osconfigserver.BuildYumRepository(osconfigTestRepo, "Google OSConfig Agent Test Repository", yumTestRepoBaseURL, yumRaptureGpgKeys)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, osconfigserver.BuildYumPackageConfig(installPkg, nil, repos), nil, nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		case "windows":
-			image = windowsImage
-			installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
-			repos := []*osconfigpb.GooRepository{osconfigserver.BuildGooRepository("Google OSConfig Agent Test Repository", gooTestRepoURL)}
-			oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(installPkg, nil, repos), nil, nil)
-			vs = fmt.Sprintf(packageInstalledString)
-			assertTimeout = 1200 * time.Second
+			for _, image := range windowsImages {
+				installPkg := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
+				repos := []*osconfigpb.GooRepository{osconfigserver.BuildGooRepository("Google OSConfig Agent Test Repository", gooTestRepoURL)}
+				oc = osconfigserver.BuildOsConfig(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, nil, nil, osconfigserver.BuildGooPackageConfig(installPkg, nil, repos), nil, nil)
+				vs = fmt.Sprintf(packageInstalledString)
+				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
+				assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
+				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
+				setup := NewPackageManagementTestSetup(image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = append(pkgTestSetup, setup)
+			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
 			continue
 		}
-
-		instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
-		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
-		ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
-		setup := packageManagementTestSetup{
-			image:         image,
-			name:          instanceName,
-			osconfig:      oc,
-			assignment:    assign,
-			fname:         testName,
-			vf:            vf,
-			assertTimeout: assertTimeout,
-			vstring:       vs,
-			startup:       ss,
-		}
-		pkgTestSetup = append(pkgTestSetup, &setup)
 	}
 	return pkgTestSetup
 }

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -67,28 +67,28 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
 				oc = osconfigserver.BuildOsConfig(instanceName, desc, osconfigserver.BuildAptPackageConfig(pkgs, nil, nil), nil, nil, nil, nil)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, time.Duration(0), vf)
 			}
 		case "centos":
 			for _, image := range centosImages {
 				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
 				oc = osconfigserver.BuildOsConfig(instanceName, desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, time.Duration(0), vf)
 			}
 		case "rhel":
 			for _, image := range rhelImages {
 				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
 				oc = osconfigserver.BuildOsConfig(instanceName, desc, nil, osconfigserver.BuildYumPackageConfig(pkgs, nil, nil), nil, nil, nil)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, time.Duration(0), vf)
 			}
 		case "windows":
 			for _, image := range windowsImages {
 				pkgs := []*osconfigpb.Package{osconfigserver.BuildPackage(packageName)}
 				instanceName := fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix)
 				oc = osconfigserver.BuildOsConfig(instanceName, desc, nil, nil, osconfigserver.BuildGooPackageConfig(pkgs, nil, nil), nil, nil)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, "", oc, nil, nil, time.Duration(0), vf)
 			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
@@ -116,7 +116,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "centos":
 			for _, image := range centosImages {
@@ -126,7 +126,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "rhel":
 			for _, image := range rhelImages {
@@ -136,7 +136,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "windows":
 			for _, image := range windowsImages {
@@ -146,7 +146,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
@@ -175,7 +175,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "centos":
 			for _, image := range centosImages {
@@ -185,7 +185,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "rhel":
 			for _, image := range rhelImages {
@@ -195,7 +195,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "windows":
 			for _, image := range windowsImages {
@@ -205,7 +205,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
@@ -235,7 +235,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "centos":
 			for _, image := range centosImages {
@@ -246,7 +246,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "rhel":
 			for _, image := range rhelImages {
@@ -257,7 +257,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "windows":
 			for _, image := range windowsImages {
@@ -268,7 +268,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 				vs = fmt.Sprintf(packageNotInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 
 		default:
@@ -299,7 +299,8 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout,
+					vf)
 			}
 		case "centos":
 			for _, image := range centosImages {
@@ -310,7 +311,7 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "rhel":
 			for _, image := range rhelImages {
@@ -321,7 +322,7 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		case "windows":
 			for _, image := range windowsImages {
@@ -332,7 +333,7 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 				vs = fmt.Sprintf(packageInstalledString)
 				assign := osconfigserver.BuildAssignment(instanceName, desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 				ss := getPackageInstallFromNewRepoTestStartupScript(tuple.pkgManager, packageName)
-				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, vf)
+				pkgTestSetup = createAndAppendSetup(pkgTestSetup, image, instanceName, testName, vs, oc, assign, ss, assertTimeout, vf)
 			}
 		default:
 			logger.Errorf(fmt.Sprintf("non existent platform: %s", tuple.platform))
@@ -342,9 +343,9 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 	return pkgTestSetup
 }
 
-func createAndAppendSetup(pkgTestSetup []*packageManagementTestSetup, image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) []*packageManagementTestSetup {
+func createAndAppendSetup(pkgTestSetup []*packageManagementTestSetup, image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, assertTimeout time.Duration, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) []*packageManagementTestSetup {
 	var setup *packageManagementTestSetup
-	newPackageManagementTestSetup(&setup, image, name, fname, vs, oc, assignment, startup, vf)
+	newPackageManagementTestSetup(&setup, image, name, fname, vs, oc, assignment, startup, assertTimeout, vf)
 	pkgTestSetup = append(pkgTestSetup, setup)
 	return pkgTestSetup
 }

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -52,7 +52,7 @@ var vf = func(inst *compute.Instance, vfString string, port int64, interval, tim
 	return inst.WaitForSerialOutput(vfString, port, interval, timeout)
 }
 
-func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+func addCreateOsConfigTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
 	testName := "createosconfigtest"
 	desc := "test osconfig creation"
 	packageName := "cowsay"
@@ -96,7 +96,7 @@ func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	}
 	return pkgTestSetup
 }
-func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+func addPackageInstallTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
 	testName := "packageinstalltest"
 	desc := "test package installation"
 	packageName := "cowsay"
@@ -159,7 +159,7 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	return pkgTestSetup
 }
 
-func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+func addPackageRemovalTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
 	testName := "packageremovaltest"
 	desc := "test package removal"
 	packageName := "cowsay"
@@ -222,7 +222,7 @@ func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProje
 	return pkgTestSetup
 }
 
-func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+func addPackageInstallRemovalTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
 	testName := "packageinstallremovaltest"
 	desc := "test package removal takes precedence over package installation"
 	packageName := "cowsay"
@@ -290,7 +290,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 	return pkgTestSetup
 }
 
-func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+func addPackageInstallFromNewRepoTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
 	testName := "packageinstallfromnewrepotest"
 	desc := "test package installation from new package"
 	packageName := "osconfig-agent-test"
@@ -357,8 +357,8 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 	return pkgTestSetup
 }
 
-func generateAllTestSetup(testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
-	pkgTestSetup := []*packageManagementTestSetup{}
+func generateAllTestSetup(testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
+	pkgTestSetup := []*PackageManagementTestSetup{}
 	pkgTestSetup = addCreateOsConfigTest(pkgTestSetup, testProjectConfig)
 	pkgTestSetup = addPackageInstallTest(pkgTestSetup, testProjectConfig)
 	pkgTestSetup = addPackageRemovalTest(pkgTestSetup, testProjectConfig)

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -53,7 +53,7 @@ var vf = func(inst *compute.Instance, vfString string, port int64, interval, tim
 	return inst.WaitForSerialOutput(vfString, port, interval, timeout)
 }
 
-func addCreateOsConfigTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
+func addCreateOsConfigTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
 	testName := "createosconfigtest"
 	desc := "test osconfig creation"
 	packageName := "cowsay"
@@ -97,7 +97,7 @@ func addCreateOsConfigTest(pkgTestSetup []*PackageManagementTestSetup, testProje
 	}
 	return pkgTestSetup
 }
-func addPackageInstallTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
+func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
 	testName := "packageinstalltest"
 	desc := "test package installation"
 	packageName := "cowsay"
@@ -156,7 +156,7 @@ func addPackageInstallTest(pkgTestSetup []*PackageManagementTestSetup, testProje
 	return pkgTestSetup
 }
 
-func addPackageRemovalTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
+func addPackageRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
 	testName := "packageremovaltest"
 	desc := "test package removal"
 	packageName := "cowsay"
@@ -215,7 +215,7 @@ func addPackageRemovalTest(pkgTestSetup []*PackageManagementTestSetup, testProje
 	return pkgTestSetup
 }
 
-func addPackageInstallRemovalTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
+func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
 	testName := "packageinstallremovaltest"
 	desc := "test package removal takes precedence over package installation"
 	packageName := "cowsay"
@@ -279,7 +279,7 @@ func addPackageInstallRemovalTest(pkgTestSetup []*PackageManagementTestSetup, te
 	return pkgTestSetup
 }
 
-func addPackageInstallFromNewRepoTest(pkgTestSetup []*PackageManagementTestSetup, testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
+func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup, testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
 	testName := "packageinstallfromnewrepotest"
 	desc := "test package installation from new package"
 	packageName := "osconfig-agent-test"
@@ -342,14 +342,15 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*PackageManagementTestSetup
 	return pkgTestSetup
 }
 
-func createAndAppendSetup(pkgTestSetup []*PackageManagementTestSetup, image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) []*PackageManagementTestSetup {
-	setup := NewPackageManagementTestSetup(image, name, fname, vs, oc, assignment, startup, vf)
+func createAndAppendSetup(pkgTestSetup []*packageManagementTestSetup, image, name, fname, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) []*packageManagementTestSetup {
+	var setup *packageManagementTestSetup
+	newPackageManagementTestSetup(&setup, image, name, fname, vs, oc, assignment, startup, vf)
 	pkgTestSetup = append(pkgTestSetup, setup)
 	return pkgTestSetup
 }
 
-func generateAllTestSetup(testProjectConfig *testconfig.Project) []*PackageManagementTestSetup {
-	pkgTestSetup := []*PackageManagementTestSetup{}
+func generateAllTestSetup(testProjectConfig *testconfig.Project) []*packageManagementTestSetup {
+	pkgTestSetup := []*packageManagementTestSetup{}
 	pkgTestSetup = addCreateOsConfigTest(pkgTestSetup, testProjectConfig)
 	pkgTestSetup = addPackageInstallTest(pkgTestSetup, testProjectConfig)
 	pkgTestSetup = addPackageRemovalTest(pkgTestSetup, testProjectConfig)

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -135,15 +135,14 @@ func addPackageInstallTest(pkgTestSetup []*packageManagementTestSetup, testProje
 		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 		ss := getPackageInstallStartupScript(tuple.pkgManager, packageName)
 		setup := packageManagementTestSetup{
-			image:         image,
-			name:          instanceName,
-			osconfig:      oc,
-			assignment:    assign,
-			fname:         testName,
-			vf:            vf,
-			assertTimeout: assertTimeout,
-			vstring:       vs,
-			startup:       ss,
+			image:      image,
+			name:       instanceName,
+			osconfig:   oc,
+			assignment: assign,
+			fname:      testName,
+			vf:         vf,
+			vstring:    vs,
+			startup:    ss,
 		}
 		pkgTestSetup = append(pkgTestSetup, &setup)
 	}
@@ -250,15 +249,14 @@ func addPackageInstallRemovalTest(pkgTestSetup []*packageManagementTestSetup, te
 		assign := osconfigserver.BuildAssignment(fmt.Sprintf("%s-%s-%s", path.Base(image), testName, uniqueSuffix), desc, osconfigserver.BuildInstanceFilterExpression(instanceName), []string{fmt.Sprintf("projects/%s/osConfigs/%s", testProjectConfig.TestProjectID, oc.Name)})
 		ss := getPackageInstallRemovalStartupScript(tuple.pkgManager, packageName)
 		setup := packageManagementTestSetup{
-			image:         image,
-			name:          instanceName,
-			osconfig:      oc,
-			assignment:    assign,
-			fname:         testName,
-			vf:            vf,
-			assertTimeout: assertTimeout,
-			vstring:       vs,
-			startup:       ss,
+			image:      image,
+			name:       instanceName,
+			osconfig:   oc,
+			assignment: assign,
+			fname:      testName,
+			vf:         vf,
+			vstring:    vs,
+			startup:    ss,
 		}
 		pkgTestSetup = append(pkgTestSetup, &setup)
 	}


### PR DESCRIPTION
This change is built on top of PR:https://github.com/GoogleCloudPlatform/compute-image-tools/pull/738

Out of the 2 commits in this PR, the other one is already being reviewed in the above mentioned PR.
