### PR TITLE
OVF import e2e tests

### DIFF
--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -16,49 +16,19 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"os"
-	"path"
-	"path/filepath"
-	"strconv"
-	"strings"
-
-	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/parse"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/validation"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/daisy_utils"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/domain"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/gce_utils"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_utils"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
-	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
-	"github.com/vmware/govmomi/ovf"
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
-)
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_importer"
 
-const (
-	ovfWorkflowDir      = "daisy_workflows/ovf_import/"
-	ovfImportWorkflow   = ovfWorkflowDir + "import_ovf.wf.json"
-	instanceNameFlagKey = "instance-names"
-	clientIDFlagKey     = "client-id"
-	ovfGcsPathFlagKey   = "ovf-gcs-path"
+	"flag"
+	"log"
+	"os"
 )
 
 var (
-	instanceNames               = flag.String(instanceNameFlagKey, "", "VM Instance names to be created, separated by commas.")
-	clientID                    = flag.String(clientIDFlagKey, "", "Identifies the client of the importer, e.g. `gcloud` or `pantheon`")
-	ovfOvaGcsPath               = flag.String(ovfGcsPathFlagKey, "", " Google Cloud Storage URI of the OVF or OVA file to import. For example: gs://my-bucket/my-vm.ovf.")
+	instanceNames               = flag.String(ovfimportparams.InstanceNameFlagKey, "", "VM Instance names to be created, separated by commas.")
+	clientID                    = flag.String(ovfimportparams.ClientIDFlagKey, "", "Identifies the client of the importer, e.g. `gcloud` or `pantheon`")
+	ovfOvaGcsPath               = flag.String(ovfimportparams.OvfGcsPathFlagKey, "", " Google Cloud Storage URI of the OVF or OVA file to import. For example: gs://my-bucket/my-vm.ovf.")
 	noGuestEnvironment          = flag.Bool("no-guest-environment", false, "Google Guest Environment will not be installed on the image.")
 	canIPForward                = flag.Bool("can-ip-forward", false, "If provided, allows the instances to send and receive packets with non-matching destination or source IP addresses.")
 	deletionProtection          = flag.Bool("deletion-protection", false, "Enables deletion protection for the instance.")
@@ -66,7 +36,6 @@ var (
 	labels                      = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
 	machineType                 = flag.String("machine-type", "", "Specifies the machine type used for the instances. To get a list of available machine types, run 'gcloud compute machine-types list'. If unspecified, the default type is n1-standard-1.")
 	network                     = flag.String("network", "", "Name of the network in your project to use for the image import. The network must have access to Google Cloud Storage. If not specified, the network named default is used. If -subnet is also specified subnet must be a subnetwork of network specified by -network.")
-	networkInterface            = flag.String("network-interface", "", "Adds a network interface to the instance. Mutually exclusive with any of these flags: --network, --network-tier, --subnet, --private-network-ip. ")
 	networkTier                 = flag.String("network-tier", "", "Specifies the network tier that will be used to configure the instance. NETWORK_TIER must be one of: PREMIUM, STANDARD. The default value is PREMIUM.")
 	subnet                      = flag.String("subnet", "", "Name of the subnetwork in your project to use for the image import. If	the network resource is in legacy mode, do not provide this property. If the network is in auto subnet mode, providing the subnetwork is optional. If the network is in custom subnet mode, then this field should be specified. Zone should be specified if this field is specified.")
 	privateNetworkIP            = flag.String("private-network-ip", "", "Specifies the RFC1918 IP to assign to the instance. The IP should be in the subnet or legacy network IP range.")
@@ -83,7 +52,7 @@ var (
 	bootDiskKmsLocation         = flag.String("boot-disk-kms-location", "", "The Cloud location for the key.")
 	bootDiskKmsProject          = flag.String("boot-disk-kms-project", "", "The Cloud project for the key.")
 	timeout                     = flag.String("timeout", "", "Maximum time a build can last before it is failed as TIMEOUT. For example, specifying 2h will fail the process after 2 hours. See `gcloud topic datetimes` for information on duration formats")
-	projectFlag                 = flag.String("project", "", "project to run in, overrides what is set in workflow")
+	project                     = flag.String("project", "", "project to run in, overrides what is set in workflow")
 	scratchBucketGcsPath        = flag.String("scratch-bucket-gcs-path", "", "GCS scratch bucket to use, overrides what is set in workflow")
 	oauth                       = flag.String("oauth", "", "path to oauth json file, overrides what is set in workflow")
 	ce                          = flag.String("compute-endpoint-override", "", "API endpoint to override default")
@@ -91,9 +60,7 @@ var (
 	cloudLogsDisabled           = flag.Bool("disable-cloud-logging", false, "do not stream logs to Cloud Logging")
 	stdoutLogsDisabled          = flag.Bool("disable-stdout-logging", false, "do not display individual workflow logs on stdout")
 
-	userLabels             map[string]string
 	nodeAffinityLabelsFlag flags.StringArrayFlag
-	nodeAffinities         []*compute.SchedulingNodeAffinity
 	currentExecutablePath  string
 )
 
@@ -102,444 +69,39 @@ func init() {
 	flag.Var(&nodeAffinityLabelsFlag, "node-affinity-label", "Node affinity label used to determine sole tenant node to schedule this instance on. Label is of the format: <key>,<operator>,<value>,<value2>... where <operator> can be one of: IN, NOT. For example: workload,IN,prod,test is a label with key 'workload' and values 'prod' and 'test'. This flag can be specified multiple times for multiple labels.")
 }
 
-func validateAndParseFlags() error {
+func buildImportParams() *ovfimportparams.OVFImportParams {
 	flag.Parse()
-
-	if err := validationutils.ValidateStringFlagNotEmpty(*instanceNames, instanceNameFlagKey); err != nil {
-		return err
-	}
-
-	instanceNameSplits := strings.Split(*instanceNames, ",")
-	if len(instanceNameSplits) > 1 {
-		return fmt.Errorf("OVF import doesn't support multi instance import at this time")
-	}
-
-	if err := validationutils.ValidateStringFlagNotEmpty(*ovfOvaGcsPath, ovfGcsPathFlagKey); err != nil {
-		return err
-	}
-
-	if err := validationutils.ValidateStringFlagNotEmpty(*clientID, clientIDFlagKey); err != nil {
-		return err
-	}
-
-	if _, _, err := storageutils.SplitGCSPath(*ovfOvaGcsPath); err != nil {
-		return fmt.Errorf("%v should be a path to OVF or OVA package in GCS", ovfGcsPathFlagKey)
-	}
-
-	if *labels != "" {
-		var err error
-		userLabels, err = parseutils.ParseKeyValues(*labels)
-		if err != nil {
-			return err
-		}
-	}
-
-	if *networkInterface != "" &&
-		(*privateNetworkIP != "" || *network != "" || *subnet != "" || *networkTier != "") {
-		return fmt.Errorf("-network-interface is mutually exclusive with any of these flags: --network, --network-tier, --subnet, --private-network-ip")
-	}
-
-	if nodeAffinityLabelsFlag != nil {
-		var err error
-		nodeAffinities, err = computeutils.ParseNodeAffinityLabels(nodeAffinityLabelsFlag)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return &ovfimportparams.OVFImportParams{InstanceNames: *instanceNames, ClientID: *clientID,
+		OvfOvaGcsPath: *ovfOvaGcsPath, NoGuestEnvironment: *noGuestEnvironment,
+		CanIPForward: *canIPForward, DeletionProtection: *deletionProtection, Description: *description,
+		Labels: *labels, MachineType: *machineType, Network: *network, NetworkTier: *networkTier,
+		Subnet: *subnet, PrivateNetworkIP: *privateNetworkIP, NoExternalIP: *noExternalIP,
+		NoRestartOnFailure: *noRestartOnFailure, OsID: *osID,
+		ShieldedIntegrityMonitoring: *shieldedIntegrityMonitoring, ShieldedSecureBoot: *shieldedSecureBoot,
+		ShieldedVtpm: *shieldedVtpm, Tags: *tags,
+		Zone: *zoneFlag, BootDiskKmskey: *bootDiskKmskey, BootDiskKmsKeyring: *bootDiskKmsKeyring,
+		BootDiskKmsLocation: *bootDiskKmsLocation, BootDiskKmsProject: *bootDiskKmsProject,
+		Timeout: *timeout, Project: *project, ScratchBucketGcsPath: *scratchBucketGcsPath,
+		Oauth: *oauth, Ce: *ce, GcsLogsDisabled: *gcsLogsDisabled,
+		CloudLogsDisabled: *cloudLogsDisabled, StdoutLogsDisabled: *stdoutLogsDisabled,
+		NodeAffinityLabelsFlag: nodeAffinityLabelsFlag, CurrentExecutablePath: currentExecutablePath}
 }
 
-func buildDaisyVars(
-	translateWorkflowPath string,
-	bootDiskGcsPath string,
-	machineType string,
-	region string) map[string]string {
-	varMap := map[string]string{}
-
-	varMap["instance_name"] = strings.ToLower(*instanceNames)
-	if translateWorkflowPath != "" {
-		varMap["translate_workflow"] = translateWorkflowPath
-		varMap["install_gce_packages"] = strconv.FormatBool(!*noGuestEnvironment)
-	}
-	if bootDiskGcsPath != "" {
-		varMap["boot_disk_file"] = bootDiskGcsPath
-	}
-	if *network != "" {
-		varMap["network"] = fmt.Sprintf("global/networks/%v", *network)
-	}
-	if *subnet != "" {
-		varMap["subnet"] = fmt.Sprintf("regions/%v/subnetworks/%v", region, *subnet)
-	}
-	if machineType != "" {
-		varMap["machine_type"] = machineType
-	}
-	if *description != "" {
-		varMap["description"] = *description
-	}
-	if *privateNetworkIP != "" {
-		varMap["private_network_ip"] = *privateNetworkIP
-	}
-
-	if *networkTier != "" {
-		varMap["network_tier"] = *networkTier
-	}
-	return varMap
-}
-
-func updateInstance(w *daisy.Workflow) {
-	instance := (*w.Steps["create-instance"].CreateInstances)[0]
-	instance.CanIpForward = *canIPForward
-	instance.DeletionProtection = *deletionProtection
-	if instance.Scheduling == nil {
-		instance.Scheduling = &compute.Scheduling{}
-	}
-	if *noRestartOnFailure {
-		vFalse := false
-		instance.Scheduling.AutomaticRestart = &vFalse
-	}
-	if nodeAffinities != nil {
-		instance.Scheduling.NodeAffinities = nodeAffinities
-	}
-}
-
-func toWorkingDir(dir string) string {
-	wd, err := filepath.Abs(filepath.Dir(currentExecutablePath))
-	if err == nil {
-		return path.Join(wd, dir)
-	}
-	return dir
-}
-
-// creates a new Daisy Compute client
-func createComputeClient(ctx *context.Context) (daisycompute.Client, error) {
-	computeOptions := []option.ClientOption{option.WithCredentialsFile(*oauth)}
-	if *ce != "" {
-		computeOptions = append(computeOptions, option.WithEndpoint(*ce))
-	}
-
-	computeClient, err := daisycompute.NewClient(*ctx, computeOptions...)
-	if err != nil {
-		return nil, err
-	}
-	return computeClient, nil
-}
-
-// OVFImporter is responsible for importing OVF into GCE
-type OVFImporter struct {
-	ctx                   context.Context
-	storageClient         commondomain.StorageClientInterface
-	computeClient         daisycompute.Client
-	tarGcsExtractor       commondomain.TarGcsExtractorInterface
-	mgce                  commondomain.MetadataGCEInterface
-	ovfDescriptorLoader   domain.OvfDescriptorLoaderInterface
-	bucketIteratorCreator commondomain.BucketIteratorCreatorInterface
-	logger                logging.LoggerInterface
-	zoneValidator         commondomain.ZoneValidatorInterface
-	gcsPathToClean        string
-	workflowPath          string
-	buildID               string
-	diskInfos             *[]ovfutils.DiskInfo
-}
-
-// newOVFImporter creates an OVF importer, including automatically poulating dependencies,
-// such as compute/storage clients.
-func newOVFImporter() (*OVFImporter, error) {
-	ctx := context.Background()
-	sc, err := storage.NewClient(ctx)
-	logger := logging.NewLogger("[import-ovf]")
-	if err != nil {
-		return nil, err
-	}
-	storageClient, err := storageutils.NewStorageClient(ctx, sc, logger)
-	if err != nil {
-		return nil, err
-	}
-	computeClient, err := createComputeClient(&ctx)
-	if err != nil {
-		return nil, err
-	}
-	tarGcsExtractor := storageutils.NewTarGcsExtractor(ctx, storageClient, logger)
-	buildID := os.Getenv("BUILD_ID")
-	if buildID == "" {
-		buildID = pathutils.RandString(5)
-	}
-	workingDirOVFImportWorkflow := toWorkingDir(ovfImportWorkflow)
-	bic := &storageutils.BucketIteratorCreator{}
-
-	ovfImporter := &OVFImporter{ctx: ctx, storageClient: storageClient, computeClient: computeClient,
-		tarGcsExtractor: tarGcsExtractor, workflowPath: workingDirOVFImportWorkflow, buildID: buildID,
-		ovfDescriptorLoader: ovfutils.NewOvfDescriptorLoader(storageClient),
-		mgce:                &computeutils.MetadataGCE{}, bucketIteratorCreator: bic, logger: logger,
-		zoneValidator: &computeutils.ZoneValidator{ComputeClient: computeClient}}
-	return ovfImporter, nil
-}
-
-func (oi *OVFImporter) getProject() (string, error) {
-	project := *projectFlag
-	if project == "" {
-		if !oi.mgce.OnGCE() {
-			return "", fmt.Errorf("project cannot be determined because build is not running on GCE")
-		}
-		var err error
-		project, err = oi.mgce.ProjectID()
-		if err != nil || project == "" {
-			return "", fmt.Errorf("project cannot be determined %v", err)
-		}
-	}
-	return project, nil
-}
-
-func (oi *OVFImporter) getZone(project string) (string, error) {
-	if *zoneFlag != "" {
-		if err := oi.zoneValidator.ZoneValid(project, *zoneFlag); err != nil {
-			return "", err
-		}
-		return *zoneFlag, nil
-	}
-
-	if !oi.mgce.OnGCE() {
-		return "", fmt.Errorf("zone cannot be determined because build is not running on GCE")
-	}
-	// determine zone based on the zone Cloud Build is running in
-	zone, err := oi.mgce.Zone()
-	if err != nil || zone == "" {
-		return "", fmt.Errorf("can't infer zone: %v", err)
-	}
-	return zone, nil
-}
-
-func (oi *OVFImporter) getRegion(zone string) (string, error) {
-	zoneSplits := strings.Split(zone, "-")
-	if len(zoneSplits) < 2 {
-		return "", fmt.Errorf("%v is not a valid zone", zone)
-	}
-	return strings.Join(zoneSplits[:len(zoneSplits)-1], "-"), nil
-}
-
-// Returns OVF GCS bucket and object path (director). If ovaOvaGcsPath is pointing to an OVA file,
-// it extracts it to a temporary GCS folder and returns it's path.
-func (oi *OVFImporter) getOvfGcsPath(tmpGcsPath string) (string, bool, error) {
-	ovfOvaGcsPathLowered := strings.ToLower(*ovfOvaGcsPath)
-
-	var ovfGcsPath string
-	var shouldCleanUp bool
-	var err error
-
-	if strings.HasSuffix(ovfOvaGcsPathLowered, ".ova") {
-		ovfGcsPath = pathutils.JoinURL(tmpGcsPath, "ovf")
-		oi.logger.Log(
-			fmt.Sprintf("Extracting %v OVA archive to %v", *ovfOvaGcsPath, ovfGcsPath))
-		err = oi.tarGcsExtractor.ExtractTarToGcs(*ovfOvaGcsPath, ovfGcsPath)
-		shouldCleanUp = true
-
-	} else if strings.HasSuffix(ovfOvaGcsPathLowered, ".ovf") {
-		// ovfOvaGcsPath is pointing to OVF descriptor, no need to unpack, just extract directory path.
-		ovfGcsPath = (*ovfOvaGcsPath)[0 : strings.LastIndex(*ovfOvaGcsPath, "/")+1]
-
-	} else {
-		ovfGcsPath = *ovfOvaGcsPath
-	}
-
-	// assume ovfOvaGcsPath is a GCS folder for the whole OVF package
-	return pathutils.ToDirectoryURL(ovfGcsPath), shouldCleanUp, err
-}
-
-func (oi *OVFImporter) createScratchBucketBucket(project string, region string) error {
-	safeProjectName := strings.Replace(project, "google", "elgoog", -1)
-	safeProjectName = strings.Replace(safeProjectName, ":", "-", -1)
-	if strings.HasPrefix(safeProjectName, "goog") {
-		safeProjectName = strings.Replace(safeProjectName, "goog", "ggoo", 1)
-	}
-	bucket := strings.ToLower(safeProjectName + "-ovf-import-bkt-" + region)
-	it := oi.bucketIteratorCreator.CreateBucketIterator(oi.ctx, oi.storageClient, project)
-	for itBucketAttrs, err := it.Next(); err != iterator.Done; itBucketAttrs, err = it.Next() {
-		if err != nil {
-			return err
-		}
-		if itBucketAttrs.Name == bucket {
-			*scratchBucketGcsPath = fmt.Sprintf("gs://%v/", bucket)
-			return nil
-		}
-	}
-
-	oi.logger.Log(fmt.Sprintf("Creating scratch bucket `%v` in %v region", bucket, region))
-	if err := oi.storageClient.CreateBucket(
-		bucket, project,
-		&storage.BucketAttrs{Name: bucket, Location: region}); err != nil {
-		return err
-	}
-	*scratchBucketGcsPath = fmt.Sprintf("gs://%v/", bucket)
-	return nil
-}
-
-func (oi *OVFImporter) buildTmpGcsPath(project string, region string) (string, error) {
-	if *scratchBucketGcsPath == "" {
-		if err := oi.createScratchBucketBucket(project, region); err != nil {
-			return "", err
-		}
-	}
-	return pathutils.JoinURL(*scratchBucketGcsPath, fmt.Sprintf("ovf-import-%v", oi.buildID)),
-		nil
-}
-
-func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
-	rl := &daisyutils.ResourceLabeler{
-		BuildID: oi.buildID, UserLabels: userLabels, BuildIDLabelKey: "gce-ovf-import-build-id",
-		InstanceLabelKeyRetriever: func(instance *daisy.Instance) string {
-			if strings.ToLower(*instanceNames) == instance.Name {
-				return "gce-ovf-import"
-			}
-			return "gce-ovf-import-tmp"
-		},
-		DiskLabelKeyRetriever: func(disk *daisy.Disk) string {
-			return "gce-ovf-import-tmp"
-		},
-		ImageLabelKeyRetriever: func(image *daisy.Image) string {
-			return "gce-ovf-import-tmp"
-		}}
-	rl.LabelResources(w)
-	daisyutils.UpdateAllInstanceNoExternalIP(w, *noExternalIP)
-}
-
-func (oi *OVFImporter) modifyWorkflowPreValidate(w *daisy.Workflow) {
-	daisyovfutils.AddDiskImportSteps(w, (*oi.diskInfos)[1:])
-	updateInstance(w)
-}
-
-func (oi *OVFImporter) getMachineType(
-	ovfDescriptor *ovf.Envelope, project string, zone string) (string, error) {
-	machineTypeProvider := ovfgceutils.MachineTypeProvider{
-		OvfDescriptor: ovfDescriptor,
-		MachineType:   *machineType,
-		ComputeClient: oi.computeClient,
-		Project:       project,
-		Zone:          zone,
-	}
-	return machineTypeProvider.GetMachineType()
-}
-
-func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, error) {
-	if err := validateAndParseFlags(); err != nil {
-		return nil, err
-	}
-	var (
-		project string
-		zone    string
-		region  string
-		err     error
-	)
-	if project, err = oi.getProject(); err != nil {
-		return nil, err
-	}
-	if zone, err = oi.getZone(project); err != nil {
-		return nil, err
-	}
-	if region, err = oi.getRegion(zone); err != nil {
-		return nil, err
-	}
-
-	tmpGcsPath, err := oi.buildTmpGcsPath(project, region)
-	if err != nil {
-		return nil, err
-	}
-
-	ovfGcsPath, shouldCleanup, err := oi.getOvfGcsPath(tmpGcsPath)
-	if shouldCleanup {
-		oi.gcsPathToClean = ovfGcsPath
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	ovfDescriptor, diskInfos, err := ovfutils.GetOVFDescriptorAndDiskPaths(
-		oi.ovfDescriptorLoader, ovfGcsPath)
-	if err != nil {
-		return nil, err
-	}
-	oi.diskInfos = &diskInfos
-
-	var osIDValue string
-	if *osID == "" {
-		if osIDValue, err = ovfutils.GetOSId(ovfDescriptor); err != nil {
-			return nil, err
-		}
-		oi.logger.Log(
-			fmt.Sprintf("Found valid osType in OVF descriptor, importing VM with `%v` as OS.",
-				osIDValue))
-	} else if err = daisyutils.ValidateOS(*osID); err != nil {
-		return nil, err
-	} else {
-		osIDValue = *osID
-	}
-
-	translateWorkflowPath := "../image_import/" + daisyutils.GetTranslateWorkflowPath(&osIDValue)
-	machineTypeStr, err := oi.getMachineType(ovfDescriptor, project, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	oi.logger.Log(fmt.Sprintf("Will create instance of `%v` machine type.", machineTypeStr))
-
-	varMap := buildDaisyVars(translateWorkflowPath, diskInfos[0].FilePath, machineTypeStr, region)
-
-	workflow, err := daisyutils.ParseWorkflow(oi.mgce, oi.workflowPath, varMap, project,
-		zone, *scratchBucketGcsPath, *oauth, *timeout, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
-		*stdoutLogsDisabled)
+func runImport() {
+	logger := log.New(os.Stdout, "[OVF Import] ", log.LstdFlags)
+	ovfImporter, err := ovfimporter.NewOVFImporter(buildImportParams())
 
 	if err != nil {
-		return nil, fmt.Errorf("error parsing workflow %q: %v", ovfImportWorkflow, err)
-	}
-	return workflow, nil
-}
-
-// Import runs OVF import
-func (oi *OVFImporter) Import() error {
-	oi.logger.Log("Starting OVF import workflow.")
-	w, err := oi.setUpImportWorkflow()
-	if err != nil {
-		return err
-	}
-
-	if err := w.RunWithModifiers(oi.ctx, oi.modifyWorkflowPreValidate, oi.modifyWorkflowPostValidate); err != nil {
-		return fmt.Errorf("%s: %v", w.Name, err)
-	}
-	oi.logger.Log("OVF import workflow finished successfully.")
-	return nil
-}
-
-// CleanUp performs clean up of any temporary resources or connections used for OVF import
-func (oi *OVFImporter) CleanUp() {
-	oi.logger.Log("Cleaning up.")
-	if oi.storageClient != nil {
-		if oi.gcsPathToClean != "" {
-			err := oi.storageClient.DeleteGcsPath(oi.gcsPathToClean)
-			if err != nil {
-				oi.logger.Log(
-					fmt.Sprintf("couldn't delete GCS path %v: %v", oi.gcsPathToClean, err.Error()))
-			}
-		}
-
-		err := oi.storageClient.Close()
-		if err != nil {
-			oi.logger.Log(fmt.Sprintf("couldn't close storage client: %v", err.Error()))
-		}
-	}
-}
-
-func main() {
-	ovfImporter, err := newOVFImporter()
-
-	if err != nil {
-		ovfImporter.logger.Log(err.Error())
-		ovfImporter.CleanUp()
-		os.Exit(1)
+		logger.Println(err.Error())
+		return
 	}
 	err = ovfImporter.Import()
 	if err != nil {
-		ovfImporter.logger.Log(err.Error())
-		ovfImporter.CleanUp()
-		os.Exit(1)
+		logger.Println(err.Error())
 	}
 	ovfImporter.CleanUp()
+}
+
+func main() {
+	runImport()
 }

--- a/cli_tools/gce_ovf_import/main_test.go
+++ b/cli_tools/gce_ovf_import/main_test.go
@@ -15,819 +15,92 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"strconv"
 	"testing"
 
-	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/test"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
-	"github.com/GoogleCloudPlatform/compute-image-tools/mocks"
-	"github.com/golang/mock/gomock"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/govmomi/ovf"
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/iterator"
 )
 
-func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
+func TestBuildParams(t *testing.T) {
 	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, "project", &projectFlag)()
-	defer testutils.ClearStringFlag(cliArgs, "zone", &zoneFlag)()
-	defer testutils.ClearStringFlag(cliArgs, "machine-type", &machineType)()
-	defer testutils.ClearStringFlag(cliArgs, "scratch-bucket-gcs-path", &scratchBucketGcsPath)()
-
 	defer testutils.BackupOsArgs()()
 	testutils.BuildOsArgs(cliArgs)
 
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	ctx := context.Background()
-
-	project := "goog-project"
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().ProjectID().Return(project, nil)
-	mockMetadataGce.EXPECT().Zone().Return("europe-north1-b", nil)
-
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	createdScratchBucketName := "ggoo-project-ovf-import-bkt-europe-north1"
-	mockStorageClient.EXPECT().CreateBucket(createdScratchBucketName, project,
-		&storage.BucketAttrs{
-			Name:     createdScratchBucketName,
-			Location: "europe-north1",
-		}).Return(nil)
-
-	mockComputeClient := mocks.NewMockClient(mockCtrl)
-	mockComputeClient.EXPECT().ListMachineTypes(project, "europe-north1-b").
-		Return(machineTypes, nil).Times(1)
-
-	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
-	mockOvfDescriptorLoader.EXPECT().Load(
-		fmt.Sprintf("gs://%v/ovf-import-build123/ovf/", createdScratchBucketName)).Return(
-		createOVFDescriptor(), nil)
-
-	mockMockTarGcsExtractorInterface := mocks.NewMockTarGcsExtractorInterface(mockCtrl)
-	mockMockTarGcsExtractorInterface.EXPECT().ExtractTarToGcs(
-		"gs://ovfbucket/ovfpath/vmware.ova",
-		fmt.Sprintf("gs://%v/ovf-import-build123/ovf", createdScratchBucketName)).
-		Return(nil).Times(1)
-
-	someBucketAttrs := &storage.BucketAttrs{
-		Name:     "some-bucket",
-		Location: "us-west2",
-	}
-	mockBucketIterator := mocks.NewMockBucketIteratorInterface(mockCtrl)
-	mockBucketIterator.EXPECT().Next().Return(someBucketAttrs, nil)
-	mockBucketIterator.EXPECT().Next().Return(nil, iterator.Done)
-
-	mockBucketIteratorCreator := mocks.NewMockBucketIteratorCreatorInterface(mockCtrl)
-	mockBucketIteratorCreator.EXPECT().
-		CreateBucketIterator(ctx, mockStorageClient, project).
-		Return(mockBucketIterator)
-
-	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../test_data/test_import_ovf.wf.json",
-		storageClient: mockStorageClient, computeClient: mockComputeClient, buildID: "build123",
-		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
-		ctx: ctx, bucketIteratorCreator: mockBucketIteratorCreator,
-		logger: logging.NewLogger("test")}
-	w, err := oi.setUpImportWorkflow()
-
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-
-	oi.modifyWorkflowPreValidate(w)
-	oi.modifyWorkflowPostValidate(w)
-	assert.Equal(t, "n1-highcpu-16", w.Vars["machine_type"].Value)
-	assert.Equal(t, project, w.Project)
-	assert.Equal(t, "europe-north1-b", w.Zone)
-	assert.Equal(t, fmt.Sprintf("gs://%v/", createdScratchBucketName), w.GCSPath)
-	assert.Equal(t, "oAuthFilePath", w.OAuthPath)
-	assert.Equal(t, "3h", w.DefaultTimeout)
-	assert.Equal(t, 3+3*3, len(w.Steps))
-	instance := (*w.Steps["create-instance"].CreateInstances)[0].Instance
-	assert.Equal(t, "build123", instance.Labels["gce-ovf-import-build-id"])
-	assert.Equal(t, "uservalue1", instance.Labels["userkey1"])
-	assert.Equal(t, "uservalue2", instance.Labels["userkey2"])
-	assert.Equal(t, false, *instance.Scheduling.AutomaticRestart)
-	assert.Equal(t, 1, len(instance.Scheduling.NodeAffinities))
-	assert.Equal(t, "env", instance.Scheduling.NodeAffinities[0].Key)
-	assert.Equal(t, "IN", instance.Scheduling.NodeAffinities[0].Operator)
-	assert.Equal(t, 2, len(instance.Scheduling.NodeAffinities[0].Values))
-	assert.Equal(t, "prod", instance.Scheduling.NodeAffinities[0].Values[0])
-	assert.Equal(t, "test", instance.Scheduling.NodeAffinities[0].Values[1])
-
-	assert.Equal(t, fmt.Sprintf("gs://%v/ovf-import-build123/ovf/", createdScratchBucketName),
-		oi.gcsPathToClean)
-}
-
-func TestSetUpWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneAsFlags(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.SetStringP(&projectFlag, "aProject")()
-	defer testutils.SetStringP(&zoneFlag, "europe-west2-b")()
-	defer testutils.ClearStringFlag(cliArgs, "machine-type", &machineType)()
-
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-
-	mockComputeClient := mocks.NewMockClient(mockCtrl)
-	mockComputeClient.EXPECT().ListMachineTypes("aProject", "europe-west2-b").
-		Return(machineTypes, nil).Times(1)
-
-	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
-	mockOvfDescriptorLoader.EXPECT().Load("gs://bucket/folder/ovf-import-build123/ovf/").Return(
-		createOVFDescriptor(), nil)
-
-	mockMockTarGcsExtractorInterface := mocks.NewMockTarGcsExtractorInterface(mockCtrl)
-	mockMockTarGcsExtractorInterface.EXPECT().ExtractTarToGcs(
-		"gs://ovfbucket/ovfpath/vmware.ova", "gs://bucket/folder/ovf-import-build123/ovf").
-		Return(nil).Times(1)
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject", "europe-west2-b").Return(nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../test_data/test_import_ovf.wf.json",
-		storageClient: mockStorageClient, computeClient: mockComputeClient, buildID: "build123",
-		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
-		logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator}
-	w, err := oi.setUpImportWorkflow()
-
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-
-	oi.modifyWorkflowPreValidate(w)
-	oi.modifyWorkflowPostValidate(w)
-	assert.Equal(t, "n1-highcpu-16", w.Vars["machine_type"].Value)
-	assert.Equal(t, "aProject", w.Project)
-	assert.Equal(t, "europe-west2-b", w.Zone)
-	assert.Equal(t, "gs://bucket/folder", w.GCSPath)
-	assert.Equal(t, "oAuthFilePath", w.OAuthPath)
-	assert.Equal(t, "3h", w.DefaultTimeout)
-	assert.Equal(t, 3+3*3, len(w.Steps))
-	assert.Equal(t, "build123", (*w.Steps["create-instance"].CreateInstances)[0].
-		Instance.Labels["gce-ovf-import-build-id"])
-	assert.Equal(t, "uservalue1", (*w.Steps["create-instance"].CreateInstances)[0].
-		Instance.Labels["userkey1"])
-	assert.Equal(t, "uservalue2", (*w.Steps["create-instance"].CreateInstances)[0].
-		Instance.Labels["userkey2"])
-	assert.Equal(t, "gs://bucket/folder/ovf-import-build123/ovf/", oi.gcsPathToClean)
-}
-
-func TestSetUpWorkflowPopulateMissingParametersError(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, "project", &projectFlag)()
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	w, err := oi.setUpImportWorkflow()
-
-	assert.NotNil(t, err)
-	assert.Nil(t, w)
-}
-
-func TestSetUpWorkflowPopulateFlagValidationFailed(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, instanceNameFlagKey, &instanceNames)()
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	w, err := oi.setUpImportWorkflow()
-
-	assert.NotNil(t, err)
-	assert.Nil(t, w)
-}
-
-func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.SetStringP(&projectFlag, "aProject")()
-	defer testutils.SetStringP(&zoneFlag, "europe-north1-b")()
-	defer testutils.ClearStringFlag(cliArgs, "machine-type", &machineType)()
-
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-
-	mockMockTarGcsExtractorInterface := mocks.NewMockTarGcsExtractorInterface(mockCtrl)
-	mockMockTarGcsExtractorInterface.EXPECT().ExtractTarToGcs(
-		"gs://ovfbucket/ovfpath/vmware.ova", "gs://bucket/folder/ovf-import-build123/ovf").
-		Return(errors.New("tar error")).Times(1)
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject", "europe-north1-b").Return(nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../test_data/test_import_ovf.wf.json",
-		storageClient: mockStorageClient, buildID: "build123",
-		tarGcsExtractor: mockMockTarGcsExtractorInterface, logger: logging.NewLogger("test"),
-		zoneValidator: mockZoneValidator}
-	w, err := oi.setUpImportWorkflow()
-
-	assert.NotNil(t, err)
-	assert.Nil(t, w)
-}
-
-func TestSetUpWorkflowErrorLoadingDescriptor(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.SetStringP(&projectFlag, "aProject")()
-	defer testutils.SetStringP(&zoneFlag, "europe-north1-b")()
-	defer testutils.SetStringP(&ovfOvaGcsPath, "gs://ovfbucket/ovffolder/")()
-
-	defer testutils.ClearStringFlag(cliArgs, "machine-type", &machineType)()
-
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
-	mockOvfDescriptorLoader.EXPECT().Load("gs://ovfbucket/ovffolder/").Return(
-		nil, errors.New("ovf desc error"))
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject", "europe-north1-b").Return(nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../test_data/test_import_ovf.wf.json",
-		buildID: "build123", ovfDescriptorLoader: mockOvfDescriptorLoader,
-		logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator}
-	w, err := oi.setUpImportWorkflow()
-
-	assert.NotNil(t, err)
-	assert.Nil(t, w)
-	assert.Equal(t, "", oi.gcsPathToClean)
-}
-
-func TestSetUpWorkOSIdFromOVFDescriptor(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, "os", &osID)()
-	defer testutils.SetStringP(&ovfOvaGcsPath, "gs://ovfbucket/ovffolder/")()
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	w, err := setupMocksForOSIdTesting(mockCtrl, "rhel7_64Guest")
-
-	assert.Nil(t, err)
-	assert.NotNil(t, w)
-	assert.Equal(t, "../image_import/enterprise_linux/translate_rhel_7_licensed.wf.json", w.Vars["translate_workflow"].Value)
-}
-
-func TestSetUpWorkOSIdFromDescriptorInvalidAndOSFlagNotSpecified(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, "os", &osID)()
-	defer testutils.SetStringP(&ovfOvaGcsPath, "gs://ovfbucket/ovffolder/")()
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	w, err := setupMocksForOSIdTesting(mockCtrl, "no-OS-ID")
-
-	assert.Nil(t, w)
-	assert.NotNil(t, err)
-}
-
-func TestSetUpWorkOSIdFromDescriptorNonDeterministicAndOSFlagNotSpecified(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, "os", &osID)()
-	defer testutils.SetStringP(&ovfOvaGcsPath, "gs://ovfbucket/ovffolder/")()
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	w, err := setupMocksForOSIdTesting(mockCtrl, "ubuntu64Guest")
-
-	assert.Nil(t, w)
-	assert.NotNil(t, err)
-}
-
-func TestSetUpWorkOSFlagInvalid(t *testing.T) {
-	cliArgs := getAllCliArgs()
-	defer testutils.SetStringP(&osID, "not-OS-ID")()
-	defer testutils.SetStringP(&ovfOvaGcsPath, "gs://ovfbucket/ovffolder/")()
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(cliArgs)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	w, err := setupMocksForOSIdTesting(mockCtrl, "")
-
-	assert.Nil(t, w)
-	assert.NotNil(t, err)
-}
-
-func setupMocksForOSIdTesting(mockCtrl *gomock.Controller, osType string) (*daisy.Workflow, error) {
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
-
-	descriptor := createOVFDescriptor()
-	if osType != "" {
-		descriptor.VirtualSystem.OperatingSystem = []ovf.OperatingSystemSection{{OSType: &osType}}
-	}
-	mockOvfDescriptorLoader.EXPECT().Load("gs://ovfbucket/ovffolder/").Return(
-		descriptor, nil)
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject", "us-central1-c").Return(nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../test_data/test_import_ovf.wf.json",
-		storageClient: mockStorageClient, buildID: "build123",
-		ovfDescriptorLoader: mockOvfDescriptorLoader, logger: logging.NewLogger("test"),
-		zoneValidator: mockZoneValidator}
-	return oi.setUpImportWorkflow()
-}
-
-func TestCleanUp(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	mockStorageClient.EXPECT().DeleteGcsPath("aPath")
-	mockStorageClient.EXPECT().Close()
-
-	oi := OVFImporter{storageClient: mockStorageClient, gcsPathToClean: "aPath",
-		logger: logging.NewLogger("test")}
-	oi.CleanUp()
-}
-
-func TestFlagsInstanceNameNotProvided(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, instanceNameFlagKey, &instanceNames)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsOvfGcsPathFlagKeyNotProvided(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, ovfGcsPathFlagKey, &ovfOvaGcsPath)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsOvfGcsPathFlagNotValid(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	cliArgs[ovfGcsPathFlagKey] = "NOT_GCS_PATH"
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsClientIdNotProvided(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	defer testutils.ClearStringFlag(cliArgs, clientIDFlagKey, &clientID)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsLabelsInvalid(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	cliArgs["labels"] = "NOT_VALID_LABEL_DEFINITION"
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsNetworkInterfaceSetWhenPrivateNetworkIPSet(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	cliArgs["network-interface"] = "aInterface"
-	defer testutils.ClearStringFlag(cliArgs, "network", &network)()
-	defer testutils.ClearStringFlag(cliArgs, "subnet", &subnet)()
-	defer testutils.ClearStringFlag(cliArgs, "network-tier", &networkTier)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsNetworkInterfaceSetWhenNetworkSet(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	cliArgs["network-interface"] = "aInterface"
-	defer testutils.ClearStringFlag(cliArgs, "private-network-ip", &privateNetworkIP)()
-	defer testutils.ClearStringFlag(cliArgs, "subnet", &subnet)()
-	defer testutils.ClearStringFlag(cliArgs, "network-tier", &networkTier)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsNetworkInterfaceSetWhenSubnetSet(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	cliArgs["network-interface"] = "aInterface"
-	defer testutils.ClearStringFlag(cliArgs, "private-network-ip", &privateNetworkIP)()
-	defer testutils.ClearStringFlag(cliArgs, "network", &network)()
-	defer testutils.ClearStringFlag(cliArgs, "network-tier", &networkTier)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsNetworkInterfaceSetWhenNetworkTierSet(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	cliArgs := getAllCliArgs()
-	cliArgs["network-interface"] = "aInterface"
-	defer testutils.ClearStringFlag(cliArgs, "private-network-ip", &privateNetworkIP)()
-	defer testutils.ClearStringFlag(cliArgs, "network", &network)()
-	defer testutils.ClearStringFlag(cliArgs, "subnet", &subnet)()
-	buildOsArgsAndAssertErrorOnValidate(cliArgs, t)
-}
-
-func TestFlagsAllValid(t *testing.T) {
-	defer testutils.BackupOsArgs()()
-	testutils.BuildOsArgs(getAllCliArgs())
-	assert.Nil(t, validateAndParseFlags())
-}
-
-func TestBuildDaisyVarsFromDisk(t *testing.T) {
-	testutils.BuildOsArgs(getAllCliArgs())
-	assert.Nil(t, validateAndParseFlags())
-
-	varMap := buildDaisyVars("translateworkflow.wf.json", "gs://abucket/apath/bootdisk.vmdk", "n1-standard-2", "aRegion")
-
-	assert.Equal(t, "instance1", varMap["instance_name"])
-	assert.Equal(t, "translateworkflow.wf.json", varMap["translate_workflow"])
-	assert.Equal(t, strconv.FormatBool(false), varMap["install_gce_packages"])
-	assert.Equal(t, "gs://abucket/apath/bootdisk.vmdk", varMap["boot_disk_file"])
-	assert.Equal(t, "global/networks/aNetwork", varMap["network"])
-	assert.Equal(t, "regions/aRegion/subnetworks/aSubnet", varMap["subnet"])
-	assert.Equal(t, "n1-standard-2", varMap["machine_type"])
-	assert.Equal(t, "aDescription", varMap["description"])
-	assert.Equal(t, "10.0.0.1", varMap["private_network_ip"])
-	assert.Equal(t, "PREMIUM", varMap["network_tier"])
-
-	assert.Equal(t, len(varMap), 10)
-}
-
-func TestProjectFromGCE(t *testing.T) {
-	defer testutils.SetStringP(&projectFlag, "")()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().ProjectID().Return("aProject", nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	project, err := oi.getProject()
-
-	assert.Nil(t, err)
-	assert.Equal(t, "aProject", project)
-}
-
-func TestGetZoneFromGCE(t *testing.T) {
-	defer testutils.SetStringP(&zoneFlag, "")()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().Zone().Return("europe-north1-b", nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	zone, err := oi.getZone("aProject")
-
-	assert.Nil(t, err)
-	assert.Equal(t, "europe-north1-b", zone)
-}
-
-func TestGetRegionE(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	oi := OVFImporter{logger: logging.NewLogger("test")}
-	region, err := oi.getRegion("europe-north1-b")
-
-	assert.Nil(t, err)
-	assert.Equal(t, "europe-north1", region)
-}
-
-func TestGetProjectFromFlagEvenIfOnGCE(t *testing.T) {
-	defer testutils.SetStringP(&projectFlag, "aProject123")()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().ProjectID().Return("aProject", nil).AnyTimes()
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	project, err := oi.getProject()
-
-	assert.Nil(t, err)
-	assert.Equal(t, "aProject123", project)
-}
-
-func TestGetZoneFromFlagEvenIfOnGCE(t *testing.T) {
-	defer testutils.SetStringP(&zoneFlag, "aZone123")()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().Zone().Return("europe-north1-b", nil).AnyTimes()
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject123", "aZone123").Return(nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test"),
-		zoneValidator: mockZoneValidator}
-	zone, err := oi.getZone("aProject123")
-
-	assert.Nil(t, err)
-	assert.Equal(t, "aZone123", zone)
-}
-
-func TestPopulateMissingParametersProjectEmptyNotOnGCE(t *testing.T) {
-	defer testutils.SetStringP(&projectFlag, "")()
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	project, err := oi.getProject()
-	assert.NotNil(t, err)
-	assert.Equal(t, "", project)
-}
-
-func TestPopulateMissingParametersErrorRetrievingProjectIDFromGCE(t *testing.T) {
-	defer testutils.SetStringP(&projectFlag, "")()
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().ProjectID().Return("", errors.New("err"))
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	project, err := oi.getProject()
-	assert.NotNil(t, err)
-	assert.Equal(t, "", project)
-}
-
-func TestGetZoneWhenZoneFlagNotSetNotOnGCE(t *testing.T) {
-	defer testutils.SetStringP(&zoneFlag, "")()
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	zone, err := oi.getZone("aProject")
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "", zone)
-}
-
-func TestGetZoneErrorRetrievingZone(t *testing.T) {
-	defer testutils.SetStringP(&zoneFlag, "")()
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().Zone().Return("", errors.New("err"))
-
-	oi := OVFImporter{mgce: mockMetadataGce}
-	zone, err := oi.getZone("aProject")
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "", zone)
-}
-
-func TestGetZoneEmptyZoneReturnedFromGCE(t *testing.T) {
-	defer testutils.SetStringP(&zoneFlag, "")()
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
-	mockMetadataGce.EXPECT().Zone().Return("", nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, logger: logging.NewLogger("test")}
-	zone, err := oi.getZone("aProject")
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "", zone)
-}
-
-func TestPopulateMissingParametersInvalidZone(t *testing.T) {
-	defer testutils.SetStringP(&zoneFlag, "europe-north1-b")()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject", "europe-north1-b").Return(fmt.Errorf("error"))
-
-	oi := OVFImporter{logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator}
-	_, err := oi.getZone("aProject")
-
-	assert.NotNil(t, err)
-	assert.Equal(t, "europe-north1-b", *zoneFlag)
-}
-
-func buildOsArgsAndAssertErrorOnValidate(cliArgs map[string]interface{}, t *testing.T) {
-	testutils.BuildOsArgs(cliArgs)
-	assert.NotNil(t, validateAndParseFlags())
-}
-
-func createControllerItem(instanceID string, resourceType uint16) ovf.ResourceAllocationSettingData {
-	return ovf.ResourceAllocationSettingData{
-		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
-			InstanceID:   instanceID,
-			ResourceType: &resourceType,
-		},
-	}
-}
-
-func createDiskItem(instanceID string, addressOnParent string,
-	elementName string, hostResource string, parent string) ovf.ResourceAllocationSettingData {
-	diskType := uint16(17)
-	return ovf.ResourceAllocationSettingData{
-		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
-			InstanceID:      instanceID,
-			ResourceType:    &diskType,
-			AddressOnParent: &addressOnParent,
-			ElementName:     elementName,
-			HostResource:    []string{hostResource},
-			Parent:          &parent,
-		},
-	}
-}
-
-func createOVFDescriptor() *ovf.Envelope {
-	virtualHardware := ovf.VirtualHardwareSection{
-		Item: []ovf.ResourceAllocationSettingData{
-			createControllerItem("5", 6),
-			createDiskItem("7", "1", "disk1",
-				"ovf:/disk/vmdisk2", "5"),
-			createDiskItem("6", "0", "disk0",
-				"ovf:/disk/vmdisk1", "5"),
-			createDiskItem("8", "2", "disk2",
-				"ovf:/disk/vmdisk3", "5"),
-			createCPUItem("11", 16),
-			createMemoryItem("12", 4096),
-		},
-	}
-	diskCapacityAllocationUnits := "byte * 2^30"
-	fileRef1 := "file1"
-	fileRef2 := "file2"
-	fileRef3 := "file3"
-	ovfDescriptor := &ovf.Envelope{
-		Disk: &ovf.DiskSection{Disks: []ovf.VirtualDiskDesc{
-			{Capacity: "20", CapacityAllocationUnits: &diskCapacityAllocationUnits, DiskID: "vmdisk1", FileRef: &fileRef1},
-			{Capacity: "1", CapacityAllocationUnits: &diskCapacityAllocationUnits, DiskID: "vmdisk2", FileRef: &fileRef2},
-			{Capacity: "5", CapacityAllocationUnits: &diskCapacityAllocationUnits, DiskID: "vmdisk3", FileRef: &fileRef3},
-		}},
-		References: []ovf.File{
-			{Href: "Ubuntu_for_Horizon71_1_1.0-disk1.vmdk", ID: "file1", Size: 1151322112},
-			{Href: "Ubuntu_for_Horizon71_1_1.0-disk2.vmdk", ID: "file2", Size: 68096},
-			{Href: "Ubuntu_for_Horizon71_1_1.0-disk3.vmdk", ID: "file3", Size: 68096},
-		},
-		VirtualSystem: &ovf.VirtualSystem{
-			VirtualHardware: []ovf.VirtualHardwareSection{virtualHardware},
-		},
-	}
-	return ovfDescriptor
-}
-
-func createCPUItem(instanceID string, quantity uint) ovf.ResourceAllocationSettingData {
-	resourceType := uint16(3)
-	mhz := "hertz * 10^6"
-	return ovf.ResourceAllocationSettingData{
-		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
-			InstanceID:      instanceID,
-			ResourceType:    &resourceType,
-			VirtualQuantity: &quantity,
-			AllocationUnits: &mhz,
-		},
-	}
-}
-
-func createMemoryItem(instanceID string, quantityMB uint) ovf.ResourceAllocationSettingData {
-	resourceType := uint16(4)
-	mb := "byte * 2^20"
-
-	return ovf.ResourceAllocationSettingData{
-		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
-			InstanceID:      instanceID,
-			ResourceType:    &resourceType,
-			VirtualQuantity: &quantityMB,
-			AllocationUnits: &mb,
-		},
-	}
+	params := buildImportParams()
+
+	assert.Equal(t, cliArgs[ovfimportparams.InstanceNameFlagKey], params.InstanceNames)
+	assert.Equal(t, cliArgs[ovfimportparams.ClientIDFlagKey], params.ClientID)
+	assert.Equal(t, cliArgs[ovfimportparams.OvfGcsPathFlagKey], params.OvfOvaGcsPath)
+	assert.Equal(t, cliArgs["no-guest-environment"], params.NoGuestEnvironment)
+	assert.Equal(t, cliArgs["can-ip-forward"], params.CanIPForward)
+	assert.Equal(t, cliArgs["deletion-protection"], params.DeletionProtection)
+	assert.Equal(t, cliArgs["description"], params.Description)
+	assert.Equal(t, cliArgs["labels"], params.Labels)
+	assert.Equal(t, cliArgs["machine-type"], params.MachineType)
+	assert.Equal(t, cliArgs["network"], params.Network)
+	assert.Equal(t, cliArgs["subnet"], params.Subnet)
+	assert.Equal(t, cliArgs["network-tier"], params.NetworkTier)
+	assert.Equal(t, cliArgs["private-network-ip"], params.PrivateNetworkIP)
+	assert.Equal(t, cliArgs["no-external-ip"], params.NoExternalIP)
+	assert.Equal(t, cliArgs["no-restart-on-failure"], params.NoRestartOnFailure)
+	assert.Equal(t, cliArgs["os"], params.OsID)
+	assert.Equal(t, cliArgs["shielded-integrity-monitoring"], params.ShieldedIntegrityMonitoring)
+	assert.Equal(t, cliArgs["shielded-secure-boot"], params.ShieldedSecureBoot)
+	assert.Equal(t, cliArgs["shielded-vtpm"], params.ShieldedVtpm)
+	assert.Equal(t, cliArgs["tags"], params.Tags)
+	assert.Equal(t, cliArgs["zone"], params.Zone)
+	assert.Equal(t, cliArgs["boot-disk-kms-key"], params.BootDiskKmskey)
+	assert.Equal(t, cliArgs["boot-disk-kms-keyring"], params.BootDiskKmsKeyring)
+	assert.Equal(t, cliArgs["boot-disk-kms-location"], params.BootDiskKmsLocation)
+	assert.Equal(t, cliArgs["boot-disk-kms-project"], params.BootDiskKmsProject)
+	assert.Equal(t, cliArgs["timeout"], params.Timeout)
+	assert.Equal(t, cliArgs["project"], params.Project)
+	assert.Equal(t, cliArgs["scratch-bucket-gcs-path"], params.ScratchBucketGcsPath)
+	assert.Equal(t, cliArgs["oauth"], params.Oauth)
+	assert.Equal(t, cliArgs["compute-endpoint-override"], params.Ce)
+	assert.Equal(t, cliArgs["disable-gcs-logging"], params.GcsLogsDisabled)
+	assert.Equal(t, cliArgs["disable-cloud-logging"], params.CloudLogsDisabled)
+	assert.Equal(t, cliArgs["disable-stdout-logging"], params.StdoutLogsDisabled)
+	assert.Equal(t, flags.StringArrayFlag{"env,IN,prod,test"}, params.NodeAffinityLabelsFlag)
 }
 
 func getAllCliArgs() map[string]interface{} {
 	return map[string]interface{}{
-		instanceNameFlagKey:             "instance1",
-		clientIDFlagKey:                 "aClient",
-		ovfGcsPathFlagKey:               "gs://ovfbucket/ovfpath/vmware.ova",
-		"no-guest-environment":          true,
-		"can-ip-forward":                true,
-		"deletion-protection":           true,
-		"description":                   "aDescription",
-		"labels":                        "userkey1=uservalue1,userkey2=uservalue2",
-		"machine-type":                  "n1-standard-2",
-		"network":                       "aNetwork",
-		"network-interface":             "",
-		"subnet":                        "aSubnet",
-		"network-tier":                  "PREMIUM",
-		"private-network-ip":            "10.0.0.1",
-		"no-external-ip":                true,
-		"no-restart-on-failure":         true,
-		"os":                            "ubuntu-1404",
-		"shielded-integrity-monitoring": true,
-		"shielded-secure-boot":          true,
-		"shielded-vtpm":                 true,
-		"tags":                          "tag1=val1",
-		"zone":                          "us-central1-c",
-		"boot-disk-kms-key":             "aKey",
-		"boot-disk-kms-keyring":         "aKeyring",
-		"boot-disk-kms-location":        "aKmsLocation",
-		"boot-disk-kms-project":         "aKmsProject",
-		"timeout":                       "3h",
-		"project":                       "aProject",
-		"scratch-bucket-gcs-path":       "gs://bucket/folder",
-		"oauth":                         "oAuthFilePath",
-		"compute-endpoint-override":     "us-east1-c",
-		"disable-gcs-logging":           true,
-		"disable-cloud-logging":         true,
-		"disable-stdout-logging":        true,
-		"node-affinity-label":           "env,IN,prod,test",
+		ovfimportparams.InstanceNameFlagKey: "instance1",
+		ovfimportparams.ClientIDFlagKey:     "aClient",
+		ovfimportparams.OvfGcsPathFlagKey:   "gs://ovfbucket/ovfpath/vmware.ova",
+		"no-guest-environment":              true,
+		"can-ip-forward":                    true,
+		"deletion-protection":               true,
+		"description":                       "aDescription",
+		"labels":                            "userkey1=uservalue1,userkey2=uservalue2",
+		"machine-type":                      "n1-standard-2",
+		"network":                           "aNetwork",
+		"subnet":                            "aSubnet",
+		"network-tier":                      "PREMIUM",
+		"private-network-ip":                "10.0.0.1",
+		"no-external-ip":                    true,
+		"no-restart-on-failure":             true,
+		"os":                                "ubuntu-1404",
+		"shielded-integrity-monitoring":     true,
+		"shielded-secure-boot":              true,
+		"shielded-vtpm":                     true,
+		"tags":                              "tag1=val1",
+		"zone":                              "us-central1-c",
+		"boot-disk-kms-key":                 "aKey",
+		"boot-disk-kms-keyring":             "aKeyring",
+		"boot-disk-kms-location":            "aKmsLocation",
+		"boot-disk-kms-project":             "aKmsProject",
+		"timeout":                           "3h",
+		"project":                           "aProject",
+		"scratch-bucket-gcs-path":           "gs://bucket/folder",
+		"oauth":                             "oAuthFilePath",
+		"compute-endpoint-override":         "us-east1-c",
+		"disable-gcs-logging":               true,
+		"disable-cloud-logging":             true,
+		"disable-stdout-logging":            true,
+		"node-affinity-label":               "env,IN,prod,test",
 	}
-}
-
-var machineTypes = []*compute.MachineType{
-	{
-		GuestCpus:                    1,
-		Id:                           2000,
-		IsSharedCpu:                  true,
-		MaximumPersistentDisks:       16,
-		MaximumPersistentDisksSizeGb: 3072,
-		MemoryMb:                     1740,
-		Name:                         "g1-small",
-		Zone:                         "us-east1-b",
-	},
-	{
-		GuestCpus:                    16,
-		Id:                           4016,
-		ImageSpaceGb:                 10,
-		MaximumPersistentDisks:       128,
-		MaximumPersistentDisksSizeGb: 65536,
-		MemoryMb:                     14746,
-		Name:                         "n1-highcpu-16",
-		Zone:                         "us-east1-b",
-	},
 }

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
@@ -1,3 +1,17 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package ovfimportparams
 
 import (

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
@@ -1,0 +1,48 @@
+package ovfimportparams
+
+import (
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
+	"google.golang.org/api/compute/v1"
+)
+
+// OVFImportParams holds flags for OVF import as well as derived (parsed) params
+type OVFImportParams struct {
+	InstanceNames               string
+	ClientID                    string
+	OvfOvaGcsPath               string
+	NoGuestEnvironment          bool
+	CanIPForward                bool
+	DeletionProtection          bool
+	Description                 string
+	Labels                      string
+	MachineType                 string
+	Network                     string
+	NetworkTier                 string
+	Subnet                      string
+	PrivateNetworkIP            string
+	NoExternalIP                bool
+	NoRestartOnFailure          bool
+	OsID                        string
+	ShieldedIntegrityMonitoring bool
+	ShieldedSecureBoot          bool
+	ShieldedVtpm                bool
+	Tags                        string
+	Zone                        string
+	BootDiskKmskey              string
+	BootDiskKmsKeyring          string
+	BootDiskKmsLocation         string
+	BootDiskKmsProject          string
+	Timeout                     string
+	Project                     string
+	ScratchBucketGcsPath        string
+	Oauth                       string
+	Ce                          string
+	GcsLogsDisabled             bool
+	CloudLogsDisabled           bool
+	StdoutLogsDisabled          bool
+	NodeAffinityLabelsFlag      flags.StringArrayFlag
+
+	UserLabels            map[string]string
+	NodeAffinities        []*compute.SchedulingNodeAffinity
+	CurrentExecutablePath string
+}

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
@@ -1,0 +1,66 @@
+package ovfimportparams
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/parse"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/validation"
+)
+
+const (
+	// InstanceNameFlagKey is key for instance name CLI flag
+	InstanceNameFlagKey = "instance-names"
+
+	// ClientIDFlagKey is key for client ID CLI flag
+	ClientIDFlagKey = "client-id"
+
+	// OvfGcsPathFlagKey is key for OVF/OVA GCS path CLI flag
+	OvfGcsPathFlagKey = "ovf-gcs-path"
+)
+
+// ValidateAndParseParams validates and parses OVFImportParams. It returns an error if params are
+// invalid. If params are valid, additional fields in OVFImportParams will be populated with
+// parsed values
+func ValidateAndParseParams(params *OVFImportParams) error {
+	if err := validationutils.ValidateStringFlagNotEmpty(params.InstanceNames, InstanceNameFlagKey); err != nil {
+		return err
+	}
+
+	instanceNameSplits := strings.Split(params.InstanceNames, ",")
+	if len(instanceNameSplits) > 1 {
+		return fmt.Errorf("OVF import doesn't support multi instance import at this time")
+	}
+
+	if err := validationutils.ValidateStringFlagNotEmpty(params.OvfOvaGcsPath, OvfGcsPathFlagKey); err != nil {
+		return err
+	}
+
+	if err := validationutils.ValidateStringFlagNotEmpty(params.ClientID, ClientIDFlagKey); err != nil {
+		return err
+	}
+
+	if _, _, err := storageutils.SplitGCSPath(params.OvfOvaGcsPath); err != nil {
+		return fmt.Errorf("%v should be a path to OVF or OVA package in GCS", OvfGcsPathFlagKey)
+	}
+
+	if params.Labels != "" {
+		var err error
+		params.UserLabels, err = parseutils.ParseKeyValues(params.Labels)
+		if err != nil {
+			return err
+		}
+	}
+
+	if params.NodeAffinityLabelsFlag != nil {
+		var err error
+		params.NodeAffinities, err = computeutils.ParseNodeAffinityLabels(params.NodeAffinityLabelsFlag)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
@@ -1,3 +1,17 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package ovfimportparams
 
 import (

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
@@ -1,0 +1,84 @@
+package ovfimportparams
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagsInstanceNameNotProvided(t *testing.T) {
+	params := getAllParams()
+	params.InstanceNames = ""
+	assertErrorOnValidate(t, params)
+}
+
+func TestFlagsOvfGcsPathFlagKeyNotProvided(t *testing.T) {
+	params := getAllParams()
+	params.OvfOvaGcsPath = ""
+	assertErrorOnValidate(t, params)
+}
+
+func TestFlagsOvfGcsPathFlagNotValid(t *testing.T) {
+	params := getAllParams()
+	params.OvfOvaGcsPath = "NOT_GCS_PATH"
+	assertErrorOnValidate(t, params)
+}
+
+func TestFlagsClientIdNotProvided(t *testing.T) {
+	params := getAllParams()
+	params.ClientID = ""
+	assertErrorOnValidate(t, params)
+}
+
+func TestFlagsLabelsInvalid(t *testing.T) {
+	params := getAllParams()
+	params.Labels = "NOT_VALID_LABEL_DEFINITION"
+	assertErrorOnValidate(t, params)
+}
+
+func TestFlagsAllValid(t *testing.T) {
+	assert.Nil(t, ValidateAndParseParams(getAllParams()))
+}
+
+func assertErrorOnValidate(t *testing.T, params *OVFImportParams) {
+	assert.NotNil(t, ValidateAndParseParams(params))
+}
+
+func getAllParams() *OVFImportParams {
+	return &OVFImportParams{
+		InstanceNames:               "instance1",
+		ClientID:                    "aClient",
+		OvfOvaGcsPath:               "gs://ovfbucket/ovfpath/vmware.ova",
+		NoGuestEnvironment:          true,
+		CanIPForward:                true,
+		DeletionProtection:          true,
+		Description:                 "aDescription",
+		Labels:                      "userkey1=uservalue1,userkey2=uservalue2",
+		MachineType:                 "n1-standard-2",
+		Network:                     "aNetwork",
+		Subnet:                      "aSubnet",
+		NetworkTier:                 "PREMIUM",
+		PrivateNetworkIP:            "10.0.0.1",
+		NoExternalIP:                true,
+		NoRestartOnFailure:          true,
+		OsID:                        "ubuntu-1404",
+		ShieldedIntegrityMonitoring: true,
+		ShieldedSecureBoot:          true,
+		ShieldedVtpm:                true,
+		Tags:                        "tag1=val1",
+		Zone:                        "us-central1-c",
+		BootDiskKmskey:              "aKey",
+		BootDiskKmsKeyring:          "aKeyring",
+		BootDiskKmsLocation:         "aKmsLocation",
+		BootDiskKmsProject:          "aKmsProject",
+		Timeout:                     "3h",
+		Project:                     "aProject",
+		ScratchBucketGcsPath:        "gs://bucket/folder",
+		Oauth:                       "oAuthFilePath",
+		Ce:                          "us-east1-c",
+		GcsLogsDisabled:             true,
+		CloudLogsDisabled:           true,
+		StdoutLogsDisabled:          true,
+		NodeAffinityLabelsFlag:      []string{"env,IN,prod,test"},
+	}
+}

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
@@ -1,3 +1,17 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package ovfimportparams
 
 import (

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -1,3 +1,17 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package ovfimporter
 
 import (

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -1,0 +1,413 @@
+package ovfimporter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/daisy_utils"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/domain"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/gce_utils"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_utils"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"github.com/vmware/govmomi/ovf"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+const (
+	ovfWorkflowDir    = "daisy_workflows/ovf_import/"
+	ovfImportWorkflow = ovfWorkflowDir + "import_ovf.wf.json"
+)
+
+// OVFImporter is responsible for importing OVF into GCE
+type OVFImporter struct {
+	ctx                   context.Context
+	storageClient         commondomain.StorageClientInterface
+	computeClient         daisycompute.Client
+	tarGcsExtractor       commondomain.TarGcsExtractorInterface
+	mgce                  commondomain.MetadataGCEInterface
+	ovfDescriptorLoader   domain.OvfDescriptorLoaderInterface
+	bucketIteratorCreator commondomain.BucketIteratorCreatorInterface
+	Logger                logging.LoggerInterface
+	zoneValidator         commondomain.ZoneValidatorInterface
+	gcsPathToClean        string
+	workflowPath          string
+	buildID               string
+	diskInfos             *[]ovfutils.DiskInfo
+	params                *ovfimportparams.OVFImportParams
+}
+
+// NewOVFImporter creates an OVF importer, including automatically populating dependencies,
+// such as compute/storage clients.
+func NewOVFImporter(params *ovfimportparams.OVFImportParams) (*OVFImporter, error) {
+	ctx := context.Background()
+	sc, err := storage.NewClient(ctx)
+	logger := logging.NewLogger("[import-ovf]")
+	if err != nil {
+		return nil, err
+	}
+	storageClient, err := storageutils.NewStorageClient(ctx, sc, logger)
+	if err != nil {
+		return nil, err
+	}
+	computeClient, err := createComputeClient(&ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	tarGcsExtractor := storageutils.NewTarGcsExtractor(ctx, storageClient, logger)
+	buildID := os.Getenv("BUILD_ID")
+	if buildID == "" {
+		buildID = pathutils.RandString(5)
+	}
+	workingDirOVFImportWorkflow := toWorkingDir(ovfImportWorkflow, params)
+	bic := &storageutils.BucketIteratorCreator{}
+
+	ovfImporter := &OVFImporter{ctx: ctx, storageClient: storageClient, computeClient: computeClient,
+		tarGcsExtractor: tarGcsExtractor, workflowPath: workingDirOVFImportWorkflow, buildID: buildID,
+		ovfDescriptorLoader: ovfutils.NewOvfDescriptorLoader(storageClient),
+		mgce:                &computeutils.MetadataGCE{}, bucketIteratorCreator: bic, Logger: logger,
+		zoneValidator: &computeutils.ZoneValidator{ComputeClient: computeClient}, params: params}
+	return ovfImporter, nil
+}
+
+func (oi *OVFImporter) buildDaisyVars(
+	translateWorkflowPath string,
+	bootDiskGcsPath string,
+	machineType string,
+	region string) map[string]string {
+	varMap := map[string]string{}
+
+	varMap["instance_name"] = strings.ToLower(oi.params.InstanceNames)
+	if translateWorkflowPath != "" {
+		varMap["translate_workflow"] = translateWorkflowPath
+		varMap["install_gce_packages"] = strconv.FormatBool(!oi.params.NoGuestEnvironment)
+	}
+	if bootDiskGcsPath != "" {
+		varMap["boot_disk_file"] = bootDiskGcsPath
+	}
+	if oi.params.Network != "" {
+		varMap["network"] = fmt.Sprintf("global/networks/%v", oi.params.Network)
+	}
+	if oi.params.Subnet != "" {
+		varMap["subnet"] = fmt.Sprintf("regions/%v/subnetworks/%v", region, oi.params.Subnet)
+	}
+	if machineType != "" {
+		varMap["machine_type"] = machineType
+	}
+	if oi.params.Description != "" {
+		varMap["description"] = oi.params.Description
+	}
+	if oi.params.PrivateNetworkIP != "" {
+		varMap["private_network_ip"] = oi.params.PrivateNetworkIP
+	}
+
+	if oi.params.NetworkTier != "" {
+		varMap["network_tier"] = oi.params.NetworkTier
+	}
+	return varMap
+}
+
+func (oi *OVFImporter) updateInstance(w *daisy.Workflow) {
+	instance := (*w.Steps["create-instance"].CreateInstances)[0]
+	instance.CanIpForward = oi.params.CanIPForward
+	instance.DeletionProtection = oi.params.DeletionProtection
+	if instance.Scheduling == nil {
+		instance.Scheduling = &compute.Scheduling{}
+	}
+	if oi.params.NoRestartOnFailure {
+		vFalse := false
+		instance.Scheduling.AutomaticRestart = &vFalse
+	}
+	if oi.params.NodeAffinities != nil {
+		instance.Scheduling.NodeAffinities = oi.params.NodeAffinities
+	}
+}
+
+func toWorkingDir(dir string, params *ovfimportparams.OVFImportParams) string {
+	wd, err := filepath.Abs(filepath.Dir(params.CurrentExecutablePath))
+	if err == nil {
+		return path.Join(wd, dir)
+	}
+	return dir
+}
+
+// creates a new Daisy Compute client
+func createComputeClient(ctx *context.Context, params *ovfimportparams.OVFImportParams) (daisycompute.Client, error) {
+	computeOptions := []option.ClientOption{option.WithCredentialsFile(params.Oauth)}
+	if params.Ce != "" {
+		computeOptions = append(computeOptions, option.WithEndpoint(params.Ce))
+	}
+
+	computeClient, err := daisycompute.NewClient(*ctx, computeOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return computeClient, nil
+}
+
+func (oi *OVFImporter) getProject() (string, error) {
+	project := oi.params.Project
+	if project == "" {
+		if !oi.mgce.OnGCE() {
+			return "", fmt.Errorf("project cannot be determined because build is not running on GCE")
+		}
+		var err error
+		project, err = oi.mgce.ProjectID()
+		if err != nil || project == "" {
+			return "", fmt.Errorf("project cannot be determined %v", err)
+		}
+	}
+	return project, nil
+}
+
+func (oi *OVFImporter) getZone(project string) (string, error) {
+	if oi.params.Zone != "" {
+		if err := oi.zoneValidator.ZoneValid(project, oi.params.Zone); err != nil {
+			return "", err
+		}
+		return oi.params.Zone, nil
+	}
+
+	if !oi.mgce.OnGCE() {
+		return "", fmt.Errorf("zone cannot be determined because build is not running on GCE")
+	}
+	// determine zone based on the zone Cloud Build is running in
+	zone, err := oi.mgce.Zone()
+	if err != nil || zone == "" {
+		return "", fmt.Errorf("can't infer zone: %v", err)
+	}
+	return zone, nil
+}
+
+func (oi *OVFImporter) getRegion(zone string) (string, error) {
+	zoneSplits := strings.Split(zone, "-")
+	if len(zoneSplits) < 2 {
+		return "", fmt.Errorf("%v is not a valid zone", zone)
+	}
+	return strings.Join(zoneSplits[:len(zoneSplits)-1], "-"), nil
+}
+
+// Returns OVF GCS bucket and object path (director). If ovaOvaGcsPath is pointing to an OVA file,
+// it extracts it to a temporary GCS folder and returns it's path.
+func (oi *OVFImporter) getOvfGcsPath(tmpGcsPath string) (string, bool, error) {
+	ovfOvaGcsPathLowered := strings.ToLower(oi.params.OvfOvaGcsPath)
+
+	var ovfGcsPath string
+	var shouldCleanUp bool
+	var err error
+
+	if strings.HasSuffix(ovfOvaGcsPathLowered, ".ova") {
+		ovfGcsPath = pathutils.JoinURL(tmpGcsPath, "ovf")
+		oi.Logger.Log(
+			fmt.Sprintf("Extracting %v OVA archive to %v", oi.params.OvfOvaGcsPath, ovfGcsPath))
+		err = oi.tarGcsExtractor.ExtractTarToGcs(oi.params.OvfOvaGcsPath, ovfGcsPath)
+		shouldCleanUp = true
+
+	} else if strings.HasSuffix(ovfOvaGcsPathLowered, ".ovf") {
+		// OvfOvaGcsPath is pointing to OVF descriptor, no need to unpack, just extract directory path.
+		ovfGcsPath = (oi.params.OvfOvaGcsPath)[0 : strings.LastIndex(oi.params.OvfOvaGcsPath, "/")+1]
+
+	} else {
+		ovfGcsPath = oi.params.OvfOvaGcsPath
+	}
+
+	// assume OvfOvaGcsPath is a GCS folder for the whole OVF package
+	return pathutils.ToDirectoryURL(ovfGcsPath), shouldCleanUp, err
+}
+
+func (oi *OVFImporter) createScratchBucketBucket(project string, region string) error {
+	safeProjectName := strings.Replace(project, "google", "elgoog", -1)
+	safeProjectName = strings.Replace(safeProjectName, ":", "-", -1)
+	if strings.HasPrefix(safeProjectName, "goog") {
+		safeProjectName = strings.Replace(safeProjectName, "goog", "ggoo", 1)
+	}
+	bucket := strings.ToLower(safeProjectName + "-ovf-import-bkt-" + region)
+	it := oi.bucketIteratorCreator.CreateBucketIterator(oi.ctx, oi.storageClient, project)
+	for itBucketAttrs, err := it.Next(); err != iterator.Done; itBucketAttrs, err = it.Next() {
+		if err != nil {
+			return err
+		}
+		if itBucketAttrs.Name == bucket {
+			oi.params.ScratchBucketGcsPath = fmt.Sprintf("gs://%v/", bucket)
+			return nil
+		}
+	}
+
+	oi.Logger.Log(fmt.Sprintf("Creating scratch bucket `%v` in %v region", bucket, region))
+	if err := oi.storageClient.CreateBucket(
+		bucket, project,
+		&storage.BucketAttrs{Name: bucket, Location: region}); err != nil {
+		return err
+	}
+	oi.params.ScratchBucketGcsPath = fmt.Sprintf("gs://%v/", bucket)
+	return nil
+}
+
+func (oi *OVFImporter) buildTmpGcsPath(project string, region string) (string, error) {
+	if oi.params.ScratchBucketGcsPath == "" {
+		if err := oi.createScratchBucketBucket(project, region); err != nil {
+			return "", err
+		}
+	}
+	return pathutils.JoinURL(oi.params.ScratchBucketGcsPath, fmt.Sprintf("ovf-import-%v", oi.buildID)),
+		nil
+}
+
+func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
+	rl := &daisyutils.ResourceLabeler{
+		BuildID: oi.buildID, UserLabels: oi.params.UserLabels, BuildIDLabelKey: "gce-ovf-import-build-id",
+		InstanceLabelKeyRetriever: func(instance *daisy.Instance) string {
+			if strings.ToLower(oi.params.InstanceNames) == instance.Name {
+				return "gce-ovf-import"
+			}
+			return "gce-ovf-import-tmp"
+		},
+		DiskLabelKeyRetriever: func(disk *daisy.Disk) string {
+			return "gce-ovf-import-tmp"
+		},
+		ImageLabelKeyRetriever: func(image *daisy.Image) string {
+			return "gce-ovf-import-tmp"
+		}}
+	rl.LabelResources(w)
+	daisyutils.UpdateAllInstanceNoExternalIP(w, oi.params.NoExternalIP)
+}
+
+func (oi *OVFImporter) modifyWorkflowPreValidate(w *daisy.Workflow) {
+	daisyovfutils.AddDiskImportSteps(w, (*oi.diskInfos)[1:])
+	oi.updateInstance(w)
+}
+
+func (oi *OVFImporter) getMachineType(
+	ovfDescriptor *ovf.Envelope, project string, zone string) (string, error) {
+	machineTypeProvider := ovfgceutils.MachineTypeProvider{
+		OvfDescriptor: ovfDescriptor,
+		MachineType:   oi.params.MachineType,
+		ComputeClient: oi.computeClient,
+		Project:       project,
+		Zone:          zone,
+	}
+	return machineTypeProvider.GetMachineType()
+}
+
+func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, error) {
+	if err := ovfimportparams.ValidateAndParseParams(oi.params); err != nil {
+		return nil, err
+	}
+	var (
+		project string
+		zone    string
+		region  string
+		err     error
+	)
+	if project, err = oi.getProject(); err != nil {
+		return nil, err
+	}
+	if zone, err = oi.getZone(project); err != nil {
+		return nil, err
+	}
+	if region, err = oi.getRegion(zone); err != nil {
+		return nil, err
+	}
+
+	tmpGcsPath, err := oi.buildTmpGcsPath(project, region)
+	if err != nil {
+		return nil, err
+	}
+
+	ovfGcsPath, shouldCleanup, err := oi.getOvfGcsPath(tmpGcsPath)
+	if shouldCleanup {
+		oi.gcsPathToClean = ovfGcsPath
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ovfDescriptor, diskInfos, err := ovfutils.GetOVFDescriptorAndDiskPaths(
+		oi.ovfDescriptorLoader, ovfGcsPath)
+	if err != nil {
+		return nil, err
+	}
+	oi.diskInfos = &diskInfos
+
+	var osIDValue string
+	if oi.params.OsID == "" {
+		if osIDValue, err = ovfutils.GetOSId(ovfDescriptor); err != nil {
+			return nil, err
+		}
+		oi.Logger.Log(
+			fmt.Sprintf("Found valid osType in OVF descriptor, importing VM with `%v` as OS.",
+				osIDValue))
+	} else if err = daisyutils.ValidateOS(oi.params.OsID); err != nil {
+		return nil, err
+	} else {
+		osIDValue = oi.params.OsID
+	}
+
+	translateWorkflowPath := "../image_import/" + daisyutils.GetTranslateWorkflowPath(&osIDValue)
+	machineTypeStr, err := oi.getMachineType(ovfDescriptor, project, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	oi.Logger.Log(fmt.Sprintf("Will create instance of `%v` machine type.", machineTypeStr))
+
+	varMap := oi.buildDaisyVars(translateWorkflowPath, diskInfos[0].FilePath, machineTypeStr, region)
+
+	workflow, err := daisyutils.ParseWorkflow(oi.mgce, oi.workflowPath, varMap, project,
+		zone, oi.params.ScratchBucketGcsPath, oi.params.Oauth, oi.params.Timeout, oi.params.Ce, oi.params.GcsLogsDisabled, oi.params.CloudLogsDisabled,
+		oi.params.StdoutLogsDisabled)
+
+	if err != nil {
+		return nil, fmt.Errorf("error parsing workflow %q: %v", ovfImportWorkflow, err)
+	}
+	return workflow, nil
+}
+
+// Import runs OVF import
+func (oi *OVFImporter) Import() error {
+	oi.Logger.Log("Starting OVF import workflow.")
+	w, err := oi.setUpImportWorkflow()
+	if err != nil {
+		return err
+	}
+
+	if err := w.RunWithModifiers(oi.ctx, oi.modifyWorkflowPreValidate, oi.modifyWorkflowPostValidate); err != nil {
+		return fmt.Errorf("%s: %v", w.Name, err)
+	}
+	oi.Logger.Log("OVF import workflow finished successfully.")
+	return nil
+}
+
+// CleanUp performs clean up of any temporary resources or connections used for OVF import
+func (oi *OVFImporter) CleanUp() {
+	oi.Logger.Log("Cleaning up.")
+	if oi.storageClient != nil {
+		if oi.gcsPathToClean != "" {
+			err := oi.storageClient.DeleteGcsPath(oi.gcsPathToClean)
+			if err != nil {
+				oi.Logger.Log(
+					fmt.Sprintf("couldn't delete GCS path %v: %v", oi.gcsPathToClean, err.Error()))
+			}
+		}
+
+		err := oi.storageClient.Close()
+		if err != nil {
+			oi.Logger.Log(fmt.Sprintf("couldn't close storage client: %v", err.Error()))
+		}
+	}
+}

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -1,0 +1,737 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ovfimporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/ovf"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/iterator"
+)
+
+func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
+	params := GetAllParams()
+	params.Project = ""
+	params.Zone = ""
+	params.MachineType = ""
+	params.ScratchBucketGcsPath = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+
+	project := "goog-project"
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().ProjectID().Return(project, nil)
+	mockMetadataGce.EXPECT().Zone().Return("europe-north1-b", nil)
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	createdScratchBucketName := "ggoo-project-ovf-import-bkt-europe-north1"
+	mockStorageClient.EXPECT().CreateBucket(createdScratchBucketName, project,
+		&storage.BucketAttrs{
+			Name:     createdScratchBucketName,
+			Location: "europe-north1",
+		}).Return(nil)
+
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().ListMachineTypes(project, "europe-north1-b").
+		Return(machineTypes, nil).Times(1)
+
+	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
+	mockOvfDescriptorLoader.EXPECT().Load(
+		fmt.Sprintf("gs://%v/ovf-import-build123/ovf/", createdScratchBucketName)).Return(
+		createOVFDescriptor(), nil)
+
+	mockMockTarGcsExtractorInterface := mocks.NewMockTarGcsExtractorInterface(mockCtrl)
+	mockMockTarGcsExtractorInterface.EXPECT().ExtractTarToGcs(
+		"gs://ovfbucket/ovfpath/vmware.ova",
+		fmt.Sprintf("gs://%v/ovf-import-build123/ovf", createdScratchBucketName)).
+		Return(nil).Times(1)
+
+	someBucketAttrs := &storage.BucketAttrs{
+		Name:     "some-bucket",
+		Location: "us-west2",
+	}
+	mockBucketIterator := mocks.NewMockBucketIteratorInterface(mockCtrl)
+	mockBucketIterator.EXPECT().Next().Return(someBucketAttrs, nil)
+	mockBucketIterator.EXPECT().Next().Return(nil, iterator.Done)
+
+	mockBucketIteratorCreator := mocks.NewMockBucketIteratorCreatorInterface(mockCtrl)
+	mockBucketIteratorCreator.EXPECT().
+		CreateBucketIterator(ctx, mockStorageClient, project).
+		Return(mockBucketIterator)
+
+	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
+		storageClient: mockStorageClient, computeClient: mockComputeClient, buildID: "build123",
+		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
+		ctx: ctx, bucketIteratorCreator: mockBucketIteratorCreator,
+		Logger: logging.NewLogger("test"), params: params}
+	w, err := oi.setUpImportWorkflow()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+
+	oi.modifyWorkflowPreValidate(w)
+	oi.modifyWorkflowPostValidate(w)
+	assert.Equal(t, "n1-highcpu-16", w.Vars["machine_type"].Value)
+	assert.Equal(t, project, w.Project)
+	assert.Equal(t, "europe-north1-b", w.Zone)
+	assert.Equal(t, fmt.Sprintf("gs://%v/", createdScratchBucketName), w.GCSPath)
+	assert.Equal(t, "oAuthFilePath", w.OAuthPath)
+	assert.Equal(t, "3h", w.DefaultTimeout)
+	assert.Equal(t, 3+3*3, len(w.Steps))
+
+	instance := (*w.Steps["create-instance"].CreateInstances)[0].Instance
+	assert.Equal(t, "build123", instance.Labels["gce-ovf-import-build-id"])
+	assert.Equal(t, "uservalue1", instance.Labels["userkey1"])
+	assert.Equal(t, "uservalue2", instance.Labels["userkey2"])
+	assert.Equal(t, false, *instance.Scheduling.AutomaticRestart)
+	assert.Equal(t, 1, len(instance.Scheduling.NodeAffinities))
+	assert.Equal(t, "env", instance.Scheduling.NodeAffinities[0].Key)
+	assert.Equal(t, "IN", instance.Scheduling.NodeAffinities[0].Operator)
+	assert.Equal(t, 2, len(instance.Scheduling.NodeAffinities[0].Values))
+	assert.Equal(t, "prod", instance.Scheduling.NodeAffinities[0].Values[0])
+	assert.Equal(t, "test", instance.Scheduling.NodeAffinities[0].Values[1])
+
+	assert.Equal(t, fmt.Sprintf("gs://%v/ovf-import-build123/ovf/", createdScratchBucketName),
+		oi.gcsPathToClean)
+}
+
+func TestSetUpWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneAsFlags(t *testing.T) {
+	params := GetAllParams()
+	params.Project = "aProject"
+	params.Zone = "europe-west2-b"
+	params.MachineType = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().ListMachineTypes("aProject", "europe-west2-b").
+		Return(machineTypes, nil).Times(1)
+
+	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
+	mockOvfDescriptorLoader.EXPECT().Load("gs://bucket/folder/ovf-import-build123/ovf/").Return(
+		createOVFDescriptor(), nil)
+
+	mockMockTarGcsExtractorInterface := mocks.NewMockTarGcsExtractorInterface(mockCtrl)
+	mockMockTarGcsExtractorInterface.EXPECT().ExtractTarToGcs(
+		"gs://ovfbucket/ovfpath/vmware.ova", "gs://bucket/folder/ovf-import-build123/ovf").
+		Return(nil).Times(1)
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject", "europe-west2-b").Return(nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
+		storageClient: mockStorageClient, computeClient: mockComputeClient, buildID: "build123",
+		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
+		Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator, params: params}
+	w, err := oi.setUpImportWorkflow()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+
+	oi.modifyWorkflowPreValidate(w)
+	oi.modifyWorkflowPostValidate(w)
+	assert.Equal(t, "n1-highcpu-16", w.Vars["machine_type"].Value)
+	assert.Equal(t, "aProject", w.Project)
+	assert.Equal(t, "europe-west2-b", w.Zone)
+	assert.Equal(t, "gs://bucket/folder", w.GCSPath)
+	assert.Equal(t, "oAuthFilePath", w.OAuthPath)
+	assert.Equal(t, "3h", w.DefaultTimeout)
+	assert.Equal(t, 3+3*3, len(w.Steps))
+	assert.Equal(t, "build123", (*w.Steps["create-instance"].CreateInstances)[0].
+		Instance.Labels["gce-ovf-import-build-id"])
+	assert.Equal(t, "uservalue1", (*w.Steps["create-instance"].CreateInstances)[0].
+		Instance.Labels["userkey1"])
+	assert.Equal(t, "uservalue2", (*w.Steps["create-instance"].CreateInstances)[0].
+		Instance.Labels["userkey2"])
+	assert.Equal(t, "gs://bucket/folder/ovf-import-build123/ovf/", oi.gcsPathToClean)
+}
+
+func TestSetUpWorkflowPopulateMissingParametersError(t *testing.T) {
+	params := GetAllParams()
+	params.Project = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	w, err := oi.setUpImportWorkflow()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, w)
+}
+
+func TestSetUpWorkflowPopulateFlagValidationFailed(t *testing.T) {
+	params := GetAllParams()
+	params.InstanceNames = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	w, err := oi.setUpImportWorkflow()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, w)
+}
+
+func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
+	params := GetAllParams()
+	params.Project = "aProject"
+	params.Zone = "europe-north1-b"
+	params.MachineType = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+
+	mockMockTarGcsExtractorInterface := mocks.NewMockTarGcsExtractorInterface(mockCtrl)
+	mockMockTarGcsExtractorInterface.EXPECT().ExtractTarToGcs(
+		"gs://ovfbucket/ovfpath/vmware.ova", "gs://bucket/folder/ovf-import-build123/ovf").
+		Return(errors.New("tar error")).Times(1)
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject", "europe-north1-b").Return(nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
+		storageClient: mockStorageClient, buildID: "build123",
+		tarGcsExtractor: mockMockTarGcsExtractorInterface, Logger: logging.NewLogger("test"),
+		zoneValidator: mockZoneValidator, params: params}
+	w, err := oi.setUpImportWorkflow()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, w)
+}
+
+func TestSetUpWorkflowErrorLoadingDescriptor(t *testing.T) {
+	params := GetAllParams()
+	params.Project = "aProject"
+	params.Zone = "europe-north1-b"
+	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
+	params.MachineType = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
+	mockOvfDescriptorLoader.EXPECT().Load("gs://ovfbucket/ovffolder/").Return(
+		nil, errors.New("ovf desc error"))
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject", "europe-north1-b").Return(nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
+		buildID: "build123", ovfDescriptorLoader: mockOvfDescriptorLoader,
+		Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator, params: params}
+	w, err := oi.setUpImportWorkflow()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, w)
+	assert.Equal(t, "", oi.gcsPathToClean)
+}
+
+func TestSetUpWorkOSIdFromOVFDescriptor(t *testing.T) {
+	params := GetAllParams()
+	params.OsID = ""
+	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	w, err := setupMocksForOSIdTesting(mockCtrl, "rhel7_64Guest", params)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+	assert.Equal(t, "../image_import/enterprise_linux/translate_rhel_7_licensed.wf.json", w.Vars["translate_workflow"].Value)
+}
+
+func TestSetUpWorkOSIdFromDescriptorInvalidAndOSFlagNotSpecified(t *testing.T) {
+	params := GetAllParams()
+	params.OsID = ""
+	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	w, err := setupMocksForOSIdTesting(mockCtrl, "no-OS-ID", params)
+
+	assert.Nil(t, w)
+	assert.NotNil(t, err)
+}
+
+func TestSetUpWorkOSIdFromDescriptorNonDeterministicAndOSFlagNotSpecified(t *testing.T) {
+	params := GetAllParams()
+	params.OsID = ""
+	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	w, err := setupMocksForOSIdTesting(mockCtrl, "ubuntu64Guest", params)
+
+	assert.Nil(t, w)
+	assert.NotNil(t, err)
+}
+
+func TestSetUpWorkOSFlagInvalid(t *testing.T) {
+	params := GetAllParams()
+	params.OsID = "not-OS-ID"
+	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	w, err := setupMocksForOSIdTesting(mockCtrl, "", params)
+
+	assert.Nil(t, w)
+	assert.NotNil(t, err)
+}
+
+func setupMocksForOSIdTesting(mockCtrl *gomock.Controller, osType string,
+	params *ovfimportparams.OVFImportParams) (*daisy.Workflow, error) {
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
+
+	descriptor := createOVFDescriptor()
+	if osType != "" {
+		descriptor.VirtualSystem.OperatingSystem = []ovf.OperatingSystemSection{{OSType: &osType}}
+	}
+	mockOvfDescriptorLoader.EXPECT().Load("gs://ovfbucket/ovffolder/").Return(
+		descriptor, nil)
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject", "us-central1-c").Return(nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
+		storageClient: mockStorageClient, buildID: "build123",
+		ovfDescriptorLoader: mockOvfDescriptorLoader, Logger: logging.NewLogger("test"),
+		zoneValidator: mockZoneValidator, params: params}
+	return oi.setUpImportWorkflow()
+}
+
+func TestCleanUp(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().DeleteGcsPath("aPath")
+	mockStorageClient.EXPECT().Close()
+
+	oi := OVFImporter{storageClient: mockStorageClient, gcsPathToClean: "aPath",
+		Logger: logging.NewLogger("test")}
+	oi.CleanUp()
+}
+
+func TestBuildDaisyVarsFromDisk(t *testing.T) {
+	oi := OVFImporter{params: GetAllParams()}
+	varMap := oi.buildDaisyVars("translateworkflow.wf.json", "gs://abucket/apath/bootdisk.vmdk", "n1-standard-2", "aRegion")
+
+	assert.Equal(t, "instance1", varMap["instance_name"])
+	assert.Equal(t, "translateworkflow.wf.json", varMap["translate_workflow"])
+	assert.Equal(t, strconv.FormatBool(false), varMap["install_gce_packages"])
+	assert.Equal(t, "gs://abucket/apath/bootdisk.vmdk", varMap["boot_disk_file"])
+	assert.Equal(t, "global/networks/aNetwork", varMap["network"])
+	assert.Equal(t, "regions/aRegion/subnetworks/aSubnet", varMap["subnet"])
+	assert.Equal(t, "n1-standard-2", varMap["machine_type"])
+	assert.Equal(t, "aDescription", varMap["description"])
+	assert.Equal(t, "10.0.0.1", varMap["private_network_ip"])
+	assert.Equal(t, "PREMIUM", varMap["network_tier"])
+
+	assert.Equal(t, len(varMap), 10)
+}
+
+func TestProjectFromGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Project = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().ProjectID().Return("aProject", nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	project, err := oi.getProject()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "aProject", project)
+}
+
+func TestGetZoneFromGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Zone = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().Zone().Return("europe-north1-b", nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	zone, err := oi.getZone("aProject")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "europe-north1-b", zone)
+}
+
+func TestGetRegionE(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	oi := OVFImporter{Logger: logging.NewLogger("test")}
+	region, err := oi.getRegion("europe-north1-b")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "europe-north1", region)
+}
+
+func TestGetProjectFromFlagEvenIfOnGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Project = "aProject123"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().ProjectID().Return("aProject", nil).AnyTimes()
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	project, err := oi.getProject()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "aProject123", project)
+}
+
+func TestGetZoneFromFlagEvenIfOnGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Zone = "aZone123"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().Zone().Return("europe-north1-b", nil).AnyTimes()
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject123", "aZone123").Return(nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"),
+		zoneValidator: mockZoneValidator, params: params}
+	zone, err := oi.getZone("aProject123")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "aZone123", zone)
+}
+
+func TestPopulateMissingParametersProjectEmptyNotOnGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Project = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	project, err := oi.getProject()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", project)
+}
+
+func TestPopulateMissingParametersErrorRetrievingProjectIDFromGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Project = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().ProjectID().Return("", errors.New("err"))
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	project, err := oi.getProject()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", project)
+}
+
+func TestGetZoneWhenZoneFlagNotSetNotOnGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Zone = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	zone, err := oi.getZone("aProject")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "", zone)
+}
+
+func TestGetZoneErrorRetrievingZone(t *testing.T) {
+	params := GetAllParams()
+	params.Zone = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().Zone().Return("", errors.New("err"))
+
+	oi := OVFImporter{mgce: mockMetadataGce, params: params}
+	zone, err := oi.getZone("aProject")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "", zone)
+}
+
+func TestGetZoneEmptyZoneReturnedFromGCE(t *testing.T) {
+	params := GetAllParams()
+	params.Zone = ""
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(true).AnyTimes()
+	mockMetadataGce.EXPECT().Zone().Return("", nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
+	zone, err := oi.getZone("aProject")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "", zone)
+}
+
+func TestPopulateMissingParametersInvalidZone(t *testing.T) {
+	params := GetAllParams()
+	params.Zone = "europe-north1-b"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject", "europe-north1-b").Return(fmt.Errorf("error"))
+
+	oi := OVFImporter{Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator,
+		params: params}
+	_, err := oi.getZone("aProject")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "europe-north1-b", params.Zone)
+}
+
+func createControllerItem(instanceID string, resourceType uint16) ovf.ResourceAllocationSettingData {
+	return ovf.ResourceAllocationSettingData{
+		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
+			InstanceID:   instanceID,
+			ResourceType: &resourceType,
+		},
+	}
+}
+
+func createDiskItem(instanceID string, addressOnParent string,
+	elementName string, hostResource string, parent string) ovf.ResourceAllocationSettingData {
+	diskType := uint16(17)
+	return ovf.ResourceAllocationSettingData{
+		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
+			InstanceID:      instanceID,
+			ResourceType:    &diskType,
+			AddressOnParent: &addressOnParent,
+			ElementName:     elementName,
+			HostResource:    []string{hostResource},
+			Parent:          &parent,
+		},
+	}
+}
+
+func createOVFDescriptor() *ovf.Envelope {
+	virtualHardware := ovf.VirtualHardwareSection{
+		Item: []ovf.ResourceAllocationSettingData{
+			createControllerItem("5", 6),
+			createDiskItem("7", "1", "disk1",
+				"ovf:/disk/vmdisk2", "5"),
+			createDiskItem("6", "0", "disk0",
+				"ovf:/disk/vmdisk1", "5"),
+			createDiskItem("8", "2", "disk2",
+				"ovf:/disk/vmdisk3", "5"),
+			createCPUItem("11", 16),
+			createMemoryItem("12", 4096),
+		},
+	}
+	diskCapacityAllocationUnits := "byte * 2^30"
+	fileRef1 := "file1"
+	fileRef2 := "file2"
+	fileRef3 := "file3"
+	ovfDescriptor := &ovf.Envelope{
+		Disk: &ovf.DiskSection{Disks: []ovf.VirtualDiskDesc{
+			{Capacity: "20", CapacityAllocationUnits: &diskCapacityAllocationUnits, DiskID: "vmdisk1", FileRef: &fileRef1},
+			{Capacity: "1", CapacityAllocationUnits: &diskCapacityAllocationUnits, DiskID: "vmdisk2", FileRef: &fileRef2},
+			{Capacity: "5", CapacityAllocationUnits: &diskCapacityAllocationUnits, DiskID: "vmdisk3", FileRef: &fileRef3},
+		}},
+		References: []ovf.File{
+			{Href: "Ubuntu_for_Horizon71_1_1.0-disk1.vmdk", ID: "file1", Size: 1151322112},
+			{Href: "Ubuntu_for_Horizon71_1_1.0-disk2.vmdk", ID: "file2", Size: 68096},
+			{Href: "Ubuntu_for_Horizon71_1_1.0-disk3.vmdk", ID: "file3", Size: 68096},
+		},
+		VirtualSystem: &ovf.VirtualSystem{
+			VirtualHardware: []ovf.VirtualHardwareSection{virtualHardware},
+		},
+	}
+	return ovfDescriptor
+}
+
+func createCPUItem(instanceID string, quantity uint) ovf.ResourceAllocationSettingData {
+	resourceType := uint16(3)
+	mhz := "hertz * 10^6"
+	return ovf.ResourceAllocationSettingData{
+		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
+			InstanceID:      instanceID,
+			ResourceType:    &resourceType,
+			VirtualQuantity: &quantity,
+			AllocationUnits: &mhz,
+		},
+	}
+}
+
+func createMemoryItem(instanceID string, quantityMB uint) ovf.ResourceAllocationSettingData {
+	resourceType := uint16(4)
+	mb := "byte * 2^20"
+
+	return ovf.ResourceAllocationSettingData{
+		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
+			InstanceID:      instanceID,
+			ResourceType:    &resourceType,
+			VirtualQuantity: &quantityMB,
+			AllocationUnits: &mb,
+		},
+	}
+}
+
+func GetAllParams() *ovfimportparams.OVFImportParams {
+	return &ovfimportparams.OVFImportParams{
+		InstanceNames:               "instance1",
+		ClientID:                    "aClient",
+		OvfOvaGcsPath:               "gs://ovfbucket/ovfpath/vmware.ova",
+		NoGuestEnvironment:          true,
+		CanIPForward:                true,
+		DeletionProtection:          true,
+		Description:                 "aDescription",
+		Labels:                      "userkey1=uservalue1,userkey2=uservalue2",
+		MachineType:                 "n1-standard-2",
+		Network:                     "aNetwork",
+		Subnet:                      "aSubnet",
+		NetworkTier:                 "PREMIUM",
+		PrivateNetworkIP:            "10.0.0.1",
+		NoExternalIP:                true,
+		NoRestartOnFailure:          true,
+		OsID:                        "ubuntu-1404",
+		ShieldedIntegrityMonitoring: true,
+		ShieldedSecureBoot:          true,
+		ShieldedVtpm:                true,
+		Tags:                        "tag1=val1",
+		Zone:                        "us-central1-c",
+		BootDiskKmskey:              "aKey",
+		BootDiskKmsKeyring:          "aKeyring",
+		BootDiskKmsLocation:         "aKmsLocation",
+		BootDiskKmsProject:          "aKmsProject",
+		Timeout:                     "3h",
+		Project:                     "aProject",
+		ScratchBucketGcsPath:        "gs://bucket/folder",
+		Oauth:                       "oAuthFilePath",
+		Ce:                          "us-east1-c",
+		GcsLogsDisabled:             true,
+		CloudLogsDisabled:           true,
+		StdoutLogsDisabled:          true,
+		NodeAffinityLabelsFlag:      []string{"env,IN,prod,test"},
+	}
+}
+
+var machineTypes = []*compute.MachineType{
+	{
+		GuestCpus:                    1,
+		Id:                           2000,
+		IsSharedCpu:                  true,
+		MaximumPersistentDisks:       16,
+		MaximumPersistentDisksSizeGb: 3072,
+		MemoryMb:                     1740,
+		Name:                         "g1-small",
+		Zone:                         "us-east1-b",
+	},
+	{
+		GuestCpus:                    16,
+		Id:                           4016,
+		ImageSpaceGb:                 10,
+		MaximumPersistentDisks:       128,
+		MaximumPersistentDisksSizeGb: 65536,
+		MemoryMb:                     14746,
+		Name:                         "n1-highcpu-16",
+		Zone:                         "us-east1-b",
+	},
+}

