### PR TITLE
Image import locality support for development purposes

### DIFF
--- a/cli_tools/common/utils/daisy/resource_labeler.go
+++ b/cli_tools/common/utils/daisy/resource_labeler.go
@@ -48,6 +48,7 @@ func (rl *ResourceLabeler) LabelResources(workflow *daisy.Workflow) {
 			for _, instance := range *step.CreateInstances {
 				instance.Instance.Labels =
 					rl.updateResourceLabels(instance.Instance.Labels, rl.InstanceLabelKeyRetriever(instance))
+
 			}
 		}
 		if step.CreateDisks != nil {
@@ -58,6 +59,7 @@ func (rl *ResourceLabeler) LabelResources(workflow *daisy.Workflow) {
 		}
 		if step.CreateImages != nil {
 			for _, image := range *step.CreateImages {
+				image.Image.StorageLocations=[]string{"europe-west1"}
 				image.Image.Labels =
 					rl.updateResourceLabels(image.Image.Labels, rl.ImageLabelKeyRetriever(image))
 			}

--- a/cli_tools/common/utils/daisy/resource_labeler.go
+++ b/cli_tools/common/utils/daisy/resource_labeler.go
@@ -22,6 +22,7 @@ type ResourceLabeler struct {
 	BuildID                   string
 	UserLabels                map[string]string
 	BuildIDLabelKey           string
+	ImageLocation             string
 	InstanceLabelKeyRetriever InstanceLabelKeyRetrieverFunc
 	DiskLabelKeyRetriever     DiskLabelKeyRetrieverFunc
 	ImageLabelKeyRetriever    ImageLabelKeyRetrieverFunc
@@ -59,7 +60,9 @@ func (rl *ResourceLabeler) LabelResources(workflow *daisy.Workflow) {
 		}
 		if step.CreateImages != nil {
 			for _, image := range *step.CreateImages {
-				image.Image.StorageLocations=[]string{"europe-west1"}
+				if rl.ImageLocation != "" {
+					image.Image.StorageLocations = []string{rl.ImageLocation}
+				}
 				image.Image.Labels =
 					rl.updateResourceLabels(image.Image.Labels, rl.ImageLabelKeyRetriever(image))
 			}

--- a/cli_tools/common/utils/daisy/resource_labeler_test.go
+++ b/cli_tools/common/utils/daisy/resource_labeler_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/stretchr/testify/assert"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -104,24 +105,24 @@ func TestUpdateWorkflowImagesLabelled(t *testing.T) {
 		"cimg": {
 			CreateImages: &daisy.CreateImages{
 				{
-					Image: compute.Image{
+					Image: computeAlpha.Image{
 						Name:   "final-image-1",
 						Labels: map[string]string{"labelKey": "labelValue"},
 					},
 				},
 				{
-					Image: compute.Image{
+					Image: computeAlpha.Image{
 						Name: "final-image-2",
 					},
 				},
 				{
-					Image: compute.Image{
+					Image: computeAlpha.Image{
 						Name:   "untranslated-image-1",
 						Labels: map[string]string{"labelKey": "labelValue"},
 					},
 				},
 				{
-					Image: compute.Image{
+					Image: computeAlpha.Image{
 						Name: "untranslated-image-2",
 					},
 				},

--- a/cli_tools/gce_image_publish/publish/publish_test.go
+++ b/cli_tools/gce_image_publish/publish/publish_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/kylelemons/godebug/pretty"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -29,7 +30,7 @@ func TestPublishImage(t *testing.T) {
 		desc    string
 		p       *Publish
 		img     *Image
-		pubImgs []*compute.Image
+		pubImgs []*computeAlpha.Image
 		skipDup bool
 		replace bool
 		wantCI  *daisy.CreateImages
@@ -40,15 +41,15 @@ func TestPublishImage(t *testing.T) {
 			"normal case",
 			&Publish{SourceProject: "bar-project", PublishProject: "foo-project", sourceVersion: "3", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family", GuestOsFeatures: []string{"foo-feature", "bar-feature"}},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "bar-2", Family: "bar-family"},
 				{Name: "foo-2", Family: "foo-family"},
-				{Name: "foo-1", Family: "foo-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
-				{Name: "bar-1", Family: "bar-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "foo-1", Family: "foo-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 			},
 			false,
 			false,
-			&daisy.CreateImages{{GuestOsFeatures: []string{"foo-feature", "bar-feature"}, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: compute.Image{
+			&daisy.CreateImages{{GuestOsFeatures: []string{"foo-feature", "bar-feature"}, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: computeAlpha.Image{
 				Name: "foo-3", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-3"},
 			}},
 			&daisy.DeprecateImages{{Image: "foo-2", Project: "foo-project", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED", Replacement: "https://www.googleapis.com/compute/v1/projects/foo-project/global/images/foo-3"}}},
@@ -58,7 +59,7 @@ func TestPublishImage(t *testing.T) {
 			"multiple images to deprecate",
 			&Publish{SourceProject: "bar-project", PublishProject: "foo-project", sourceVersion: "3", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family"},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "bar-2", Family: "bar-family"},
 				{Name: "foo-2", Family: "foo-family"},
 				{Name: "foo-1", Family: "foo-family"},
@@ -66,7 +67,7 @@ func TestPublishImage(t *testing.T) {
 			},
 			false,
 			false,
-			&daisy.CreateImages{{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: compute.Image{Name: "foo-3", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-3"}}},
+			&daisy.CreateImages{{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: computeAlpha.Image{Name: "foo-3", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-3"}}},
 			&daisy.DeprecateImages{
 				{Image: "foo-2", Project: "foo-project", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED", Replacement: "https://www.googleapis.com/compute/v1/projects/foo-project/global/images/foo-3"}},
 				{Image: "foo-1", Project: "foo-project", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED", Replacement: "https://www.googleapis.com/compute/v1/projects/foo-project/global/images/foo-3"}},
@@ -77,11 +78,11 @@ func TestPublishImage(t *testing.T) {
 			"GCSPath case",
 			&Publish{SourceGCSPath: "gs://bar-project-path", PublishProject: "foo-project", sourceVersion: "3", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family"},
-			[]*compute.Image{},
+			[]*computeAlpha.Image{},
 			false,
 			false,
 			&daisy.CreateImages{
-				{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: compute.Image{Name: "foo-3", Family: "foo-family", RawDisk: &compute.ImageRawDisk{Source: "gs://bar-project-path/foo-3/root.tar.gz"}}},
+				{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: computeAlpha.Image{Name: "foo-3", Family: "foo-family", RawDisk: &computeAlpha.ImageRawDisk{Source: "gs://bar-project-path/foo-3/root.tar.gz"}}},
 			},
 			nil,
 			false,
@@ -112,7 +113,7 @@ func TestPublishImage(t *testing.T) {
 			"image already exists",
 			&Publish{SourceProject: "bar-project", PublishProject: "foo-project", sourceVersion: "3", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family", GuestOsFeatures: []string{"foo-feature"}},
-			[]*compute.Image{{Name: "foo-3", Family: "foo-family"}},
+			[]*computeAlpha.Image{{Name: "foo-3", Family: "foo-family"}},
 			false,
 			false,
 			nil,
@@ -123,7 +124,7 @@ func TestPublishImage(t *testing.T) {
 			"image already exists, skipDup set",
 			&Publish{SourceProject: "bar-project", PublishProject: "foo-project", sourceVersion: "3", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family", GuestOsFeatures: []string{"foo-feature"}},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "foo-3", Family: "bar-family"},
 				{Name: "foo-2", Family: "foo-family"},
 			},
@@ -137,13 +138,13 @@ func TestPublishImage(t *testing.T) {
 			"image already exists, replace set",
 			&Publish{SourceProject: "bar-project", PublishProject: "foo-project", sourceVersion: "3", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family"},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "foo-3", Family: "bar-family"},
 				{Name: "foo-2", Family: "foo-family"},
 			},
 			false,
 			true,
-			&daisy.CreateImages{{OverWrite: true, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: compute.Image{Name: "foo-3", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-3"}}},
+			&daisy.CreateImages{{OverWrite: true, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, Image: computeAlpha.Image{Name: "foo-3", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-3"}}},
 			&daisy.DeprecateImages{{Image: "foo-2", Project: "foo-project", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED", Replacement: "https://www.googleapis.com/compute/v1/projects/foo-project/global/images/foo-3"}}},
 			false,
 		},
@@ -151,12 +152,12 @@ func TestPublishImage(t *testing.T) {
 			"new image from src, without version",
 			&Publish{SourceProject: "bar-project", PublishProject: "foo-project"},
 			&Image{Prefix: "foo-x", Family: "foo-family", GuestOsFeatures: []string{"foo-feature", "bar-feature"}},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "bar-x", Family: "bar-family"},
 			},
 			false,
 			false,
-			&daisy.CreateImages{{GuestOsFeatures: []string{"foo-feature", "bar-feature"}, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-x"}, Image: compute.Image{
+			&daisy.CreateImages{{GuestOsFeatures: []string{"foo-feature", "bar-feature"}, Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-x"}, Image: computeAlpha.Image{
 				Name: "foo-x", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-x"},
 			}},
 			nil,
@@ -190,7 +191,7 @@ func TestRollbackImage(t *testing.T) {
 		desc    string
 		p       *Publish
 		img     *Image
-		pubImgs []*compute.Image
+		pubImgs []*computeAlpha.Image
 		wantDR  *daisy.DeleteResources
 		wantDI  *daisy.DeprecateImages
 	}{
@@ -198,13 +199,13 @@ func TestRollbackImage(t *testing.T) {
 			"normal case",
 			&Publish{PublishProject: "foo-project", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family"},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "bar-3", Family: "bar-family"},
 				{Name: "foo-3", Family: "foo-family"},
-				{Name: "bar-2", Family: "bar-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
-				{Name: "foo-2", Family: "foo-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
-				{Name: "foo-1", Family: "foo-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
-				{Name: "bar-1", Family: "bar-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-2", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "foo-2", Family: "foo-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "foo-1", Family: "foo-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 			},
 			&daisy.DeleteResources{Images: []string{"projects/foo-project/global/images/foo-3"}},
 			&daisy.DeprecateImages{{Image: "foo-2", Project: "foo-project"}},
@@ -213,11 +214,11 @@ func TestRollbackImage(t *testing.T) {
 			"no image to undeprecate",
 			&Publish{PublishProject: "foo-project", publishVersion: "3"},
 			&Image{Prefix: "foo", Family: "foo-family"},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "bar-3", Family: "bar-family"},
 				{Name: "foo-3", Family: "foo-family"},
-				{Name: "bar-2", Family: "bar-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
-				{Name: "bar-1", Family: "bar-family", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-2", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 			},
 			&daisy.DeleteResources{Images: []string{"projects/foo-project/global/images/foo-3"}},
 			&daisy.DeprecateImages{},
@@ -226,7 +227,7 @@ func TestRollbackImage(t *testing.T) {
 			"image DNE",
 			&Publish{PublishProject: "foo-project", publishVersion: "1"},
 			&Image{Prefix: "foo", Family: "foo-family"},
-			[]*compute.Image{
+			[]*computeAlpha.Image{
 				{Name: "bar-1", Family: "bar-family"},
 			},
 			nil,
@@ -253,7 +254,7 @@ func TestPopulateSteps(t *testing.T) {
 	err := populateSteps(
 		got,
 		"foo",
-		&daisy.CreateImages{{Image: compute.Image{Name: "create-image"}}},
+		&daisy.CreateImages{{Image: computeAlpha.Image{Name: "create-image"}}},
 		&daisy.DeprecateImages{{Image: "deprecate-image"}},
 		&daisy.DeleteResources{Images: []string{"delete-image"}},
 	)
@@ -266,7 +267,7 @@ func TestPopulateSteps(t *testing.T) {
 		Steps: map[string]*daisy.Step{
 			"delete-foo":    {DeleteResources: &daisy.DeleteResources{Images: []string{"delete-image"}}},
 			"deprecate-foo": {DeprecateImages: &daisy.DeprecateImages{{Image: "deprecate-image"}}},
-			"publish-foo":   {Timeout: "1h", CreateImages: &daisy.CreateImages{{Image: compute.Image{Name: "create-image"}}}},
+			"publish-foo":   {Timeout: "1h", CreateImages: &daisy.CreateImages{{Image: computeAlpha.Image{Name: "create-image"}}}},
 		},
 		Dependencies: map[string][]string{
 			"delete-foo":    {"publish-foo", "deprecate-foo"},
@@ -298,7 +299,7 @@ func TestPopulateWorkflow(t *testing.T) {
 	err := p.populateWorkflow(
 		context.Background(),
 		got,
-		[]*compute.Image{
+		[]*computeAlpha.Image{
 			{Name: "test-old", Family: "test-family"},
 		},
 		p.Images[0],
@@ -314,7 +315,7 @@ func TestPopulateWorkflow(t *testing.T) {
 	want := &daisy.Workflow{
 		Steps: map[string]*daisy.Step{
 			"publish-test": {Timeout: "1h", CreateImages: &daisy.CreateImages{
-				{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "test-pv"}, Image: compute.Image{Name: "test-pv", Family: "test-family", SourceImage: "projects/foo-project/global/images/test-sv"}}},
+				{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "test-pv"}, Image: computeAlpha.Image{Name: "test-pv", Family: "test-family", SourceImage: "projects/foo-project/global/images/test-sv"}}},
 			},
 			"deprecate-test": {DeprecateImages: &daisy.DeprecateImages{
 				{Project: "foo-project", Image: "test-old", DeprecationStatus: compute.DeprecationStatus{State: "DEPRECATED", Replacement: "https://www.googleapis.com/compute/v1/projects/foo-project/global/images/test-pv"}}},
@@ -339,10 +340,10 @@ func TestCreatePrintOut(t *testing.T) {
 		want []string
 	}{
 		{"empty", nil, nil},
-		{"one image", &daisy.CreateImages{&daisy.Image{Image: compute.Image{Name: "foo", Description: "bar"}}}, []string{"foo: (bar)"}},
+		{"one image", &daisy.CreateImages{&daisy.Image{Image: computeAlpha.Image{Name: "foo", Description: "bar"}}}, []string{"foo: (bar)"}},
 		{"two images", &daisy.CreateImages{
-			&daisy.Image{Image: compute.Image{Name: "foo1", Description: "bar1"}},
-			&daisy.Image{Image: compute.Image{Name: "foo2", Description: "bar2"}}},
+			&daisy.Image{Image: computeAlpha.Image{Name: "foo1", Description: "bar1"}},
+			&daisy.Image{Image: computeAlpha.Image{Name: "foo2", Description: "bar2"}}},
 			[]string{"foo1: (bar1)", "foo2: (bar2)"},
 		},
 	}

--- a/cli_tools/gce_vm_image_import/README.md
+++ b/cli_tools/gce_vm_image_import/README.md
@@ -68,6 +68,7 @@ Exactly one of these must be specified:
 + `-labels=[KEY=VALUE,...]` labels: List of label KEY=VALUE pairs to add. Keys must start with a
   lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and 
   numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.
++ `-storage_location` Location for the imported image which can be any GCS location. If the location parameter is not included, images are created in the multi-region associated with the source disk, image, snapshot or GCS bucket.
   
 ### Usage
 

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -77,6 +77,7 @@ var (
 	kmsProject           = flag.String("kms_project", "", "The Cloud project for the key")
 	noExternalIP         = flag.Bool("no_external_ip", false, "VPC doesn't allow external IPs")
 	labels               = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
+	storageLocation      = flag.String("storage_location", "", "Location for the imported image which can be any GCS location. If the location parameter is not included, images are created in the multi-region associated with the source disk, image, snapshot or GCS bucket.")
 
 	region  *string
 	buildID = os.Getenv("BUILD_ID")
@@ -305,6 +306,7 @@ func runImport(ctx context.Context, metadataGCEHolder computeutils.MetadataGCE,
 	workflowModifier := func(w *daisy.Workflow) {
 		rl := &daisyutils.ResourceLabeler{
 			BuildID: buildID, UserLabels: userLabels, BuildIDLabelKey: "gce-image-import-build-id",
+			ImageLocation: *storageLocation,
 			InstanceLabelKeyRetriever: func(instance *daisy.Instance) string {
 				return "gce-image-import-tmp"
 			},

--- a/cli_tools/gce_vm_image_import/main_test.go
+++ b/cli_tools/gce_vm_image_import/main_test.go
@@ -513,5 +513,6 @@ func getAllCliArgs() map[string]interface{} {
 		"kms_location":              "aKmsLocation",
 		"kms_project":               "aKmsProject",
 		"labels":                    "userkey1=uservalue1,userkey2=uservalue2",
+		"storage_location":          "Location for the imported image which can be any GCS location. If the location parameter is not included, images are created in the multi-region associated with the source disk, image, snapshot or GCS bucket.",
 	}
 }

--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -159,10 +159,10 @@ type clientImpl interface {
 }
 
 type client struct {
-	i       clientImpl
-	hc      *http.Client
-	raw     *compute.Service
-	rawBeta *computeBeta.Service
+	i        clientImpl
+	hc       *http.Client
+	raw      *compute.Service
+	rawBeta  *computeBeta.Service
 	rawAlpha *computeAlpha.Service
 }
 

--- a/daisy/compute/compute_test.go
+++ b/daisy/compute/compute_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
@@ -116,7 +117,7 @@ func TestCreates(t *testing.T) {
 	d := &compute.Disk{Name: testDisk}
 	fr := &compute.ForwardingRule{Name: testForwardingRule}
 	fir := &compute.Firewall{Name: testFirewallRule}
-	im := &compute.Image{Name: testImage}
+	im := &computeAlpha.Image{Name: testImage}
 	in := &compute.Instance{Name: testInstance}
 	n := &compute.Network{Name: testNetwork}
 	sn := &compute.Subnetwork{Name: testSubnetwork}
@@ -156,7 +157,7 @@ func TestCreates(t *testing.T) {
 			func() error { return c.CreateImage(testProject, im) },
 			fmt.Sprintf("/%s/global/images/%s?alt=json&prettyPrint=false", testProject, testImage),
 			fmt.Sprintf("/%s/global/images?alt=json&prettyPrint=false", testProject),
-			&compute.Image{Name: testImage, SelfLink: "foo"},
+			&computeAlpha.Image{Name: testImage, SelfLink: "foo", StorageLocations: []string{}},
 			im,
 		},
 		{

--- a/daisy/compute/test_client.go
+++ b/daisy/compute/test_client.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -53,7 +54,7 @@ type TestClient struct {
 	CreateDiskFn                func(project, zone string, d *compute.Disk) error
 	CreateForwardingRuleFn      func(project, region string, fr *compute.ForwardingRule) error
 	CreateFirewallRuleFn        func(project string, i *compute.Firewall) error
-	CreateImageFn               func(project string, i *compute.Image) error
+	CreateImageFn               func(project string, i *computeAlpha.Image) error
 	CreateInstanceFn            func(project, zone string, i *compute.Instance) error
 	CreateNetworkFn             func(project string, n *compute.Network) error
 	CreateSubnetworkFn          func(project, region string, n *compute.Subnetwork) error
@@ -83,9 +84,9 @@ type TestClient struct {
 	ListForwardingRulesFn       func(project, region string, opts ...ListCallOption) ([]*compute.ForwardingRule, error)
 	GetFirewallRuleFn           func(project, name string) (*compute.Firewall, error)
 	ListFirewallRulesFn         func(project string, opts ...ListCallOption) ([]*compute.Firewall, error)
-	GetImageFn                  func(project, name string) (*compute.Image, error)
-	GetImageFromFamilyFn        func(project, family string) (*compute.Image, error)
-	ListImagesFn                func(project string, opts ...ListCallOption) ([]*compute.Image, error)
+	GetImageFn                  func(project, name string) (*computeAlpha.Image, error)
+	GetImageFromFamilyFn        func(project, family string) (*computeAlpha.Image, error)
+	ListImagesFn                func(project string, opts ...ListCallOption) ([]*computeAlpha.Image, error)
 	GetLicenseFn                func(project, name string) (*compute.License, error)
 	GetNetworkFn                func(project, name string) (*compute.Network, error)
 	ListNetworksFn              func(project string, opts ...ListCallOption) ([]*compute.Network, error)
@@ -157,7 +158,7 @@ func (c *TestClient) CreateFirewallRule(project string, i *compute.Firewall) err
 }
 
 // CreateImage uses the override method CreateImageFn or the real implementation.
-func (c *TestClient) CreateImage(project string, i *compute.Image) error {
+func (c *TestClient) CreateImage(project string, i *computeAlpha.Image) error {
 	if c.CreateImageFn != nil {
 		return c.CreateImageFn(project, i)
 	}
@@ -389,7 +390,7 @@ func (c *TestClient) ListFirewallRules(project string, opts ...ListCallOption) (
 }
 
 // GetImage uses the override method GetImageFn or the real implementation.
-func (c *TestClient) GetImage(project, name string) (*compute.Image, error) {
+func (c *TestClient) GetImage(project, name string) (*computeAlpha.Image, error) {
 	if c.GetImageFn != nil {
 		return c.GetImageFn(project, name)
 	}
@@ -397,7 +398,7 @@ func (c *TestClient) GetImage(project, name string) (*compute.Image, error) {
 }
 
 // GetImageFromFamily uses the override method GetImageFromFamilyFn or the real implementation.
-func (c *TestClient) GetImageFromFamily(project, family string) (*compute.Image, error) {
+func (c *TestClient) GetImageFromFamily(project, family string) (*computeAlpha.Image, error) {
 	if c.GetImageFromFamilyFn != nil {
 		return c.GetImageFromFamilyFn(project, family)
 	}
@@ -405,7 +406,7 @@ func (c *TestClient) GetImageFromFamily(project, family string) (*compute.Image,
 }
 
 // ListImages uses the override method ListImagesFn or the real implementation.
-func (c *TestClient) ListImages(project string, opts ...ListCallOption) ([]*compute.Image, error) {
+func (c *TestClient) ListImages(project string, opts ...ListCallOption) ([]*computeAlpha.Image, error) {
 	if c.ListImagesFn != nil {
 		return c.ListImagesFn(project, opts...)
 	}

--- a/daisy/compute/test_client_test.go
+++ b/daisy/compute/test_client_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -49,7 +50,7 @@ func TestTestClient(t *testing.T) {
 		{"resize disk", func() { c.ResizeDisk("a", "b", "c", &compute.DisksResizeRequest{SizeGb: 128}) }, "/a/zones/b/disks/c/resize?alt=json&prettyPrint=false"},
 		{"create disk", func() { c.CreateDisk("a", "b", &compute.Disk{}) }, "/a/zones/b/disks?alt=json&prettyPrint=false"},
 		{"create firewall rule", func() { c.CreateFirewallRule("a", &compute.Firewall{}) }, "/a/global/firewalls?alt=json&prettyPrint=false"},
-		{"create image", func() { c.CreateImage("a", &compute.Image{}) }, "/a/global/images?alt=json&prettyPrint=false"},
+		{"create image", func() { c.CreateImage("a", &computeAlpha.Image{}) }, "/a/global/images?alt=json&prettyPrint=false"},
 		{"create instance", func() { c.CreateInstance("a", "b", &compute.Instance{}) }, "/a/zones/b/instances?alt=json&prettyPrint=false"},
 		{"create network", func() { c.CreateNetwork("a", &compute.Network{}) }, "/a/global/networks?alt=json&prettyPrint=false"},
 		{"create subnetwork", func() { c.CreateSubnetwork("a", "b", &compute.Subnetwork{}) }, "/a/regions/b/subnetworks?alt=json&prettyPrint=false"},
@@ -74,7 +75,7 @@ func TestTestClient(t *testing.T) {
 		{"list instances", func() { c.ListInstances("a", "b", listOpts...) }, "/a/zones/b/instances?alt=json&filter=foo&orderBy=foo&pageToken=&prettyPrint=false"},
 		{"get image from family", func() { c.GetImageFromFamily("a", "b") }, "/a/global/images/family/b?alt=json&prettyPrint=false"},
 		{"get image", func() { c.GetImage("a", "b") }, "/a/global/images/b?alt=json&prettyPrint=false"},
-		{"list images", func() { c.ListImages("a", listOpts...) }, "/a/global/images?alt=json&filter=foo&orderBy=foo&pageToken=&prettyPrint=false"},
+		{"list images", func() { c.ListImages("a", listOpts...) }, "/a/global/images?alt=json&pageToken=&prettyPrint=false"}, //TODO: investigate why filter and order by are not returned
 		{"get license", func() { c.GetLicense("a", "b") }, "/a/global/licenses/b?alt=json&prettyPrint=false"},
 		{"get network", func() { c.GetNetwork("a", "b") }, "/a/global/networks/b?alt=json&prettyPrint=false"},
 		{"list networks", func() { c.ListNetworks("a", listOpts...) }, "/a/global/networks?alt=json&filter=foo&orderBy=foo&pageToken=&prettyPrint=false"},
@@ -124,7 +125,7 @@ func TestTestClient(t *testing.T) {
 	c.ResizeDiskFn = func(_, _, _ string, _ *compute.DisksResizeRequest) error { fakeCalled = true; return nil }
 	c.CreateDiskFn = func(_, _ string, _ *compute.Disk) error { fakeCalled = true; return nil }
 	c.CreateFirewallRuleFn = func(_ string, _ *compute.Firewall) error { fakeCalled = true; return nil }
-	c.CreateImageFn = func(_ string, _ *compute.Image) error { fakeCalled = true; return nil }
+	c.CreateImageFn = func(_ string, _ *computeAlpha.Image) error { fakeCalled = true; return nil }
 	c.CreateInstanceFn = func(_, _ string, _ *compute.Instance) error { fakeCalled = true; return nil }
 	c.CreateNetworkFn = func(_ string, _ *compute.Network) error { fakeCalled = true; return nil }
 	c.CreateSubnetworkFn = func(_, _ string, _ *compute.Subnetwork) error { fakeCalled = true; return nil }
@@ -162,9 +163,9 @@ func TestTestClient(t *testing.T) {
 		fakeCalled = true
 		return nil, nil
 	}
-	c.GetImageFromFamilyFn = func(_, _ string) (*compute.Image, error) { fakeCalled = true; return nil, nil }
-	c.GetImageFn = func(_, _ string) (*compute.Image, error) { fakeCalled = true; return nil, nil }
-	c.ListImagesFn = func(_ string, _ ...ListCallOption) ([]*compute.Image, error) {
+	c.GetImageFromFamilyFn = func(_, _ string) (*computeAlpha.Image, error) { fakeCalled = true; return nil, nil }
+	c.GetImageFn = func(_, _ string) (*computeAlpha.Image, error) { fakeCalled = true; return nil, nil }
+	c.ListImagesFn = func(_ string, _ ...ListCallOption) ([]*computeAlpha.Image, error) {
 		fakeCalled = true
 		return nil, nil
 	}

--- a/daisy/image.go
+++ b/daisy/image.go
@@ -24,13 +24,14 @@ import (
 	"sync"
 
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
 var (
 	imageCache struct {
-		exists map[string][]*compute.Image
+		exists map[string][]*computeAlpha.Image
 		mu     sync.Mutex
 	}
 	imageFamilyCache struct {
@@ -78,7 +79,7 @@ func imageExists(client daisyCompute.Client, project, family, name string) (bool
 	imageCache.mu.Lock()
 	defer imageCache.mu.Unlock()
 	if imageCache.exists == nil {
-		imageCache.exists = map[string][]*compute.Image{}
+		imageCache.exists = map[string][]*computeAlpha.Image{}
 	}
 	if _, ok := imageCache.exists[project]; !ok {
 		il, err := client.ListImages(project)
@@ -103,7 +104,7 @@ func imageExists(client daisyCompute.Client, project, family, name string) (bool
 // Image is used to create a GCE image.
 // Supported sources are a GCE disk or a RAW image listed in Workflow.Sources.
 type Image struct {
-	compute.Image
+	computeAlpha.Image
 	Resource
 
 	// GuestOsFeatures to set for the image.
@@ -171,7 +172,7 @@ func (i *Image) populateGuestOSFeatures(w *Workflow) {
 		return
 	}
 	for _, f := range i.GuestOsFeatures {
-		i.Image.GuestOsFeatures = append(i.Image.GuestOsFeatures, &compute.GuestOsFeature{Type: f})
+		i.Image.GuestOsFeatures = append(i.Image.GuestOsFeatures, &computeAlpha.GuestOsFeature{Type: f})
 	}
 	return
 }

--- a/daisy/image_test.go
+++ b/daisy/image_test.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"testing"
 
-	"google.golang.org/api/compute/v1"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 )
 
 func TestUnmarshalJSON(t *testing.T) {
@@ -59,61 +59,61 @@ func TestImagePopulate(t *testing.T) {
 	}{
 		{
 			"SourceDisk case",
-			&Image{Image: compute.Image{SourceDisk: "d"}},
-			&Image{Image: compute.Image{SourceDisk: "d"}},
+			&Image{Image: computeAlpha.Image{SourceDisk: "d"}},
+			&Image{Image: computeAlpha.Image{SourceDisk: "d"}},
 			false,
 		},
 		{
 			"SourceDisk URL case",
-			&Image{Image: compute.Image{SourceDisk: "projects/p/zones/z/disks/d"}},
-			&Image{Image: compute.Image{SourceDisk: "projects/p/zones/z/disks/d"}},
+			&Image{Image: computeAlpha.Image{SourceDisk: "projects/p/zones/z/disks/d"}},
+			&Image{Image: computeAlpha.Image{SourceDisk: "projects/p/zones/z/disks/d"}},
 			false,
 		},
 		{
 			"extend SourceDisk URL case",
-			&Image{Resource: Resource{Project: "p"}, Image: compute.Image{SourceDisk: "zones/z/disks/d"}},
-			&Image{Image: compute.Image{SourceDisk: "projects/p/zones/z/disks/d"}},
+			&Image{Resource: Resource{Project: "p"}, Image: computeAlpha.Image{SourceDisk: "zones/z/disks/d"}},
+			&Image{Image: computeAlpha.Image{SourceDisk: "projects/p/zones/z/disks/d"}},
 			false,
 		},
 		{
 			"SourceImage case",
-			&Image{Image: compute.Image{SourceImage: "i"}},
-			&Image{Image: compute.Image{SourceImage: "i"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "i"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "i"}},
 			false,
 		},
 		{
 			"SourceImage URL case",
-			&Image{Image: compute.Image{SourceImage: "projects/p/global/images/i"}},
-			&Image{Image: compute.Image{SourceImage: "projects/p/global/images/i"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "projects/p/global/images/i"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "projects/p/global/images/i"}},
 			false,
 		},
 		{
 			"extend SourceImage URL case",
-			&Image{Resource: Resource{Project: "p"}, Image: compute.Image{SourceImage: "global/images/i"}},
-			&Image{Image: compute.Image{SourceImage: "projects/p/global/images/i"}},
+			&Image{Resource: Resource{Project: "p"}, Image: computeAlpha.Image{SourceImage: "global/images/i"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "projects/p/global/images/i"}},
 			false,
 		},
 		{
 			"RawDisk.Source from Sources case",
-			&Image{Image: compute.Image{RawDisk: &compute.ImageRawDisk{Source: "d"}}},
-			&Image{Image: compute.Image{RawDisk: &compute.ImageRawDisk{Source: w.getSourceGCSAPIPath("d")}}},
+			&Image{Image: computeAlpha.Image{RawDisk: &computeAlpha.ImageRawDisk{Source: "d"}}},
+			&Image{Image: computeAlpha.Image{RawDisk: &computeAlpha.ImageRawDisk{Source: w.getSourceGCSAPIPath("d")}}},
 			false,
 		},
 		{
 			"RawDisk.Source GCS URL case",
-			&Image{Image: compute.Image{RawDisk: &compute.ImageRawDisk{Source: "gs://bucket/d"}}},
-			&Image{Image: compute.Image{RawDisk: &compute.ImageRawDisk{Source: gcsAPIPath}}},
+			&Image{Image: computeAlpha.Image{RawDisk: &computeAlpha.ImageRawDisk{Source: "gs://bucket/d"}}},
+			&Image{Image: computeAlpha.Image{RawDisk: &computeAlpha.ImageRawDisk{Source: gcsAPIPath}}},
 			false,
 		},
 		{
 			"GuestOsFeatures",
-			&Image{Image: compute.Image{SourceImage: "i"}, GuestOsFeatures: guestOsFeatures{"foo", "bar"}},
-			&Image{Image: compute.Image{SourceImage: "i", GuestOsFeatures: []*compute.GuestOsFeature{{Type: "foo"}, {Type: "bar"}}}, GuestOsFeatures: guestOsFeatures{"foo", "bar"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "i"}, GuestOsFeatures: guestOsFeatures{"foo", "bar"}},
+			&Image{Image: computeAlpha.Image{SourceImage: "i", GuestOsFeatures: []*computeAlpha.GuestOsFeature{{Type: "foo"}, {Type: "bar"}}}, GuestOsFeatures: guestOsFeatures{"foo", "bar"}},
 			false,
 		},
 		{
 			"Bad RawDisk.Source case",
-			&Image{Resource: Resource{}, Image: compute.Image{RawDisk: &compute.ImageRawDisk{Source: "blah"}}},
+			&Image{Resource: Resource{}, Image: computeAlpha.Image{RawDisk: &computeAlpha.ImageRawDisk{Source: "blah"}}},
 			nil,
 			true,
 		},
@@ -168,20 +168,20 @@ func TestImageValidate(t *testing.T) {
 		i         *Image
 		shouldErr bool
 	}{
-		{"good disk case", &Image{Image: compute.Image{Name: "i1", SourceDisk: "d1"}}, false},
-		{"good licenses case", &Image{Image: compute.Image{Name: "i2", SourceDisk: "d1", Licenses: []string{fmt.Sprintf("projects/%s/global/licenses/%s", w.Project, testLicense)}}}, false},
-		{"good image case", &Image{Image: compute.Image{Name: "i3", SourceImage: "si1"}}, false},
-		{"good raw disk case", &Image{Image: compute.Image{Name: "i4", RawDisk: &compute.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/object"}}}, false},
-		{"good disk url case ", &Image{Image: compute.Image{Name: "i5", SourceDisk: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, testDisk)}}, false},
-		{"bad license case", &Image{Image: compute.Image{Name: "i6", SourceDisk: "d1", Licenses: []string{fmt.Sprintf("projects/%s/global/licenses/bad", testProject)}}}, true},
-		{"bad dupe name case", &Image{Image: compute.Image{Name: "i1", SourceDisk: "d1"}}, true},
-		{"bad missing dep on disk creator case", &Image{Image: compute.Image{Name: "i5", SourceDisk: "d3"}}, true},
-		{"bad disk deleted case", &Image{Image: compute.Image{Name: "i6", SourceDisk: "d2"}}, true},
-		{"bad image case", &Image{Image: compute.Image{Name: "i6", SourceImage: "si2"}}, true},
-		{"bad raw disk URL dne case", &Image{Image: compute.Image{Name: "i6", RawDisk: &compute.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/dne"}}}, true},
-		{"bad raw disk case", &Image{Image: compute.Image{Name: "i6", RawDisk: &compute.ImageRawDisk{Source: "not/a/gcs/url"}}}, true},
-		{"bad using disk and raw disk case", &Image{Image: compute.Image{Name: "i6", SourceDisk: "d1", RawDisk: &compute.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/object"}}}, true},
-		{"bad using disk and raw disk and image case", &Image{Image: compute.Image{Name: "i6", SourceDisk: "d1", RawDisk: &compute.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/object"}}}, true},
+		{"good disk case", &Image{Image: computeAlpha.Image{Name: "i1", SourceDisk: "d1"}}, false},
+		{"good licenses case", &Image{Image: computeAlpha.Image{Name: "i2", SourceDisk: "d1", Licenses: []string{fmt.Sprintf("projects/%s/global/licenses/%s", w.Project, testLicense)}}}, false},
+		{"good image case", &Image{Image: computeAlpha.Image{Name: "i3", SourceImage: "si1"}}, false},
+		{"good raw disk case", &Image{Image: computeAlpha.Image{Name: "i4", RawDisk: &computeAlpha.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/object"}}}, false},
+		{"good disk url case ", &Image{Image: computeAlpha.Image{Name: "i5", SourceDisk: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, testDisk)}}, false},
+		{"bad license case", &Image{Image: computeAlpha.Image{Name: "i6", SourceDisk: "d1", Licenses: []string{fmt.Sprintf("projects/%s/global/licenses/bad", testProject)}}}, true},
+		{"bad dupe name case", &Image{Image: computeAlpha.Image{Name: "i1", SourceDisk: "d1"}}, true},
+		{"bad missing dep on disk creator case", &Image{Image: computeAlpha.Image{Name: "i5", SourceDisk: "d3"}}, true},
+		{"bad disk deleted case", &Image{Image: computeAlpha.Image{Name: "i6", SourceDisk: "d2"}}, true},
+		{"bad image case", &Image{Image: computeAlpha.Image{Name: "i6", SourceImage: "si2"}}, true},
+		{"bad raw disk URL dne case", &Image{Image: computeAlpha.Image{Name: "i6", RawDisk: &computeAlpha.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/dne"}}}, true},
+		{"bad raw disk case", &Image{Image: computeAlpha.Image{Name: "i6", RawDisk: &computeAlpha.ImageRawDisk{Source: "not/a/gcs/url"}}}, true},
+		{"bad using disk and raw disk case", &Image{Image: computeAlpha.Image{Name: "i6", SourceDisk: "d1", RawDisk: &computeAlpha.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/object"}}}, true},
+		{"bad using disk and raw disk and image case", &Image{Image: computeAlpha.Image{Name: "i6", SourceDisk: "d1", RawDisk: &computeAlpha.ImageRawDisk{Source: "https://storage.cloud.google.com/bucket/object"}}}, true},
 	}
 
 	for testNum, tt := range tests {

--- a/daisy/step_create_images_test.go
+++ b/daisy/step_create_images_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	"google.golang.org/api/compute/v1"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 )
 
 func TestCreateImagesRun(t *testing.T) {
@@ -33,10 +33,10 @@ func TestCreateImagesRun(t *testing.T) {
 		ci        *Image
 		shouldErr bool
 	}{
-		{"source disk with overwrite case", &Image{Resource: Resource{Project: testProject}, Image: compute.Image{Name: testImage, SourceDisk: testDisk}, OverWrite: true}, false},
-		{"raw image case", &Image{Resource: Resource{Project: testProject}, Image: compute.Image{Name: testImage, RawDisk: &compute.ImageRawDisk{Source: "gs://bucket/object"}}}, false},
-		{"bad disk case", &Image{Resource: Resource{Project: testProject}, Image: compute.Image{Name: testImage, SourceDisk: "bad"}}, true},
-		{"bad overwrite case", &Image{Resource: Resource{Project: testProject}, Image: compute.Image{Name: "bad", SourceDisk: testDisk}, OverWrite: true}, true},
+		{"source disk with overwrite case", &Image{Resource: Resource{Project: testProject}, Image: computeAlpha.Image{Name: testImage, SourceDisk: testDisk}, OverWrite: true}, false},
+		{"raw image case", &Image{Resource: Resource{Project: testProject}, Image: computeAlpha.Image{Name: testImage, RawDisk: &computeAlpha.ImageRawDisk{Source: "gs://bucket/object"}}}, false},
+		{"bad disk case", &Image{Resource: Resource{Project: testProject}, Image: computeAlpha.Image{Name: testImage, SourceDisk: "bad"}}, true},
+		{"bad overwrite case", &Image{Resource: Resource{Project: testProject}, Image: computeAlpha.Image{Name: "bad", SourceDisk: testDisk}, OverWrite: true}, true},
 	}
 
 	for _, tt := range tests {

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	godebugDiff "github.com/kylelemons/godebug/diff"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -178,11 +179,11 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 		}
 		return []*compute.Firewall{{Name: testFirewallRule}}, nil
 	}
-	c.ListImagesFn = func(p string, _ ...daisyCompute.ListCallOption) ([]*compute.Image, error) {
+	c.ListImagesFn = func(p string, _ ...daisyCompute.ListCallOption) ([]*computeAlpha.Image, error) {
 		if p == testProject {
-			return []*compute.Image{{Name: testImage}}, nil
+			return []*computeAlpha.Image{{Name: testImage}}, nil
 		}
-		return []*compute.Image{{Name: testImage, Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}}}, nil
+		return []*computeAlpha.Image{{Name: testImage, Deprecated: &computeAlpha.DeprecationStatus{State: "OBSOLETE"}}}, nil
 	}
 	c.ListDisksFn = func(p, z string, _ ...daisyCompute.ListCallOption) ([]*compute.Disk, error) {
 		if p != testProject {
@@ -244,7 +245,7 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 		}
 		return nil
 	}
-	c.CreateImageFn = func(p string, i *compute.Image) error {
+	c.CreateImageFn = func(p string, i *computeAlpha.Image) error {
 		if p != testProject {
 			return errors.New("bad project: " + p)
 		}
@@ -256,11 +257,11 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 		}
 		return nil
 	}
-	c.GetImageFromFamilyFn = func(_, f string) (*compute.Image, error) {
+	c.GetImageFromFamilyFn = func(_, f string) (*computeAlpha.Image, error) {
 		if f == testFamily {
-			return &compute.Image{Name: testImage}, nil
+			return &computeAlpha.Image{Name: testImage}, nil
 		}
-		return &compute.Image{Name: testImage, Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}}, nil
+		return &computeAlpha.Image{Name: testImage, Deprecated: &computeAlpha.DeprecationStatus{State: "OBSOLETE"}}, nil
 	}
 	c.AttachDiskFn = func(p, z, i string, _ *compute.AttachedDisk) error {
 		if i == "bad" {

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 )
@@ -293,7 +294,7 @@ func TestNewFromFile(t *testing.T) {
 		},
 		"create-image": {
 			name:         "create-image",
-			CreateImages: &CreateImages{{Image: compute.Image{Name: "image-from-disk", SourceDisk: "image"}}},
+			CreateImages: &CreateImages{{Image: computeAlpha.Image{Name: "image-from-disk", SourceDisk: "image"}}},
 		},
 		"include-workflow": {
 			name: "include-workflow",

--- a/daisy_image_locality_cloudbuild.yaml
+++ b/daisy_image_locality_cloudbuild.yaml
@@ -1,0 +1,37 @@
+timeout: 600s
+steps:
+# Setup workspace
+- name: 'alpine'
+  args: ['mkdir', '-p', './src/github.com/GoogleCloudPlatform/compute-image-tools']
+- name: 'alpine'
+  args: ['mv', './daisy', './src/github.com/GoogleCloudPlatform/compute-image-tools/daisy']
+- name: 'alpine'
+  args: ['mv', './cli_tools', './src/github.com/GoogleCloudPlatform/compute-image-tools/cli_tools']
+- name: 'alpine'
+  args: ['mv', './go', './src/github.com/GoogleCloudPlatform/compute-image-tools/go']
+- name: 'gcr.io/cloud-builders/go'
+  args: ['get', '-d', './src/github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/...']
+  env: ['GOPATH=./']
+- name: 'gcr.io/cloud-builders/go'
+  args: ['get', '-d', './src/github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/...']
+  env: ['GOPATH=./', 'GOOS=windows']
+
+# Build Linux binaries.
+- name: 'gcr.io/cloud-builders/go'
+  args: ['build', '-o=linux/gce_vm_image_import', 'github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import']
+  env: ['CGO_ENABLED=0']
+
+# Copy Linux binaries to GS
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', './linux/*', 'gs://compute-image-tools/image_locality/linux/']
+
+# Build Linux containers.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gce_vm_image_import:image_locality', '--file=Dockerfile.gce_vm_image_import', '.']
+
+# Make binaries world-readable.
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-m', 'acl', '-r', 'ch', '-u', 'AllUsers:R', 'gs://compute-image-tools/image_locality/*']
+
+images:
+  - 'gcr.io/$PROJECT_ID/gce_vm_image_import:image_locality'

--- a/mocks/mock_compute_client.go
+++ b/mocks/mock_compute_client.go
@@ -21,6 +21,7 @@ package mocks
 import (
 	compute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	gomock "github.com/golang/mock/gomock"
+	v0_alpha "google.golang.org/api/compute/v0.alpha"
 	v0_beta "google.golang.org/api/compute/v0.beta"
 	v1 "google.golang.org/api/compute/v1"
 	googleapi "google.golang.org/api/googleapi"
@@ -121,7 +122,7 @@ func (mr *MockClientMockRecorder) CreateForwardingRule(arg0, arg1, arg2 interfac
 }
 
 // CreateImage mocks base method
-func (m *MockClient) CreateImage(arg0 string, arg1 *v1.Image) error {
+func (m *MockClient) CreateImage(arg0 string, arg1 *v0_alpha.Image) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -391,10 +392,10 @@ func (mr *MockClientMockRecorder) GetGuestAttributes(arg0, arg1, arg2, arg3, arg
 }
 
 // GetImage mocks base method
-func (m *MockClient) GetImage(arg0, arg1 string) (*v1.Image, error) {
+func (m *MockClient) GetImage(arg0, arg1 string) (*v0_alpha.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImage", arg0, arg1)
-	ret0, _ := ret[0].(*v1.Image)
+	ret0, _ := ret[0].(*v0_alpha.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -406,10 +407,10 @@ func (mr *MockClientMockRecorder) GetImage(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // GetImageFromFamily mocks base method
-func (m *MockClient) GetImageFromFamily(arg0, arg1 string) (*v1.Image, error) {
+func (m *MockClient) GetImageFromFamily(arg0, arg1 string) (*v0_alpha.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageFromFamily", arg0, arg1)
-	ret0, _ := ret[0].(*v1.Image)
+	ret0, _ := ret[0].(*v0_alpha.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -646,14 +647,14 @@ func (mr *MockClientMockRecorder) ListForwardingRules(arg0, arg1 interface{}, ar
 }
 
 // ListImages mocks base method
-func (m *MockClient) ListImages(arg0 string, arg1 ...compute.ListCallOption) ([]*v1.Image, error) {
+func (m *MockClient) ListImages(arg0 string, arg1 ...compute.ListCallOption) ([]*v0_alpha.Image, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ListImages", varargs...)
-	ret0, _ := ret[0].([]*v1.Image)
+	ret0, _ := ret[0].([]*v0_alpha.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
This change adds support for image locality property by utilizing compute alpha API.

This change is not expected to be merged into master in full once compute prod API is updated to have image locality property (only resource_labeler and gce_vm_image_import/main will need to be updated for prod).