### PR TITLE
Increased timeout for VMDK export e2e latest test

### DIFF
--- a/daisy_integration_tests/image_export_vmdk_latest.wf.json
+++ b/daisy_integration_tests/image_export_vmdk_latest.wf.json
@@ -11,6 +11,7 @@
   },
   "Steps": {
     "test-export": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "image_export_vmdk.subwf.json",
         "Vars": {


### PR DESCRIPTION
Increased timeout for VMDK export e2e latest test as it occasionally times out after 10 minutes. Match the 20 minute timeout from the equivalent test for release worker image.