### PR TITLE
osconfig_tests: attempt to deflake Windows patch tests

### DIFF
--- a/osconfig_tests/compute/instance.go
+++ b/osconfig_tests/compute/instance.go
@@ -29,14 +29,14 @@ import (
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
-	computeBeta "google.golang.org/api/compute/v0.beta"
-	compute "google.golang.org/api/compute/v1"
+	computeApiBeta "google.golang.org/api/compute/v0.beta"
+	computeApi "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
 // Instance is a compute instance.
 type Instance struct {
-	*compute.Instance
+	*computeApi.Instance
 	client        daisyCompute.Client
 	Project, Zone string
 }
@@ -93,7 +93,7 @@ func (i *Instance) WaitForSerialOutput(match string, port int64, interval, timeo
 }
 
 // WaitForGuestAttributes waits for guest attribute (queryPath, variableKey) to appear.
-func (i *Instance) WaitForGuestAttributes(queryPath string, interval, timeout time.Duration) ([]*computeBeta.GuestAttributesEntry, error) {
+func (i *Instance) WaitForGuestAttributes(queryPath string, interval, timeout time.Duration) ([]*computeApiBeta.GuestAttributesEntry, error) {
 	tick := time.Tick(interval)
 	timedout := time.Tick(timeout)
 	for {
@@ -115,7 +115,7 @@ func (i *Instance) WaitForGuestAttributes(queryPath string, interval, timeout ti
 }
 
 // GetGuestAttributes gets guest attributes for an instance.
-func (i *Instance) GetGuestAttributes(queryPath string) ([]*computeBeta.GuestAttributesEntry, error) {
+func (i *Instance) GetGuestAttributes(queryPath string) ([]*computeApiBeta.GuestAttributesEntry, error) {
 	resp, err := i.client.GetGuestAttributes(i.Project, i.Zone, i.Name, queryPath, "")
 	if err != nil {
 		return nil, err
@@ -170,7 +170,7 @@ func isTerminal(status string) bool {
 }
 
 // CreateInstance creates a compute instance.
-func CreateInstance(client daisyCompute.Client, project, zone string, i *compute.Instance) (*Instance, error) {
+func CreateInstance(client daisyCompute.Client, project, zone string, i *computeApi.Instance) (*Instance, error) {
 	logger.Infof("Creating instance %s in zone %s", i.Name, zone)
 	if err := client.CreateInstance(project, zone, i); err != nil {
 		return nil, err
@@ -179,8 +179,8 @@ func CreateInstance(client daisyCompute.Client, project, zone string, i *compute
 }
 
 // BuildInstanceMetadataItem create an metadata item
-func BuildInstanceMetadataItem(key, value string) *compute.MetadataItems {
-	return &compute.MetadataItems{
+func BuildInstanceMetadataItem(key, value string) *computeApi.MetadataItems {
+	return &computeApi.MetadataItems{
 		Key:   key,
 		Value: func() *string { v := value; return &v }(),
 	}

--- a/osconfig_tests/test_suites/package_management/package_management.go
+++ b/osconfig_tests/test_suites/package_management/package_management.go
@@ -32,7 +32,7 @@ import (
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
 	"github.com/kylelemons/godebug/pretty"
-	api "google.golang.org/api/compute/v1"
+	computeApi "google.golang.org/api/compute/v1"
 
 	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
 )
@@ -60,13 +60,13 @@ type packageManagementTestSetup struct {
 	fname         packageMangementTestFunctionName // this is used to identify the test case for this test setup
 	osconfig      *osconfigpb.OsConfig
 	assignment    *osconfigpb.Assignment
-	startup       *api.MetadataItems
+	startup       *computeApi.MetadataItems
 	vstring       string
 	assertTimeout time.Duration
 	vf            func(*compute.Instance, string, int64, time.Duration, time.Duration) error
 }
 
-func newPackageManagementTestSetup(setup **packageManagementTestSetup, image, name string, fname packageMangementTestFunctionName, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, assertTimeout time.Duration, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) {
+func newPackageManagementTestSetup(setup **packageManagementTestSetup, image, name string, fname packageMangementTestFunctionName, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *computeApi.MetadataItems, assertTimeout time.Duration, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) {
 	*setup = &packageManagementTestSetup{
 		image:         image,
 		name:          name,
@@ -138,7 +138,7 @@ func runPackageRemovalTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	}
 
 	testCase.Logf("Creating instance with image %q", testSetup.image)
-	var metadataItems []*api.MetadataItems
+	var metadataItems []*computeApi.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
 	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
@@ -193,7 +193,7 @@ func runPackageInstallRemovalTest(ctx context.Context, testCase *junitxml.TestCa
 	}
 
 	testCase.Logf("Creating instance with image %q", testSetup.image)
-	var metadataItems []*api.MetadataItems
+	var metadataItems []*computeApi.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
 	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
@@ -247,7 +247,7 @@ func runPackageInstallTest(ctx context.Context, testCase *junitxml.TestCase, tes
 	}
 
 	testCase.Logf("Creating instance with image %q", testSetup.image)
-	var metadataItems []*api.MetadataItems
+	var metadataItems []*computeApi.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
 	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
@@ -301,7 +301,7 @@ func runPackageInstallFromNewRepoTest(ctx context.Context, testCase *junitxml.Te
 	}
 
 	testCase.Logf("Creating instance with image %q", testSetup.image)
-	var metadataItems []*api.MetadataItems
+	var metadataItems []*computeApi.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospackage"))
 	inst, err := utils.CreateComputeInstance(metadataItems, client, "n1-standard-4", testSetup.image, testSetup.name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)

--- a/osconfig_tests/test_suites/package_management/package_management_test_data.go
+++ b/osconfig_tests/test_suites/package_management/package_management_test_data.go
@@ -24,7 +24,7 @@ import (
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
-	api "google.golang.org/api/compute/v1"
+	computeApi "google.golang.org/api/compute/v1"
 
 	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
 )
@@ -242,7 +242,7 @@ func addPackageInstallFromNewRepoTest(pkgTestSetup []*packageManagementTestSetup
 	return pkgTestSetup
 }
 
-func createAndAppendSetup(pkgTestSetup []*packageManagementTestSetup, image, name string, fname packageMangementTestFunctionName, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *api.MetadataItems, assertTimeout time.Duration, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) []*packageManagementTestSetup {
+func createAndAppendSetup(pkgTestSetup []*packageManagementTestSetup, image, name string, fname packageMangementTestFunctionName, vs string, oc *osconfigpb.OsConfig, assignment *osconfigpb.Assignment, startup *computeApi.MetadataItems, assertTimeout time.Duration, vf func(*compute.Instance, string, int64, time.Duration, time.Duration) error) []*packageManagementTestSetup {
 	var setup *packageManagementTestSetup
 	newPackageManagementTestSetup(&setup, image, name, fname, vs, oc, assignment, startup, assertTimeout, vf)
 	pkgTestSetup = append(pkgTestSetup, setup)

--- a/osconfig_tests/test_suites/package_management/package_management_utils.go
+++ b/osconfig_tests/test_suites/package_management/package_management_utils.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
 	"github.com/google/logger"
-	api "google.golang.org/api/compute/v1"
+	computeApi "google.golang.org/api/compute/v1"
 )
 
 var (
@@ -36,7 +36,7 @@ var (
 	}
 )
 
-func getPackageInstallStartupScript(image, pkgManager, packageName string) *api.MetadataItems {
+func getPackageInstallStartupScript(image, pkgManager, packageName string) *computeApi.MetadataItems {
 	var ss, key string
 
 	switch pkgManager {
@@ -92,13 +92,13 @@ func getPackageInstallStartupScript(image, pkgManager, packageName string) *api.
 		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
-	return &api.MetadataItems{
+	return &computeApi.MetadataItems{
 		Key:   key,
 		Value: &ss,
 	}
 }
 
-func getPackageRemovalStartupScript(image, pkgManager, packageName string) *api.MetadataItems {
+func getPackageRemovalStartupScript(image, pkgManager, packageName string) *computeApi.MetadataItems {
 	var ss, key string
 
 	switch pkgManager {
@@ -191,13 +191,13 @@ func getPackageRemovalStartupScript(image, pkgManager, packageName string) *api.
 		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
-	return &api.MetadataItems{
+	return &computeApi.MetadataItems{
 		Key:   key,
 		Value: &ss,
 	}
 }
 
-func getPackageInstallRemovalStartupScript(image, pkgManager, packageName string) *api.MetadataItems {
+func getPackageInstallRemovalStartupScript(image, pkgManager, packageName string) *computeApi.MetadataItems {
 	var ss, key string
 
 	switch pkgManager {
@@ -252,13 +252,13 @@ func getPackageInstallRemovalStartupScript(image, pkgManager, packageName string
 		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
-	return &api.MetadataItems{
+	return &computeApi.MetadataItems{
 		Key:   key,
 		Value: &ss,
 	}
 }
 
-func getPackageInstallFromNewRepoTestStartupScript(image, pkgManager, packageName string) *api.MetadataItems {
+func getPackageInstallFromNewRepoTestStartupScript(image, pkgManager, packageName string) *computeApi.MetadataItems {
 	var ss, key string
 
 	switch pkgManager {
@@ -321,7 +321,7 @@ func getPackageInstallFromNewRepoTestStartupScript(image, pkgManager, packageNam
 		logger.Errorf(fmt.Sprintf("invalid package manager: %s", pkgManager))
 	}
 
-	return &api.MetadataItems{
+	return &computeApi.MetadataItems{
 		Key:   key,
 		Value: &ss,
 	}

--- a/osconfig_tests/test_suites/patch/patch.go
+++ b/osconfig_tests/test_suites/patch/patch.go
@@ -28,13 +28,11 @@ import (
 
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/junitxml"
-	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/compute"
 	gcpclients "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/gcp_clients"
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/test_config"
 	"github.com/GoogleCloudPlatform/compute-image-tools/osconfig_tests/utils"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/kylelemons/godebug/pretty"
-	api "google.golang.org/api/compute/v1"
 
 	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha1"
 )
@@ -167,11 +165,8 @@ func runExecutePatchJobTest(ctx context.Context, testCase *junitxml.TestCase, te
 	}
 
 	testCase.Logf("Creating instance with image %q", testSetup.image)
-	var metadataItems []*api.MetadataItems
-	metadataItems = append(metadataItems, testSetup.startup)
-	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospatch"))
 	name := fmt.Sprintf("patch-test-%s-%s-%s", path.Base(testSetup.testName), testSuffix, utils.RandString(5))
-	inst, err := utils.CreateComputeInstance(metadataItems, client, testSetup.machineType, testSetup.image, name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(testSetup.metadata, client, testSetup.machineType, testSetup.image, name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
 		return
@@ -217,11 +212,8 @@ func runRebootPatchTest(ctx context.Context, testCase *junitxml.TestCase, testSe
 	}
 
 	testCase.Logf("Creating instance with image %q", testSetup.image)
-	var metadataItems []*api.MetadataItems
-	metadataItems = append(metadataItems, testSetup.startup)
-	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("os-config-enabled-prerelease-features", "ospatch"))
 	name := fmt.Sprintf("patch-reboot-%s-%s-%s", path.Base(testSetup.testName), testSuffix, utils.RandString(5))
-	inst, err := utils.CreateComputeInstance(metadataItems, client, testSetup.machineType, testSetup.image, name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(testSetup.metadata, client, testSetup.machineType, testSetup.image, name, testProjectConfig.TestProjectID, testProjectConfig.GetZone(), testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", utils.GetStatusFromError(err))
 		return


### PR DESCRIPTION
Move setting of WSUS server to sysprep startup script so we don't get hung up on the reboot.