### PR TITLE
extend test cloudbuild timeout to 30min

### DIFF
--- a/test-infra/prowjobs/cloudbuild.yaml
+++ b/test-infra/prowjobs/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 900s
+timeout: 1800s
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/wrapper:latest', '--tag=gcr.io/$PROJECT_ID/wrapper:$COMMIT_SHA', './test-infra/prowjobs/wrapper']


### PR DESCRIPTION
15min is not enough anymore since more images were added