### PR TITLE
[import/export cli] add more image import/export cli tool e2e tests for rich params

### DIFF
--- a/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
@@ -91,8 +91,8 @@ func runImageExportVMDKTest(
 
 // Test most of params except -oauth, -compute_endpoint_override, and -scratch_bucket_gcs_path
 func runImageExportWithRichParamsTest(
-		ctx context.Context, testCase *junitxml.TestCase,
-		logger *log.Logger, testProjectConfig *testconfig.Project) {
+	ctx context.Context, testCase *junitxml.TestCase,
+	logger *log.Logger, testProjectConfig *testconfig.Project) {
 
 	suffix := pathutils.RandString(5)
 	bucketName := fmt.Sprintf("%v-test-image", testProjectConfig.TestProjectID)

--- a/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
@@ -43,11 +43,14 @@ func TestSuite(
 		testSuiteName, fmt.Sprintf("[ImageExport] %v", "Export Raw"))
 	imageExportVMDKTestCase := junitxml.NewTestCase(
 		testSuiteName, fmt.Sprintf("[ImageExport] %v", "Export VMDK"))
+	imageExportWithRichParamsTestCase := junitxml.NewTestCase(
+		testSuiteName, fmt.Sprintf("[ImageExport] %v", "Export with rich params"))
 
 	testsMap := map[*junitxml.TestCase]func(
 		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project){
-		imageExportRawTestCase:  runImageExportRawTest,
-		imageExportVMDKTestCase: runImageExportVMDKTest,
+		imageExportRawTestCase:            runImageExportRawTest,
+		imageExportVMDKTestCase:           runImageExportVMDKTest,
+		imageExportWithRichParamsTestCase: runImageExportWithRichParamsTest,
 	}
 
 	testsuiteutils.TestSuite(ctx, tswg, testSuites, logger, testSuiteRegex, testCaseRegex,
@@ -81,6 +84,26 @@ func runImageExportVMDKTest(
 	cmd := "gce_vm_image_export"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		"-source_image=e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI), "-format=vmdk"}
+	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+
+	verifyExportedImageFile(ctx, testCase, bucketName, objectName, logger)
+}
+
+// Test most of params except -oauth, -compute_endpoint_override, and -scratch_bucket_gcs_path
+func runImageExportWithRichParamsTest(
+		ctx context.Context, testCase *junitxml.TestCase,
+		logger *log.Logger, testProjectConfig *testconfig.Project) {
+
+	suffix := pathutils.RandString(5)
+	bucketName := fmt.Sprintf("%v-test-image", testProjectConfig.TestProjectID)
+	objectName := fmt.Sprintf("e2e-export-raw-test-%v", suffix)
+	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
+	cmd := "gce_vm_image_export"
+	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
+		"-source_image=e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
+		"-network=default", "-subnet=default", fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
+		"-timeout=2h", "-disable_gcs_logging", "-disable_cloud_logging", "-disable_stdout_logging",
+		"-labels=key1=value1,key2=value"}
 	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
 
 	verifyExportedImageFile(ctx, testCase, bucketName, objectName, logger)

--- a/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
@@ -117,7 +117,7 @@ func runImageImportWithRichParamsTest(
 	cmd := "gce_vm_image_import"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		fmt.Sprintf("-image_name=%s", imageName), "-data_disk", fmt.Sprintf("-source_file=gs://%v-test-image/image-file-10g-vmdk", testProjectConfig.TestProjectID),
-		"-no_guest_environment", fmt.Sprintf("-family=test-family", family), fmt.Sprintf("-description=test-description", description),
+		"-no_guest_environment", fmt.Sprintf("-family=%v", family), fmt.Sprintf("-description=%v", description),
 		"-network=default", "-subnet=default", fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
 		"-timeout=2h", "-disable_gcs_logging", "-disable_cloud_logging", "-disable_stdout_logging",
 		"-no_external_ip", fmt.Sprintf("-labels=%v", labels)}


### PR DESCRIPTION
Add more image import/export cli tool e2e tests for rich params.
Some params are hard to test and is not critical to our main scenario, so we skipped them for now:
-oauth, -compute_endpoint_override, and -scratch_bucket_gcs_path,
and all KMS-related params.