### PR TITLE
import_image.sh: Bring back manual disk attachment.

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -50,10 +50,7 @@
       "CreateInstances": [
         {
           "Name": "inst-importer",
-          "Disks": [
-            {"Source": "disk-importer"},
-            {"Source": "${disk_name}"}
-          ],
+          "Disks": [{"Source": "disk-importer"}],
           "MachineType": "n1-standard-4",
           "Metadata": {
             "block-project-ssh-keys": "true",

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -77,6 +77,12 @@ if [[ ${SIZE_GB} -gt 10 ]]; then
   resizeDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}"
 fi
 
+if ! out=$(gcloud -q compute instances attach-disk ${ME} --disk=${DISKNAME} --zone=${ZONE} 2>&1); then
+  echo "ImportFailed: Failed to attach ${DISKNAME} to ${ME}, error: ${out}"
+  exit
+fi
+echo ${out}
+
 # Decompress the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdb is used since it's the second disk that is attached
 # in import_disk.wf.json.


### PR DESCRIPTION
This was prompted by failures in integration tests, where the previous
behavior was expected. The typical failure message in those tests
was:

```
Ubuntu 1604 import and translate: step "import-and-translate-image" validation error: step "translate" validation error: step "translate-disk" validation error: step "translate-disk-inst" validation error: step "translate-disk-inst" cannot attach disk "temp-translation-disk-lv8zb" to instance "inst-translator": concurrent RW attachment of disk "temp-translation-disk-lv8zb" between instances "inst-translator" (READ_WRITE) and "inst-importer" (READ_WRITE)
```

To confirm the fix, I ran `daisy -zone=us-central1-a -project=edens-test daisy_integration_tests/ubuntu_1604_import_and_translate.wf.json` and observed that the message 'cannot attach disk' was no longer present.