### PR TITLE
image_test: don't rely on logger

### DIFF
--- a/image_test/boot/boot.sh
+++ b/image_test/boot/boot.sh
@@ -19,7 +19,9 @@ sleep 10
 if ! ls /reboot.txt; then
   echo "REBOOT" > /reboot.txt
   logger -p daemon.info "BOOTED"
+  echo "BOOTED" > /dev/console
 else
   cat /reboot.txt | logger -p daemon.info
+  cat /reboot.txt > /dev/console
 fi
 sync

--- a/image_test/disk/disk-local-ssd.sh
+++ b/image_test/disk/disk-local-ssd.sh
@@ -54,8 +54,10 @@ if [ $IS_SCSI -eq 1 ]; then
   # check for Multiqueue SCSI on Linux
   if [ $IS_BSD -eq 0 ]; then
     grep scsi_mod.use_blk_mq=Y /proc/cmdline &> /dev/null \
-      && logger -p daemon.info "Multiqueue is enable" \
-      || logger -p daemon.info "Multiqueue is DISABLED"
+      && (logger -p daemon.info "Multiqueue is enable"; \
+          echo "Multiqueue is enable" > /dev/console)\
+      || (logger -p daemon.info "Multiqueue is DISABLED"; \
+          echo "Multiqueue is DISABLED" > /dev/console)
   fi
 fi
 
@@ -88,6 +90,8 @@ umount $MOUNT_POINT
 mount $PARTITION $MOUNT_POINT
 if [ $CHECK_STRING = $(cat $MOUNT_POINT/$CHECK_FILENAME) ]; then
   logger -p daemon.info "CheckSuccessful"
+  echo "CheckSuccessful" > /dev/console
 else
   logger -p daemon.info "CheckFailed"
+  echo "CheckFailed" > /dev/console
 fi

--- a/image_test/disk/disk-testee.sh
+++ b/image_test/disk/disk-testee.sh
@@ -15,21 +15,26 @@
 
 if [ ! -e /reboot.txt ]; then
     logger -p daemon.info "BOOTED"
+    echo "BOOTED" > /dev/console
     echo > /reboot.txt
 else
     logger -p daemon.info "REBOOT"
+    echo "REBOOT" > /dev/console
 fi
 
 while [ 1 ]; do
   if [ -e /dev/sda ]; then
     # Linux style
     printf TotalDisks:%d\\n `ls /dev/sd* | grep [a-z]$ | wc -l` | logger -p daemon.info
+    printf TotalDisks:%d\\n `ls /dev/sd* | grep [a-z]$ | wc -l` > /dev/console
   elif [ -e /dev/da0 ]; then
     # BSD style
     printf TotalDisks:%d\\n `ls /dev/da* | grep da[0-9]$ | wc -l` | logger -p daemon.info
+    printf TotalDisks:%d\\n `ls /dev/da* | grep da[0-9]$ | wc -l` > /dev/console
   else
     # unknown
     logger -p daemon.info "TotalDisksUnrecognized"
+    echo "TotalDisksUnrecognized" > /dev/console
   fi
 
   # Avoid flooding the logs, otherwise we might lose the BOOTED/REBOOT message

--- a/image_test/metadata-script/metadata-script-test-shutdown-hash.sh
+++ b/image_test/metadata-script/metadata-script-test-shutdown-hash.sh
@@ -214,3 +214,4 @@ fi
 
 # Finish the script by outputing the hash which is the SuccessMatch
 $md5bin ./shutdown_tester.sh | logger -p daemon.info
+$md5bin ./shutdown_tester.sh > /dev/console

--- a/image_test/metadata-script/metadata-script-test-startup-hash.sh
+++ b/image_test/metadata-script/metadata-script-test-startup-hash.sh
@@ -191,3 +191,5 @@ chmod +x startup_tester.sh
 ./startup_tester.sh
 (which md5sum && md5sum ./startup_tester.sh || md5 ./startup_tester.sh) \
     | logger -p daemon.info
