### PR TITLE
[OsConfig Agent] Add daisy workflow for integration test

### DIFF
--- a/osconfig_tests/daisy_workflow/build_osconfig_agent_test.sh
+++ b/osconfig_tests/daisy_workflow/build_osconfig_agent_test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+function exit_error
+{
+  echo "build failed"
+  exit 1
+}
+
+trap exit_error ERR
+
+URL="http://metadata/computeMetadata/v1/instance/attributes"
+BASE_REPO=$(curl -f -H Metadata-Flavor:Google ${URL}/base-repo)
+REPO_BRANCH=$(curl -f -H Metadata-Flavor:Google ${URL}/branch)
+TEST_PROJECT_ID=$(curl -f -H Metadata-Flavor:Google ${URL}/test-project-id)
+TEST_ZONE=$(curl -f -H Metadata-Flavor:Google ${URL}/test-zone)
+
+# Optional fields
+TEST_SUITE_FILTER=$(curl -f -H Metadata-Flavor:Google ${URL}/test-suite-filter) || true
+TEST_CASE_FILTER=$(curl -f -H Metadata-Flavor:Google ${URL}/test-case-filter) || true
+
+GOLANG="go1.12.1.linux-amd64.tar.gz"
+GO=/tmp/go/bin/go
+export GOPATH=/usr/share/gocode
+export GOCACHE=/tmp/.cache
+
+apt-get install -y git-core
+echo "cloning package"
+git clone "https://github.com/${BASE_REPO}/compute-image-tools.git"
+cd compute-image-tools
+git checkout ${REPO_BRANCH}
+
+# Golang setup
+[[ -d /tmp/go ]] && rm -rf /tmp/go
+mkdir -p /tmp/go/
+echo "Downloading Go"
+curl -s "https://dl.google.com/go/${GOLANG}" -o /tmp/go/go.tar.gz
+echo "Extracting Go"
+tar -C /tmp/go/ --strip-components=1 -xf /tmp/go/go.tar.gz
+
+echo "Pulling dependencies"
+sudo su -c "GOPATH=${GOPATH} ${GO} get -d ./..."
+
+CMD="osconfig_tests/main.go"
+ARGS="-test_project_id ${TEST_PROJECT_ID} -test_zone ${TEST_ZONE}"
+
+if [ ! -z "$TEST_SUITE_FILTER" ]
+then
+    ARGS="${ARGS} -test_suite_filter $TEST_SUITE_FILTER"
+fi
+
+if [ ! -z "$TEST_CASE_FILTER" ]
+then
+    ARGS="${ARGS} -test_case_filter $TEST_CASE_FILTER"
+fi
+
+
+echo "running $CMD $ARGS..."
+${GO} run ${CMD} ${ARGS}
+
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "End to End Test run failed"
+else
+    echo "End to End Test run succeeded"
+fi
+
+exit 0

--- a/osconfig_tests/daisy_workflow/build_osconfig_agent_test.sh
+++ b/osconfig_tests/daisy_workflow/build_osconfig_agent_test.sh
@@ -40,9 +40,8 @@ export GOCACHE=/tmp/.cache
 
 apt-get install -y git-core
 echo "cloning package"
-git clone "https://github.com/${BASE_REPO}/compute-image-tools.git"
+git clone --branch ${REPO_BRANCH} "https://github.com/${BASE_REPO}/compute-image-tools.git"
 cd compute-image-tools
-git checkout ${REPO_BRANCH}
 
 # Golang setup
 [[ -d /tmp/go ]] && rm -rf /tmp/go
@@ -51,6 +50,10 @@ echo "Downloading Go"
 curl -s "https://dl.google.com/go/${GOLANG}" -o /tmp/go/go.tar.gz
 echo "Extracting Go"
 tar -C /tmp/go/ --strip-components=1 -xf /tmp/go/go.tar.gz
+
+echo "Copy local code to GOPATH"
+sudo install -d ${GOPATH}/github.com/GoogleCloudPlatform/compute-image-tools
+sudo cp -r . ${GOPATH}/github.com/GoogleCloudPlatform/compute-image-tools
 
 echo "Pulling dependencies"
 sudo su -c "GOPATH=${GOPATH} ${GO} get -d ./..."

--- a/osconfig_tests/daisy_workflow/integration_test.json
+++ b/osconfig_tests/daisy_workflow/integration_test.json
@@ -1,0 +1,101 @@
+{
+  "Name": "Run-OsConfig-integration-tests",
+  "Vars": {
+    "base-repo": {
+      "Required": true,
+      "Description": "Base GitHub repo"
+    },
+    "branch": {
+      "Required": true,
+      "Description": "Branch to use"
+    },
+    "test-project-id": {
+      "Required": true,
+      "Description": "project where the end to end test needs to run"
+    },
+    "test-zone": {
+      "Required": true,
+      "Description": "project zone where the end to end test needs to run"
+    },
+    "test-suite-filter": {
+      "Required": false,
+      "Description": "filters for test suite"
+    },
+    "test-case-filter": {
+      "Required": false,
+      "Description": "filters for test case"
+    }
+  },
+  "Sources": {
+    "build_osconfig_agent_test.sh": "./build_osconfig_agent_test.sh"
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-build",
+          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "Type": "pd-ssd"
+        }
+      ]
+    },
+    "build-and-run-test": {
+      "CreateInstances": [
+        {
+          "Name": "inst-build-and-run-osconfig-tests",
+          "Disks": [
+            {
+              "Source": "disk-build"
+            }
+          ],
+          "StartupScript": "build_osconfig_agent_test.sh",
+          "MachineType": "n1-standard-4",
+          "Metadata": {
+            "base-repo": "${base-repo}",
+            "branch": "${branch}",
+            "test-project-id": "${test-project-id}",
+            "test-zone": "${test-zone}",
+            "test-suite-filter": "${test-suite-filter}",
+            "test-case-filter": "${test-case-filter}"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        }
+      ]
+    },
+    "wait-test-run": {
+      "Timeout": "30m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-build-and-run-osconfig-tests",
+          "SerialOutput": {
+            "Port": 1,
+            "FailureMatch": "BuildFailed:",
+            "SuccessMatch": "BuildSuccess:",
+            "StatusMatch": "BuildStatus:"
+          }
+        }
+      ]
+    },
+    "cleanup-test-runner": {
+      "DeleteResources": {
+        "Instances": [
+          "inst-build-and-run-osconfig-tests"
+        ]
+      }
+    }
+  },
+  "Dependencies": {
+    "build-and-run-test": [
+      "setup-disks"
+    ],
+    "wait-test-run": [
+      "build-and-run-test"
+    ],
+    "cleanup-test-runner": [
+      "wait-test-run"
+    ]
+  }
+}


### PR DESCRIPTION
With the introduction of dependency on metadata attributes, executing osconfig-test binary is no longer an option. This daisy workflow will
- spin up a vm
- pull the latest code from repo & branch specified by user
- run the osconfig-agent-test binary
- publish the logs in gcs bucket

P.S.: To test the latest changes with the integration test framework, make sure you have pushed the changes to a remote branch and use the remote branch as input to the daisy workflow

Future TODO items:
- currently, this does not support testing changes done to agent itself, through e2e tests. This is because we have a hard dependency e2e-test-runner on [rapture](https://github.com/GoogleCloudPlatform/compute-image-tools/blob/master/osconfig_tests/utils/utils.go#L40).
Will address this TODO item in a future PR