### PR TITLE
Fix potential time issues with Windows import: set UTC time zone

### DIFF
--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -33,6 +33,7 @@ for /f "tokens=2 delims=:" %%a in (
   netsh interface ipv4 set dnsservers "Local Area Connection 3" static address=%%a primary
 )
 
+tzutil /s 'UTC'
 w32tm /resync
 
 C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet > COM1:


### PR DESCRIPTION
Fix potential time issues with Windows import: set UTC time zone before re-syncing clock.