### PR TITLE
[gce_export] Export raw: support exporting to local disk

### DIFF
--- a/cli_tools/gce_export/README.md
+++ b/cli_tools/gce_export/README.md
@@ -3,9 +3,11 @@
 The `gce_export` tool streams a local disk to a Google Compute Engine image 
 file in a Google Cloud Storage bucket (steps 9 and 10 in the
 [image export documentation](https://cloud.google.com/compute/docs/images/export-image)).
-No local file is created so no additional disk space needs to be allocated. 
+When exporting to GCS, no local file is created so no additional disk space needs to be allocated. 
 Once complete the image file can be imported in GCE as described in the 
 [image import documentation](https://cloud.google.com/compute/docs/images/import-existing-image).
+
+This tool can also be used to export the image to local disk.
 
 ### Build
 Download and install [Go](https://golang.org/doc/install). Then pull and 

--- a/cli_tools/gce_export/README.md
+++ b/cli_tools/gce_export/README.md
@@ -20,8 +20,8 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_export
 
 + `-disk` disk to export, on linux this would be something like `/dev/sdb`, and on
 Windows `\\.\PhysicalDrive1`
-+ `-local_path` local path to store the image on disk, on linux this would
-be something like `/dev/sdb/buffer`, and on Windows `\\.\PhysicalDrive1\buffer`.
++ `-local_path` local path to store the image on disk, on linux this would be something
+like `/my_folder/linux.tar.gz`, and on Windows `\\.\PhysicalDrive2\path\windows.tar.gz`.
 + `-gcs_path` GCS path to upload the image to, in the form of gs://my-bucket/image.tar.gz
 + `-oauth` path to oauth json file fo authenticating to the GCS bucket
 + `-licenses` (optional) comma separated list of licenses to add to the image
@@ -41,6 +41,12 @@ This will stream `/dev/sdb` to the GCS path gs://some-bucket/linux.tar.gz
 gce_export -disk /dev/sdb -gcs_path gs://some-bucket/linux.tar.gz
 ```
 
+This will stream `/dev/sdb` to the local path /my_folder/linux.tar.gz
+
+```
+gce_export -disk /dev/sdb -local_path /my_folder/linux.tar.gz
+```
+
 #### Windows:
 
 This will stream `\\.\PhysicalDrive1` to the GCS path
@@ -48,5 +54,12 @@ gs://some-bucket/path/windows.tar.gz
 
 ```
 gce_export.exe -disk \\.\PhysicalDrive1 -gcs_path gs://some-bucket/windows.tar.gz
+```
+
+This will stream `\\.\PhysicalDrive1` to the local path
+`\\.\PhysicalDrive2\path\windows.tar.gz`
+
+```
+gce_export.exe -disk \\.\PhysicalDrive1 -local_path \\.\PhysicalDrive2\path\windows.tar.gz
 ```
 

--- a/cli_tools/gce_export/README.md
+++ b/cli_tools/gce_export/README.md
@@ -18,13 +18,10 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_export
 
 ### Flags
 
-+ `-disk` disk to copy, on linux this would be something like `/dev/sdb`, and on
++ `-disk` disk to export, on linux this would be something like `/dev/sdb`, and on
 Windows `\\.\PhysicalDrive1`
-+ `-buffer_path` buffer path to store the .tar.gz file on local, on linux this would
-be something like `/dev/sdb/buffer`, and on Windows `\\.\PhysicalDrive1\buffer`. It's
-optional: when it's provided, the .tar.gz file will be stored on the given buffer path
-and then copied to gcs_path, which is more stable but needs extra disk space.
-Without this param, it's directly streamed to gcs. 
++ `-local_path` local path to store the image on disk, on linux this would
+be something like `/dev/sdb/buffer`, and on Windows `\\.\PhysicalDrive1\buffer`.
 + `-gcs_path` GCS path to upload the image to, in the form of gs://my-bucket/image.tar.gz
 + `-oauth` path to oauth json file fo authenticating to the GCS bucket
 + `-licenses` (optional) comma separated list of licenses to add to the image

--- a/cli_tools/gce_export/README.md
+++ b/cli_tools/gce_export/README.md
@@ -20,6 +20,11 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_export
 
 + `-disk` disk to copy, on linux this would be something like `/dev/sdb`, and on
 Windows `\\.\PhysicalDrive1`
++ `-buffer_path` buffer path to store the .tar.gz file on local, on linux this would
+be something like `/dev/sdb/buffer`, and on Windows `\\.\PhysicalDrive1\buffer`. It's
+optional: when it's provided, the .tar.gz file will be stored on the given buffer path
+and then copied to gcs_path, which is more stable but needs extra disk space.
+Without this param, it's directly streamed to gcs. 
 + `-gcs_path` GCS path to upload the image to, in the form of gs://my-bucket/image.tar.gz
 + `-oauth` path to oauth json file fo authenticating to the GCS bucket
 + `-licenses` (optional) comma separated list of licenses to add to the image

--- a/cli_tools/gce_export/file_writer.go
+++ b/cli_tools/gce_export/file_writer.go
@@ -1,0 +1,29 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+
+package main
+
+import (
+	"bufio"
+)
+
+// FileWriter writes file with a buffer
+type FileWriter struct {
+	*bufio.Writer
+}
+
+func (fw *FileWriter) Close() error {
+	return fw.Flush()
+}

--- a/cli_tools/gce_export/file_writer.go
+++ b/cli_tools/gce_export/file_writer.go
@@ -12,7 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 package main
 
 import (

--- a/cli_tools/gce_export/file_writer.go
+++ b/cli_tools/gce_export/file_writer.go
@@ -24,6 +24,7 @@ type FileWriter struct {
 	*bufio.Writer
 }
 
+// Close preparing for detaching resources
 func (fw *FileWriter) Close() error {
 	return fw.Flush()
 }

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -37,8 +37,8 @@ import (
 )
 
 var (
-	disk      = flag.String("disk", "", "disk to export, on linux this would be something like '/dev/sda', and on Windows '\\\\.\\PhysicalDrive0'")
-	localPath = flag.String("local_path", "", "local path to store the image file on disk, on linux this would be something like '/dev/sdb/buffer', and on Windows '\\\\.\\PhysicalDrive1\buffer'. ")
+	disk      = flag.String("disk", "", "disk to export, on linux this would be something like '/dev/sda', and on Windows '\\\\.\\PhysicalDrive1'")
+	localPath = flag.String("local_path", "", "local path to store the image file on disk, on linux this would be something like '/my_folder/linux.tar.gz', and on Windows '\\\\.\\PhysicalDrive2\buffer'. ")
 	gcsPath   = flag.String("gcs_path", "", "GCS path to upload the image to, gs://my-bucket/image.tar.gz")
 	oauth     = flag.String("oauth", "", "path to oauth json file")
 	licenses  = flag.String("licenses", "", "comma delimited list of licenses to add to the image")

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -206,17 +206,22 @@ func createGzipFile(file *os.File, size int64, writer io.WriteCloser, targetPath
 			time.Sleep(45 * time.Second)
 		}
 	}()
+
 	if _, err := io.CopyN(tw, file, size); err != nil {
 		log.Fatal(err)
 	}
+
 	if err := tw.Close(); err != nil {
 		log.Fatal(err)
 	}
+
 	if err := gw.Close(); err != nil {
 		log.Fatal(err)
 	}
+
 	if err := writer.Close(); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("GCEExport: Finished compress in ", time.Since(start))
+	
+	fmt.Println("GCEExport: Finished export in ", time.Since(start))
 }

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -222,6 +222,6 @@ func createGzipFile(file *os.File, size int64, writer io.WriteCloser, targetPath
 	if err := writer.Close(); err != nil {
 		log.Fatal(err)
 	}
-	
+
 	fmt.Println("GCEExport: Finished export in ", time.Since(start))
 }

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -136,6 +136,7 @@ func createGzipFile(file *os.File, size int64, writer io.WriteCloser, targetPath
 	}
 	rp := progress{}
 	tw := tar.NewWriter(io.MultiWriter(&rp, gw))
+
 	ls := splitLicenses(*licenses)
 	fmt.Printf("GCEExport: Disk %s is %s, compressed size will most likely be much smaller.\n", *disk, humanize.IBytes(uint64(size)))
 	if ls != nil {
@@ -153,8 +154,10 @@ func createGzipFile(file *os.File, size int64, writer io.WriteCloser, targetPath
 			os.Exit(0)
 		}
 	}
+
 	fmt.Println("GCEExport: Beginning export...")
 	start := time.Now()
+
 	if ls != nil {
 		type lsJSON struct {
 			Licenses []string `json:"licenses"`

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -99,7 +99,7 @@
     "delete-inst": {
       "DeleteResources": {
         "Instances": ["inst-${NAME}"],
-	"Disks": ["disk-${NAME}-os", "disk-${NAME}-buffer-${ID}"]
+        "Disks": ["disk-${NAME}-os", "disk-${NAME}-buffer-${ID}"]
       }
     },
     "copy-image-object": {


### PR DESCRIPTION
A new param "local_path" is added. Now it's a either-or between "local_path" and "gcs_path".
The reason to add this is because we plan to change the way of exporting raw. This PR is the 1st half of the change. The 2nd half would be: change export workflow to use "local_path" and then do "gsutil cp" to gcs. Between 1st half and 2nd half, we need to release a new debian-9-worker image to adopt the new gce_export.

The purpose is to avoid long TCP connection with GCS. Currently, when directly writing .tar.gz file to GCS, a super long TCP connection to write the whole file (by io.CopyN) has to be established. However, it's not as stable as before (tcp connection reset happens a lot), and it's anyways unstable while writing a large image.

Per my testing, the performance of new implementation is the same as the current one.
The cost is higher due to more disk consumed, but no more than $0.1 for a 200GB exporting.