### PR TITLE
Add testing tide config

### DIFF
--- a/test-infra/prow/Makefile
+++ b/test-infra/prow/Makefile
@@ -59,6 +59,9 @@ horologium-deployment: get-cluster-credentials
 plank-deployment: get-cluster-credentials
 	kubectl apply -f cluster/plank_deployment.yaml
 
-.PHONY: hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment
+tide-deployment: get-cluster-credentials
+	kubectl apply -f cluster/tide_deployment.yaml
 
-update-all: update-config update-plugins hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment
+.PHONY: hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment tide-deployment
+
+update-all: update-config update-plugins hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment tide-deployment

--- a/test-infra/prow/cluster/tide_deployment.yaml
+++ b/test-infra/prow/cluster/tide_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - name: tide
         image: gcr.io/k8s-prow/tide:v20180830-eabe43164
         args:
-        - --dry-run=false
+        - --dry-run=true
         ports:
           - name: http
             containerPort: 8888

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -1,3 +1,23 @@
+tide:
+  merge_method:
+    GoogleCloudPlatform/compute-image-tools: squash
+
+  queries:
+  - repos:
+    - GoogleCloudPlatform/compute-image-tools
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+    includedBranches:
+    - tide-test
+
+
 plank:
  job_url_template: 'https://k8s-gubernator.appspot.com/build/compute-image-tools-test/{{if eq .Spec.Type "presubmit"}}pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}pr-logs/pull/batch{{else}}logs{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
  report_template: '[Full PR test history](https://k8s-gubernator.appspot.com/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://k8s-gubernator.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'


### PR DESCRIPTION
This should enable tide to merge PRs targeting the named branch (and bc of the confusion around this feature[1], I've also enabled dry run mode). The tide component has already been set up and deployed, this config will enable it.

Following merge I will generate and upload the modified configmap using the relevant Makefile target e.g. `make update-config`. 

[1]: https://github.com/kubernetes/test-infra/issues/12304