+(which md5sum && md5sum ./startup_tester.sh || md5 ./startup_tester.sh) \
+    > /dev/console

--- a/image_test/metadata-ssh/metadata-ssh.wf.json
+++ b/image_test/metadata-ssh/metadata-ssh.wf.json
@@ -72,7 +72,7 @@
           "RealName": "inst-metadata-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
-            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED"
+            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED; echo BOOTED > /dev/console"
           }
         }
       ]

--- a/image_test/multi-nic/multi-nic-master.sh
+++ b/image_test/multi-nic/multi-nic-master.sh
@@ -23,4 +23,6 @@ if [  -n "$(uname -a | grep Ubuntu)" ]; then
     fi
 fi
 
-ping -c 5 ${HOST} && logger -p daemon.info 'MultiNICSuccess' || logger -p daemon.info 'MultiNICFailed'
+ping -c 5 ${HOST} && \
+ (logger -p daemon.info 'MultiNICSuccess'; echo 'MultiNICSuccess' > /dev/console) || \
+ (logger -p daemon.info 'MultiNICFailed'; echo 'MultiNICFailed' > /dev/console)

--- a/image_test/multi-nic/multi-nic-slave.sh
+++ b/image_test/multi-nic/multi-nic-slave.sh
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 logger -p daemon.info BOOTED
+echo BOOTED > /dev/console

--- a/image_test/network/network-testee-checker.sh
+++ b/image_test/network/network-testee-checker.sh
@@ -19,10 +19,13 @@
 getent hosts $INSTANCE
 
 # Raise error if it occurred
-[ $? -ne 0 ] && logger -p daemon.info "DNS_Failed"
+[ $? -ne 0 ] && \
+ (logger -p daemon.info "DNS_Failed"; echo "DNS_Failed" > /dev/console)
 
 # Verify VM to external DNS connection
 getent hosts www.google.com
 
 # Signalize wait-for-instance that instance is ready or error occurred
-[ $? -ne 0 ] && logger -p daemon.info "DNS_Failed" || logger -p daemon.info "DNS_Success"
+[ $? -ne 0 ] && \
+ (logger -p daemon.info "DNS_Failed"; echo "DNS_Failed" > /dev/console) || \
+ (logger -p daemon.info "DNS_Success"; echo "DNS_Success" > /dev/console)

--- a/image_test/network/network-testee.sh
+++ b/image_test/network/network-testee.sh
@@ -15,6 +15,7 @@
 
 # Signalize wait-for-instance that instance is ready
 logger -p daemon.info "BOOTED"
+echo "BOOTED" > /dev/console
 
 # Serve a file server that prints the hostname when requesting "/hostname"
 # and "linux" when requesting "/os"

--- a/image_test/oslogin-ssh/oslogin-ssh.wf.json
+++ b/image_test/oslogin-ssh/oslogin-ssh.wf.json
@@ -137,7 +137,7 @@
           "RealName": "inst-oslogin-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
-            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED"
+            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED; echo BOOTED > /dev/console"
           }
         }
       ]

--- a/image_test/oslogin-ssh/oslogin_slave_tester.sh
+++ b/image_test/oslogin-ssh/oslogin_slave_tester.sh
@@ -72,3 +72,4 @@ chmod a+x /bin/slave_tester.sh
 # Allow writting to serial port
 chmod a+w /dev/ttyS0
 logger -p daemon.info "BOOTED"
+echo "BOOTED" > /dev/console


### PR DESCRIPTION
Print messages directly to /dev/console.
Do not rely only on logger to print to the serial port (it is not working on
Debian 10 for instance).
This error will be caught by the configuration test, thus update all the
other tests to ouput in both, logger and /dev/console.

Also, if logger is failing, metadata-script tests will fail as well, as we wait
for the messages from google_metadata_script_runner of type:

```
startup-script: INFO Starting startup scripts.
startup-script: INFO Found startup-script in metadata.
startup-script: INFO Finished running startup scripts.
```