### PR TITLE
osconfig agent: rename inventory timestamp, fix string logging

### DIFF
--- a/cli_tools/google-osconfig-agent/inventory/inventory.go
+++ b/cli_tools/google-osconfig-agent/inventory/inventory.go
@@ -51,7 +51,7 @@ type InstanceInventory struct {
 func write(state *InstanceInventory, url string) {
 	logger.Infof("Writing instance inventory.")
 
-	if err := attributes.PostAttribute(url+"/Timestamp", strings.NewReader(time.Now().UTC().Format(time.RFC3339))); err != nil {
+	if err := attributes.PostAttribute(url+"/LastUpdated", strings.NewReader(time.Now().UTC().Format(time.RFC3339))); err != nil {
 		logger.Errorf("postAttribute error: %v", err)
 	}
 


### PR DESCRIPTION
Inventory Timestamp entry changed to LastUpdated
Rejiggered string log lines
Logs will now be written to all outputs ignoring errors