### PR TITLE
daisy: compute: Retry on transport-level failures

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -184,9 +184,9 @@ func shouldRetryWithWait(tripper http.RoundTripper, err error, multiplier int) b
 	apiErr, ok := err.(*googleapi.Error)
 	var retry bool
 	switch {
-	case !ok && tkValid:
-		// Not a googleapi.Error and the token is still valid.
-		return false
+	case !ok:
+		// Not a googleapi.Error. Likely a transport error.
+		retry = true
 	case apiErr.Code >= 500 && apiErr.Code <= 599:
 		retry = true
 	case apiErr.Code >= 429:

--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -184,9 +185,11 @@ func shouldRetryWithWait(tripper http.RoundTripper, err error, multiplier int) b
 	apiErr, ok := err.(*googleapi.Error)
 	var retry bool
 	switch {
-	case !ok:
-		// Not a googleapi.Error. Likely a transport error.
+	case !ok && (strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "unexpected EOF")):
 		retry = true
+	case !ok && tkValid:
+		// Not a googleapi.Error and the token is still valid.
+		return false
 	case apiErr.Code >= 500 && apiErr.Code <= 599:
 		retry = true
 	case apiErr.Code >= 429:

--- a/daisy/compute/compute_test.go
+++ b/daisy/compute/compute_test.go
@@ -51,7 +51,7 @@ func TestShouldRetryWithWait(t *testing.T) {
 		want bool
 	}{
 		{"nil error", nil, false},
-		{"non googleapi.Error", errors.New("foo"), false},
+		{"non googleapi.Error", errors.New("foo"), true},
 		{"400 error", &googleapi.Error{Code: 400}, false},
 		{"429 error", &googleapi.Error{Code: 429}, true},
 		{"500 error", &googleapi.Error{Code: 500}, true},

--- a/daisy/compute/compute_test.go
+++ b/daisy/compute/compute_test.go
@@ -51,10 +51,12 @@ func TestShouldRetryWithWait(t *testing.T) {
 		want bool
 	}{
 		{"nil error", nil, false},
-		{"non googleapi.Error", errors.New("foo"), true},
+		{"non googleapi.Error", errors.New("foo"), false},
 		{"400 error", &googleapi.Error{Code: 400}, false},
 		{"429 error", &googleapi.Error{Code: 429}, true},
 		{"500 error", &googleapi.Error{Code: 500}, true},
+		{"connection reset", errors.New("read tcp 192.168.10.2:59590->74.125.135.95:443: read: connection reset by peer"), true},
+		{"EOF", errors.New("unexpected EOF"), true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, Daisy only retries when a GCE API error returns a
googleapi.Error. However, errors that are not googleapi.Errors are most
likely transport errors, which should always be retried. Lets retry for
errors that are not googleapi.Errors as well.