### PR TITLE
Fix OVF e2e test

### DIFF
--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -162,7 +162,7 @@ func TestSuite(
 			startup: computeUtils.BuildInstanceMetadataItem(
 				"windows-startup-script-ps1", startupScriptWindowsSingleDisk),
 			assertTimeout:         7200 * time.Second,
-			expectedMachineType:   "n1-highmem-2",
+			expectedMachineType:   "n2-standard-2",
 			expectedStartupOutput: "All Tests Passed",
 		},
 	}


### PR DESCRIPTION
Fix OVF e2e test that is failing due to the introduction of a new machine type family today (N2 - https://cloud.google.com/blog/products/compute/expanding-virtual-machine-types-to-drive-performance-and-efficiency) 