### PR TITLE
Fix is_windows variable name causing E2E test failures

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -150,7 +150,7 @@ func buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, f
 	if translateWorkflowPath != "" {
 		varMap["translate_workflow"] = translateWorkflowPath
 		varMap["install_gce_packages"] = strconv.FormatBool(!noGuestEnvironment)
-		varMap["isWindows"] = strconv.FormatBool(strings.Contains(translateWorkflowPath, "windows"))
+		varMap["is_windows"] = strconv.FormatBool(strings.Contains(translateWorkflowPath, "windows"))
 	}
 	if sourceFile != "" {
 		varMap["source_disk_file"] = sourceFile

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -270,7 +270,7 @@ func TestBuildDaisyVarsFromDisk(t *testing.T) {
 	assert.Equal(t, got["description"], "a-description")
 	assert.Equal(t, got["import_network"], "global/networks/a-network")
 	assert.Equal(t, got["import_subnet"], "regions/a-region/subnetworks/a-subnet")
-	assert.Equal(t, got["isWindows"], "false")
+	assert.Equal(t, got["is_windows"], "false")
 	assert.Equal(t, len(got), 9)
 }
 
@@ -297,7 +297,7 @@ func TestBuildDaisyVarsFromImage(t *testing.T) {
 	assert.Equal(t, got["description"], "a-description")
 	assert.Equal(t, got["import_network"], "global/networks/a-network")
 	assert.Equal(t, got["import_subnet"], "regions/a-region/subnetworks/a-subnet")
-	assert.Equal(t, got["isWindows"], "false")
+	assert.Equal(t, got["is_windows"], "false")
 	assert.Equal(t, len(got), 9)
 }
 
@@ -309,7 +309,7 @@ func TestBuildDaisyVarsWindow(t *testing.T) {
 	got := buildDaisyVars("translate/workflow/path/windows", imageName, sourceFile,
 		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
 
-	assert.Equal(t, "true", got["isWindows"])
+	assert.Equal(t, "true", got["is_windows"])
 }
 
 func TestBuildDaisyVarsImageNameLowercase(t *testing.T) {


### PR DESCRIPTION
Fix is_windows variable name causing E2E test failures: `unknown workflow Var "isWindows" passed to Workflow "import-from-image"`