### PR TITLE
Daisy bugs in non-JSON workflow creation paths.

### DIFF
--- a/daisy/disk_test.go
+++ b/daisy/disk_test.go
@@ -106,14 +106,20 @@ func TestDiskRegAttach(t *testing.T) {
 	// iw2:
 	// iw2SubStep
 	w := testWorkflow()
-	iw := w.NewIncludedWorkflow()
-	iw2 := w.NewIncludedWorkflow()
+
+	iw := New()
+	w.includeWorkflow(iw)
+	iw2 := New()
+	w.includeWorkflow(iw2)
+
 	iwStep, e1 := w.NewStep("iwStep")
 	iwStep.IncludeWorkflow = &IncludeWorkflow{Workflow: iw}
 	iwSubStep, e2 := iw.NewStep("iwSubStep")
+
 	iw2Step, e3 := w.NewStep("iw2Step")
 	iw2Step.IncludeWorkflow = &IncludeWorkflow{Workflow: iw2}
 	iw2SubStep, e4 := iw2.NewStep("iw2SubStep")
+
 	s, e5 := w.NewStep("s")
 	s2, e6 := w.NewStep("s2")
 	att, e7 := w.NewStep("att")

--- a/daisy/step_includeworkflow.go
+++ b/daisy/step_includeworkflow.go
@@ -38,10 +38,11 @@ func (i *IncludeWorkflow) populate(ctx context.Context, s *Step) dErr {
 		if i.Workflow, err = s.w.NewIncludedWorkflowFromFile(i.Path); err != nil {
 			return newErr(err)
 		}
-	}
-
-	if i.Workflow == nil {
-		return errf("IncludeWorkflow %q does not have a workflow", s.name)
+	} else {
+		if i.Workflow == nil {
+			return errf("IncludeWorkflow %q does not have a workflow", s.name)
+		}
+		s.w.includeWorkflow(i.Workflow)
 	}
 
 	i.Workflow.id = i.Workflow.parent.id

--- a/daisy/step_includeworkflow_test.go
+++ b/daisy/step_includeworkflow_test.go
@@ -82,6 +82,10 @@ func TestIncludeWorkflowPopulate(t *testing.T) {
 			},
 		},
 	}
+	// Register the 'got' workflow attrs with values from the 'want'
+	// workflow. This is done by populateStep, so it must be done here too
+	// for these objects to match.
+	want.includeWorkflow(got)
 
 	// Fixes for pretty.Compare.
 	for _, wf := range []*Workflow{got, want} {
@@ -108,7 +112,8 @@ func TestIncludeWorkflowRun(t *testing.T) {}
 func TestIncludeWorkflowValidate(t *testing.T) {
 	ctx := context.Background()
 	w := testWorkflow()
-	iw := w.NewIncludedWorkflow()
+	iw := New()
+	w.includeWorkflow(iw)
 	dCreator, _ := w.NewStep("dCreator")
 	dCreator.CreateImages = &CreateImages{}
 	incStep, _ := w.NewStep("incStep")

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -30,10 +30,11 @@ const (
 // WaitForInstancesSignal is a Daisy WaitForInstancesSignal workflow step.
 type WaitForInstancesSignal []*InstanceSignal
 
-type failureMatches []string
+// FailureMatches is a list of matching failure strings.
+type FailureMatches []string
 
-// UnmarshalJSON unmarshals failureMatches.
-func (fms *failureMatches) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON unmarshals FailureMatches.
+func (fms *FailureMatches) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err == nil {
 		*fms = []string{s}
@@ -46,7 +47,7 @@ func (fms *failureMatches) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*fms = failureMatches(ss)
+	*fms = FailureMatches(ss)
 	return nil
 }
 
@@ -58,7 +59,7 @@ func (fms *failureMatches) UnmarshalJSON(b []byte) error {
 type SerialOutput struct {
 	Port         int64          `json:",omitempty"`
 	SuccessMatch string         `json:",omitempty"`
-	FailureMatch failureMatches `json:"failureMatch,omitempty"`
+	FailureMatch FailureMatches `json:"failureMatch,omitempty"`
 	StatusMatch  string         `json:",omitempty"`
 }
 

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -492,9 +492,7 @@ func (w *Workflow) AddDependency(dependent *Step, dependencies ...*Step) error {
 	return nil
 }
 
-// NewIncludedWorkflow instantiates a new workflow with the same resources as the parent.
-func (w *Workflow) NewIncludedWorkflow() *Workflow {
-	iw := New()
+func (w *Workflow) includeWorkflow(iw *Workflow) {
 	iw.Cancel = w.Cancel
 	iw.parent = w
 	iw.disks = w.disks
@@ -506,7 +504,6 @@ func (w *Workflow) NewIncludedWorkflow() *Workflow {
 	iw.subnetworks = w.subnetworks
 	iw.targetInstances = w.targetInstances
 	iw.objects = w.objects
-	return iw
 }
 
 // ID is the unique identifyier for this Workflow.
@@ -516,7 +513,8 @@ func (w *Workflow) ID() string {
 
 // NewIncludedWorkflowFromFile reads and unmarshals a workflow with the same resources as the parent.
 func (w *Workflow) NewIncludedWorkflowFromFile(file string) (*Workflow, error) {
-	iw := w.NewIncludedWorkflow()
+	iw := New()
+	w.includeWorkflow(iw)
 	if !filepath.IsAbs(file) {
 		file = filepath.Join(w.workflowDir, file)
 	}


### PR DESCRIPTION
WaitForInstancesSignal failure match list should be public
IncludeWorkflow needs to set parent during populate