### PR TITLE
Basic PatchJob e2e tests

### DIFF
--- a/osconfig_tests/config/config.go
+++ b/osconfig_tests/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"time"
 )
@@ -22,7 +23,7 @@ import (
 var (
 	// TODO: allow this to be configurable through flag to test against staging
 	prodEndpoint           = "osconfig.googleapis.com:443"
-	oauthDefault           = ""
+	oauthDefault           = flag.String("local_oauth", "", "path to service creds file")
 	bucketDefault          = "osconfig-agent-end2end-tests"
 	logPushIntervalDefault = 3 * time.Second
 	logsPath               = fmt.Sprintf("logs-%s", time.Now().Format("2006-01-02-15:04:05"))
@@ -35,7 +36,7 @@ func SvcEndpoint() string {
 
 // OauthPath returns the oauthPath file path
 func OauthPath() string {
-	return oauthDefault
+	return *oauthDefault
 }
 
 // LogBucket returns the oauthPath file path

--- a/osconfig_tests/gcp_clients/gcp_clients.go
+++ b/osconfig_tests/gcp_clients/gcp_clients.go
@@ -21,7 +21,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/config"
-	"github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
+	osconfig "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/cloud.google.com/go/osconfig/apiv1alpha1"
 	"github.com/GoogleCloudPlatform/osconfig/logger"
 	"google.golang.org/api/option"
 )

--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -28,12 +28,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/gcp_clients"
-
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/junitxml"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/inventory"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/package_management"
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/patch"
+
+	gcpclients "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/gcp_clients"
+	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
+	packagemanagement "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_suites/package_management"
 )
 
 var (
@@ -47,6 +48,7 @@ var (
 var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp, *testconfig.Project){
 	packagemanagement.TestSuite,
 	inventory.TestSuite,
+	patch.TestSuite,
 }
 
 func main() {


### PR DESCRIPTION
- Runs a PatchJob on all supported distros (even though some of those fail today).
- Includes a little bit of cleanup.
- Does not verify that agent did anything but report success. That will be done in subsequent PRs.
