### PR TITLE
Fix OVF import failure when location restrictions are on

### DIFF
--- a/cli_tools/common/utils/daisy/resource_labeler_test.go
+++ b/cli_tools/common/utils/daisy/resource_labeler_test.go
@@ -208,6 +208,7 @@ func TestUpdateWorkflowImageStorageLocationSet(t *testing.T) {
 	validateLabels(t, &(*w.Steps["cimg"].CreateImages).ImagesBeta[0].Image.Labels, "gce-image-import",
 		buildID, &existingLabels)
 
+	assert.Equal(t, 1, len((*w.Steps["cimg"].CreateImages).ImagesBeta[0].Image.StorageLocations))
 	assert.Equal(t, "europe-west5", (*w.Steps["cimg"].CreateImages).ImagesBeta[0].Image.StorageLocations[0])
 }
 

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -59,6 +60,7 @@ var (
 	gcsLogsDisabled             = flag.Bool("disable-gcs-logging", false, "do not stream logs to GCS")
 	cloudLogsDisabled           = flag.Bool("disable-cloud-logging", false, "do not stream logs to Cloud Logging")
 	stdoutLogsDisabled          = flag.Bool("disable-stdout-logging", false, "do not display individual workflow logs on stdout")
+	releaseTrack                = flag.String("release-track", ovfimporter.GA, fmt.Sprintf("Release track of OVF import. One of: %s, %s or %s. Impacts which compute API release track is used by the import tool.", ovfimporter.Alpha, ovfimporter.Beta, ovfimporter.GA))
 
 	nodeAffinityLabelsFlag flags.StringArrayFlag
 	currentExecutablePath  string
@@ -77,14 +79,16 @@ func buildImportParams() *ovfimportparams.OVFImportParams {
 		Labels: *labels, MachineType: *machineType, Network: *network, NetworkTier: *networkTier,
 		Subnet: *subnet, PrivateNetworkIP: *privateNetworkIP, NoExternalIP: *noExternalIP,
 		NoRestartOnFailure: *noRestartOnFailure, OsID: *osID,
-		ShieldedIntegrityMonitoring: *shieldedIntegrityMonitoring, ShieldedSecureBoot: *shieldedSecureBoot,
-		ShieldedVtpm: *shieldedVtpm, Tags: *tags,
+		ShieldedIntegrityMonitoring: *shieldedIntegrityMonitoring,
+		ShieldedSecureBoot:          *shieldedSecureBoot, ShieldedVtpm: *shieldedVtpm, Tags: *tags,
 		Zone: *zoneFlag, BootDiskKmskey: *bootDiskKmskey, BootDiskKmsKeyring: *bootDiskKmsKeyring,
 		BootDiskKmsLocation: *bootDiskKmsLocation, BootDiskKmsProject: *bootDiskKmsProject,
 		Timeout: *timeout, Project: *project, ScratchBucketGcsPath: *scratchBucketGcsPath,
 		Oauth: *oauth, Ce: *ce, GcsLogsDisabled: *gcsLogsDisabled,
 		CloudLogsDisabled: *cloudLogsDisabled, StdoutLogsDisabled: *stdoutLogsDisabled,
-		NodeAffinityLabelsFlag: nodeAffinityLabelsFlag, CurrentExecutablePath: currentExecutablePath}
+		NodeAffinityLabelsFlag: nodeAffinityLabelsFlag, CurrentExecutablePath: currentExecutablePath,
+		ReleaseTrack: *releaseTrack,
+	}
 }
 
 func runImport() error {
@@ -92,7 +96,9 @@ func runImport() error {
 	ovfImporter, err := ovfimporter.NewOVFImporter(buildImportParams())
 	if err != nil {
 		logger.Println(err.Error())
-		ovfImporter.CleanUp()
+		if ovfImporter != nil {
+			ovfImporter.CleanUp()
+		}
 		return err
 	}
 	err = ovfImporter.Import()

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -79,15 +79,14 @@ func buildImportParams() *ovfimportparams.OVFImportParams {
 		Labels: *labels, MachineType: *machineType, Network: *network, NetworkTier: *networkTier,
 		Subnet: *subnet, PrivateNetworkIP: *privateNetworkIP, NoExternalIP: *noExternalIP,
 		NoRestartOnFailure: *noRestartOnFailure, OsID: *osID,
-		ShieldedIntegrityMonitoring: *shieldedIntegrityMonitoring,
-		ShieldedSecureBoot:          *shieldedSecureBoot, ShieldedVtpm: *shieldedVtpm, Tags: *tags,
-		Zone: *zoneFlag, BootDiskKmskey: *bootDiskKmskey, BootDiskKmsKeyring: *bootDiskKmsKeyring,
-		BootDiskKmsLocation: *bootDiskKmsLocation, BootDiskKmsProject: *bootDiskKmsProject,
-		Timeout: *timeout, Project: *project, ScratchBucketGcsPath: *scratchBucketGcsPath,
-		Oauth: *oauth, Ce: *ce, GcsLogsDisabled: *gcsLogsDisabled,
-		CloudLogsDisabled: *cloudLogsDisabled, StdoutLogsDisabled: *stdoutLogsDisabled,
-		NodeAffinityLabelsFlag: nodeAffinityLabelsFlag, CurrentExecutablePath: currentExecutablePath,
-		ReleaseTrack: *releaseTrack,
+		ShieldedIntegrityMonitoring: *shieldedIntegrityMonitoring, ShieldedSecureBoot: *shieldedSecureBoot,
+		ShieldedVtpm: *shieldedVtpm, Tags: *tags, Zone: *zoneFlag, BootDiskKmskey: *bootDiskKmskey,
+		BootDiskKmsKeyring: *bootDiskKmsKeyring, BootDiskKmsLocation: *bootDiskKmsLocation,
+		BootDiskKmsProject: *bootDiskKmsProject, Timeout: *timeout, Project: *project,
+		ScratchBucketGcsPath: *scratchBucketGcsPath, Oauth: *oauth, Ce: *ce,
+		GcsLogsDisabled: *gcsLogsDisabled, CloudLogsDisabled: *cloudLogsDisabled,
+		StdoutLogsDisabled: *stdoutLogsDisabled, NodeAffinityLabelsFlag: nodeAffinityLabelsFlag,
+		CurrentExecutablePath: currentExecutablePath, ReleaseTrack: *releaseTrack,
 	}
 }
 

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
@@ -55,6 +55,7 @@ type OVFImportParams struct {
 	CloudLogsDisabled           bool
 	StdoutLogsDisabled          bool
 	NodeAffinityLabelsFlag      flags.StringArrayFlag
+	ReleaseTrack                string
 
 	UserLabels            map[string]string
 	NodeAffinities        []*compute.SchedulingNodeAffinity

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -277,8 +277,8 @@ func (oi *OVFImporter) buildTmpGcsPath(project string, region string) (string, e
 			return "", err
 		}
 	}
-	return pathutils.JoinURL(oi.params.ScratchBucketGcsPath, fmt.Sprintf("ovf-import-%v", oi.buildID)),
-		nil
+	return pathutils.JoinURL(oi.params.ScratchBucketGcsPath,
+		fmt.Sprintf("ovf-import-%v", oi.buildID)), nil
 }
 
 func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
@@ -339,6 +339,9 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, error) {
 	if region, err = oi.getRegion(zone); err != nil {
 		return nil, err
 	}
+	if err := validateReleaseTrack(oi.params.ReleaseTrack); err != nil {
+		return nil, err
+	}
 	if oi.params.ReleaseTrack == Alpha || oi.params.ReleaseTrack == Beta {
 		oi.imageLocation = region
 	}
@@ -395,6 +398,13 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, error) {
 		return nil, fmt.Errorf("error parsing workflow %q: %v", ovfImportWorkflow, err)
 	}
 	return workflow, nil
+}
+
+func validateReleaseTrack(releaseTrack string) error {
+	if releaseTrack != "" && releaseTrack != Alpha && releaseTrack != Beta && releaseTrack != GA {
+		return fmt.Errorf("invalid value for release-track flag: %v", releaseTrack)
+	}
+	return nil
 }
 
 // Import runs OVF import


### PR DESCRIPTION
Fix OVF import failure when location restrictions are on due to images being created in multi-regions. Since this change is internal to the importer, added releaseTrack flag to indicate which Compute API release track is allowed to be used. Image location is only in Beta and we shouldn't use Beta API in GA release.
