### PR TITLE
osconfig agent: update how agent state is saved

### DIFF
--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -49,7 +48,8 @@ const (
 	osPatchEnabledDefault     = false
 	debugEnabledDefault       = false
 
-	osPatchStateFile = "osconfig_patch.state"
+	osPatchStateFileWindows = `C:\Program Files\Google\OSConfig\osconfig_patch.state`
+	osPatchStateFileLinux   = "/etc/osconfig/osconfig_patch.state"
 
 	osConfigPollIntervalDefault = 10
 )
@@ -372,8 +372,8 @@ func SetVersion(v string) {
 // PatchStateFile is the location of the patch state file.
 func PatchStateFile() string {
 	if runtime.GOOS == "windows" {
-		return filepath.Join(`C:\Program Files\Google\OSConfig`, osPatchStateFile)
+		return osPatchStateFileWindows
 	}
 
-	return filepath.Join(`/etc/osconfig`, osPatchStateFile)
+	return osPatchStateFileLinux
 }

--- a/cli_tools/google-osconfig-agent/config/config.go
+++ b/cli_tools/google-osconfig-agent/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -47,6 +48,8 @@ const (
 	osPackageEnabledDefault   = false
 	osPatchEnabledDefault     = false
 	debugEnabledDefault       = false
+
+	osPatchStateFile = "osconfig_patch.state"
 
 	osConfigPollIntervalDefault = 10
 )
@@ -364,4 +367,13 @@ func Version() string {
 // SetVersion sets the agent version.
 func SetVersion(v string) {
 	version = v
+}
+
+// PatchStateFile is the location of the patch state file.
+func PatchStateFile() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(`C:\Program Files\Google\OSConfig`, osPatchStateFile)
+	}
+
+	return filepath.Join(`/etc/osconfig`, osPatchStateFile)
 }

