### PR TITLE
Allocate a scratch disk when importing OVFs.

### DIFF
--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -48,7 +48,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 
 		setupDataDiskStepName := fmt.Sprintf("setup-data-disk-%v", dataDiskIndex)
 		diskImporterDiskName := fmt.Sprintf("disk-importer-%v", dataDiskIndex)
-		scratchDiskDiskName := fmt.Sprintf("disk-importer-scratch-%s-%v", w.ID(), dataDiskIndex)
+		scratchDiskDiskName := fmt.Sprintf("disk-importer-scratch-%v", dataDiskIndex)
 
 		setupDataDiskStep := daisy.NewStep(setupDataDiskStepName, w, time.Hour)
 		setupDataDiskStep.CreateDisks = &daisy.CreateDisks{
@@ -77,9 +77,6 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Type: "pd-ssd",
 				},
 				SizeGb: "10",
-				Resource: daisy.Resource{
-					ExactName: true,
-				},
 			},
 		}
 		w.Steps[setupDataDiskStepName] = setupDataDiskStep
@@ -92,7 +89,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		createDiskImporterInstanceStep.CreateInstances = &daisy.CreateInstances{
 			{
 				Instance: compute.Instance{
-					Name:        dataDiskImporterInstanceName,
+					Name: dataDiskImporterInstanceName,
 					Disks: []*compute.AttachedDisk{
 						{Source: diskImporterDiskName},
 						{Source: scratchDiskDiskName}},


### PR DESCRIPTION
This fixes an error in the OVF tests:
```
 - "[OVFImportTests] [OVFImport] Windows 2012 R2 two disks": error while performing OVF import: step "wait-for-data-disk-1-signal" run error: WaitForInstancesSignal FailureMatch found for "data-disk-importer-1-import-ovf-33v2j": "ImportFailed: Failed to prepare scratch disk.'"
```

To confirm the fix, I ran:

```
go run gce_ovf_import_tests/main.go -test_project_id edens-test -test_zone us-central1-a
```
