### PR TITLE
Add debug logs prior to using dynamically-sized disks.

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -86,6 +86,12 @@ function copyImageToScratchDisk() {
     echo "ImportFailed: Failed to prepare scratch disk."
   fi
 
+  # Output the size of the persistent disks for debugging.
+  # The '-i' parameter is for ascii; without it the output is
+  # garbled in serial output.
+  lsblk -i
+  df
+
   # Standard error for `gsutil cp` contains a progress meter that when written
   # to the console will exceed the logging daemon's buffer for large files.
   # The stream may contain useful debugging messages, however, so if there's an
@@ -142,6 +148,14 @@ if ! out=$(gcloud -q compute instances attach-disk ${ME} --disk=${DISKNAME} --zo
   exit
 fi
 echo ${out}
+
+# Output the size of the persistent disks for debugging.
+# The '-i' parameter is for ascii; without it the output is
+# garbled in serial output.
+#
+# No df here since we're interested in /dev/sdc which doesn't
+# have a filesystem yet.
+lsblk -i
 
 # Convert the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdc is used since we're manually attaching this disk, and sdb was already


### PR DESCRIPTION
We've seen intermittent disk-full failures when using /dev/sdb and /dev/sdc in import_image.sh. These debug logs will help to diagnose the issue.