### PR TITLE
Fix Windows 2003 import translate failing

### DIFF
--- a/daisy_workflows/image_import/windows/translate_windows_2003.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2003.wf.json
@@ -40,7 +40,7 @@
       "CreateDisks": [
         {
           "Name": "disk-bootstrap",
-          "SourceImage": "projects/windows-cloud/global/images/family/windows-1709-core",
+          "SourceImage": "projects/windows-cloud/global/images/family/windows-2019-core",
           "Type": "pd-ssd"
         }
       ]


### PR DESCRIPTION
Fix Windows 2003 translate failing due to usage of a deprecated windows 1709 core image for bootstrap step.