### PR TITLE
fix param network/subnet logic for import/export wrapper

### DIFF
--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -114,11 +114,15 @@ func buildDaisyVars() map[string]string {
 	if *format != "" {
 		varMap["format"] = *format
 	}
-	if *network != "" {
-		varMap["export_network"] = fmt.Sprintf("global/networks/%v", *network)
-	}
 	if *subnet != "" {
 		varMap["export_subnet"] = fmt.Sprintf("regions/%v/subnetworks/%v", *region, *subnet)
+		// When subnet is set, we need to grant a value to network to avoid fallback to default
+		if *network == "" {
+			varMap["import_network"] = ""
+		}
+	}
+	if *network != "" {
+		varMap["export_network"] = fmt.Sprintf("global/networks/%v", *network)
 	}
 	return varMap
 }

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -199,11 +199,15 @@ func buildDaisyVars(translateWorkflowPath string) map[string]string {
 	}
 	varMap["family"] = *family
 	varMap["description"] = *description
-	if *network != "" {
-		varMap["import_network"] = fmt.Sprintf("global/networks/%v", *network)
-	}
 	if *subnet != "" {
 		varMap["import_subnet"] = fmt.Sprintf("regions/%v/subnetworks/%v", *region, *subnet)
+		// When subnet is set, we need to grant a value to network to avoid fallback to default
+		if *network == "" {
+			varMap["import_network"] = ""
+		}
+	}
+	if *network != "" {
+		varMap["import_network"] = fmt.Sprintf("global/networks/%v", *network)
 	}
 	return varMap
 }

--- a/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
@@ -107,7 +107,7 @@ func runImageExportWithRichParamsTest(
 
 	suffix := pathutils.RandString(5)
 	bucketName := fmt.Sprintf("%v-test-image", testProjectConfig.TestProjectID)
-	objectName := fmt.Sprintf("e2e-export-raw-test-%v", suffix)
+	objectName := fmt.Sprintf("e2e-export-rich-param-test-%v", suffix)
 	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
 	cmd := "gce_vm_image_export"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),

--- a/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
@@ -45,12 +45,15 @@ func TestSuite(
 		testSuiteName, fmt.Sprintf("[ImageExport] %v", "Export VMDK"))
 	imageExportWithRichParamsTestCase := junitxml.NewTestCase(
 		testSuiteName, fmt.Sprintf("[ImageExport] %v", "Export with rich params"))
+	imageExportWithSubnetWithoutNetworkTestCase := junitxml.NewTestCase(
+		testSuiteName, fmt.Sprintf("[ImageExport] %v", "Export with subnet but without network"))
 
 	testsMap := map[*junitxml.TestCase]func(
 		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project){
-		imageExportRawTestCase:            runImageExportRawTest,
-		imageExportVMDKTestCase:           runImageExportVMDKTest,
-		imageExportWithRichParamsTestCase: runImageExportWithRichParamsTest,
+		imageExportRawTestCase:                      runImageExportRawTest,
+		imageExportVMDKTestCase:                     runImageExportVMDKTest,
+		imageExportWithRichParamsTestCase:           runImageExportWithRichParamsTest,
+		imageExportWithSubnetWithoutNetworkTestCase: runImageExportWithSubnetWithoutNetworkParamsTest,
 	}
 
 	testsuiteutils.TestSuite(ctx, tswg, testSuites, logger, testSuiteRegex, testCaseRegex,
@@ -109,9 +112,32 @@ func runImageExportWithRichParamsTest(
 	cmd := "gce_vm_image_export"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
-		"-network=default", "-subnet=default", fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
+		fmt.Sprintf("-network=%v-vpc-1", testProjectConfig.TestProjectID),
+		fmt.Sprintf("-subnet=%v-subnet-1", testProjectConfig.TestProjectID),
+		fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
 		"-timeout=2h", "-disable_gcs_logging", "-disable_cloud_logging", "-disable_stdout_logging",
 		"-labels=key1=value1,key2=value"}
+	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return
+	}
+
+	verifyExportedImageFile(ctx, testCase, bucketName, objectName, logger)
+}
+
+func runImageExportWithSubnetWithoutNetworkParamsTest(
+	ctx context.Context, testCase *junitxml.TestCase,
+	logger *log.Logger, testProjectConfig *testconfig.Project) {
+
+	suffix := pathutils.RandString(5)
+	bucketName := fmt.Sprintf("%v-test-image", testProjectConfig.TestProjectID)
+	objectName := fmt.Sprintf("e2e-export-subnet-test-%v", suffix)
+	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
+	cmd := "gce_vm_image_export"
+	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
+		fmt.Sprintf("-subnet=%v-subnet-1", testProjectConfig.TestProjectID),
+		"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI)}
 	if err := testsuiteutils.RunCliTool(logger, testCase, cmd, args); err != nil {
 		logger.Printf("Error running cmd: %v\n", err)
 		testCase.WriteFailure("Error running cmd: %v", err)

--- a/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/import/image_import_test_suite.go
@@ -128,7 +128,7 @@ func runImageImportWithRichParamsTest(
 	labels := []string{"key1=value1", "key2=value2"}
 
 	suffix := pathutils.RandString(5)
-	imageName := "e2e-test-image-import-data-disk-" + suffix
+	imageName := "e2e-test-image-import-rich-param-" + suffix
 	cmd := "gce_vm_image_import"
 	args := []string{"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
 		fmt.Sprintf("-image_name=%s", imageName), "-data_disk", fmt.Sprintf("-source_file=gs://%v-test-image/image-file-10g-vmdk", testProjectConfig.TestProjectID),


### PR DESCRIPTION
Currently there is a logic lost in import/export wrapper: when subnet is specified and network is not, we should set network to empty string to avoid falling back to default network.

This logic exists in gcloud GA. However, since gcloud is going to call wrapper, this logic should be hosted in this repo. There are 2 reasons to do it:
1. Rich logic should be handled by wrapper layer as much as possible.
2. For a cli tool, there is no way to distinguish network=none v.s. network='', due that param is not nullable.

Added e2e test correspondingly.

This fix is required to fix the behavior of gcloud calling wrapper.