### PR TITLE
OS Config - run tests across multiple zones

### DIFF
--- a/osconfig_tests/compute/instance.go
+++ b/osconfig_tests/compute/instance.go
@@ -133,6 +133,7 @@ func isTerminal(status string) bool {
 
 // CreateInstance creates a compute instance.
 func CreateInstance(client daisyCompute.Client, project, zone string, i *api.Instance) (*Instance, error) {
+	logger.Infof("Creating instance %s in zone %s", i.Name, zone)
 	if err := client.CreateInstance(project, zone, i); err != nil {
 		return nil, err
 	}

--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -17,11 +17,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -43,6 +45,7 @@ var (
 	outDir          = flag.String("out_dir", "/tmp", "junit xml directory")
 	testProjectID   = flag.String("test_project_id", "", "test project id")
 	testZone        = flag.String("test_zone", "", "test zone")
+	testZones       = flag.String("test_zones", "{}", "test zones")
 )
 
 var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp, *testconfig.Project){
@@ -62,13 +65,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: check if the zone is valid, fail fast
-	if len(strings.TrimSpace(*testZone)) == 0 {
-		fmt.Println("-test_zone is invalid")
+	zones := make(map[string]int)
+
+	if len(strings.TrimSpace(*testZone)) != 0 {
+		zones[*testZone] = math.MaxInt32
+	} else {
+		err := json.Unmarshal([]byte(*testZones), &zones)
+		if err != nil {
+			fmt.Printf("Error parsing zones `%s`\n", testZones)
+			os.Exit(1)
+		}
+	}
+
+	if len(zones) == 0 {
+		fmt.Println("Error, no zones specified")
 		os.Exit(1)
 	}
 
-	pr := testconfig.GetProject(*testProjectID, *testZone)
+	pr := testconfig.GetProject(*testProjectID, &zones)
 
 	var testSuiteRegex *regexp.Regexp
 	if *testSuiteFilter != "" {

--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -82,7 +82,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	pr := testconfig.GetProject(*testProjectID, &zones)
+	pr := testconfig.GetProject(*testProjectID, zones)
 
 	var testSuiteRegex *regexp.Regexp
 	if *testSuiteFilter != "" {

--- a/osconfig_tests/main.go
+++ b/osconfig_tests/main.go
@@ -72,7 +72,7 @@ func main() {
 	} else {
 		err := json.Unmarshal([]byte(*testZones), &zones)
 		if err != nil {
-			fmt.Printf("Error parsing zones `%s`\n", testZones)
+			fmt.Printf("Error parsing zones `%s`\n", *testZones)
 			os.Exit(1)
 		}
 	}

--- a/osconfig_tests/test_config/project_config.go
+++ b/osconfig_tests/test_config/project_config.go
@@ -25,9 +25,9 @@ import (
 type Project struct {
 	TestProjectID        string
 	ServiceAccountEmail  string
-	TestZones            *map[string]int
-	zoneIndices          *map[int]string
 	ServiceAccountScopes []string
+	testZones            map[string]int
+	zoneIndices          map[int]string
 	mux                  sync.Mutex
 }
 
@@ -43,8 +43,8 @@ func GetProject(projectID string, testZones *map[string]int) *Project {
 
 	return &Project{
 		TestProjectID:       projectID,
-		TestZones:           testZones,
-		zoneIndices:         &zoneIndices,
+		testZones:           *testZones,
+		zoneIndices:         zoneIndices,
 		ServiceAccountEmail: "default",
 		ServiceAccountScopes: []string{
 			"https://www.googleapis.com/auth/cloud-platform",
@@ -58,19 +58,19 @@ func (p *Project) GetZone() string {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 
-	zc := len(*p.zoneIndices)
+	zc := len(p.zoneIndices)
 	if zc == 0 {
 		fmt.Println("Not enough zone quota sepcified. Specify additional quota in `test_zones`.")
 		os.Exit(1)
 	}
 
 	zi := rand.Intn(zc)
-	z := (*p.zoneIndices)[zi]
+	z := p.zoneIndices[zi]
 
-	(*p.TestZones)[z]--
+	p.testZones[z]--
 
-	if (*p.TestZones)[z] == 0 {
-		delete(*p.zoneIndices, zi)
+	if p.testZones[z] == 0 {
+		delete(p.zoneIndices, zi)
 	}
 
 	return z

--- a/osconfig_tests/test_config/project_config.go
+++ b/osconfig_tests/test_config/project_config.go
@@ -14,23 +14,64 @@
 
 package testconfig
 
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+)
+
 // Project is details of test Project.
 type Project struct {
 	TestProjectID        string
 	ServiceAccountEmail  string
-	TestZone             string
+	TestZones            *map[string]int
+	zoneIndices          *map[int]string
 	ServiceAccountScopes []string
+	mux                  sync.Mutex
 }
 
 // GetProject ...
-func GetProject(projectID, testZone string) *Project {
+func GetProject(projectID string, testZones *map[string]int) *Project {
+	zoneIndices := make(map[int]string, len(*testZones))
+
+	i := 0
+	for z := range *testZones {
+		zoneIndices[i] = z
+		i++
+	}
+
 	return &Project{
 		TestProjectID:       projectID,
-		TestZone:            testZone,
+		TestZones:           testZones,
+		zoneIndices:         &zoneIndices,
 		ServiceAccountEmail: "default",
 		ServiceAccountScopes: []string{
 			"https://www.googleapis.com/auth/cloud-platform",
 			"https://www.googleapis.com/auth/devstorage.full_control",
 		},
 	}
+}
+
+// GetZone gets a random zone that still has capacity.
+func (p *Project) GetZone() string {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	zc := len(*p.zoneIndices)
+	if zc == 0 {
+		fmt.Println("Not enough zone quota sepcified. Specify additional quota in `test_zones`.")
+		os.Exit(1)
+	}
+
+	zi := rand.Intn(zc)
+	z := (*p.zoneIndices)[zi]
+
+	(*p.TestZones)[z]--
+
+	if (*p.TestZones)[z] == 0 {
+		delete(*p.zoneIndices, zi)
+	}
+
+	return z
 }

--- a/osconfig_tests/test_config/project_config.go
+++ b/osconfig_tests/test_config/project_config.go
@@ -32,18 +32,18 @@ type Project struct {
 }
 
 // GetProject ...
-func GetProject(projectID string, testZones *map[string]int) *Project {
-	zoneIndices := make(map[int]string, len(*testZones))
+func GetProject(projectID string, testZones map[string]int) *Project {
+	zoneIndices := make(map[int]string, len(testZones))
 
 	i := 0
-	for z := range *testZones {
+	for z := range testZones {
 		zoneIndices[i] = z
 		i++
 	}
 
 	return &Project{
 		TestProjectID:       projectID,
-		testZones:           *testZones,
+		testZones:           testZones,
 		zoneIndices:         zoneIndices,
 		ServiceAccountEmail: "default",
 		ServiceAccountScopes: []string{
@@ -60,6 +60,7 @@ func (p *Project) GetZone() string {
 
 	zc := len(p.zoneIndices)
 	if zc == 0 {
+		// TODO: return an error instead of stopping the process.
 		fmt.Println("Not enough zone quota sepcified. Specify additional quota in `test_zones`.")
 		os.Exit(1)
 	}

--- a/osconfig_tests/test_suites/inventory/inventory.go
+++ b/osconfig_tests/test_suites/inventory/inventory.go
@@ -21,8 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/config"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/gcp_clients"
 	"io"
 	"log"
 	"path"
@@ -30,11 +28,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/config"
+	gcpclients "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/gcp_clients"
+
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/compute"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/junitxml"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
+	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
 	apiBeta "google.golang.org/api/compute/v0.beta"
 	api "google.golang.org/api/compute/v1"
@@ -265,7 +266,7 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("enable-guest-attributes", "true"))
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-inventory-enabled", "true"))
 
-	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-2", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-2", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", err)
 		return nil, false

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -160,7 +160,7 @@ func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	var metadataItems []*api.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
-	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %s", utils.GetStatusFromError(err))
 		return
@@ -215,7 +215,7 @@ func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCa
 	var metadataItems []*api.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
-	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
 		return
@@ -269,7 +269,7 @@ func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	var metadataItems []*api.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
-	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
 		return
@@ -323,7 +323,7 @@ func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.Te
 	var metadataItems []*api.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
-	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
 		return

--- a/osconfig_tests/test_suites/patch/patch.go
+++ b/osconfig_tests/test_suites/patch/patch.go
@@ -245,7 +245,7 @@ func runExecutePatchTest(ctx context.Context, testCase *junitxml.TestCase, testS
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospatch"))
 	testSetupName := fmt.Sprintf("patch-test-%s-%s", path.Base(testSetup.image), suffix)
-	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetupName, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetupName, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
 		return

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -190,7 +190,7 @@ periodics:
       secret:
        secretName: compute-image-tools-test-service-account
  - name: osconfig-tests
-   interval: 3h
+   interval: 2h
    agent: kubernetes
    spec:
     containers:
@@ -198,7 +198,7 @@ periodics:
       args:
       - "-out_dir=/artifacts"
       - "-test_project_id=compute-image-osconfig-agent"
-      - "-test_zone=us-central1-c"
+      - "-test_zones={\"us-central1-c\":120,\"us-west1-a\":20,\"us-west1-b\":20,\"us-west1-c\":20,\"us-east1-b\":20,\"us-east1-c\":20,\"us-east1-d\":20}"
       volumeMounts:
       - name: compute-image-tools-test-service-account
         mountPath: /etc/compute-image-tools-test-service-account

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -190,7 +190,7 @@ periodics:
       secret:
        secretName: compute-image-tools-test-service-account
  - name: osconfig-tests
-   interval: 2h
+   interval: 1h
    agent: kubernetes
    spec:
     containers:


### PR DESCRIPTION
- Avoids sporadic stock out issues.
- Test runner flags also supports JSON map of zones to quota.
- Increases frequency of E2e test runs.
- Updates prow test runner to run tests in multiple zones.
- Simply chooses a random zone that still has quota to run the test.

Additional, more complex ways of breaking these tests up will be added when needed.