### PR TITLE
Use the image's original filename when caching on disk.

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -26,7 +26,7 @@ ZONE=$(curl -f -H Metadata-Flavor:Google ${URL}/zone)
 
 SOURCE_FILE_EXT="${SOURCE_URL##*.}"
 SOURCE_SIZE_BYTES="$(gsutil du ${SOURCE_URL} | grep -o '^[0-9]\+')"
-IMAGE_PATH="/daisy-scratch/image.${SOURCE_FILE_EXT}"
+IMAGE_PATH="/daisy-scratch/$(basename ${SOURCE_URL})"
 
 # Print info.
 echo "#################" 2> /dev/null


### PR DESCRIPTION
Fixes #904.

For testing, I re-ran the example given in #904.