### PR TITLE
[OsConfig Agent] answer yes to all questions

### DIFF
--- a/go/packages/yum.go
+++ b/go/packages/yum.go
@@ -30,7 +30,7 @@ var (
 	yumInstallArgs     = []string{"install", "-y"}
 	yumRemoveArgs      = []string{"remove", "-y"}
 	yumUpdateArgs      = []string{"update", "-y"}
-	yumCheckUpdateArgs = []string{"check-update", "--quiet"}
+	yumCheckUpdateArgs = []string{"-y", "check-update", "--quiet"}
 )
 
 func init() {


### PR DESCRIPTION
when a new yum repository is added by the user, we add the repo
details in the yum database, but do not import the gpg keys.
When we check for updates, yum will first try to add the gpg keys
for the newly added repo. Yum prompts for confirmation to add
the gpg keys.
Without this change, yum update check fails.