### PR TITLE
Image-import: Preattach destination disk prior to running import_disk.sh

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -50,7 +50,10 @@
       "CreateInstances": [
         {
           "Name": "inst-importer",
-          "Disks": [{"Source": "disk-importer"}],
+          "Disks": [
+            {"Source": "disk-importer"},
+            {"Source": "${disk_name}"}
+          ],
           "MachineType": "n1-standard-4",
           "Metadata": {
             "block-project-ssh-keys": "true",


### PR DESCRIPTION
This is a small refactor that prepares for an upcoming change that
removes usage of gcsfuse in import_disk.sh.

## Testing

To test the change, I downloaded an Ubuntu 18.04 vmdk from Canonical and then ran daisy with the update workflow below. Here are the logs:

```bash
% daisy -var:source_disk_file=gs://<bkt>/images/ubuntu-18.04-server-cloudimg-amd64.vmdk \
        -var:image_name=ubuntu18 \
        -zone=us-central1-a \
        -project=$PROJECT \
        daisy_workflows/image_import/import_image.wf.json

[Daisy] Running workflow "import-image" (id=jl8b5)
[import-image]: 2019-08-19T14:17:53-07:00 Validating workflow
[import-image]: 2019-08-19T14:17:53-07:00 Validating step "import-disk"
[import-image.import-disk]: 2019-08-19T14:17:53-07:00 Validating step "setup-disks"
[import-image.import-disk]: 2019-08-19T14:17:53-07:00 Validating step "import-virtual-disk"
[import-image.import-disk]: 2019-08-19T14:17:54-07:00 Validating step "wait-for-signal"
[import-image]: 2019-08-19T14:17:54-07:00 Validating step "create-image"
[import-image]: 2019-08-19T14:17:54-07:00 Validating step "delete-disk"
[import-image]: 2019-08-19T14:17:54-07:00 Validation Complete
[import-image]: 2019-08-19T14:17:54-07:00 Workflow Project: $PROJECT
[import-image]: 2019-08-19T14:17:54-07:00 Workflow Zone: us-central1-a
[import-image]: 2019-08-19T14:17:54-07:00 Workflow GCSPath: gs://$PROJECT-daisy-bkt
[import-image]: 2019-08-19T14:17:54-07:00 Daisy scratch path: https://console.cloud.google.com/storage/browser/$PROJECT-daisy-bkt/daisy-import-image-20190819-21:17:52-jl8b5
[import-image]: 2019-08-19T14:17:54-07:00 Uploading sources
[import-image]: 2019-08-19T14:17:55-07:00 Running workflow
[import-image]: 2019-08-19T14:17:55-07:00 Running step "import-disk" (IncludeWorkflow)
[import-image.import-disk]: 2019-08-19T14:17:55-07:00 Running step "setup-disks" (CreateDisks)
[import-image.import-disk.setup-disks]: 2019-08-19T14:17:55-07:00 CreateDisks: Creating disk "imported-disk-jl8b5".
[import-image.import-disk.setup-disks]: 2019-08-19T14:17:55-07:00 CreateDisks: Creating disk "disk-importer-import-image-import-disk-jl8b5".
[import-image.import-disk]: 2019-08-19T14:17:58-07:00 Step "setup-disks" (CreateDisks) successfully finished.
[import-image.import-disk]: 2019-08-19T14:17:58-07:00 Running step "import-virtual-disk" (CreateInstances)
[import-image.import-disk.import-virtual-disk]: 2019-08-19T14:17:58-07:00 CreateInstances: Creating instance "inst-importer-import-image-import-disk-jl8b5".
[import-image.import-disk]: 2019-08-19T14:18:05-07:00 Step "import-virtual-disk" (CreateInstances) successfully finished.
[import-image.import-disk.import-virtual-disk]: 2019-08-19T14:18:05-07:00 CreateInstances: Streaming instance "inst-importer-import-image-import-disk-jl8b5" serial port 1 output to https://storage.cloud.google.com/$PROJECT-daisy-bkt/daisy-import-image-20190819-21:17:52-jl8b5/logs/inst-importer-import-image-import-disk-jl8b5-serial-port1.log
[import-image.import-disk]: 2019-08-19T14:18:05-07:00 Running step "wait-for-signal" (WaitForInstancesSignal)
[import-image.import-disk.wait-for-signal]: 2019-08-19T14:18:05-07:00 WaitForInstancesSignal: Instance "inst-importer-import-image-import-disk-jl8b5": watching serial port 1, SuccessMatch: "ImportSuccess:", FailureMatch: ["ImportFailed:" "WARNING Failed to download metadata script"], StatusMatch: "Import:".
[import-image.import-disk.wait-for-signal]: 2019-08-19T14:18:25-07:00 WaitForInstancesSignal: Instance "inst-importer-import-image-import-disk-jl8b5": StatusMatch found: "Import: Importing $PROJECT-daisy-bkt/images/ubuntu-18.04-server-cloudimg-amd64.vmdk of size 11GB to imported-disk-jl8b5 in projects/302819429230/zones/us-central1-a.'"
[import-image.import-disk.wait-for-signal]: 2019-08-19T14:18:25-07:00 WaitForInstancesSignal: Instance "inst-importer-import-image-import-disk-jl8b5": StatusMatch found: "Import: Importing $PROJECT-daisy-bkt/images/ubuntu-18.04-server-cloudimg-amd64.vmdk of size 11GB to imported-disk-jl8b5 in projects/302819429230/zones/us-central1-a."
[import-image.import-disk.wait-for-signal]: 2019-08-19T14:18:25-07:00 WaitForInstancesSignal: Instance "inst-importer-import-image-import-disk-jl8b5": StatusMatch found: "Import: Resizing imported-disk-jl8b5 to 11GB in projects/302819429230/zones/us-central1-a.'"
[import-image.import-disk.wait-for-signal]: 2019-08-19T14:18:25-07:00 WaitForInstancesSignal: Instance "inst-importer-import-image-import-disk-jl8b5": StatusMatch found: "Import: Resizing imported-disk-jl8b5 to 11GB in projects/302819429230/zones/us-central1-a."
[import-image.import-disk.wait-for-signal]: 2019-08-19T14:25:45-07:00 WaitForInstancesSignal: Instance "inst-importer-import-image-import-disk-jl8b5": SuccessMatch found "ImportSuccess: Finished import.'"
[import-image.import-disk]: 2019-08-19T14:25:45-07:00 Step "wait-for-signal" (WaitForInstancesSignal) successfully finished.
[import-image]: 2019-08-19T14:25:45-07:00 Step "import-disk" (IncludeWorkflow) successfully finished.
[import-image]: 2019-08-19T14:25:45-07:00 Running step "create-image" (CreateImages)
[import-image.create-image]: 2019-08-19T14:25:45-07:00 CreateImages: Creating image "ubuntu18".
[import-image]: 2019-08-19T14:28:08-07:00 Step "create-image" (CreateImages) successfully finished.
[import-image]: 2019-08-19T14:28:08-07:00 Running step "delete-disk" (DeleteResources)
[import-image.delete-disk]: 2019-08-19T14:28:08-07:00 DeleteResources: Deleting disk "imported-disk-jl8b5".
[import-image]: 2019-08-19T14:28:10-07:00 Step "delete-disk" (DeleteResources) successfully finished.
[import-image]: 2019-08-19T14:28:10-07:00 Workflow "import-image" cleaning up (this may take up to 2 minutes).
[import-image]: 2019-08-19T14:30:48-07:00 Workflow "import-image" finished cleanup.
[Daisy] Workflow "import-image" finished
[Daisy] All workflows completed successfully
```