### PR TITLE
fix bucket split logic

### DIFF
--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	bucketRegex = regexp.MustCompile(`^gs://([a-z0-9][-_.a-z0-9]*)/?$`)
-	gsRegex = regexp.MustCompile(`^gs://([a-z0-9][-_.a-z0-9]*)/(.+)$`)
+	bucket = `([a-z0-9][-_.a-z0-9]*)`
+	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/?$`, bucket))
+	gsRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.+)$`, bucket))
 )
 
 // StorageClient implements domain.StorageClientInterface. It implements main Storage functions
@@ -187,14 +188,14 @@ func SplitGCSPath(p string) (string, string, error) {
 	return "", "", fmt.Errorf("%q is not a valid GCS path", p)
 }
 
-// SplitBucketGCSPath splits GCS path to get bucket name
-func SplitBucketGCSPath(p string) (string, error) {
+// GetBucketNameFromGCSPath splits GCS path to get bucket name
+func GetBucketNameFromGCSPath(p string) (string, error) {
 	matches := bucketRegex.FindStringSubmatch(p)
 	if matches != nil {
 		return matches[1], nil
 	}
 
-	return "", fmt.Errorf("%q is not a valid GCS bucket", p)
+	return "", fmt.Errorf("%q is not a valid GCS bucket path", p)
 }
 
 // HTTPClient implements domain.HTTPClientInterface which abstracts HTTP functionality used by

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	bucket      = `([a-z0-9][-_.a-z0-9]*)`
-	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.*)$`, bucket))
-	gsRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.+)$`, bucket))
+	bucketNameRegex = `([a-z0-9][-_.a-z0-9]*)`
+	bucketPathRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.*)$`, bucketNameRegex))
+	gsPathRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.+)$`, bucketNameRegex))
 )
 
 // StorageClient implements domain.StorageClientInterface. It implements main Storage functions
@@ -180,7 +180,7 @@ func (sc *StorageClient) Close() error {
 
 // SplitGCSPath splits GCS path into bucket and object path portions
 func SplitGCSPath(p string) (string, string, error) {
-	matches := gsRegex.FindStringSubmatch(p)
+	matches := gsPathRegex.FindStringSubmatch(p)
 	if matches != nil {
 		return matches[1], matches[2], nil
 	}
@@ -190,7 +190,7 @@ func SplitGCSPath(p string) (string, string, error) {
 
 // GetBucketNameFromGCSPath splits GCS path to get bucket name
 func GetBucketNameFromGCSPath(p string) (string, error) {
-	matches := bucketRegex.FindStringSubmatch(p)
+	matches := bucketPathRegex.FindStringSubmatch(p)
 	if matches != nil {
 		return matches[1], nil
 	}

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	bucket = `([a-z0-9][-_.a-z0-9]*)`
+	bucket      = `([a-z0-9][-_.a-z0-9]*)`
 	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.*)$`, bucket))
-	gsRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.+)$`, bucket))
+	gsRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.+)$`, bucket))
 )
 
 // StorageClient implements domain.StorageClientInterface. It implements main Storage functions

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	bucket = `([a-z0-9][-_.a-z0-9]*)`
-	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/?$`, bucket))
+	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.*)$`, bucket))
 	gsRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/(.+)$`, bucket))
 )
 

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -31,6 +31,7 @@ import (
 )
 
 var (
+	bucketRegex = regexp.MustCompile(`^gs://([a-z0-9][-_.a-z0-9]*)/?$`)
 	gsRegex = regexp.MustCompile(`^gs://([a-z0-9][-_.a-z0-9]*)/(.+)$`)
 )
 
@@ -184,6 +185,16 @@ func SplitGCSPath(p string) (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("%q is not a valid GCS path", p)
+}
+
+// SplitGCSPath splits GCS path to get bucket name
+func SplitBucketGCSPath(p string) (string, error) {
+	matches := bucketRegex.FindStringSubmatch(p)
+	if matches != nil {
+		return matches[1], nil
+	}
+
+	return "", fmt.Errorf("%q is not a valid GCS bucket", p)
 }
 
 // HTTPClient implements domain.HTTPClientInterface which abstracts HTTP functionality used by

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -187,7 +187,7 @@ func SplitGCSPath(p string) (string, string, error) {
 	return "", "", fmt.Errorf("%q is not a valid GCS path", p)
 }
 
-// SplitGCSPath splits GCS path to get bucket name
+// SplitBucketGCSPath splits GCS path to get bucket name
 func SplitBucketGCSPath(p string) (string, error) {
 	matches := bucketRegex.FindStringSubmatch(p)
 	if matches != nil {

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -189,9 +189,9 @@ func populateMissingParameters(mgce commondomain.MetadataGCEInterface,
 		newScratchBucketGcsPath := fmt.Sprintf("gs://%v/", scratchBucketName)
 		scratchBucketGcsPath = &newScratchBucketGcsPath
 	} else {
-		scratchBucketName, _, err := storageutils.SplitGCSPath(*scratchBucketGcsPath)
+		scratchBucketName, err := storageutils.SplitBucketGCSPath(*scratchBucketGcsPath)
 		if err != nil {
-			return fmt.Errorf("invalid scratch bucket GCS path %v", scratchBucketGcsPath)
+			return fmt.Errorf("invalid scratch bucket GCS path %v", *scratchBucketGcsPath)
 		}
 		scratchBucketAttrs, err := storageClient.GetBucketAttrs(scratchBucketName)
 		if err == nil {

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -189,7 +189,7 @@ func populateMissingParameters(mgce commondomain.MetadataGCEInterface,
 		newScratchBucketGcsPath := fmt.Sprintf("gs://%v/", scratchBucketName)
 		scratchBucketGcsPath = &newScratchBucketGcsPath
 	} else {
-		scratchBucketName, err := storageutils.SplitBucketGCSPath(*scratchBucketGcsPath)
+		scratchBucketName, err := storageutils.GetBucketNameFromGCSPath(*scratchBucketGcsPath)
 		if err != nil {
 			return fmt.Errorf("invalid scratch bucket GCS path %v", *scratchBucketGcsPath)
 		}


### PR DESCRIPTION
Currently, scratch bucket name can't be processed correctly since regex doesn't match. Fix by changing to correct regex.