### PR TITLE
Log Cloud Build ID in import/export wrappers to help with debugging

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -98,8 +98,6 @@ func NewOVFImporter(params *ovfimportparams.OVFImportParams) (*OVFImporter, erro
 
 	if buildID == "" {
 		buildID = pathutils.RandString(5)
-	} else {
-		logger.Log(fmt.Sprintf("Cloud Build ID: %s", buildID))
 	}
 	workingDirOVFImportWorkflow := toWorkingDir(ovfImportWorkflow, params)
 	bic := &storageutils.BucketIteratorCreator{}
@@ -285,6 +283,7 @@ func (oi *OVFImporter) buildTmpGcsPath(project string, region string) (string, e
 }
 
 func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
+	w.LogWorkflowInfo("Cloud Build ID: %s", os.Getenv(oi.buildID))
 	rl := &daisyutils.ResourceLabeler{
 		BuildID:         oi.buildID,
 		UserLabels:      oi.params.UserLabels,

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -283,7 +283,7 @@ func (oi *OVFImporter) buildTmpGcsPath(project string, region string) (string, e
 }
 
 func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
-	w.LogWorkflowInfo("Cloud Build ID: %s", os.Getenv(oi.buildID))
+	w.LogWorkflowInfo("Cloud Build ID: %s", oi.buildID)
 	rl := &daisyutils.ResourceLabeler{
 		BuildID:         oi.buildID,
 		UserLabels:      oi.params.UserLabels,

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -15,6 +15,7 @@
 package ovfimporter
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -99,6 +100,7 @@ func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
 
+	w.Logger = DummyLogger{}
 	oi.modifyWorkflowPreValidate(w)
 	oi.modifyWorkflowPostValidate(w)
 	assert.Equal(t, "n1-highcpu-16", w.Vars["machine_type"].Value)
@@ -166,6 +168,8 @@ func TestSetUpWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneAsFlags(t 
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
 
+	w.Logger = DummyLogger{}
+
 	oi.modifyWorkflowPreValidate(w)
 	oi.modifyWorkflowPostValidate(w)
 	assert.Equal(t, "n1-highcpu-16", w.Vars["machine_type"].Value)
@@ -225,6 +229,8 @@ func doTestSetUpWorkflowUsesImageLocationForReleaseTrack(
 
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
+
+	w.Logger = DummyLogger{}
 
 	oi.modifyWorkflowPreValidate(w)
 	oi.modifyWorkflowPostValidate(w)
@@ -749,3 +755,9 @@ var machineTypes = []*compute.MachineType{
 		Zone:                         "us-east1-b",
 	},
 }
+
+type DummyLogger struct{}
+
+func (dl DummyLogger) WriteLogEntry(e *daisy.LogEntry)                                          {}
+func (dl DummyLogger) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {}
+func (dl DummyLogger) Flush()                                                                   {}

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -115,6 +115,7 @@ func runExportWorkflow(ctx context.Context, exportWorkflowPath string, varMap ma
 	}
 
 	workflowModifier := func(w *daisy.Workflow) {
+		w.LogWorkflowInfo("Cloud Build ID: %s", os.Getenv(buildIDOSEnv))
 		rl := &daisyutils.ResourceLabeler{
 			BuildID: os.Getenv("BUILD_ID"), UserLabels: userLabels, BuildIDLabelKey: "gce-image-export-build-id",
 			InstanceLabelKeyRetriever: func(instance *daisy.Instance) string {
@@ -145,12 +146,8 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 
 	ctx := context.Background()
 	metadataGCE := &compute.MetadataGCE{}
-	logger := logging.NewLogger("[image-export]")
-
-	logger.Log(fmt.Sprintf("Cloud Build ID: %s", os.Getenv(buildIDOSEnv)))
-
 	storageClient, err := storage.NewStorageClient(
-		ctx, logger, oauth)
+		ctx, logging.NewLogger("[image-export]"), oauth)
 	if err != nil {
 		return err
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -187,6 +187,7 @@ func runImport(ctx context.Context, varMap map[string]string, importWorkflowPath
 	}
 
 	workflowModifier := func(w *daisy.Workflow) {
+		workflow.LogWorkflowInfo("Cloud Build ID: %s", os.Getenv(buildIDOSEnv))
 		rl := &daisyutils.ResourceLabeler{
 			BuildID:         os.Getenv(buildIDOSEnv),
 			UserLabels:      userLabels,
@@ -228,12 +229,8 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 
 	ctx := context.Background()
 	metadataGCE := &compute.MetadataGCE{}
-	logger := logging.NewLogger("[image-import]")
-
-	logger.Log(fmt.Sprintf("Cloud Build ID: %s", os.Getenv(buildIDOSEnv)))
-
 	storageClient, err := storage.NewStorageClient(
-		ctx, logger, oauth)
+		ctx, logging.NewLogger("[image-import]"), oauth)
 	if err != nil {
 		return daisy.Errf("error creating storage client: %v", err)
 	}


### PR DESCRIPTION
Log Cloud Build ID in import/export wrappers to help with debugging: log using Daisy logger to log to GCS

For a proper solution, wrappers should initialize Logger and inject it into workflow. For the time being, this workaround is fine.