### PR TITLE
e2e test for gcloud images import/export

### DIFF
--- a/gce_image_import_export_tests/main.go
+++ b/gce_image_import_export_tests/main.go
@@ -16,23 +16,26 @@ package main
 
 import (
 	"context"
-	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils"
 	"log"
+	"os"
 	"regexp"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/gce_image_import_export_tests/test_suites/export"
 	"github.com/GoogleCloudPlatform/compute-image-tools/gce_image_import_export_tests/test_suites/import"
+	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/junitxml"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/test_config"
 )
 
-var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
-	*regexp.Regexp, *regexp.Regexp, *testconfig.Project){
-	importtestsuites.TestSuite,
-	exporttestsuites.TestSuite,
-}
-
 func main() {
-	e2etestutils.LaunchTests(testFunctions, "[ImageImportExportTests]")
+	exportTestFail := e2etestutils.RunTestsAndOutput([]func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
+		*regexp.Regexp, *regexp.Regexp, *testconfig.Project){exporttestsuites.TestSuite},
+		"[ImageExportTests]")
+	importTestFail := e2etestutils.RunTestsAndOutput([]func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
+		*regexp.Regexp, *regexp.Regexp, *testconfig.Project){importtestsuites.TestSuite},
+		"[ImageImportTests]")
+	if exportTestFail || importTestFail {
+		os.Exit(1)
+	}
 }

--- a/gce_image_import_export_tests/test_suites/test_suite_utils.go
+++ b/gce_image_import_export_tests/test_suites/test_suite_utils.go
@@ -17,11 +17,11 @@ package testsuiteutils
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -29,11 +29,25 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/test_config"
 )
 
+// TestType defines which type of test is going to be executed
+type TestType string
+
+// List all test types here
+const (
+	Wrapper                   TestType = "1 wrapper"
+	GcloudProdWrapperLatest   TestType = "2 gcloud-prod wrapper-latest"
+	GcloudLatestWrapperLatest TestType = "3 gcloud-latest wrapper-latest"
+)
+
+var (
+	gcloudUpdateLock = sync.Mutex{}
+)
+
 // TestSuite executes given test suite.
 func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junitxml.TestSuite,
 	logger *log.Logger, testSuiteRegex, testCaseRegex *regexp.Regexp,
