### PR TITLE
[daisy export] New export workflow for raw format

### DIFF
--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -35,16 +35,22 @@
     }
   },
   "Sources": {
-    "${NAME}_export_disk.sh": "./export_disk.sh"
+    "${NAME}_export_disk.sh": "./export_disk.sh",
+    "${NAME}_disk_resizing_mon.sh": "./disk_resizing_mon.sh"
   },
   "Steps": {
     "setup-disks": {
       "CreateDisks": [
         {
-          "Name": "disk-${NAME}",
+          "Name": "disk-${NAME}-os",
           "SourceImage": "${export_instance_disk_image}",
-          "SizeGb": "${export_instance_disk_size}",
           "Type": "${export_instance_disk_type}"
+        },
+        {
+          "Name": "disk-${NAME}-buffer-${ID}",
+          "SizeGb": "${export_instance_disk_size}",
+          "Type": "${export_instance_disk_type}",
+          "ExactName": true
         }
       ]
     },
@@ -52,12 +58,17 @@
       "CreateInstances": [
         {
           "Name": "inst-${NAME}",
-          "Disks": [{"Source": "disk-${NAME}"}, {"Source": "${source_disk}", "Mode": "READ_ONLY"}],
+          "Disks": [
+            {"Source": "disk-${NAME}-os"},
+            {"Source": "${source_disk}", "Mode": "READ_ONLY"},
+            {"Source": "disk-${NAME}-buffer-${ID}"}
+          ],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
             "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}.tar.gz",
-            "licenses": "${licenses}"
+            "licenses": "${licenses}",
+            "resizing-script-name": "${NAME}_disk_resizing_mon.sh"
           },
           "networkInterfaces": [
             {

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -76,7 +76,7 @@
               "subnetwork": "${export_subnet}"
             }
           ],
-          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],
+          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control","https://www.googleapis.com/auth/compute"],
           "StartupScript": "${NAME}_export_disk.sh"
         }
       ]

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -68,6 +68,7 @@
             "block-project-ssh-keys": "true",
             "gcs-path": "${OUTSPATH}/${NAME}.tar.gz",
             "licenses": "${licenses}",
+	    "buffer-disk": "disk-${NAME}-buffer-${ID}",
             "resizing-script-name": "${NAME}_disk_resizing_mon.sh"
           },
           "networkInterfaces": [

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -76,7 +76,7 @@
               "subnetwork": "${export_subnet}"
             }
           ],
-          "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],
+          "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control"],
           "StartupScript": "${NAME}_export_disk.sh"
         }
       ]

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -51,7 +51,7 @@
           "Name": "disk-${NAME}-buffer-${ID}",
           "SizeGb": "${export_instance_disk_size}",
           "Type": "${export_instance_disk_type}",
