### PR TITLE
[export wrapper] support simple image name

### DIFF
--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
@@ -83,7 +84,7 @@ func buildDaisyVars(destinationURI string, sourceImage string, format string, ne
 
 	varMap["destination"] = destinationURI
 
-	varMap["source_image"] = sourceImage
+	varMap["source_image"] = getFullImagePath(sourceImage)
 
 	if format != "" {
 		varMap["format"] = format
@@ -99,6 +100,14 @@ func buildDaisyVars(destinationURI string, sourceImage string, format string, ne
 		varMap["export_network"] = fmt.Sprintf("global/networks/%v", network)
 	}
 	return varMap
+}
+
+func getFullImagePath(imageName string) string {
+	if !strings.Contains(imageName, "/") {
+		// Extend simple image name to full image name
+		return fmt.Sprintf("global/images/%v", imageName)
+	}
+	return imageName
 }
 
 func runExportWorkflow(ctx context.Context, exportWorkflowPath string, varMap map[string]string,

--- a/cli_tools/gce_vm_image_export/exporter/exporter_test.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter_test.go
@@ -91,6 +91,14 @@ func TestBuildDaisyVarsWithFormatConversion(t *testing.T) {
 	assert.Equal(t, 5, len(got))
 }
 
+func TestBuildDaisyVarsWithSimpleImageName(t *testing.T) {
+	resetArgs()
+	sourceImage = "anImage"
+	got := buildDaisyVars(destinationURI, sourceImage, format, network, subnet, "aRegion")
+
+	assert.Equal(t, "global/images/anImage", got["source_image"])
+}
+
 func resetArgs() {
 	clientID = "aClient"
 	destinationURI = "gs://bucket/exported_image"

--- a/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
+++ b/gce_image_import_export_tests/test_suites/export/image_export_test_suite.go
@@ -130,7 +130,7 @@ func runImageExportWithRichParamsTest(ctx context.Context, testCase *junitxml.Te
 
 	argsMap := map[testsuiteutils.TestType][]string{
 		testsuiteutils.Wrapper: {"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-			"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
+			"-source_image=e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
 			fmt.Sprintf("-network=%v-vpc-1", testProjectConfig.TestProjectID),
 			fmt.Sprintf("-subnet=%v-subnet-1", testProjectConfig.TestProjectID),
 			fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),


### PR DESCRIPTION
[export wrapper] support simple image name.
Before: only support format like "global/images/anImage"
Now: support "anImage" as well, which will be extended to "global/images/anImage" automatically