-	testProjectConfig *testconfig.Project, testSuiteName string, testsMap map[*junitxml.TestCase]func(
-		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project)) {
+	testProjectConfig *testconfig.Project, testSuiteName string, testsMap map[TestType]map[*junitxml.TestCase]func(
+		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, TestType)) {
 
 	defer tswg.Done()
 
@@ -44,7 +58,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 	testSuite := junitxml.NewTestSuite(testSuiteName)
 	defer testSuite.Finish(testSuites)
 	logger.Printf("Running TestSuite %q", testSuite.Name)
-	tests := runTestCases(ctx, logger, testCaseRegex, testProjectConfig, testsMap)
+	tests := runTestCases(ctx, logger, testCaseRegex, testProjectConfig, testSuite.Name, testsMap)
 
 	for ret := range tests {
 		testSuite.TestCase = append(testSuite.TestCase, ret)
@@ -54,40 +68,151 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 }
 
 func runTestCases(ctx context.Context, logger *log.Logger, regex *regexp.Regexp,
-	testProjectConfig *testconfig.Project, testsMap map[*junitxml.TestCase]func(
-		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project)) chan *junitxml.TestCase {
+	testProjectConfig *testconfig.Project, testSuiteName string, testsMap map[TestType]map[*junitxml.TestCase]func(
+		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, TestType)) chan *junitxml.TestCase {
 
-	var wg sync.WaitGroup
 	tests := make(chan *junitxml.TestCase)
-	for tc, f := range testsMap {
-		wg.Add(1)
-		go func(ctx context.Context, wg *sync.WaitGroup, tc *junitxml.TestCase, f func(
-			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project)) {
-			defer wg.Done()
-			if tc.FilterTestCase(regex) {
-				tc.Finish(tests)
-			} else {
-				defer tc.Finish(tests)
-				logger.Printf("Running TestCase %s.%q", tc.Classname, tc.Name)
-				f(ctx, tc, logger, testProjectConfig)
-				logger.Printf("TestCase %s.%q finished in %fs", tc.Classname, tc.Name, tc.Time)
-			}
-		}(ctx, &wg, tc, f)
+	var ttwg sync.WaitGroup
+	ttwg.Add(len(testsMap))
+	tts := make([]string, 0, len(testsMap))
+	for tt := range testsMap {
+		tts = append(tts, string(tt))
 	}
+	sort.Strings(tts)
+	go func() {
+		for _, ttStr := range tts {
+			tt := TestType(ttStr)
+			m := testsMap[tt]
+			logger.Printf("=== Running TestSuite %v for test type %v ===", testSuiteName, tt)
+
+			var wg sync.WaitGroup
+			for tc, f := range m {
+				wg.Add(1)
+				go func(ctx context.Context, wg *sync.WaitGroup, tc *junitxml.TestCase, tt TestType, f func(
+					context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, TestType)) {
+
+					defer wg.Done()
+					if tc.FilterTestCase(regex) {
+						tc.Finish(tests)
+					} else {
+						defer tc.Finish(tests)
+						logger.Printf("Running TestCase %s.%q", tc.Classname, tc.Name)
+						f(ctx, tc, logger, testProjectConfig, tt)
+						logger.Printf("TestCase %s.%q finished in %fs", tc.Classname, tc.Name, tc.Time)
+					}
+				}(ctx, &wg, tc, tt, f)
+			}
+			wg.Wait()
+
+			ttwg.Done()
+			logger.Printf("=== Fnished running TestSuite %v for test type %v ===", testSuiteName, tt)
+		}
+	}()
 
 	go func() {
-		wg.Wait()
+		ttwg.Wait()
 		close(tests)
 	}()
 
 	return tests
 }
 
-// RunCliTool executes cli tool with params
-func RunCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString string, args []string) error {
+func runCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString string, args []string) error {
 	logger.Printf("[%v] Running command: '%s %s'", testCase.Name, cmdString, strings.Join(args, " "))
-	cmd := exec.Command(fmt.Sprintf("./%s", cmdString), args...)
+	cmd := exec.Command(cmdString, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// RunTestCommand runs given test command
+func RunTestCommand(cmd string, args []string, logger *log.Logger, testCase *junitxml.TestCase) bool {
+	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return false
+	}
+	return true
+}
+
+func auth(logger *log.Logger, testCase *junitxml.TestCase) bool {
+	// This file exists in test env. For local testing, download a creds file from project
+	// compute-image-tools-test.
+	credsPath := "/etc/compute-image-tools-test-service-account/creds.json"
+	cmd := "gcloud"
+	args := []string{"auth", "activate-service-account", "--key-file=" + credsPath}
+	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return false
+	}
+	return true
+}
+
+func gcloudUpdate(logger *log.Logger, testCase *junitxml.TestCase, latest bool) bool {
+	gcloudUpdateLock.Lock()
+	defer gcloudUpdateLock.Unlock()
+
+	// auth is required for gcloud updates
+	if !auth(logger, testCase) {
+		return false
+	}
+
+	cmd := "gcloud"
+
+	if latest {
+		args := []string{"components", "repositories", "add",
+			"https://storage.googleapis.com/cloud-sdk-testing/ci/staging/components-2.json", "--quiet"}
+		if err := runCliTool(logger, testCase, cmd, args); err != nil {
+			logger.Printf("Error running cmd: %v\n", err)
+			testCase.WriteFailure("Error running cmd: %v", err)
+			return false
+		}
+	} else {
+		args := []string{"components", "repositories", "remove", "--all"}
+		if err := runCliTool(logger, testCase, cmd, args); err != nil {
+			logger.Printf("Error running cmd: %v\n", err)
+			testCase.WriteFailure("Error running cmd: %v", err)
+			return false
+		}
+	}
+
+	args := []string{"components", "update", "--quiet"}
+	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+		logger.Printf("Error running cmd: %v\n", err)
+		testCase.WriteFailure("Error running cmd: %v", err)
+		return false
+	}
+
+	// an additional auth is required if updated through a different repository
+	if !auth(logger, testCase) {
+		return false
+	}
+
+	return true
+}
+
+// RunTestForTestType runs test for given test type
+func RunTestForTestType(cmd string, args []string, testType TestType, logger *log.Logger, testCase *junitxml.TestCase) bool {
+	switch testType {
+	case Wrapper:
+		if !RunTestCommand(cmd, args, logger, testCase) {
+			return false
+		}
+	case GcloudProdWrapperLatest:
+		if !gcloudUpdate(logger, testCase, false) {
+			return false
+		}
+		if !RunTestCommand(cmd, args, logger, testCase) {
+			return false
+		}
+	case GcloudLatestWrapperLatest:
+		if !gcloudUpdate(logger, testCase, true) {
+			return false
+		}
+		if !RunTestCommand(cmd, args, logger, testCase) {
+			return false
+		}
+	}
+	return true
 }

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -216,7 +216,7 @@ periodics:
          args:
            - "-out_dir=/artifacts"
            - "-test_project_id=compute-image-test-pool-001"
