### PR TITLE
Increase test Docker build timeout to 15min to account for the newly …

### DIFF
--- a/test-infra/prowjobs/cloudbuild.yaml
+++ b/test-infra/prowjobs/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 600s
+timeout: 900s
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/wrapper:latest', '--tag=gcr.io/$PROJECT_ID/wrapper:$COMMIT_SHA', './test-infra/prowjobs/wrapper']


### PR DESCRIPTION
…added OVF import test Docker image build.