### PR TITLE
OS Config - Make service poll interval overridable from metadata

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -83,15 +83,6 @@ func parseBool(s string) bool {
 	return enabled
 }
 
-func parseInt(s string) int {
-	val, err := strconv.Atoi(s)
-	if err != nil {
-		// Bad entry returns default
-		return 0
-	}
-	return val
-}
-
 type metadataJSON struct {
 	Instance instanceJSON
 	Project  projectJSON
@@ -111,12 +102,12 @@ type projectJSON struct {
 }
 
 type attributesJSON struct {
-	OSInventoryEnabled   string `json:"os-inventory-enabled"`
-	OSPatchEnabled       string `json:"os-patch-enabled"`
-	OSPackageEnabled     string `json:"os-package-enabled"`
-	OSDebugEnabled       string `json:"os-debug-enabled"`
-	OSConfigEndpoint     string `json:"os-config-endpoint"`
-	OSConfigPollInterval string `json:"os-config-poll-interval"`
+	OSInventoryEnabled   string       `json:"os-inventory-enabled"`
+	OSPatchEnabled       string       `json:"os-patch-enabled"`
+	OSPackageEnabled     string       `json:"os-package-enabled"`
+	OSDebugEnabled       string       `json:"os-debug-enabled"`
+	OSConfigEndpoint     string       `json:"os-config-endpoint"`
+	OSConfigPollInterval *json.Number `json:"os-config-poll-interval"`
 }
 
 func createConfigFromMetadata(md metadataJSON) *config {
@@ -178,11 +169,8 @@ func createConfigFromMetadata(md metadataJSON) *config {
 		c.osPackageEnabled = parseBool(md.Instance.Attributes.OSPackageEnabled)
 	}
 
-	if md.Instance.Attributes.OSConfigPollInterval != "" {
-		val := parseInt(md.Instance.Attributes.OSConfigPollInterval)
-		if val > 0 {
-			c.osConfigPollInterval = val
-		}
+	if val, err := md.Instance.Attributes.OSConfigPollInterval.Int64(); err == nil {
+		c.osConfigPollInterval = int(val)
 	}
 
 	// Flags take precedence over metadata.

--- a/cli_tools/google-osconfig-agent/config/config_test.go
+++ b/cli_tools/google-osconfig-agent/config/config_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSetConfig(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"project":{"projectId":"projectId","attributes":{"os-config-endpoint":"bad!!1","os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"id":12345,"name":"name","zone":"zone","attributes":{"os-config-endpoint":"SvcEndpoint","os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo", "os-debug-enabled":"true"}}}`)
+		fmt.Fprintln(w, `{"project":{"projectId":"projectId","attributes":{"os-config-endpoint":"bad!!1","os-inventory-enabled":"false","os-patch-enabled":"true","os-package-enabled":"true"}},"instance":{"id":12345,"name":"name","zone":"zone","attributes":{"os-config-endpoint":"SvcEndpoint","os-inventory-enabled":"1","os-patch-enabled":"false","os-package-enabled":"foo", "os-debug-enabled":"true", "os-config-poll-interval":"3"}}}`)
 	}))
 	defer ts.Close()
 
@@ -70,5 +70,9 @@ func TestSetConfig(t *testing.T) {
 		if tt.op() != tt.want {
 			t.Errorf("%q: got(%t) != want(%t)", tt.desc, tt.op(), tt.want)
 		}
+	}
+
+	if SvcPollInterval().Minutes() != float64(3) {
+		t.Errorf("Default poll interval: got(%f) != want(%d)", SvcPollInterval().Minutes(), 3)
 	}
 }


### PR DESCRIPTION
- Only supports instance metadata since we don't want this done very often.
- Handy for testing and demos.