### PR TITLE
Update tide image, disable dry-run

### DIFF
--- a/test-infra/prow/Makefile
+++ b/test-infra/prow/Makefile
@@ -62,6 +62,9 @@ plank-deployment: get-cluster-credentials
 tide-deployment: get-cluster-credentials
 	kubectl apply -f cluster/tide_deployment.yaml
 
-.PHONY: hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment tide-deployment
+tide-service: get-cluster-credentials
+	kubectl apply -f cluster/tide_service.yaml
 
-update-all: update-config update-plugins hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment tide-deployment
+.PHONY: hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment tide-deployment tide-service
+
+update-all: update-config update-plugins hook-deployment hook-service sinker-deployment deck-deployment deck-service horologium-deployment plank-deployment tide-deployment tide-service

--- a/test-infra/prow/cluster/tide_deployment.yaml
+++ b/test-infra/prow/cluster/tide_deployment.yaml
@@ -27,9 +27,9 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180830-eabe43164
+        image: gcr.io/k8s-prow/tide:v20190424-461925da2
         args:
-        - --dry-run=true
+        - --dry-run=false
         ports:
           - name: http
             containerPort: 8888


### PR DESCRIPTION
* After running with dry-run enabled for a day, we see tide does honor the branch restriction. Running now with dry-run disabled for further testing.
* Updated container image to latest (as of today)

To be entirely clear, this change is already live and the PR is just to commit this config.