### PR TITLE
Fix Debian 9 import failing if gnupg is not installed

### DIFF
--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -50,7 +50,7 @@ def DistroSpecific(g):
     logging.info('Installing GCE packages.')
 
     g.command(['apt-get', 'update'])
-    g.command(['apt-get', 'install', '-y', 'gnupg'])
+    g.sh('DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes gnupg')
 
     g.command(
         ['wget', 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -48,6 +48,10 @@ def DistroSpecific(g):
 
   if install_gce == 'true':
     logging.info('Installing GCE packages.')
+
+    g.command(['apt-get', 'update'])
+    g.command(['apt-get', 'install', '-y', 'gnupg'])
+
     g.command(
         ['wget', 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
         '-O', '/tmp/gce_key'])


### PR DESCRIPTION
Fix Debian 9 import failing if gnupg is not installed with "gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation" error.