-	  "ExactName": true
+          "ExactName": true
         }
       ]
     },

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -56,7 +56,7 @@ echo "GCEExport: Launching disk size monitor in background..."
 chmod +x ${DISK_RESIZING_MON_LOCAL_PATH}
 ${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
 
-echo "GCEExport: Exporting image to local by gce_export tool..."
+echo "GCEExport: Exporting image to local disk by gce_export tool..."
 if [[ -n $LICENSES ]]; then
   gce_export -local_path "/gs/${IMAGE_OUTPUT_PATH}" -disk /dev/sdb -licenses "$LICENSES" -y
 else
@@ -73,8 +73,6 @@ if ! out=$(gsutil cp "/gs/${IMAGE_OUTPUT_PATH}" "${GCS_PATH}" 2>&1); then
   exit 1
 fi
 echo ${out}
-
-"$GCS_PATH"
 
 echo "ExportSuccess"
 sync

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -58,12 +58,12 @@ ${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
 
 echo "GCEExport: Exporting image to local by gce_export tool..."
 if [[ -n $LICENSES ]]; then
-  gce_export -local_path "$IMAGE_OUTPUT_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
+  gce_export -local_path "/gs/${IMAGE_OUTPUT_PATH}" -disk /dev/sdb -licenses "$LICENSES" -y
 else
-  gce_export -local_path "$IMAGE_OUTPUT_PATH" -disk /dev/sdb -y
+  gce_export -local_path "/gs/${IMAGE_OUTPUT_PATH}" -disk /dev/sdb -y
 fi
 if [ $? -ne 0 ]; then
-  echo "ExportFailed: Failed to export disk source to ${IMAGE_OUTPUT_PATH}."
+  echo "ExportFailed: Failed to export disk source to /gs/${IMAGE_OUTPUT_PATH}."
   exit 1
 fi
 

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -13,20 +13,68 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+BYTES_1GB=1073741824
 URL="http://metadata/computeMetadata/v1/instance/attributes"
 GCS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
+DISK_RESIZING_MON=$(curl -f -H Metadata-Flavor:Google ${URL}/resizing-script-name)
 
-echo "GCEExport: Running export tool."
-if [[ -n $LICENSES ]]; then
-  gce_export -gcs_path "$GCS_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
-else
-  gce_export -gcs_path "$GCS_PATH" -disk /dev/sdb -y
+# Strip gs://
+IMAGE_OUTPUT_PATH=${GCS_PATH##*//}
+# Create dir for output
+OUTS_PATH=${IMAGE_OUTPUT_PATH%/*}
+mkdir -p "/gs/${OUTS_PATH}"
+
+# Prepare disk size info.
+# 1. Disk image size info.
+SIZE_BYTES=$(lsblk /dev/sdb --output=size -b | sed -n 2p)
+# 2. Round up to the next GB.
+SIZE_OUTPUT_GB=$(awk "BEGIN {print int(((${SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
+# 3. Add 5GB of additional space to max size to prevent the corner case that output
+# file is slightly larger than source disk.
+MAX_BUFFER_DISK_SIZE_GB=$(awk "BEGIN {print int(${SIZE_OUTPUT_GB} + 5)}")
+
+# Prepare buffer disk.
+echo "GCEExport: Initializing buffer disk for gce_export output..."
+mkfs.ext4 /dev/sdc
+mount /dev/sdc "/gs/${OUTS_PATH}"
+if [[ $? -ne 0 ]]; then
+  echo "ExportFailed: Failed to prepare buffer disk by mkfs + mount."
 fi
-if [ $? -ne 0 ]; then
-  echo "ExportFailed: Failed to export disk source to ${GCS_PATH}."
+
+# Fetch disk size monitor script from GCS1
+DISK_RESIZING_MON_GCS_PATH=gs://${OUTS_PATH%/*}/sources/${DISK_RESIZING_MON}
+DISK_RESIZING_MON_LOCAL_PATH=/gs/${DISK_RESIZING_MON}
+echo "GCEExport: Copying disk size monitor script..."
+if ! out=$(gsutil cp "${DISK_RESIZING_MON_GCS_PATH}" "${DISK_RESIZING_MON_LOCAL_PATH}" 2>&1); then
+  echo "ExportFailed: Failed to copy disk size monitor script. Error: ${out}"
   exit 1
 fi
+echo ${out}
+
+echo "GCEExport: Launching disk size monitor in background..."
+chmod +x ${DISK_RESIZING_MON_LOCAL_PATH}
+${DISK_RESIZING_MON_LOCAL_PATH} ${MAX_BUFFER_DISK_SIZE_GB} &
+
+echo "GCEExport: Exporting image to local by gce_export tool..."
+if [[ -n $LICENSES ]]; then
+  gce_export -local_path "$IMAGE_OUTPUT_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
+else
+  gce_export -local_path "$IMAGE_OUTPUT_PATH" -disk /dev/sdb -y
+fi
+if [ $? -ne 0 ]; then
+  echo "ExportFailed: Failed to export disk source to ${IMAGE_OUTPUT_PATH}."
+  exit 1
+fi
+
+echo "GCEExport: Copying output image to target GCS path..."
+if ! out=$(gsutil cp "/gs/${IMAGE_OUTPUT_PATH}" "${GCS_PATH}" 2>&1); then
+  echo "ExportFailed: Failed to copy output image to ${GCS_PATH}, error: ${out}"
+  exit 1
+fi
+echo ${out}
+
+"$GCS_PATH"
 
 echo "ExportSuccess"
 sync


### PR DESCRIPTION
New export workflow for raw format.
Old: export directly to GCS
New: export to local disk, and then copy to GCS.

Currently, long TCP connection has a high chance to be reset by GCS. It caused ~40% failure for a 10GB disk exporting. Let's avoid that.

It's quite similar to the existing "export ext" workflow now.