### PR TITLE
Export raw with new gce_export with parallel uploading

### DIFF
--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -17,6 +17,14 @@ URL="http://metadata/computeMetadata/v1/instance/attributes"
 GCS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
 
+echo "GCEExport: Downloading gce_export."
+curl --output /usr/bin/gce_export https://storage.googleapis.com/compute-image-tools/release/linux/gce_export
+if [[ $? -ne 0 ]]; then
+  echo "ExportFailed: Could not download gce_export."
+  exit 1
+fi
+chmod +x /usr/bin/gce_export
+
 mkdir ~/upload
 
 echo "GCEExport: Running export tool."
@@ -25,7 +33,7 @@ if [[ -n $LICENSES ]]; then
 else
   gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -y
 fi
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
   echo "ExportFailed: Failed to export disk source to ${GCS_PATH}."
   exit 1
 fi

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -17,11 +17,13 @@ URL="http://metadata/computeMetadata/v1/instance/attributes"
 GCS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
 
+mkdir ~/upload
+
 echo "GCEExport: Running export tool."
 if [[ -n $LICENSES ]]; then
-  gce_export -buffer_prefix=/ -gcs_path "$GCS_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
+  gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
 else
-  gce_export -buffer_prefix=/ -gcs_path "$GCS_PATH" -disk /dev/sdb -y
+  gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -y
 fi
 if [ $? -ne 0 ]; then
   echo "ExportFailed: Failed to export disk source to ${GCS_PATH}."

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -19,9 +19,9 @@ LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
 
 echo "GCEExport: Running export tool."
 if [[ -n $LICENSES ]]; then
-  gce_export -gcs_path "$GCS_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
+  gce_export -buffer_prefix=/ -gcs_path "$GCS_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
 else
-  gce_export -gcs_path "$GCS_PATH" -disk /dev/sdb -y
+  gce_export -buffer_prefix=/ -gcs_path "$GCS_PATH" -disk /dev/sdb -y
 fi
 if [ $? -ne 0 ]; then
   echo "ExportFailed: Failed to export disk source to ${GCS_PATH}."


### PR DESCRIPTION
1. Export raw with new gce_export with parallel uploading
Perf improvement:

2. Download gce_export form our official GCS path. It will override pre-installed one in debian-9-worker. The purpose is to make the rollout process of gce_export being align with other cli tools. Otherwise, after a compute-image-tools release, we need to wait for one more debian-9-worker release.

After this code is released, we can remove pre-install step of gce_export from debian-9-worker build process.