--- a/daisy_workflows/ovf_import/import_ovf.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf.wf.json
@@ -24,7 +24,6 @@
     },
     "translation_disk_name": "temp-translation-disk-${ID}",
     "boot_image_name": "boot-image-${ID}",
-    "boot_image_name_untranslated": "boot-image-untranslated-${ID}",
     "machine_type": "n1-standard-1",
     "network": {
       "Value": "global/networks/default",
@@ -54,13 +53,6 @@
           "import_subnet": "${subnet}"
         }
       }
-    },
-    "take-image-of-untranslated-disk": {
-      "CreateImages": [{
-        "Name": "${boot_image_name_untranslated}",
-        "Description": "Imported (untranslated) image from ${boot_disk_file}",
-        "SourceDisk": "${translation_disk_name}"
-      }]
     },
     "translate": {
       "IncludeWorkflow": {
@@ -120,13 +112,12 @@
     "cleanup": {
       "DeleteResources": {
         "Disks": ["${translation_disk_name}"],
-        "Images": ["${boot_image_name_untranslated}", "${boot_image_name}"]
+        "Images": ["${boot_image_name}"]
       }
     }
   },
   "Dependencies": {
-    "take-image-of-untranslated-disk": ["import-boot-disk"],
-    "translate": ["take-image-of-untranslated-disk"],
+    "translate": ["import-boot-disk"],
     "create-boot-disk": ["translate"],
     "create-instance": ["create-boot-disk"],
     "cleanup": ["create-instance"]

--- a/gce_ovf_import_tests/compute/instance.go
+++ b/gce_ovf_import_tests/compute/instance.go
@@ -1,0 +1,99 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package compute contains wrappers around the GCE compute API.
+package compute
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	api "google.golang.org/api/compute/v1"
+)
+
+// Instance is a compute instance.
+type Instance struct {
+	*api.Instance
+	Client        daisyCompute.Client
+	Project, Zone string
+}
+
+// Cleanup deletes the Instance.
+func (i *Instance) Cleanup() {
+	if err := i.Client.DeleteInstance(i.Project, i.Zone, i.Name); err != nil {
+		fmt.Printf("Error deleting instance: %v\n", err)
+	}
+}
+
+// WaitForSerialOutput waits to a string match on a serial port.
+func (i *Instance) WaitForSerialOutput(match string, port int64, interval, timeout time.Duration) error {
+	var start int64
+	var errs int
+	tick := time.Tick(interval)
+	timedout := time.Tick(timeout)
+	for {
+		select {
+		case <-timedout:
+			return fmt.Errorf("timed out waiting for %q", match)
+		case <-tick:
+			resp, err := i.Client.GetSerialPortOutput(i.Project, i.Zone, i.Name, port, start)
+			if err != nil {
+				status, sErr := i.Client.InstanceStatus(i.Project, i.Zone, i.Name)
+				if sErr != nil {
+					err = fmt.Errorf("%v, error getting InstanceStatus: %v", err, sErr)
+				} else {
+					err = fmt.Errorf("%v, InstanceStatus: %q", err, status)
+				}
+
+				// Wait until machine restarts to evaluate SerialOutput.
+				if status == "TERMINATED" || status == "STOPPED" || status == "STOPPING" {
+					continue
+				}
+
+				// Retry up to 3 times in a row on any error if we successfully got InstanceStatus.
+				if errs < 3 {
+					errs++
+					continue
+				}
+
+				return err
+			}
+			start = resp.Next
+			for _, ln := range strings.Split(resp.Contents, "\n") {
+				if i := strings.Index(ln, match); i != -1 {
+					return nil
+				}
+			}
+			errs = 0
+		}
+	}
+}
+
+// CreateInstance creates a compute instance.
+func CreateInstance(client daisyCompute.Client, project, zone string, i *api.Instance) (*Instance, error) {
+	if err := client.CreateInstance(project, zone, i); err != nil {
+		return nil, err
+	}
+	return &Instance{Instance: i, Client: client, Project: project, Zone: zone}, nil
+}
+
+// BuildInstanceMetadataItem create an metadata item
+func BuildInstanceMetadataItem(key, value string) *api.MetadataItems {
+	return &api.MetadataItems{
+		Key:   key,
+		Value: func() *string { v := value; return &v }(),
+	}
+}

--- a/gce_ovf_import_tests/junitxml/junitxml.go
+++ b/gce_ovf_import_tests/junitxml/junitxml.go
@@ -1,0 +1,139 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package junitxml provides helpers around creating junit XML data.
+package junitxml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NewTestSuite creates a new TestSuite.
+func NewTestSuite(name string) *TestSuite {
+	return &TestSuite{
+		Name:  name,
+		start: time.Now(),
+	}
+}
+
+// TestSuite is a junitxml TestSuite.
+type TestSuite struct {
+	XMLName  xml.Name `xml:"testsuite"`
+	Name     string   `xml:"name,attr"`
+	Tests    int      `xml:"tests,attr"`
+	Failures int      `xml:"failures,attr"`
+	Errors   int      `xml:"errors,attr"`
+	Disabled int      `xml:"disabled,attr"`
+	Skipped  int      `xml:"skipped,attr"`
+	Time     float64  `xml:"time,attr"`
+
+	TestCase []*TestCase `xml:"testcase"`
+
+	start time.Time
+}
+
+// Finish marks a TestSuite as finished and sends it in the provided channel.
+func (s *TestSuite) Finish(tests chan *TestSuite) {
+	s.Time = time.Since(s.start).Seconds()
+	s.Tests = len(s.TestCase)
+	for _, tc := range s.TestCase {
+		if tc.Failure != nil {
+			s.Failures++
+		}
+		if tc.Skipped != nil {
+			s.Skipped++
+		}
+	}
+	tests <- s
+}
+
+// NewTestCase creates a new TestCase.
+func NewTestCase(classname, name string) *TestCase {
+	return &TestCase{
+		Classname: classname,
+		Name:      fmt.Sprintf("[%s] %s", classname, name),
+		ID:        uuid.New().String(),
+		start:     time.Now(),
+	}
+}
+
+// TestCase is a junitxml TestCase.
+type TestCase struct {
+	Classname string        `xml:"classname,attr"`
+	ID        string        `xml:"id,attr"`
+	Name      string        `xml:"name,attr"`
+	Time      float64       `xml:"time,attr"`
+	Skipped   *junitSkipped `xml:"skipped,omitempty"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+	SystemOut string        `xml:"system-out,omitempty"`
+
+	start time.Time
+	buf   bytes.Buffer
+}
+
+type junitSkipped struct {
+	Message string `xml:"message,attr"`
+}
+
+type junitFailure struct {
+	FailMessage string `xml:",chardata"`
+	FailType    string `xml:"type,attr"`
+}
+
+// Logf logs to the TestCase SystemOut.
+func (c *TestCase) Logf(msg string, args ...interface{}) {
+	c.buf.WriteString(fmt.Sprintf(msg, args...) + "\n")
+}
+
+// WriteFailure marks a TestCase as failed with the provided message.
+func (c *TestCase) WriteFailure(msg string, args ...interface{}) {
+	msg = fmt.Sprintf(msg, args...)
+	c.Logf(msg)
+	c.Failure = &junitFailure{
+		FailMessage: msg,
+		FailType:    "Failure",
+	}
+}
+
+// WriteSkipped marks a TestCase as skipped with the provided message.
+func (c *TestCase) WriteSkipped(msg string, args ...interface{}) {
+	msg = fmt.Sprintf(msg, args...)
+	c.Skipped = &junitSkipped{
+		Message: msg,
+	}
+}
+
+// Finish marks a TestCase as finished and sends it in the provided channel.
+func (c *TestCase) Finish(tests chan *TestCase) {
+	c.Time = time.Since(c.start).Seconds()
+	c.SystemOut = c.buf.String()
+	tests <- c
+}
+
+// FilterTestCase markes a TestCase as skipped if the name matches does not
+// match the regex.
+func (c *TestCase) FilterTestCase(regex *regexp.Regexp) bool {
+	if regex != nil && !regex.MatchString(c.Name) {
+		c.WriteSkipped("Test does not match filter: %q", regex.String())
+		return true
+	}
+
+	return false
+}

--- a/gce_ovf_import_tests/main.go
+++ b/gce_ovf_import_tests/main.go
@@ -42,7 +42,7 @@ var (
 )
 
 var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp, *testconfig.Project){
-	ovf_test_suites.TestSuite,
+	ovftestsuite.TestSuite,
 }
 
 func main() {

--- a/gce_ovf_import_tests/main.go
+++ b/gce_ovf_import_tests/main.go
@@ -1,0 +1,134 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests/junitxml"
+	"github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests/test_config"
+	"github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests/test_suites"
+)
+
+var (
+	testSuiteFilter = flag.String("test_suite_filter", "", "test suite filter")
+	testCaseFilter  = flag.String("test_case_filter", "", "test case filter")
+	outDir          = flag.String("out_dir", "/tmp", "junit xml directory")
+	testProjectID   = flag.String("test_project_id", "", "test project id")
+	testZone        = flag.String("test_zone", "", "test zone")
+)
+
+var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp, *testconfig.Project){
+	ovf_test_suites.TestSuite,
+}
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+
+	if len(strings.TrimSpace(*testProjectID)) == 0 {
+		fmt.Println("-test_project_id is invalid")
+		os.Exit(1)
+	}
+
+	if len(strings.TrimSpace(*testZone)) == 0 {
+		fmt.Println("-test_zone is invalid")
+		os.Exit(1)
+	}
+
+	pr := testconfig.GetProject(*testProjectID, *testZone)
+
+	var testSuiteRegex *regexp.Regexp
+	if *testSuiteFilter != "" {
+		var err error
+		testSuiteRegex, err = regexp.Compile(*testSuiteFilter)
+		if err != nil {
+			fmt.Println("-testSuiteFilter flag not valid:", err)
+			os.Exit(1)
+		}
+	}
+
+	var testCaseRegex *regexp.Regexp
+	if *testCaseFilter != "" {
+		var err error
+		testCaseRegex, err = regexp.Compile(*testCaseFilter)
+		if err != nil {
+			fmt.Println("-testCaseFilter flag not valid:", err)
+			os.Exit(1)
+		}
+	}
+
+	logger := log.New(os.Stdout, "[OvfImportTests] ", 0)
+	logger.Println("Starting...")
+
+	tests := make(chan *junitxml.TestSuite)
+	var wg sync.WaitGroup
+	for _, tf := range testFunctions {
+		wg.Add(1)
+		go tf(ctx, &wg, tests, logger, testSuiteRegex, testCaseRegex, pr)
+	}
+	go func() {
+		wg.Wait()
+		close(tests)
+	}()
+
+	var testSuites []*junitxml.TestSuite
+	for ret := range tests {
+		testSuites = append(testSuites, ret)
+		testSuiteOutPath := filepath.Join(*outDir, fmt.Sprintf("junit_%s.xml", ret.Name))
+		if err := os.MkdirAll(filepath.Dir(testSuiteOutPath), 0770); err != nil {
+			log.Fatal(err)
+		}
+
+		logger.Printf("Creating junit xml file: %s", testSuiteOutPath)
+		d, err := xml.MarshalIndent(ret, "  ", "   ")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := ioutil.WriteFile(testSuiteOutPath, d, 0644); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	for _, ts := range testSuites {
+		if ts.Failures > 0 {
+			buf.WriteString(fmt.Sprintf("TestSuite %q has errors:\n", ts.Name))
+			for _, tc := range ts.TestCase {
+				if tc.Failure != nil {
+					buf.WriteString(fmt.Sprintf(" - %q: %s\n", tc.Name, tc.Failure.FailMessage))
+				}
+			}
+
+		}
+	}
+
+	if buf.Len() > 0 {
+		logger.Fatalf("%sExiting with exit code 1", buf.String())
+	}
+	logger.Print("All test cases completed successfully.")
+}

--- a/gce_ovf_import_tests/scripts/ovf_import_test_ubuntu_3_disks.sh
+++ b/gce_ovf_import_tests/scripts/ovf_import_test_ubuntu_3_disks.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests to validate if Ubuntu OVF with 3 disks was imported successfully.
+
+FAIL=0
+FAILURES=""
+
+function status {
+  local message="${1}"
+  echo "STATUS: ${message}"
+}
+
+function fail {
+  local message="${1}"
+  FAIL=$((FAIL+1))
+  FAILURES+="TestFailed: $message"$'\n'
+}
+
+# Check network connectivity.
+function check_connectivity {
+  status "Checking metadata connection."
+  ping -q -c 2 metadata.google.internal
+  if [[ $? -ne 0 ]]; then
+    fail "Failed to connect to metadata.google.internal."
+  fi
+
+  status "Checking external connectivity."
+  ping -q -c 2 google.com
+  if [[ $? -ne 0 ]]; then
+    fail "Failed to ping google.com."
+  fi
+}
+
+# Check Google services.
+function check_google_services {
+  status "Checking if instance setup ran."
+  if [[ ! -f /etc/default/instance_configs.cfg ]]; then
+    fail "Instance setup failed."
+  fi
+
+  # Upstart
+  if [[ -d /etc/init ]]; then
+    status "Checking google-accounts-daemon."
+    if initctl status google-accounts-daemon | grep -qv 'running'; then
+      fail "Google accounts daemon not running."
+    fi
+
+    status "Checking google-network-daemon."
+    if initctl status google-network-daemon | grep -qv 'running'; then
+      fail "Google Network daemon not running."
+    fi
+
+    status "Checking google-clock-skew-daemon."
+    if initctl status google-clock-skew-daemon | grep -qv 'running'; then
+      fail "Google Clock Skew daemon not running."
+    fi
+  else
+    status "Checking google-accounts-daemon."
+    service google-accounts-daemon status
+    if [[ $? -ne 0 ]]; then
+      fail "Google accounts daemon not running."
+    fi
+
+    status "Checking google-network-daemon."
+    service google-network-daemon status
+    if [[ $? -ne 0 ]]; then
+      fail "Google Network daemon not running."
+    fi
+
+    status "Checking google-clock-skew-daemon."
+    service google-clock-skew-daemon status
+    if [[ $? -ne 0 ]]; then
+      fail "Google Clock Skew daemon not running."
+    fi
+  fi
+}
+
+# Check Google Cloud SDK.
+function check_google_cloud_sdk {
+  # Skip for EL6
+  if [ -f /etc/redhat-release ]; then
+    grep -q "release 6" /etc/redhat-release
+    if [ $? -eq 0 ]; then
+      return
+    fi
+  fi
+
+  status "Checking for gcloud."
+  gcloud version
+  if [[ $? -ne 0 ]]; then
+    fail "gcloud is not installed."
+  fi
+
+  status "Checking for gsutil."
+  gsutil -v
+  if [[ $? -ne 0 ]]; then
+    fail "gsutil is not installed."
+  fi
+}
+
+# Check cloud-init if it exists.
+function check_cloud_init {
+  if [[ -x /usr/bin/cloud-init ]]; then
+    status "Checking if cloud-init runs."
+    cloud-init init
+    if [[ $? -ne 0 ]]; then
+      fail "cloud-init failed to run."
+    fi
+  fi
+}
+
+# Check package installs.
+function check_package_install {
+  # Apt
+  if [[ -d /etc/apt ]]; then
+    status "Checking if apt can update cache."
+    apt-get update
+    if [[ $? -ne 0 ]]; then
+      fail "apt-get update failed."
+    fi
+
+    status "Checking if apt can install a package."
+    apt-get install --reinstall make
+    if [[ $? -ne 0 ]]; then
+      fail "apt-get cannot install make."
+    fi
+  fi
+
+  # Yum
+  if [[ -d /etc/yum ]]; then
+    status "Checking if yum can install a package."
+    yum -y reinstall make
+    if [[ $? -ne 0 ]]; then
+      fail "yum cannot install make."
+    fi
+  fi
+
+  # Zypper
+  if [[ -d /etc/zypp ]]; then
+    status "Checking if zypper can install a package."
+    zypper install -f -y make
+    if [[ $? -ne 0 ]]; then
+      fail "zypper cannot install make."
+    fi
+  fi
+}
+
+function check_data_disk_content {
+  if [[ $(< /mnt/b/test_sdb.txt) != "on_sdb" ]]; then
+      fail "/mnt/b/test_sdb.txt not found or content doesn't match."
+  fi
+  if [[ $(< /mnt/c/test_sdc.txt) != "on_sdc" ]]; then
+      fail "/mnt/c/test_sdc.txt not found or content doesn't match."
+  fi
+}
+
+# Run tests.
+check_google_services
+check_google_cloud_sdk
+check_cloud_init
+check_package_install
+check_connectivity
+check_data_disk_content
+
+# Return results.
+if [[ ${FAIL} -eq 0 ]]; then
+  echo "PASSED: All tests passed!"
+else
+  echo "FAILED: ${FAIL} tests failed. ${FAILURES}"
+fi

--- a/gce_ovf_import_tests/test_config/project_config.go
+++ b/gce_ovf_import_tests/test_config/project_config.go
@@ -1,0 +1,35 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package testconfig
+
+// Project is details of test Project.
+type Project struct {
+	TestProjectID        string
+	ServiceAccountEmail  string
+	TestZone             string
+	ServiceAccountScopes []string
+}
+
+// GetProject creates a Project object for given project ID and zone
+func GetProject(projectID, testZone string) *Project {
+	return &Project{
+		TestProjectID:       projectID,
+		TestZone:            testZone,
+		ServiceAccountEmail: "default",
+		ServiceAccountScopes: []string{
+			"https://www.googleapis.com/auth/cloud-platform",
+		},
+	}
+}

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -1,0 +1,208 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package main contains e2e tests for OVF import
+package ovf_test_suites
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_importer"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	computeUtils "github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests/junitxml"
+	"github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests/test_config"
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
+	"github.com/kylelemons/godebug/pretty"
+	api "google.golang.org/api/compute/v1"
+)
+
+const (
+	testSuiteName = "OVFImportTests"
+)
+
+var (
+	dump = &pretty.Config{IncludeUnexported: true}
+)
+
+var vf = func(inst *compute.Instance, vfString string, port int64, interval, timeout time.Duration) error {
+	return inst.WaitForSerialOutput(vfString, port, interval, timeout)
+}
+
+type ovfImportTestSetup struct {
+	importParams  *ovfimportparams.OVFImportParams
+	name          string
+	startup       *api.MetadataItems
+	assertTimeout time.Duration
+	vf            func(*compute.Instance, string, int64, time.Duration, time.Duration) error
+}
+
+// TestSuite is OVF import test suite.
+func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junitxml.TestSuite, logger *log.Logger, testSuiteRegex, testCaseRegex *regexp.Regexp, testProjectConfig *testconfig.Project) {
+	defer tswg.Done()
+
+	if testSuiteRegex != nil && !testSuiteRegex.MatchString(testSuiteName) {
+		return
+	}
+
+	testSuite := junitxml.NewTestSuite(testSuiteName)
+	defer testSuite.Finish(testSuites)
+	suffix := utils.RandString(5)
+	logger.Printf("Running TestSuite %q", testSuite.Name)
+
+	//startupScript := "echo 'SUCCESS wVnWw3a41CVe3mBVvTMn'"
+	startupScript, err := ioutil.ReadFile("gce_ovf_import_tests/scripts/ovf_import_test_ubuntu_3_disks.sh")
+	if err != nil {
+		os.Exit(1)
+	}
+	testSetup := []*ovfImportTestSetup{
+		{
+			importParams: &ovfimportparams.OVFImportParams{
+				ClientID:      "test",
+				InstanceNames: fmt.Sprintf("test-instance-ubuntu-3mounteddisks-%v", suffix),
+				OvfOvaGcsPath: "gs://zoran-playground/ova/Ubuntu_for_Horizon_three_disks_mounted.ova",
+				OsID:          "ubuntu-1404",
+				Labels:        "lk1=lv1,lk2=kv2",
+				Project:       testProjectConfig.TestProjectID,
+				Zone:          testProjectConfig.TestZone,
+				MachineType:   "n1-standard-2",
+			},
+			name:          fmt.Sprintf("ovf-import-test-%s", suffix),
+			startup:       computeUtils.BuildInstanceMetadataItem("startup-script", string(startupScript)),
+			assertTimeout: 7200 * time.Second,
+		},
+	}
+
+	var wg sync.WaitGroup
+	tests := make(chan *junitxml.TestCase)
+	for _, setup := range testSetup {
+		wg.Add(1)
+		go ovfImportTestCase(ctx, setup, tests, &wg, logger, testCaseRegex, testProjectConfig)
+	}
+
+	go func() {
+		wg.Wait()
+		close(tests)
+	}()
+
+	for ret := range tests {
+		testSuite.TestCase = append(testSuite.TestCase, ret)
+	}
+
+	logger.Printf("Finished TestSuite %q", testSuite.Name)
+}
+
+func ovfImportTestCase(ctx context.Context, testSetup *ovfImportTestSetup, tests chan *junitxml.TestCase, wg *sync.WaitGroup, logger *log.Logger, regex *regexp.Regexp, testProjectConfig *testconfig.Project) {
+	defer wg.Done()
+
+	ovfImportTestCase := junitxml.NewTestCase(testSuiteName, "[OVFImport] Import OVF")
+
+	for tc, f := range map[*junitxml.TestCase]func(context.Context, *junitxml.TestCase, *ovfImportTestSetup, *log.Logger, *testconfig.Project){
+		ovfImportTestCase: runOvfImportTest,
+	} {
+		if tc.FilterTestCase(regex) {
+			tc.Finish(tests)
+		} else {
+			logger.Printf("Running TestCase %s.%q", tc.Classname, tc.Name)
+			f(ctx, tc, testSetup, logger, testProjectConfig)
+			tc.Finish(tests)
+			logger.Printf("TestCase %s.%q finished in %fs", tc.Classname, tc.Name, tc.Time)
+		}
+	}
+}
+
+func runOvfImportTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *ovfImportTestSetup, logger *log.Logger, testProjectConfig *testconfig.Project) {
+	logger.Printf("Creating OVF importer")
+	ovfImporter, err := ovfimporter.NewOVFImporter(testSetup.importParams)
+
+	if err != nil {
+		testCase.WriteFailure("error creating OVF importer: %v", err)
+		return
+	}
+
+	logger.Printf("Starting OVF import")
+	err = ovfImporter.Import()
+	if err != nil {
+		testCase.WriteFailure("error while performing OVF import: %v", err)
+		ovfImporter.CleanUp()
+		return
+	}
+
+	logger.Printf("OVF import finished")
+	ovfImporter.CleanUp()
+
+	// assertion
+	client, err := daisyCompute.NewClient(ctx)
+	if err != nil {
+		testCase.WriteFailure("Error creating client: %v", err)
+		return
+	}
+
+	instanceName := testSetup.importParams.InstanceNames
+	//instanceName := "test-instance-ubuntu-3mounteddisks-v0352"
+
+	instance, err := client.GetInstance(testProjectConfig.TestProjectID, testProjectConfig.TestZone, instanceName)
+	if !strings.HasSuffix(instance.MachineType, testSetup.importParams.MachineType) {
+		testCase.WriteFailure("Instance machine type `%v` doesn't match requested machine type `%v`", instance.MachineType, testSetup.importParams.MachineType)
+		return
+	}
+
+	if !strings.HasSuffix(instance.Zone, testSetup.importParams.Zone) {
+		testCase.WriteFailure("Instance zone `%v` doesn't match requested zone `%v`", instance.Zone, testSetup.importParams.Zone)
+		return
+	}
+
+	logger.Printf("Stopping instance before restarting with test startup script")
+	err = client.StopInstance(testProjectConfig.TestProjectID, testProjectConfig.TestZone, instanceName)
+
+	if err != nil {
+		testCase.WriteFailure("Error stopping imported instance: %v", err)
+		return
+	}
+
+	logger.Printf("Setting instance metadata with test startup script")
+	err = client.SetInstanceMetadata(testProjectConfig.TestProjectID, testProjectConfig.TestZone,
+		instanceName, &api.Metadata{Items: []*api.MetadataItems{testSetup.startup}, Fingerprint: instance.Metadata.Fingerprint})
+	if err != nil {
+		testCase.WriteFailure("Couldn't set instance metadata to verify OVF import: %v", err)
+		return
+	}
+
+	logger.Printf("Starting instance with test startup script")
+	err = client.StartInstance(testProjectConfig.TestProjectID, testProjectConfig.TestZone, instanceName)
+	if err != nil {
+		testCase.WriteFailure("Couldn't start instance to verify OVF import: %v", err)
+		return
+	}
+
+	inst := computeUtils.Instance{Instance: instance, Client: client,
+		Project: testProjectConfig.TestProjectID, Zone: testProjectConfig.TestZone}
+
+	if err := inst.WaitForSerialOutput("PASSED: All tests passed!", 1, 5*time.Second, 7*time.Minute); err != nil {
+		testCase.WriteFailure("Error during VM validation: %v", err)
+		return
+	}
+
+	inst.Cleanup()
+}

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -12,8 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package main contains e2e tests for OVF import
-package ovf_test_suites
+// Package ovftestsuite contains e2e tests for OVF import
+package ovftestsuite
 
 import (
 	"context"

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -71,7 +71,6 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 	suffix := utils.RandString(5)
 	logger.Printf("Running TestSuite %q", testSuite.Name)
 
-	//startupScript := "echo 'SUCCESS wVnWw3a41CVe3mBVvTMn'"
 	startupScript, err := ioutil.ReadFile("gce_ovf_import_tests/scripts/ovf_import_test_ubuntu_3_disks.sh")
 	if err != nil {
 		os.Exit(1)
@@ -81,14 +80,14 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 			importParams: &ovfimportparams.OVFImportParams{
 				ClientID:      "test",
 				InstanceNames: fmt.Sprintf("test-instance-ubuntu-3mounteddisks-%v", suffix),
-				OvfOvaGcsPath: "gs://zoran-playground/ova/Ubuntu_for_Horizon_three_disks_mounted.ova",
+				OvfOvaGcsPath: "gs://compute-image-tools-test-resources/ova/Ubuntu_for_Horizon_three_disks_mounted.ova",
 				OsID:          "ubuntu-1404",
 				Labels:        "lk1=lv1,lk2=kv2",
 				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-2",
 			},
-			name:          fmt.Sprintf("ovf-import-test-%s", suffix),
+			name:          fmt.Sprintf("ovf-import-test-ubuntu-3-disks-%s", suffix),
 			startup:       computeUtils.BuildInstanceMetadataItem("startup-script", string(startupScript)),
 			assertTimeout: 7200 * time.Second,
 		},
@@ -160,7 +159,6 @@ func runOvfImportTest(ctx context.Context, testCase *junitxml.TestCase, testSetu
 	}
 
 	instanceName := testSetup.importParams.InstanceNames
-	//instanceName := "test-instance-ubuntu-3mounteddisks-v0352"
 
 	instance, err := client.GetInstance(testProjectConfig.TestProjectID, testProjectConfig.TestZone, instanceName)
 	if !strings.HasSuffix(instance.MachineType, testSetup.importParams.MachineType) {
@@ -204,5 +202,6 @@ func runOvfImportTest(ctx context.Context, testCase *junitxml.TestCase, testSetu
 		return
 	}
 
+	logger.Printf("Deleting instance `%v`", instanceName)
 	inst.Cleanup()
 }

--- a/test-infra/README.md
+++ b/test-infra/README.md
@@ -26,7 +26,9 @@ https://k8s-testgrid.appspot.com/google-gce-compute-image-tools#ci-daisy-e2e
 | `prow/plugins.yaml` | Configuration for Prow plugins. |
 | `prowjobs/` | Prow job containers. |
 | `prowjobs/daisy-e2e/` | Runs workflows in `daisy_workflows` against the latest (master:HEAD) Daisy binary. |
+| `prowjobs/gce-ovf-import-tests/` | Runs OVF importer tests against the latest (master:HEAD) OVF Importer binary. |
 | `prowjobs/gocheck/` | Runs `go fmt`, `golint`, `go vet` against Go code in the repo. |
+| `prowjobs/osconfig-tests/` | Runs OS Config tests. |
 | `prowjobs/flake8/` | Runs `flake8` against python code in the repo. |
 | `prowjobs/unittests/` | Runs all scripts within the repo with the filename `unittests.sh`. Each script is run within its own directory. Publishes code coverage results to Codecov. |
 | `prowjobs/wrapper/` | Imported by other Prow jobs. Contains a wrapper binary that manages test log/artifact uploads. |

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -189,6 +189,24 @@ periodics:
     - name: compute-image-tools-test-service-account
       secret:
        secretName: compute-image-tools-test-service-account
+ - name: ci-ovf-import-e2e-tests-daily
+   interval: 24h
+   agent: kubernetes
+   spec:
+     containers:
+       - image: gcr.io/compute-image-tools-test/gce-ovf-import-tests:latest
+         args:
+           - "-out_dir=/artifacts"
+           - "-test_project_id=compute-image-test-pool-001"
+           - "-test_zone=us-central1-c"
+         volumeMounts:
+           - name: compute-image-tools-test-service-account
+             mountPath: /etc/compute-image-tools-test-service-account
+             readOnly: true
+     volumes:
+       - name: compute-image-tools-test-service-account
+         secret:
+           secretName: compute-image-tools-test-service-account
  - name: osconfig-tests
    interval: 3h
    agent: kubernetes

--- a/test-infra/prowjobs/cloudbuild.yaml
+++ b/test-infra/prowjobs/cloudbuild.yaml
@@ -13,6 +13,8 @@ steps:
   args: ['build', '--tag=gcr.io/$PROJECT_ID/test-runner:latest', '--tag=gcr.io/$PROJECT_ID/test-runner:$COMMIT_SHA', './test-infra/prowjobs/test-runner']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/osconfig-tests:latest', '--tag=gcr.io/$PROJECT_ID/osconfig-tests:$COMMIT_SHA', './test-infra/prowjobs/osconfig-tests']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gce-ovf-import-tests:latest', '--tag=gcr.io/$PROJECT_ID/gce-ovf-import-tests:$COMMIT_SHA', './test-infra/prowjobs/gce-ovf-import-tests']
 
 images:
   - 'gcr.io/$PROJECT_ID/wrapper:latest'
@@ -29,3 +31,5 @@ images:
   - 'gcr.io/$PROJECT_ID/test-runner:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/osconfig-tests:latest'
   - 'gcr.io/$PROJECT_ID/osconfig-tests:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/gce-ovf-import-tests:latest'
+  - 'gcr.io/$PROJECT_ID/gce-ovf-import-tests:$COMMIT_SHA'

--- a/test-infra/prowjobs/gce-ovf-import-tests/Dockerfile
+++ b/test-infra/prowjobs/gce-ovf-import-tests/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM golang:alpine
+
+ENV GOPATH=/usr/local/google/home/zoranl/go/
+RUN apk add --no-cache git
+
+WORKDIR /tmp
+RUN go get -d github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests
+RUN CGO_ENABLED=0 go build -o /gce_ovf_import_test_runner github.com/GoogleCloudPlatform/compute-image-tools/gce_ovf_import_tests
+RUN chmod +x /gce_ovf_import_test_runner
+
+FROM gcr.io/compute-image-tools-test/wrapper:latest
+
+ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
+
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=0 /gce_ovf_import_test_runner gce_ovf_import_test_runner
+ENTRYPOINT ["./wrapper", "./gce_ovf_import_test_runner"]

--- a/test-infra/prowjobs/gce-ovf-import-tests/Dockerfile
+++ b/test-infra/prowjobs/gce-ovf-import-tests/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 FROM golang:alpine
 
-ENV GOPATH=/usr/local/google/home/zoranl/go/
 RUN apk add --no-cache git
 
 WORKDIR /tmp
@@ -27,4 +26,5 @@ ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account
 
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_ovf_import_test_runner gce_ovf_import_test_runner
+COPY gce_ovf_import_tests/scripts/ /gce_ovf_import_tests/scripts/
 ENTRYPOINT ["./wrapper", "./gce_ovf_import_test_runner"]


### PR DESCRIPTION
Notes to make the review easier:
- this change includes refactoring gce_ovf_import/main.go by extracting most of the logic to ovf_importer.go and ovf_import_params_validator.go (including tests). Most of this code was already reviewed. This was necessary to make e2e tests easier to write.
- Code in gce_ovf_import_tests/ is based on osconfig_tests/
- gce_ovf_import_tests/scripts/ovf_import_test_ubuntu_3_disks.sh is based on daisy_integration_tests/scripts/post_translate_test.sh with extra check for mounted disks added

Docker image build was not tested yet. The test did run successfully when executed directly on dev box.

The test suite currently includes only one (fairly complex) scenario. Once we verify Prow is configured correctly to run this test, more test cases will follow.