### PR TITLE
[Logging] return disk/image/file size from import/export script

### DIFF
--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -13,11 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function serialOutputKeyValuePair() {
+  echo "<serial-output key:'$1' value:'$2'>"
+}
+
+BYTES_1GB=1073741824
 URL="http://metadata/computeMetadata/v1/instance/attributes"
 GCS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
 
 mkdir ~/upload
+
+# Source disk size info.
+SOURCE_SIZE_BYTES=$(lsblk /dev/sdb --output=size -b | sed -n 2p)
+SOURCE_SIZE_GB=$(awk "BEGIN {print int(((${SOURCE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
+echo "GCEExport: $(serialOutputKeyValuePair "source-size-gb" "${SOURCE_SIZE_GB}")"
 
 echo "GCEExport: Running export tool."
 if [[ -n $LICENSES ]]; then
@@ -29,6 +39,11 @@ if [[ $? -ne 0 ]]; then
   echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GCS_PATH}. <-Privacy]."
   exit 1
 fi
+
+# Exported image size info.
+TARGET_SIZE_BYTES=$(gsutil ls -l "${GCS_PATH}" | head -n 1 | awk '{print $1}')
+TARGET_SIZE_GB=$(awk "BEGIN {print int(((${TARGET_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
+echo "GCEExport: $(serialOutputKeyValuePair "target-size-gb" "${TARGET_SIZE_GB}")"
 
 echo "ExportSuccess"
 sync


### PR DESCRIPTION
We want to log target/source disk/image/file size for import/export for usage/perf analysis.
We need to expose the value from .sh script. Thus, using a string pattern is almost the only way. I defined this pattern: <serial-output key:'(.*)' value:'(.*)'>
key-value pair in this pattern will be catched and recorded in workflow, and thus can be stored to logging.
