### PR TITLE
A couple of improvements for gce_export

### DIFF
--- a/cli_tools/gce_export/README.md
+++ b/cli_tools/gce_export/README.md
@@ -22,8 +22,8 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_export
 
 + `-disk` disk to export, on linux this would be something like `/dev/sdb`, and on
 Windows `\\.\PhysicalDrive1`
-+ `-local_path` local path to store the image on disk, on linux this would be something
-like `/my_folder/linux.tar.gz`, and on Windows `\\.\PhysicalDrive2\path\windows.tar.gz`.
++ `-buffer_prefix` if set will use this local path as the local buffer prefix, on linux this would
+be something like `/my_folder`, and on Windows `\\.\PhysicalDrive2\path`.
 + `-gcs_path` GCS path to upload the image to, in the form of gs://my-bucket/image.tar.gz
 + `-oauth` path to oauth json file fo authenticating to the GCS bucket
 + `-licenses` (optional) comma separated list of licenses to add to the image

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -43,8 +43,6 @@ import (
 	htransport "google.golang.org/api/transport/http"
 )
 
-const gcsChunkSize = 0
-
 var (
 	disk         = flag.String("disk", "", "disk to export, on linux this would be something like '/dev/sda', and on Windows '\\\\.\\PhysicalDrive1'")
 	bufferPrefix = flag.String("buffer_prefix", "", "if set will use this local path as the local buffer prefix")
@@ -133,12 +131,10 @@ func (b *bufferedWriter) uploadWorker() {
 					return err
 				}
 				defer file.Close()
-				defer os.Remove(in)
 
 				tmpObj := path.Join(b.obj, strings.TrimPrefix(in, b.prefix))
 				b.addObj(tmpObj)
 				dst := client.Bucket(b.bkt).Object(tmpObj).NewWriter(b.ctx)
-				dst.ChunkSize = gcsChunkSize
 				if _, err := io.Copy(dst, file); err != nil {
 					if io.EOF != err {
 						return err
@@ -148,19 +144,22 @@ func (b *bufferedWriter) uploadWorker() {
 				return dst.Close()
 			}()
 			if err != nil {
+				fmt.Printf("Failed %v time(s) to upload '%v', error: %v\n", i, in, err)
 				if i > 16 {
 					log.Fatal(err)
 				}
+				fmt.Printf("Retrying uploading '%v' after %v s...\n", in, i)
 				time.Sleep(time.Duration(1*i) * time.Second)
 				continue
 			}
+			os.Remove(in)
 			break
 		}
 	}
 }
 
 func (b *bufferedWriter) newChunk() error {
-	fp := fmt.Sprint(b.prefix, b.id, "_part", b.part)
+	fp := path.Join(b.prefix, fmt.Sprint(b.id, "_part", b.part))
 	f, err := os.Create(fp)
 	if err != nil {
 		return err
@@ -210,7 +209,7 @@ func (b *bufferedWriter) Close() error {
 			objs[0].Delete(b.ctx)
 			break
 		}
-		newObj := client.Bucket(b.bkt).Object(path.Join(b.obj, "compose_"+strconv.Itoa(i)))
+		newObj := client.Bucket(b.bkt).Object(path.Join(b.obj, b.id+"_compose_"+strconv.Itoa(i)))
 		b.tmpObjs = append([]string{newObj.ObjectName()}, b.tmpObjs[int(l):]...)
 		if _, err := newObj.ComposerFrom(objs...).Run(b.ctx); err != nil {
 			return err
@@ -266,7 +265,8 @@ func gcsClient(ctx context.Context) (*storage.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: transport}))
+	return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: transport}),
+		option.WithCredentialsFile(*oauth))
 }
 
 func newBuffer(ctx context.Context, size, workers int64, prefix, bkt, obj string) *bufferedWriter {
@@ -416,7 +416,6 @@ func stream(ctx context.Context, src *os.File, size int64, prefix, bkt, obj stri
 	}
 
 	w := client.Bucket(bkt).Object(obj).NewWriter(ctx)
-	w.ChunkSize = gcsChunkSize
 	fmt.Println("GCEExport: No local cache set, streaming directly to GCS.")
 	return gzipDisk(src, size, w)
 }

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -148,7 +148,7 @@ func (b *bufferedWriter) uploadWorker() {
 				if i > 16 {
 					log.Fatal(err)
 				}
-				fmt.Printf("Retrying uploading '%v' after %v s...\n", in, i)
+				fmt.Printf("Retrying upload '%v' after %v second(s)...\n", in, i)
 				time.Sleep(time.Duration(1*i) * time.Second)
 				continue
 			}


### PR DESCRIPTION
gce_export responses for exporting raw format. A couple of improvements aree done by this PR.
1. Reliability: chunk size
Removed chunkSize=0, which means, using default setting instead. By testing, without this change, while exporting by a non-gcp computer, for a 2GB OS disk, it's 33% chance to fail; for a full-filled 10GB disk, it's 100% to fail. It's very fragile because it's very hard to finish sending a huge single request (256MB) via public network. Theoretically, even for a gcp computer, it is not super stable as well. So I changed it to default chunk size. With this change, it's 100% success. The perf is almost not impacted: 2s slower for a 10GB disk, which is, 1m44s v.s. 1m42s.

2. Reliability: retry logic
Moved "defer os.Remove(in)" to the correct place. Without this change retry logic doesn't work: once any error happens, os.Remove(in) will be executed in the for-loop. In that case, the next retry will fail because the file has been removed. I moved it to the "break" place and verified it works.

3. Bug: Fixed how to construct the file path for "_part" file. Before the fix, the expected path "/upload/abcde_part1" will become to "/uploadabcde_part1".

4. Concurrent issue: for the composing, I added a random prefix for "compose_i" file. It's because when user run multiple exports concurrently targeting the same file name, the dup operation happens to "compose_i" file and can fail the whole workflow. It can be repo by my test. The scenario can happen in the real world: customer may run dup commands by accident, or run a new command but forgot to kill the previous command.

5. Bug: Missed use of parameter "oauth": Usage of this parameter was deleted in the last version. I added it back.