### PR TITLE
[import wrapper] source_image param should accept long format

### DIFF
--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -195,7 +195,7 @@ func buildDaisyVars(translateWorkflowPath string) map[string]string {
 		varMap["source_disk_file"] = *sourceFile
 	}
 	if *sourceImage != "" {
-		varMap["source_image"] = fmt.Sprintf("global/images/%v", *sourceImage)
+		varMap["source_image"] = *sourceImage
 	}
 	varMap["family"] = *family
 	varMap["description"] = *description

--- a/cli_tools/gce_vm_image_import/main_test.go
+++ b/cli_tools/gce_vm_image_import/main_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestGetWorkflowPathsFromImage(t *testing.T) {
-	defer testutils.SetStringP(&sourceImage, "image-1")()
+	defer testutils.SetStringP(&sourceImage, "global/images/image-1")()
 	defer testutils.SetStringP(&osID, "ubuntu-1404")()
 	workflow, translate := getWorkflowPaths()
 	if workflow != pathutils.ToWorkingDir(importFromImageWorkflow, *currentExecutablePath) || translate != "ubuntu/translate_ubuntu_1404.wf.json" {
@@ -47,7 +47,7 @@ func TestGetWorkflowPathsDataDisk(t *testing.T) {
 func TestGetWorkflowPathsWithCustomTranslateWorkflow(t *testing.T) {
 	defer testutils.SetStringP(&imageName, "image-a")()
 	defer testutils.SetStringP(&clientID, "gcloud")()
-	defer testutils.SetStringP(&sourceImage, "image-1")()
+	defer testutils.SetStringP(&sourceImage, "global/images/image-1")()
 	defer testutils.SetStringP(&customTranWorkflow, "custom.wf")()
 	if err := validateAndParseFlags(); err != nil {
 		t.Errorf("Unexpected flags error: %v", err)
@@ -85,7 +85,6 @@ func TestFlagsUnexpectedCustomTranslateWorkflowWithDataDisk(t *testing.T) {
 func TestGetWorkflowPathsFromFile(t *testing.T) {
 	homeDir := "/home/gce/"
 	defer testutils.SetBoolP(&dataDisk, false)()
-	defer testutils.SetStringP(&sourceImage, "image-1")()
 	defer testutils.SetStringP(&osID, "ubuntu-1404")()
 	defer testutils.SetStringP(&sourceImage, "")()
 	defer testutils.SetStringP(&currentExecutablePath, homeDir+"executable")()
@@ -272,7 +271,7 @@ func TestBuildDaisyVarsFromImage(t *testing.T) {
 	defer testutils.SetStringP(&imageName, "image-a")()
 	defer testutils.SetBoolP(&noGuestEnvironment, true)()
 	defer testutils.SetStringP(&sourceFile, "")()
-	defer testutils.SetStringP(&sourceImage, "source-image")()
+	defer testutils.SetStringP(&sourceImage, "global/images/source-image")()
 	defer testutils.SetStringP(&family, "a-family")()
 	defer testutils.SetStringP(&description, "a-description")()
 	defer testutils.SetStringP(&network, "a-network")()
@@ -307,7 +306,7 @@ func getAllCliArgs() map[string]interface{} {
 		"data_disk":                 true,
 		"os":                        "ubuntu-1404",
 		"source_file":               "gs://source_bucket/source_file",
-		"source_image":              "anImage",
+		"source_image":              "global/images/anImage",
 		"no_guest_environment":      true,
 		"family":                    "aFamily",
 		"description":               "aDescription",

--- a/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
@@ -105,7 +105,7 @@ func runImageImportOSFromImageTest(
 	imageName := "e2e-test-image-import-os-from-image-" + suffix
 	cmd := "gce_vm_image_import"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-		fmt.Sprintf("-image_name=%v", imageName), "-os=debian-9", "-source_image=e2e-test-image-10g"}
+		fmt.Sprintf("-image_name=%v", imageName), "-os=debian-9", "-source_image=global/images/e2e-test-image-10g"}
 	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
 		logger.Printf("Error running cmd: %v\n", err)
 		testCase.WriteFailure("Error running cmd: %v", err)


### PR DESCRIPTION
Just as what I did for export wrapper in https://github.com/GoogleCloudPlatform/compute-image-tools/pull/833:
we need to be compatible with 2 kind of inputs:
"global/images/anImage"
"projects/myproject/global/images/anImage"
So removed the fixed prefix "global/images" from code. Currently, the fixed prefix is conflict with gcloud