### PR TITLE
osconfig_test: fix many of the flakes

### DIFF
--- a/osconfig_tests/compute/instance.go
+++ b/osconfig_tests/compute/instance.go
@@ -93,15 +93,15 @@ func (i *Instance) WaitForSerialOutput(match string, port int64, interval, timeo
 }
 
 // WaitForGuestAttributes waits for guest attribute (queryPath, variableKey) to appear.
-func (i *Instance) WaitForGuestAttributes(queryPath, variableKey string, interval, timeout time.Duration) ([]*computeBeta.GuestAttributesEntry, error) {
+func (i *Instance) WaitForGuestAttributes(queryPath string, interval, timeout time.Duration) ([]*computeBeta.GuestAttributesEntry, error) {
 	tick := time.Tick(interval)
 	timedout := time.Tick(timeout)
 	for {
 		select {
 		case <-timedout:
-			return nil, fmt.Errorf("timed out waiting for guest attribute %q", path.Join(queryPath, variableKey))
+			return nil, fmt.Errorf("timed out waiting for guest attribute %q", queryPath)
 		case <-tick:
-			attr, err := i.GetGuestAttributes(queryPath, variableKey)
+			attr, err := i.GetGuestAttributes(queryPath)
 			if err != nil {
 				apiErr, ok := err.(*googleapi.Error)
 				if ok && apiErr.Code == http.StatusNotFound {
@@ -115,8 +115,8 @@ func (i *Instance) WaitForGuestAttributes(queryPath, variableKey string, interva
 }
 
 // GetGuestAttributes gets guest attributes for an instance.
-func (i *Instance) GetGuestAttributes(queryPath, variableKey string) ([]*computeBeta.GuestAttributesEntry, error) {
-	resp, err := i.client.GetGuestAttributes(i.Project, i.Zone, i.Name, queryPath, variableKey)
+func (i *Instance) GetGuestAttributes(queryPath string) ([]*computeBeta.GuestAttributesEntry, error) {
+	resp, err := i.client.GetGuestAttributes(i.Project, i.Zone, i.Name, queryPath, "")
 	if err != nil {
 		return nil, err
 	}

--- a/osconfig_tests/test_suites/inventory/inventory.go
+++ b/osconfig_tests/test_suites/inventory/inventory.go
@@ -106,7 +106,7 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 	go inst.StreamSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), logwg, 1, config.LogPushInterval())
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return nil, false
 	}
@@ -118,13 +118,13 @@ func gatherInventory(testCase *junitxml.TestCase, inst *compute.Instance) ([]*ap
 	testCase.Logf("Checking inventory data")
 	// It can take a long time to start collecting data, especially on Windows.
 	// LastUpdated is the last entry written by the agent, so wait on that.
-	_, err := inst.WaitForGuestAttributes("guestInventory/", "LastUpdated", 10*time.Second, 25*time.Minute)
+	_, err := inst.WaitForGuestAttributes("guestInventory/LastUpdated", 10*time.Second, 25*time.Minute)
 	if err != nil {
 		testCase.WriteFailure("Error waiting for guest attributes: %v", err)
 		return nil, false
 	}
 
-	ga, err := inst.GetGuestAttributes("guestInventory/", "")
+	ga, err := inst.GetGuestAttributes("guestInventory/")
 	if err != nil {
 		testCase.WriteFailure("Error getting guest attributes: %v", err)
 		return nil, false

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -156,7 +156,7 @@ func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	go inst.StreamSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), logwg, 1, config.LogPushInterval())
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return
 	}
@@ -211,7 +211,7 @@ func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCa
 	go inst.StreamSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), logwg, 1, config.LogPushInterval())
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return
 	}
@@ -265,7 +265,7 @@ func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	go inst.StreamSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), logwg, 1, config.LogPushInterval())
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return
 	}
@@ -319,7 +319,7 @@ func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.Te
 	go inst.StreamSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), logwg, 1, config.LogPushInterval())
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return
 	}

--- a/osconfig_tests/test_suites/patch/patch.go
+++ b/osconfig_tests/test_suites/patch/patch.go
@@ -179,7 +179,7 @@ func runExecutePatchJobTest(ctx context.Context, testCase *junitxml.TestCase, te
 	defer inst.Cleanup()
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return
 	}
@@ -229,7 +229,7 @@ func runRebootPatchTest(ctx context.Context, testCase *junitxml.TestCase, testSe
 	defer inst.Cleanup()
 
 	testCase.Logf("Waiting for agent install to complete")
-	if _, err := inst.WaitForGuestAttributes("osconfig_tests/", "install_done", 5*time.Second, 5*time.Minute); err != nil {
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 5*time.Minute); err != nil {
 		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
 		return
 	}
@@ -271,7 +271,7 @@ func runRebootPatchTest(ctx context.Context, testCase *junitxml.TestCase, testSe
 	}
 
 	testCase.Logf("Checking reboot count")
-	attr, err := inst.GetGuestAttributes("osconfig_tests/", "boot_count")
+	attr, err := inst.GetGuestAttributes("osconfig_tests/boot_count")
 	if err != nil {
 		testCase.WriteFailure("Error retrieving boot count: %v", err)
 		return

--- a/osconfig_tests/utils/utils.go
+++ b/osconfig_tests/utils/utils.go
@@ -46,8 +46,8 @@ if [[ n -gt 3 ]]; then
 fi
 n=$[$n+1]
 sleep 5
-done
-`
+done` + curlPost
+
 	curlPost = `
 uri=http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/osconfig_tests/install_done
 curl -X PUT --data "1" $uri -H "Metadata-Flavor: Google"
@@ -76,7 +76,7 @@ gpgcheck=0
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOM` + yumInstallAgent + curlPost
+EOM` + yumInstallAgent
 
 	// InstallOSConfigYumEL6 installs the osconfig agent on el6 based systems.
 	InstallOSConfigYumEL6 = `sleep 10
@@ -89,7 +89,7 @@ gpgcheck=0
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOM` + yumInstallAgent + curlPost
+EOM` + yumInstallAgent
 )
 
 // HeadAptImages is a map of names to image paths for public image families that use APT.


### PR DESCRIPTION
Don't use variableKey when requesting guest attributes, that was a legacy option.