### PR TITLE
Fix nil pointer failure and add unit test

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -169,8 +169,10 @@ func createConfigFromMetadata(md metadataJSON) *config {
 		c.osPackageEnabled = parseBool(md.Instance.Attributes.OSPackageEnabled)
 	}
 
-	if val, err := md.Instance.Attributes.OSConfigPollInterval.Int64(); err == nil {
-		c.osConfigPollInterval = int(val)
+	if md.Instance.Attributes.OSConfigPollInterval != nil {
+		if val, err := md.Instance.Attributes.OSConfigPollInterval.Int64(); err == nil {
+			c.osConfigPollInterval = int(val)
+		}
 	}
 
 	// Flags take precedence over metadata.

--- a/cli_tools/google-osconfig-agent/config/config_test.go
+++ b/cli_tools/google-osconfig-agent/config/config_test.go
@@ -76,3 +76,56 @@ func TestSetConfig(t *testing.T) {
 		t.Errorf("Default poll interval: got(%f) != want(%d)", SvcPollInterval().Minutes(), 3)
 	}
 }
+
+func TestSetConfigDefaultValues(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"instance":{"id":12345,"name":"name","zone":"zone","attributes":{"os-config-endpoint":"SvcEndpoint"}}}`)
+	}))
+	defer ts.Close()
+
+	if err := os.Setenv("GCE_METADATA_HOST", strings.Trim(ts.URL, "http://")); err != nil {
+		t.Fatalf("Error running os.Setenv: %v", err)
+	}
+
+	if err := SetConfig(); err != nil {
+		t.Fatalf("Error running SetConfig: %v", err)
+	}
+
+	testsString := []struct {
+		desc string
+		op   func() string
+		want string
+	}{
+		{"SvcEndpoint", SvcEndpoint, "SvcEndpoint"},
+		{"Instance", Instance, "zone/instances/name"},
+		{"ID", ID, "12345"},
+		{"ProjectID", ProjectID, "projectId"},
+		{"Zone", Zone, "zone"},
+		{"Name", Name, "name"},
+	}
+	for _, tt := range testsString {
+		if tt.op() != tt.want {
+			t.Errorf("%q: got(%q) != want(%q)", tt.desc, tt.op(), tt.want)
+		}
+	}
+
+	testsBool := []struct {
+		desc string
+		op   func() bool
+		want bool
+	}{
+		{"osinventory should be enabled (proj disabled, inst enabled)", OSInventoryEnabled, osInventoryEnabledDefault},
+		{"ospatch should be disabled (proj enabled, inst disabled)", OSPatchEnabled, osPatchEnabledDefault},
+		{"ospackage should be disabled (proj enabled, inst bad value)", OSPackageEnabled, osPackageEnabledDefault},
+		{"debugenabled should be true (proj disabled, inst enabled)", Debug, osDebugEnabledDefault},
+	}
+	for _, tt := range testsBool {
+		if tt.op() != tt.want {
+			t.Errorf("%q: got(%t) != want(%t)", tt.desc, tt.op(), tt.want)
+		}
+	}
+
+	if SvcPollInterval().Minutes() != float64(osConfigPollIntervalDefault) {
+		t.Errorf("Default poll interval: got(%f) != want(%d)", SvcPollInterval().Minutes(), osConfigPollIntervalDefault)
+	}
+}

--- a/cli_tools/google-osconfig-agent/config/config_test.go
+++ b/cli_tools/google-osconfig-agent/config/config_test.go
@@ -79,7 +79,7 @@ func TestSetConfig(t *testing.T) {
 
 func TestSetConfigDefaultValues(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"instance":{"id":12345,"name":"name","zone":"zone","attributes":{"os-config-endpoint":"SvcEndpoint"}}}`)
+		fmt.Fprintln(w, `{"instance":{"id":12345,"name":"name","zone":"zone"}}`)
 	}))
 	defer ts.Close()
 
@@ -96,7 +96,6 @@ func TestSetConfigDefaultValues(t *testing.T) {
 		op   func() string
 		want string
 	}{
-		{"SvcEndpoint", SvcEndpoint, "SvcEndpoint"},
 		{"Instance", Instance, "zone/instances/name"},
 		{"ID", ID, "12345"},
 		{"ProjectID", ProjectID, "projectId"},
@@ -127,5 +126,9 @@ func TestSetConfigDefaultValues(t *testing.T) {
 
 	if SvcPollInterval().Minutes() != float64(osConfigPollIntervalDefault) {
 		t.Errorf("Default poll interval: got(%f) != want(%d)", SvcPollInterval().Minutes(), osConfigPollIntervalDefault)
+	}
+
+	if SvcEndpoint() != prodEndpoint {
+		t.Errorf("Default endpoint: got(%s) != want(%s)", SvcEndpoint(), prodEndpoint)
 	}
 }


### PR DESCRIPTION
If the osconfigpollinterval is not set in the metadata(like in case of our end to end tests), the code path generates nil pointer exception.

[Fail test](https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/osconfig-tests/1116435195327680512)