--- a/cli_tools/google-osconfig-agent/ospatch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_run.go
@@ -16,6 +16,7 @@ package ospatch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -40,7 +41,7 @@ const (
 	acked          = "acked"
 	prePatchReboot = "prePatchReboot"
 	patching       = "patching"
-	completed      = "completed"
+	complete       = "completed"
 )
 
 var (
@@ -83,25 +84,19 @@ func Configure(ctx context.Context) {
 // Run runs patching as a single blocking agent, use cancel to cancel.
 func Run(ctx context.Context, cancel <-chan struct{}) {
 	logger.Debugf("Running OSPatch background task.")
-	savedPatchJobName := checkSavedState(ctx)
-	watcher(ctx, savedPatchJobName, cancel, ackPatch)
-	logger.Debugf("OSPatch background task stopping.")
-}
 
-// Load current patch state off disk, schedule the patch if it isn't complete,
-// and return its name.
-func checkSavedState(ctx context.Context) string {
-	savedPatchJobName := ""
-	pr, err := loadState(state)
-	if err != nil {
+	if err := loadState(config.PatchStateFile()); err != nil {
 		logger.Errorf("loadState error: %v", err)
-	} else if pr != nil && !pr.Complete {
-		savedPatchJobName = pr.Job.PatchJob
-		logger.Infof("Loaded State, running patch: '%s'...", savedPatchJobName)
-		pr.ctx = ctx
+	}
+
+	liveState.RLock()
+	for _, pr := range liveState.PatchRuns {
 		tasker.Enqueue("Run patch", pr.runPatch)
 	}
-	return savedPatchJobName
+	liveState.RUnlock()
+
+	watcher(ctx, cancel, ackPatch)
+	logger.Debugf("OSPatch background task stopping.")
 }
 
 type patchRun struct {
@@ -142,60 +137,70 @@ func (r *patchRun) close() {
 	}
 }
 
-func (r *patchRun) saveState() (shouldStop bool) {
-	if err := saveState(state, r); err != nil {
-		logger.Errorf("saveState error: %v", err)
-		return true
+func (r *patchRun) setStep(step patchStep) error {
+	r.PatchStep = step
+	if err := saveState(); err != nil {
+		return fmt.Errorf("error saving state: %v", err)
 	}
-	return false
+	return nil
 }
 
-func (r *patchRun) finishAndReportError(msg string) {
-	r.Complete = true
-	r.EndedAt = time.Now()
+func (r *patchRun) handleErrorState(msg string, err error) {
+	if err == errServerCancel {
+		r.reportCanceledState()
+	} else {
+		r.reportFailedState(msg)
+	}
+}
+
+func (r *patchRun) reportFailedState(msg string) {
 	logger.Errorf(msg)
 	if err := r.reportPatchDetails(osconfigpb.Instance_FAILED, 0, msg); err != nil {
-		logger.Errorf("Failed to report patch failure. Error: %v", err)
-		return
+		logger.Errorf("Failed to report patch failure: %v", err)
 	}
-	r.saveState()
 }
 
-func (r *patchRun) finishJobComplete() {
-	r.Complete = true
-	r.EndedAt = time.Now()
-	logger.Infof("PatchJob %s is complete. Canceling patch execution.", r.Job.PatchJob)
-	r.saveState()
+func (r *patchRun) reportCanceledState() {
+	logger.Infof("Canceling patch execution for PatchJob %q: %s", r.Job.PatchJob, errServerCancel)
+	if err := r.reportPatchDetails(osconfigpb.Instance_FAILED, 0, errServerCancel.Error()); err != nil {
+		logger.Errorf("Failed to report patch cancelation: %v", err)
+	}
 }
 
-func (r *patchRun) reportState(patchState osconfigpb.Instance_PatchState) (shouldStop bool) {
+var errServerCancel = errors.New("service marked PatchJob as completed")
+
+func (r *patchRun) reportContinuingState(patchState osconfigpb.Instance_PatchState) error {
 	if err := r.reportPatchDetails(patchState, 0, ""); err != nil {
-		// If we fail to report state, we can't report that we failed.
-		logger.Errorf("Failed to report state %s. Error: %v", patchState, err)
-		return true
+		return fmt.Errorf("error reporting state %s: %v", patchState, err)
 	}
 	if r.Job.PatchJobState == osconfigpb.ReportPatchJobInstanceDetailsResponse_COMPLETED {
-		r.finishJobComplete()
-		return true
+		return errServerCancel
 	}
-	r.saveState()
-	return false
+	return saveState()
 }
 
-// TODO: Replace the shouldStop returns with something easier to follow.
+func (r *patchRun) complete() {
+	liveState.removePatchRun(r)
+	liveState.jobComplete(r.Job.PatchJob)
+	if err := saveState(); err != nil {
+		logger.Errorf("Error saving state: %v", err)
+	}
+	r.close()
+}
+
 // TODO: Add MaxRebootCount so we don't loop endlessly.
 
-func (r *patchRun) prePatchReboot() (shouldStop bool) {
+func (r *patchRun) prePatchReboot() error {
 	return r.rebootIfNeeded(true)
 }
 
-func (r *patchRun) postPatchReboot() (shouldStop bool) {
+func (r *patchRun) postPatchReboot() error {
 	return r.rebootIfNeeded(false)
 }
 
-func (r *patchRun) rebootIfNeeded(prePatch bool) (shouldStop bool) {
+func (r *patchRun) rebootIfNeeded(prePatch bool) error {
 	if r.Job.PatchConfig.RebootConfig == osconfigpb.PatchConfig_NEVER {
-		return false
+		return nil
 	}
 
 	var reboot bool
@@ -206,8 +211,7 @@ func (r *patchRun) rebootIfNeeded(prePatch bool) (shouldStop bool) {
 	} else {
 		reboot, err = systemRebootRequired()
 		if err != nil {
-			r.finishAndReportError(fmt.Sprintf("Error checking if a system reboot is required: %v", err))
-			return true
+			return fmt.Errorf("error checking if a system reboot is required: %v", err)
 		}
 		if reboot {
 			logger.Infof("System indicates a reboot is required.")
@@ -217,22 +221,21 @@ func (r *patchRun) rebootIfNeeded(prePatch bool) (shouldStop bool) {
 	}
 
 	if !reboot {
-		return false
+		return nil
 	}
 
-	if r.reportState(osconfigpb.Instance_REBOOTING) {
-		return true
+	if err := r.reportContinuingState(osconfigpb.Instance_REBOOTING); err != nil {
+		return err
 	}
 
 	if r.Job.DryRun {
 		logger.Infof("Dry run - not rebooting for patch job '%s'", r.Job.PatchJob)
-		return false
+		return nil
 	}
 
 	r.RebootCount++
 	if err := rebootSystem(); err != nil {
-		r.finishAndReportError(fmt.Sprintf("Failed to reboot system: %v", err))
-		return true
+		return fmt.Errorf("failed to reboot system: %v", err)
 	}
 
 	// Reboot can take a bit, pause here so other activities don't start.
@@ -240,24 +243,6 @@ func (r *patchRun) rebootIfNeeded(prePatch bool) (shouldStop bool) {
 		logger.Debugf("Waiting for system reboot.")
 		time.Sleep(1 * time.Minute)
 	}
-}
-
-func (r *patchRun) reportSucceeded() {
-	isFinalRebootRequired, err := systemRebootRequired()
-	if err != nil {
-		r.finishAndReportError(fmt.Sprintf("Unable to check if reboot is required: %v", err))
-		return
-	}
-
-	r.Complete = true
-	r.EndedAt = time.Now()
-
-	finalState := osconfigpb.Instance_SUCCEEDED
-	if isFinalRebootRequired {
-		finalState = osconfigpb.Instance_SUCCEEDED_REBOOT_REQUIRED
-	}
-
-	r.reportState(finalState)
 }
 
 func (r *patchRun) createClient() error {
@@ -284,64 +269,80 @@ func (r *patchRun) runPatch() {
 	if err := r.createClient(); err != nil {
 		logger.Errorf("Error creating osconfig client: %v", err)
 	}
-	defer r.close()
+	defer r.complete()
 
 	for {
 		switch r.PatchStep {
 		default:
-			r.finishAndReportError(fmt.Sprintf("Unknown step: %q", r.PatchStep))
+			r.reportFailedState(fmt.Sprintf("unknown step: %q", r.PatchStep))
 			return
 		case acked:
 			logger.Debugf("Starting patchJob %s", r.Job)
 			r.StartedAt = time.Now()
-			r.PatchStep = prePatchReboot
+			if err := r.setStep(prePatchReboot); err != nil {
+				r.reportFailedState(fmt.Sprintf("Error saving agent step: %v", err))
+			}
 
-			if r.reportState(osconfigpb.Instance_STARTED) {
+			if err := r.reportContinuingState(osconfigpb.Instance_STARTED); err != nil {
+				r.handleErrorState(err.Error(), err)
 				return
 			}
 		case prePatchReboot:
-			if r.prePatchReboot() {
+			// We do this now to avoid a reboot loop prior to patching.
+			if err := r.setStep(patching); err != nil {
+				r.reportFailedState(fmt.Sprintf("Error saving agent step: %v", err))
+			}
+			if err := r.prePatchReboot(); err != nil {
+				r.handleErrorState(fmt.Sprintf("Error runnning prePatchReboot: %v", err), err)
 				return
 			}
-			r.PatchStep = patching
 		case patching:
 			if r.Job.DryRun {
-				if r.reportState(osconfigpb.Instance_APPLYING_PATCHES) {
+				if err := r.reportContinuingState(osconfigpb.Instance_APPLYING_PATCHES); err != nil {
+					r.handleErrorState(err.Error(), err)
 					return
 				}
 				logger.Infof("Dry run - No updates applied for patch job '%s'", r.Job.PatchJob)
 			} else {
 				if err := runUpdates(r); err != nil {
-					r.finishAndReportError(fmt.Sprintf("Failed to apply patches: %v", err))
+					r.handleErrorState(fmt.Sprintf("Failed to apply patches: %v", err), err)
 					return
 				}
 			}
-			if r.postPatchReboot() {
+			if err := r.postPatchReboot(); err != nil {
+				r.handleErrorState(fmt.Sprintf("Error runnning postPatchReboot: %v", err), err)
 				return
 			}
-			// We have not rebooted so no need to rerun updates.
-			r.PatchStep = completed
-		case completed:
-			r.reportSucceeded()
-			logger.Debugf("Completed patchJob %s", r.Job)
+			// We have not rebooted so patching is complete.
+			if err := r.setStep(complete); err != nil {
+				r.reportFailedState(fmt.Sprintf("Error saving agent step: %v", err))
+			}
+		case complete:
+			isFinalRebootRequired, err := systemRebootRequired()
+			if err != nil {
+				r.reportFailedState(fmt.Sprintf("Unable to check if reboot is required: %v", err))
+				return
+			}
+
+			finalState := osconfigpb.Instance_SUCCEEDED
+			if isFinalRebootRequired {
+				finalState = osconfigpb.Instance_SUCCEEDED_REBOOT_REQUIRED
+			}
+
+			if err := r.reportPatchDetails(finalState, 0, ""); err != nil {
+				logger.Errorf("Failed to report state %s. Error: %v", finalState, err)
+			}
+			logger.Debugf("Successfully completed patchJob %s", r.Job)
 			return
 		}
 	}
 }
 
 func ackPatch(ctx context.Context, patchJobName string) {
-	// TODO: Don't load the state off disk. This should be cached in memory with its access
-	// blocked by a mutex.
-	currentPatchJob, err := loadState(state)
-	if err != nil {
-		logger.Errorf("Unable to load state to ack notification. Error: %v", err)
-		return
-	}
-
-	// Ack if we haven't yet. If we've already been notified about this Job,
+	// Notify the server if we haven't yet. If we've already been notified about this Job,
 	// the server may have inadvertantly notified us twice (at least once deliver) so we
 	// can ignore it.
-	if currentPatchJob == nil || currentPatchJob.Job.PatchJob != patchJobName {
+	if !liveState.alreadyAckedJob(patchJobName) {
 		j := &patchJob{&osconfigpb.ReportPatchJobInstanceDetailsResponse{PatchJob: patchJobName}}
 		pr := &patchRun{ctx: ctx, Job: j}
 		if err := pr.createClient(); err != nil {
@@ -349,10 +350,10 @@ func ackPatch(ctx context.Context, patchJobName string) {
 		}
 		if err := pr.reportPatchDetails(osconfigpb.Instance_ACKED, 0, ""); err != nil {
 			logger.Errorf("reportPatchDetails Error: %v", err)
-			pr.close()
+			pr.complete()
 			return
 		}
-		pr.PatchStep = acked
+		pr.setStep(acked)
 		tasker.Enqueue("Run patch", pr.runPatch)
 	}
 }

--- a/cli_tools/google-osconfig-agent/ospatch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_run.go
@@ -41,7 +41,7 @@ const (
 	acked          = "acked"
 	prePatchReboot = "prePatchReboot"
 	patching       = "patching"
-	complete       = "completed"
+	complete       = "complete"
 )
 
 var (

--- a/cli_tools/google-osconfig-agent/ospatch/patch_run.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_run.go
@@ -318,14 +318,14 @@ func (r *patchRun) runPatch() {
 				r.reportFailedState(fmt.Sprintf("Error saving agent step: %v", err))
 			}
 		case complete:
-			isFinalRebootRequired, err := systemRebootRequired()
+			isRebootRequired, err := systemRebootRequired()
 			if err != nil {
-				r.reportFailedState(fmt.Sprintf("Unable to check if reboot is required: %v", err))
+				r.reportFailedState(fmt.Sprintf("Error checking if system reboot is required: %v", err))
 				return
 			}
 
 			finalState := osconfigpb.Instance_SUCCEEDED
-			if isFinalRebootRequired {
+			if isRebootRequired {
 				finalState = osconfigpb.Instance_SUCCEEDED_REBOOT_REQUIRED
 			}
 

--- a/cli_tools/google-osconfig-agent/ospatch/patch_state.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_state.go
@@ -26,6 +26,8 @@ import (
 
 var liveState state
 
+const pastJobsNum = 10
+
 type state struct {
 	PatchRuns []*patchRun
 	PastJobs  []string
@@ -38,7 +40,7 @@ func (s *state) jobComplete(job string) {
 	defer s.Unlock()
 	s.PastJobs = append(s.PastJobs, job)
 	for {
-		if len(s.PastJobs) <= 10 {
+		if len(s.PastJobs) <= pastJobsNum {
 			return
 		}
 		s.PastJobs = s.PastJobs[1:]

--- a/cli_tools/google-osconfig-agent/ospatch/patch_state.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_state.go
@@ -39,11 +39,8 @@ func (s *state) jobComplete(job string) {
 	s.Lock()
 	defer s.Unlock()
 	s.PastJobs = append(s.PastJobs, job)
-	for {
-		if len(s.PastJobs) <= pastJobsNum {
-			return
-		}
-		s.PastJobs = s.PastJobs[1:]
+	if len(s.PastJobs) > pastJobsNum {
+		s.PastJobs = s.PastJobs[len(s.PastJobs)-pastJobsNum : len(s.PastJobs)]
 	}
 }
 

--- a/cli_tools/google-osconfig-agent/ospatch/patch_state.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_state.go
@@ -18,34 +18,123 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/google-osconfig-agent/config"
 )
 
-const state = "osconfig_patch.state"
+var liveState state
 
-func loadState(state string) (*patchRun, error) {
-	d, err := ioutil.ReadFile(state)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
+type state struct {
+	PatchRuns []*patchRun
+	PastJobs  []string
 
-	var pw patchRun
-	return &pw, json.Unmarshal(d, &pw)
+	sync.RWMutex `json:"-"`
 }
 
-func saveState(state string, w *patchRun) error {
-	if w == nil {
-		return ioutil.WriteFile(state, []byte("{}"), 0600)
+func (s *state) jobComplete(job string) {
+	s.Lock()
+	defer s.Unlock()
+	s.PastJobs = append(s.PastJobs, job)
+	for {
+		if len(s.PastJobs) <= 10 {
+			return
+		}
+		s.PastJobs = s.PastJobs[1:]
+	}
+}
+
+func (s *state) addPatchRun(pr *patchRun) {
+	s.Lock()
+	defer s.Unlock()
+	(*s).PatchRuns = append((*s).PatchRuns, pr)
+}
+
+func (s *state) removePatchRun(pr *patchRun) {
+	s.Lock()
+	defer s.Unlock()
+
+	for i, r := range s.PatchRuns {
+		if r.Job.PatchJob == pr.Job.PatchJob {
+			copy(s.PatchRuns[i:], s.PatchRuns[i+1:])
+			s.PatchRuns[len(s.PatchRuns)-1] = nil
+			s.PatchRuns = s.PatchRuns[:len(s.PatchRuns)-1]
+			return
+		}
+	}
+}
+
+func (s *state) alreadyAckedJob(job string) bool {
+	s.RLock()
+	defer s.RUnlock()
+	for _, r := range s.PatchRuns {
+		if r.Job.PatchJob == job {
+			return true
+		}
+	}
+	for _, j := range s.PastJobs {
+		if j == job {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *state) save(path string) error {
+	s.RLock()
+	defer s.RUnlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
 	}
 
-	d, err := json.Marshal(w)
+	if s == nil {
+		return writeFile(path, []byte("{}"))
+	}
+
+	d, err := json.Marshal(s)
 	if err != nil {
 		return err
 	}
 
-	// TODO: Once we are storing more state consider atomic state save
-	// operations.
-	return ioutil.WriteFile(state, d, 0600)
+	return writeFile(path, d)
+}
+
+func saveState() error {
+	return liveState.save(config.PatchStateFile())
+}
+
+func loadState(path string) error {
+	liveState.Lock()
+	defer liveState.Unlock()
+
+	d, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(d, &liveState)
+}
+
+func writeFile(path string, data []byte) error {
+	// Write state to a temporary file first.
+	tmp, err := ioutil.TempFile(filepath.Dir(path), "")
+	if err != nil {
+		return err
+	}
+	newStateFile := tmp.Name()
+
+	if _, err = tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	// Move the new temp file to the live path.
+	return os.Rename(newStateFile, path)
 }

--- a/cli_tools/google-osconfig-agent/ospatch/patch_state_test.go
+++ b/cli_tools/google-osconfig-agent/ospatch/patch_state_test.go
@@ -268,8 +268,13 @@ func TestJobComplete(t *testing.T) {
 	}{
 		{
 			"add 1 job",
-			&state{PastJobs: []string{"job1"}},
-			[]string{"job1", newjob},
+			&state{PastJobs: []string{"job1", "job2", "job3", "job4", "job5", "job6", "job7", "job8", "job9"}},
+			[]string{"job1", "job2", "job3", "job4", "job5", "job6", "job7", "job8", "job9", newjob},
+		},
+		{
+			"add 1 job, remove first job",
+			&state{PastJobs: []string{"job1", "job2", "job3", "job4", "job5", "job6", "job7", "job8", "job9", "job10"}},
+			[]string{"job2", "job3", "job4", "job5", "job6", "job7", "job8", "job9", "job10", newjob},
 		},
 		{
 			"add 1 job, remove 2 first jobs",

--- a/cli_tools/google-osconfig-agent/ospatch/updates_linux.go
+++ b/cli_tools/google-osconfig-agent/ospatch/updates_linux.go
@@ -87,8 +87,8 @@ func systemRebootRequired() (bool, error) {
 }
 
 func runUpdates(r *patchRun) error {
-	if r.reportState(osconfigpb.Instance_APPLYING_PATCHES) {
-		return nil
+	if err := r.reportContinuingState(osconfigpb.Instance_APPLYING_PATCHES); err != nil {
+		return err
 	}
 	return packages.UpdatePackages()
 }

--- a/cli_tools/google-osconfig-agent/ospatch/updates_windows.go
+++ b/cli_tools/google-osconfig-agent/ospatch/updates_windows.go
@@ -131,7 +131,7 @@ func installUpdate(r *patchRun, classFilter, excludes map[string]struct{}, sessi
 		return fmt.Errorf(`updateColl.CallMethod("Add", updt): %v`, err)
 	}
 
-	if err := r.recordContinuingState(osconfigpb.Instance_DOWNLOADING_PATCHES); err != nil {
+	if err := r.reportContinuingState(osconfigpb.Instance_DOWNLOADING_PATCHES); err != nil {
 		return err
 	}
 
@@ -139,7 +139,7 @@ func installUpdate(r *patchRun, classFilter, excludes map[string]struct{}, sessi
 		return fmt.Errorf("DownloadWUAUpdateCollection error: %v", err)
 	}
 
-	if err := r.recordContinuingState(osconfigpb.Instance_APPLYING_PATCHES); err != nil {
+	if err := r.reportContinuingState(osconfigpb.Instance_APPLYING_PATCHES); err != nil {
 		return err
 	}
 
@@ -236,7 +236,7 @@ func runUpdates(r *patchRun) error {
 	}
 
 	if packages.GooGetExists {
-		if err := r.recordContinuingState(osconfigpb.Instance_APPLYING_PATCHES); err != nil {
+		if err := r.reportContinuingState(osconfigpb.Instance_APPLYING_PATCHES); err != nil {
 			return err
 		}
 

--- a/cli_tools/google-osconfig-agent/ospatch/watcher.go
+++ b/cli_tools/google-osconfig-agent/ospatch/watcher.go
@@ -100,8 +100,7 @@ func formatError(err error) string {
 	return err.Error()
 }
 
-func watcher(ctx context.Context, savedPatchJobName string, cancel <-chan struct{}, action func(context.Context, string)) {
-	currentPatchJobName = savedPatchJobName
+func watcher(ctx context.Context, cancel <-chan struct{}, action func(context.Context, string)) {
 	webError := 0
 	// We use a pointer so that each loops goroutine can update this.
 	// If this was a global var we would have a data race, and puting
@@ -132,15 +131,7 @@ func watcher(ctx context.Context, savedPatchJobName string, cancel <-chan struct
 			if patchJobName == "" {
 				continue
 			}
-			if currentPatchJobName == patchJobName {
-				logger.Debugf("Already ran patch '%s'. Ignoring notification.", patchJobName)
-				continue
-			}
-
-			currentPatchJobName = patchJobName
-			if patchJobName != "" {
-				action(ctx, patchJobName)
-			}
+			action(ctx, patchJobName)
 
 			webError = 0
 		}

--- a/cli_tools/google-osconfig-agent/ospatch/watcher_test.go
+++ b/cli_tools/google-osconfig-agent/ospatch/watcher_test.go
@@ -45,12 +45,6 @@ func TestWatcher(t *testing.T) {
 			false,
 		},
 		{
-			"same patch run name",
-			"?name=foo",
-			"foo",
-			false,
-		},
-		{
 			"canceled case",
 			"?name=cancel",
 			"",
@@ -81,7 +75,7 @@ func TestWatcher(t *testing.T) {
 
 		metadataURL = ts.URL + tt.url
 		ran = false
-		watcher(ctx, tt.name, c, action)
+		watcher(ctx, c, action)
 		if ran != tt.wantRun {
 			t.Errorf("%s: wantRun=%t, got=%t", tt.desc, tt.wantRun, ran)
 		}


### PR DESCRIPTION
A global patch state is now kept in memory and saved to disk after each edit
All current patch runs are recorded in the order that they were received, after agent restart they will be enqueued in the same order
The last 10 completed PatchJob names are also recorded
A patch job will not be acked if it exists in the either the current list of PatchRuns or past list of completed jobs