### PR TITLE
Use the image's original filename when caching on disk.

### DIFF
--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -106,6 +106,12 @@
     },
     "Image import and translate non-default network latest": {
      "Path": "./image_import_and_translate_nondefault_network_latest.wf.json"
+    },
+    "Image import and translate ova": {
+      "Path": "./image_import_and_translate_ova.wf.json"
+    },
+    "Image import and translate no extension": {
+      "Path": "./image_import_and_translate_no_extension.wf.json"
     }
   }
 }

--- a/daisy_integration_tests/image_import_and_translate_no_extension.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_no_extension.wf.json
@@ -1,0 +1,36 @@
+{
+  "Name": "image-import-and-translate-no-ext",
+  "Vars": {
+    "image_name": {
+      "Value": "image-import-and-translate-no-ext-${ID}"
+    },
+    "source_disk_file": {
+      "Value": "gs://compute-image-tools-test-resources/xenial-server-cloudimg-amd64-disk1-no-ext"
+    }
+  },
+  "Steps": {
+    "import-and-translate-image": {
+      "Timeout": "45m",
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/image_import/import_and_translate.wf.json",
+        "Vars": {
+          "image_name": "${image_name}",
+          "source_disk_file": "${source_disk_file}",
+          "translate_workflow": "ubuntu/translate_ubuntu_1604.wf.json"
+        }
+      }
+    },
+    "delete-image": {
+      "DeleteResources": {
+        "Images": [
+          "${image_name}"
+        ]
+      }
+    }
+  },
+  "Dependencies": {
+    "delete-image": [
+      "import-and-translate-image"
+    ]
+  }
+}

--- a/daisy_integration_tests/image_import_and_translate_ova.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_ova.wf.json
@@ -1,0 +1,36 @@
+{
+  "Name": "image-import-and-translate-ova",
+  "Vars": {
+    "image_name": {
+      "Value": "image-import-and-translate-ova-${ID}"
+    },
+    "source_disk_file": {
+      "Value": "gs://compute-image-tools-test-resources/ova/ubuntu-16.04-server-cloudimg-amd64.ova"
+    }
+  },
+  "Steps": {
+    "import-and-translate-image": {
+      "Timeout": "45m",
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/image_import/import_and_translate.wf.json",
+        "Vars": {
+          "image_name": "${image_name}",
+          "source_disk_file": "${source_disk_file}",
+          "translate_workflow": "ubuntu/translate_ubuntu_1604.wf.json"
+        }
+      }
+    },
+    "delete-image": {
+      "DeleteResources": {
+        "Images": [
+          "${image_name}"
+        ]
+      }
+    }
+  },
+  "Dependencies": {
+    "delete-image": [
+      "import-and-translate-image"
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #904.

Three changes:
 1. Use the image's original filename.
 2. Use Bash's regex operator (`=~`) to determine whether the image is an `ova`.
 2. Added two tests to confirm this behavior.