### PR TITLE
Fix OVF import e2e test docker to include Daisy workflows

### DIFF
--- a/test-infra/prowjobs/gce-ovf-import-tests/Dockerfile
+++ b/test-infra/prowjobs/gce-ovf-import-tests/Dockerfile
@@ -27,4 +27,5 @@ ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_ovf_import_test_runner gce_ovf_import_test_runner
 COPY /gce_ovf_import_tests/scripts/ /gce_ovf_import_tests/scripts/
+COPY /daisy_workflows/ /daisy_workflows/
 ENTRYPOINT ["./wrapper", "./gce_ovf_import_test_runner"]


### PR DESCRIPTION
Fix OVF import e2e test docker to include Daisy workflows (necessary for running OVF import)