### PR TITLE
Update translation workflows to use debian-9 worker image.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
@@ -47,7 +47,7 @@
       "CreateDisks": [
         {
           "Name": "disk-installerprep",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "50",
           "Type": "pd-ssd"
         },

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux_uefi.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux_uefi.wf.json
@@ -52,7 +52,7 @@
       "CreateDisks": [
         {
           "Name": "disk-installerprep",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "50",
           "Type": "pd-ssd"
         },

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -34,7 +34,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -30,9 +30,9 @@ import utils.diskutils as diskutils
 
 
 repo_compute = '''
-[google-cloud-compute]
-name=Google Cloud Compute
-baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-compute-el%s-x86_64
+[google-compute-engine]
+name=Google Compute Engine
+baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el%s-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -35,7 +35,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -35,7 +35,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -35,7 +35,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -35,7 +35,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -35,7 +35,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -35,7 +35,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -42,7 +42,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -34,7 +34,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }


### PR DESCRIPTION
- Will make these faster and more reliable.
- Also use newer RHEL compute engine repo.