### PR TITLE
Support VirtualBox ovfs

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -276,11 +276,11 @@ func getDiskControllersPrioritized(virtualHardware *ovf.VirtualHardwareSection) 
 }
 
 func filterItemsByResourceTypes(virtualHardware *ovf.VirtualHardwareSection, resourceTypes ...uint16) []ovf.ResourceAllocationSettingData {
-	all := make([]ovf.ResourceAllocationSettingData, len(virtualHardware.Item))
-	copy(all, virtualHardware.Item)
+	allItems := make([]ovf.ResourceAllocationSettingData, len(virtualHardware.Item))
+	copy(allItems, virtualHardware.Item)
 
 	for _, storageItem := range virtualHardware.StorageItem {
-		all = append(all, ovf.ResourceAllocationSettingData{
+		allItems = append(allItems, ovf.ResourceAllocationSettingData{
 			CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
 				AddressOnParent: storageItem.AddressOnParent,
 				Caption:         storageItem.Caption,
@@ -293,15 +293,15 @@ func filterItemsByResourceTypes(virtualHardware *ovf.VirtualHardwareSection, res
 		})
 	}
 
-	filtered := make([]ovf.ResourceAllocationSettingData, 0)
-	for _, item := range all {
+	filteredItems := make([]ovf.ResourceAllocationSettingData, 0)
+	for _, item := range allItems {
 		for _, resourceType := range resourceTypes {
 			if *item.ResourceType == resourceType {
-				filtered = append(filtered, item)
+				filteredItems = append(filteredItems, item)
 			}
 		}
 	}
-	return filtered
+	return filteredItems
 }
 
 func getDiskFileInfo(diskHostResource string, disks *[]ovf.VirtualDiskDesc,

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
@@ -106,6 +106,19 @@ func TestGetDiskFileInfosAllocationUnitExtraSpace(t *testing.T) {
 	assert.Equal(t, 12, diskInfos[1].SizeInGB)
 }
 
+func TestGetDiskFileInfosFromVirtualbox(t *testing.T) {
+	envelope := parseOVF(t, "testdata/from-virtualbox.ovf")
+
+	virtualHardware, e := GetVirtualHardwareSectionFromDescriptor(envelope)
+	assert.NoError(t, e)
+
+	diskInfo, e := GetDiskInfos(virtualHardware, envelope.Disk, &envelope.References)
+	assert.NoError(t, e)
+
+	assert.Equal(t, 1, len(diskInfo))
+	assert.Equal(t, 10, diskInfo[0].SizeInGB)
+}
+
 func TestGetDiskFileInfosDisksOnSeparateControllersOutOfOrder(t *testing.T) {
 	virtualHardware := &ovf.VirtualHardwareSection{
 		Item: []ovf.ResourceAllocationSettingData{

--- a/cli_tools/gce_ovf_import/ovf_utils/testdata/from-virtualbox.ovf
+++ b/cli_tools/gce_ovf_import/ovf_utils/testdata/from-virtualbox.ovf
@@ -1,0 +1,149 @@
+<Envelope ovf:version="2.0" xml:lang="en-US" xmlns="http://schemas.dmtf.org/ovf/envelope/2" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/2" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:vbox="http://www.virtualbox.org/ovf/machine" xmlns:epasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_EthernetPortAllocationSettingData.xsd" xmlns:sasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_StorageAllocationSettingData.xsd">
+  <References>
+    <File ovf:id="file1" ovf:href="ubuntu-xenial-16-disk001.vmdk"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks used in the package</Info>
+    <Disk ovf:capacity="10737418240" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" vbox:uuid="7113a5c1-375f-4882-87f1-b489f78388a1"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>Logical networks used in the package</Info>
+    <Network ovf:name="Bridged">
+      <Description>Logical network used by this appliance.</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="ubuntu-xenial-16.04-cloudimg-20190909">
+    <Info>A virtual machine</Info>
+    <OperatingSystemSection ovf:id="93">
+      <Info>The kind of installed guest operating system</Info>
+      <Description>Ubuntu</Description>
+      <vbox:OSType ovf:required="false">Ubuntu</vbox:OSType>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements for a virtual machine</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>ubuntu-xenial-16.04-cloudimg-20190909</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>virtualbox-2.2</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:Caption>2 virtual CPU</rasd:Caption>
+        <rasd:Description>Number of virtual CPUs</rasd:Description>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
+        <rasd:Caption>923 MB of memory</rasd:Caption>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>923</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>ideController0</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>1</rasd:Address>
+        <rasd:Caption>ideController1</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>scsiController0</rasd:Caption>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:Caption>floppy0</rasd:Caption>
+        <rasd:Description>Floppy Drive</rasd:Description>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:ResourceType>14</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>3</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:Caption>sound</rasd:Caption>
+        <rasd:Description>Sound Card</rasd:Description>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:ResourceSubType>ensoniq1371</rasd:ResourceSubType>
+        <rasd:ResourceType>35</rasd:ResourceType>
+      </Item>
+      <StorageItem>
+        <sasd:AddressOnParent>0</sasd:AddressOnParent>
+        <sasd:Caption>disk1</sasd:Caption>
+        <sasd:Description>Disk Image</sasd:Description>
+        <sasd:HostResource>/disk/vmdisk1</sasd:HostResource>
+        <sasd:InstanceID>8</sasd:InstanceID>
+        <sasd:Parent>5</sasd:Parent>
+        <sasd:ResourceType>17</sasd:ResourceType>
+      </StorageItem>
+      <EthernetPortItem>
+        <epasd:AutomaticAllocation>true</epasd:AutomaticAllocation>
+        <epasd:Caption>Ethernet adapter on 'Bridged'</epasd:Caption>
+        <epasd:Connection>Bridged</epasd:Connection>
+        <epasd:InstanceID>9</epasd:InstanceID>
+        <epasd:ResourceSubType>E1000</epasd:ResourceSubType>
+        <epasd:ResourceType>10</epasd:ResourceType>
+      </EthernetPortItem>
+    </VirtualHardwareSection>
+    <vbox:Machine ovf:required="false" version="1.16-linux" uuid="{dc77c962-ad6e-4801-9278-ce87f0754e46}" name="ubuntu-xenial-16.04-cloudimg-20190909" OSType="Ubuntu" snapshotFolder="Snapshots" lastStateChange="2019-09-11T18:52:53Z">
+      <ovf:Info>Complete VirtualBox machine configuration in VirtualBox format</ovf:Info>
+      <ExtraData>
+        <ExtraDataItem name="GUI/LastNormalWindowPosition" value="320,339,640,522"/>
+      </ExtraData>
+      <Hardware>
+        <CPU count="2">
+          <PAE enabled="true"/>
+          <LongMode enabled="false"/>
+          <X2APIC enabled="true"/>
+          <HardwareVirtExLargePages enabled="false"/>
+        </CPU>
+        <Memory RAMSize="923"/>
+        <Display VRAMSize="16"/>
+        <VideoCapture fps="25" options="ac_enabled=false"/>
+        <BIOS>
+          <IOAPIC enabled="true"/>
+        </BIOS>
+        <Network>
+          <Adapter slot="0" enabled="true" MACAddress="080027701AA4" type="82540EM">
+            <DisabledModes>
+              <InternalNetwork name="intnet"/>
+              <NATNetwork name="NatNetwork"/>
+            </DisabledModes>
+            <BridgedInterface name="ens4"/>
+          </Adapter>
+        </Network>
+        <AudioAdapter driver="Pulse" enabled="true" enabledIn="false" enabledOut="false"/>
+        <GuestProperties>
+          <GuestProperty name="/VirtualBox/HostInfo/GUI/LanguageID" value="C" timestamp="1568228054869260000" flags=""/>
+        </GuestProperties>
+      </Hardware>
+      <StorageControllers>
+        <StorageController name="IDE" type="PIIX4" PortCount="2" useHostIOCache="true" Bootable="true"/>
+        <StorageController name="SCSI" type="LsiLogic" PortCount="16" useHostIOCache="false" Bootable="true">
+          <AttachedDevice type="HardDisk" hotpluggable="false" port="0" device="0">
+            <Image uuid="{7113a5c1-375f-4882-87f1-b489f78388a1}"/>
+          </AttachedDevice>
+        </StorageController>
+        <StorageController name="Floppy" type="I82078" PortCount="1" useHostIOCache="true" Bootable="true">
+          <AttachedDevice type="Floppy" hotpluggable="false" port="0" device="0"/>
+        </StorageController>
+      </StorageControllers>
+    </vbox:Machine>
+  </VirtualSystem>
+</Envelope>

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -184,6 +184,25 @@ func TestSuite(
 			expectedMachineType:   "n1-standard-4",
 			expectedStartupOutput: "All tests passed!",
 		},
+		{
+			importParams: &ovfimportparams.OVFImportParams{
+				ClientID:      "test",
+				InstanceNames: fmt.Sprintf("test-instance-virtualbox-6-%v", suffix),
+				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
+				OsID:          "ubuntu-1604",
+				Labels:        "lk1=lv1,lk2=kv2",
+				Project:       testProjectConfig.TestProjectID,
+				Zone:          testProjectConfig.TestZone,
+				MachineType:   "n1-standard-4",
+			},
+			name:        fmt.Sprintf("ovf-import-test-virtualbox-%s", suffix),
+			description: "Ubuntu 1604 from Virtualbox",
+			startup: computeUtils.BuildInstanceMetadataItem(
+				"startup-script", startupScriptLinuxSingleDisk),
+			assertTimeout:         7200 * time.Second,
+			expectedMachineType:   "n1-standard-4",
+			expectedStartupOutput: "All tests passed!",
+		},
 	}
 
 	var wg sync.WaitGroup

--- a/vendor/github.com/vmware/govmomi/ovf/cim.go
+++ b/vendor/github.com/vmware/govmomi/ovf/cim.go
@@ -78,3 +78,51 @@ type CIMResourceAllocationSettingData struct {
 	VirtualQuantityUnits  *string  `xml:"VirtualQuantityUnits"`
 	Weight                *uint    `xml:"Weight"`
 }
+
+/*
+Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_StorageAllocationSettingData.xsd
+*/
+
+// CIMStorageAllocationSettingData holds virtual system settings
+type CIMStorageAllocationSettingData struct {
+	ElementName string `xml:"ElementName"`
+	InstanceID  string `xml:"InstanceID"`
+
+	ResourceType      *uint16 `xml:"ResourceType"`
+	OtherResourceType *string `xml:"OtherResourceType"`
+	ResourceSubType   *string `xml:"ResourceSubType"`
+
+	Access                       *uint16       `xml:"Access"`
+	Address                      *string       `xml:"Address"`
+	AddressOnParent              *string       `xml:"AddressOnParent"`
+	AllocationUnits              *string       `xml:"AllocationUnits"`
+	AutomaticAllocation          *bool         `xml:"AutomaticAllocation"`
+	AutomaticDeallocation        *bool         `xml:"AutomaticDeallocation"`
+	Caption                      *string       `xml:"Caption"`
+	ChangeableType               *uint16       `xml:"ChangeableType"`
+	ComponentSetting             []interface{} `xml:"ComponentSetting"`
+	ConfigurationName            *string       `xml:"ConfigurationName"`
+	Connection                   []string      `xml:"Connection"`
+	ConsumerVisibility           *uint16       `xml:"ConsumerVisibility"`
+	Description                  *string       `xml:"Description"`
+	Generation                   *uint64       `xml:"Generation"`
+	HostExtentName               *string       `xml:"HostExtentName"`
+	HostExtentNameFormat         *uint16       `xml:"HostExtentNameFormat"`
+	HostExtentNameNamespace      *uint16       `xml:"HostExtentNameNamespace"`
+	HostExtentStartingAddress    *uint64       `xml:"HostExtentStartingAddress"`
+	HostResource                 []string      `xml:"HostResource"`
+	HostResourceBlockSize        *uint64       `xml:"HostResourceBlockSize"`
+	Limit                        *uint64       `xml:"Limit"`
+	MappingBehavior              *uint         `xml:"MappingBehavior"`
+	OtherHostExtentNameFormat    *string       `xml:"OtherHostExtentNameFormat"`
+	OtherHostExtentNameNamespace *string       `xml:"OtherHostExtentNameNamespace"`
+	Parent                       *string       `xml:"Parent"`
+	PoolID                       *string       `xml:"PoolID"`
+	Reservation                  *uint64       `xml:"Reservation"`
+	SoID                         *string       `xml:"SoID"`
+	SoOrgID                      *string       `xml:"SoOrgID"`
+	VirtualQuantity              *uint         `xml:"VirtualQuantity"`
+	VirtualQuantityUnits         *string       `xml:"VirtualQuantityUnits"`
+	VirtualResourceBlockSize     *uint64       `xml:"VirtualResourceBlockSize"`
+	Weight                       *uint         `xml:"Weight"`
+}

--- a/vendor/github.com/vmware/govmomi/ovf/envelope.go
+++ b/vendor/github.com/vmware/govmomi/ovf/envelope.go
@@ -170,8 +170,9 @@ type VirtualHardwareSection struct {
 	ID        *string `xml:"id,attr"`
 	Transport *string `xml:"transport,attr"`
 
-	System *VirtualSystemSettingData       `xml:"System"`
-	Item   []ResourceAllocationSettingData `xml:"Item"`
+	System      *VirtualSystemSettingData       `xml:"System"`
+	Item        []ResourceAllocationSettingData `xml:"Item"`
+	StorageItem []StorageAllocationSettingData  `xml:"StorageItem"`
 }
 
 // VirtualSystemSettingData represents OVF Virtual System Setting Data
@@ -182,6 +183,15 @@ type VirtualSystemSettingData struct {
 // ResourceAllocationSettingData represents Resource Allocation Setting Data
 type ResourceAllocationSettingData struct {
 	CIMResourceAllocationSettingData
+
+	Required      *bool   `xml:"required,attr"`
+	Configuration *string `xml:"configuration,attr"`
+	Bound         *string `xml:"bound,attr"`
+}
+
+// StorageAllocationSettingData represents OVF Resource Allocation Section
+type StorageAllocationSettingData struct {
+	CIMStorageAllocationSettingData
 
 	Required      *bool   `xml:"required,attr"`
 	Configuration *string `xml:"configuration,attr"`


### PR DESCRIPTION
Two changes were required here, and each has its own commit:

1. Update the govmomi schema to support `StorageItem`, which is the node where virtualbox defines to which controller a disk is attached. (vmware puts that info in an `Item` node)
2. Update `ovf_utils` to use the new node.

Testing:
- `go test ./...`
- `gofmt -d $(find . -type f -name "*.go")`
- `go run gce_ovf_import_tests/main.go -test_project_id edens-test -test_zone us-central1-a`