### PR TITLE
[export cli tool] modify "source_image" param and fix e2e tests

### DIFF
--- a/cli_tools/gce_vm_image_export/README.md
+++ b/cli_tools/gce_vm_image_export/README.md
@@ -20,7 +20,7 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image
   `pantheon`.
 + `-destination_uri=DESTINATION_URI` The Google Cloud Storage URI destination for the exported
   virtual disk file. For example: gs://my-bucket/my-exported-image.vmdk.
-+ `-source_image=SOURCE_IMAGE` An existing Compute Engine image from which to 
++ `-source_image=SOURCE_IMAGE` An existing Compute Engine image URI from which to 
   export.
 
 #### Optional flags  

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -109,7 +109,7 @@ func buildDaisyVars() map[string]string {
 
 	varMap["destination"] = *destinationURI
 
-	varMap["source_image"] = fmt.Sprintf("global/images/%v", *sourceImage)
+	varMap["source_image"] = *sourceImage
 
 	if *format != "" {
 		varMap["format"] = *format

--- a/cli_tools/gce_vm_image_export/main_test.go
+++ b/cli_tools/gce_vm_image_export/main_test.go
@@ -96,7 +96,7 @@ func getAllCliArgs() map[string]interface{} {
 	return map[string]interface{}{
 		clientIDFlagKey:             "aClient",
 		destinationURIFlagKey:       "gs://bucket/exported_image",
-		sourceImageFlagKey:          "anImage",
+		sourceImageFlagKey:          "global/images/anImage",
 		"format":                    "",
 		"project":                   "aProject",
 		"network":                   "aNetwork",

--- a/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
@@ -67,8 +67,12 @@ func runImageExportRawTest(
 	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
 	cmd := "gce_vm_image_export"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-		"-source_image=e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI)}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+		"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI)}
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyExportedImageFile(ctx, testCase, bucketName, objectName, logger)
 }
@@ -83,8 +87,12 @@ func runImageExportVMDKTest(
 	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
 	cmd := "gce_vm_image_export"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-		"-source_image=e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI), "-format=vmdk"}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+		"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI), "-format=vmdk"}
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyExportedImageFile(ctx, testCase, bucketName, objectName, logger)
 }
@@ -100,11 +108,15 @@ func runImageExportWithRichParamsTest(
 	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
 	cmd := "gce_vm_image_export"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-		"-source_image=e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
+		"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
 		"-network=default", "-subnet=default", fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
 		"-timeout=2h", "-disable_gcs_logging", "-disable_cloud_logging", "-disable_stdout_logging",
 		"-labels=key1=value1,key2=value"}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyExportedImageFile(ctx, testCase, bucketName, objectName, logger)
 }

--- a/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
@@ -70,7 +70,11 @@ func runImageImportDataDiskTest(
 	cmd := "gce_vm_image_import"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		fmt.Sprintf("-image_name=%s", imageName), "-data_disk", fmt.Sprintf("-source_file=gs://%v-test-image/image-file-10g-vmdk", testProjectConfig.TestProjectID)}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyImportedImage(ctx, testCase, testProjectConfig, imageName, logger)
 }
@@ -84,7 +88,11 @@ func runImageImportOSTest(
 	cmd := "gce_vm_image_import"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		fmt.Sprintf("-image_name=%v", imageName), "-os=debian-9", fmt.Sprintf("-source_file=gs://%v-test-image/image-file-10g-vmdk", testProjectConfig.TestProjectID)}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyImportedImage(ctx, testCase, testProjectConfig, imageName, logger)
 }
@@ -98,7 +106,11 @@ func runImageImportOSFromImageTest(
 	cmd := "gce_vm_image_import"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		fmt.Sprintf("-image_name=%v", imageName), "-os=debian-9", "-source_image=e2e-test-image-10g"}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyImportedImage(ctx, testCase, testProjectConfig, imageName, logger)
 }
@@ -121,7 +133,11 @@ func runImageImportWithRichParamsTest(
 		"-network=default", "-subnet=default", fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
 		"-timeout=2h", "-disable_gcs_logging", "-disable_cloud_logging", "-disable_stdout_logging",
 		"-no_external_ip", fmt.Sprintf("-labels=%v", labels)}
-	testsuiteutils.RunCliTool(logger, testCase, cmd, args)
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
 
 	verifyImportedImageWithParams(ctx, testCase, testProjectConfig, imageName, logger, family, description, labels)
 }

--- a/gce_image_import_export_tests/test_suites/test_suite_utils.go
+++ b/gce_image_import_export_tests/test_suites/test_suite_utils.go
@@ -84,13 +84,10 @@ func runTestCases(ctx context.Context, logger *log.Logger, regex *regexp.Regexp,
 }
 
 // RunCliTool executes cli tool with params
-func RunCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString string, args []string) {
+func RunCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString string, args []string) error {
 	logger.Printf("[%v] Running command: '%s %s'", testCase.Name, cmdString, strings.Join(args, " "))
 	cmd := exec.Command(fmt.Sprintf("./%s", cmdString), args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		logger.Fatalf("Error running cmd: %v\n", err.Error())
-	}
+	return cmd.Run()
 }


### PR DESCRIPTION
There are changes:
1. Changed format of "source_image" to be align with daisy input. The purpose is to be compatible with 2 forms of input:
  - "global/images/anImage"
  - "projects/myproject/global/images/anImage"
2. Changed e2e test error handling to avoid exiting process unexpected.