### PR TITLE
OVF import: fixed error handling

### DIFF
--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -95,10 +95,7 @@ func runImport() {
 		logger.Println(err.Error())
 		return
 	}
-	err = ovfImporter.Import()
-	if err != nil {
-		logger.Println(err.Error())
-	}
+	ovfImporter.Import()
 	ovfImporter.CleanUp()
 }
 

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -87,18 +87,28 @@ func buildImportParams() *ovfimportparams.OVFImportParams {
 		NodeAffinityLabelsFlag: nodeAffinityLabelsFlag, CurrentExecutablePath: currentExecutablePath}
 }
 
-func runImport() {
+func runImport() error {
 	logger := log.New(os.Stdout, "[OVF Import] ", log.LstdFlags)
 	ovfImporter, err := ovfimporter.NewOVFImporter(buildImportParams())
 
 	if err != nil {
 		logger.Println(err.Error())
-		return
+		ovfImporter.CleanUp()
+		return err
 	}
-	ovfImporter.Import()
+	err = ovfImporter.Import()
+	if err != nil {
+		ovfImporter.CleanUp()
+		return err
+	}
+
 	ovfImporter.CleanUp()
+	return nil
 }
 
 func main() {
-	runImport()
+	err := runImport()
+	if err != nil {
+		os.Exit(1)
+	}
 }

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -397,11 +397,13 @@ func (oi *OVFImporter) Import() error {
 	oi.Logger.Log("Starting OVF import workflow.")
 	w, err := oi.setUpImportWorkflow()
 	if err != nil {
+		oi.Logger.Log(err.Error())
 		return err
 	}
 
 	if err := w.RunWithModifiers(oi.ctx, oi.modifyWorkflowPreValidate, oi.modifyWorkflowPostValidate); err != nil {
-		return fmt.Errorf("%s: %v", w.Name, err)
+		oi.Logger.Log(err.Error())
+		return err
 	}
 	oi.Logger.Log("OVF import workflow finished successfully.")
 	return nil


### PR DESCRIPTION
OVF import: logging errors in OVF importer instead of main as they are otherwise not logged to GCS preventing users from seeing the error in gcloud command output.