-           - "-test_zone=us-central1-c"
+           - "-test_zone=us-central1-b"
          volumeMounts:
            - name: compute-image-tools-test-service-account
              mountPath: /etc/compute-image-tools-test-service-account

--- a/test-infra/prowjobs/cloudbuild.yaml
+++ b/test-infra/prowjobs/cloudbuild.yaml
@@ -3,6 +3,8 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/wrapper:latest', '--tag=gcr.io/$PROJECT_ID/wrapper:$COMMIT_SHA', './test-infra/prowjobs/wrapper']
 - name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/wrapper-with-gcloud:latest', '--tag=gcr.io/$PROJECT_ID/wrapper-with-gcloud:$COMMIT_SHA', './test-infra/prowjobs/wrapper/DockerfileWithGcloud']
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/gocheck:latest', '--tag=gcr.io/$PROJECT_ID/gocheck:$COMMIT_SHA', './test-infra/prowjobs/gocheck']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/gobuild:latest', '--tag=gcr.io/$PROJECT_ID/gobuild:$COMMIT_SHA', './test-infra/prowjobs/gobuild']

--- a/test-infra/prowjobs/gce-image-import-export-tests/Dockerfile
+++ b/test-infra/prowjobs/gce-image-import-export-tests/Dockerfile
@@ -31,12 +31,11 @@ RUN CGO_ENABLED=0 go build -o /gce_vm_image_export github.com/GoogleCloudPlatfor
 RUN chmod +x /gce_vm_image_export
 
 # Prepare content of docker
-FROM gcr.io/compute-image-tools-test/wrapper:latest
+FROM gcr.io/compute-image-tools-test/wrapper-with-gcloud:latest
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_image_import_export_test_runner gce_image_import_export_test_runner
 COPY --from=0 /gce_vm_image_import gce_vm_image_import
 COPY --from=0 /gce_vm_image_export gce_vm_image_export
 COPY /daisy_workflows/ /daisy_workflows/
-
 ENTRYPOINT ["./wrapper", "./gce_image_import_export_test_runner"]

--- a/test-infra/prowjobs/wrapper/DockerfileWithGcloud
+++ b/test-infra/prowjobs/wrapper/DockerfileWithGcloud
@@ -1,0 +1,28 @@
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM golang:alpine
+
+RUN apk add --no-cache git
+
+WORKDIR /tmp
+COPY main.go main.go
+RUN go get -d ./...
+RUN CGO_ENABLED=0 go build -o /wrapper .
+RUN chmod +x /wrapper
+
+FROM google/cloud-sdk:alpine
+
+COPY --from=0 wrapper wrapper
+RUN gcloud components install beta --quiet
+RUN gcloud components update --quiet


### PR DESCRIPTION
Originally we only have e2e test for wrapper. Now we added for gcloud, and there are 3 test types now:
"1 wrapper"
"2 gcloud-prod wrapper-latest"
"3 gcloud-latest wrapper-latest"

For each test scenario, we will run above 3 types of tests.
To support the new test type, some other changes are required:
1. Added a base docker image which contains gcloud pre-installed.
2. Before test run, install corresponding gcloud version and auth. The "latest" gcloud sdk is hosted in by gcloud team, and we just need to ref to it.
3. Moved test zone from us-central1-c to us-central1-b to balance the test load.
