### PR TITLE
Correct DetachDisks[].DeviceName field in the spec

### DIFF
--- a/docs/daisy-workflow-config-spec.md
+++ b/docs/daisy-workflow-config-spec.md
@@ -190,7 +190,7 @@ daisy uses the same representation with a few modifications:
 
 | Field Name | Type | Description |
 | - | - | - |
-| Name | string | The name of the disk to detach, either disk [partial URLs](#glossary-partialurl) or workflow-internal disk names are valid. |
+| DeviceName | string | The name of the disk to detach, either disk [partial URLs](#glossary-partialurl) or workflow-internal disk names are valid. |
 
 Added fields:
 
@@ -212,7 +212,7 @@ detaching it.
 "detach-step": {
   "DetachDisks": [
     {
-      "Name": "my-disk",
+      "DeviceName": "my-disk",
       "Instance": "my-instance"
     }
   ]


### PR DESCRIPTION
The actual field name is `DeviceName`, not `Name`.
https://github.com/GoogleCloudPlatform/compute-image-tools/blob/def68e87dd9e05dba74e1b9aff49d8199922f420/daisy/step_detach_disks.go#L26-L32