### PR TITLE
Added explanation that info about FailureMatch is not an error. 

### DIFF
--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -110,7 +110,7 @@ func waitForSerialOutput(s *Step, project, zone, name string, so *SerialOutput, 
 		msg += fmt.Sprintf(", SuccessMatch: %q", so.SuccessMatch)
 	}
 	if len(so.FailureMatch) > 0 {
-		msg += fmt.Sprintf(", FailureMatch: %q", so.FailureMatch)
+		msg += fmt.Sprintf(", FailureMatch: %q (this is not an error)", so.FailureMatch)
 	}
 	if so.StatusMatch != "" {
 		msg += fmt.Sprintf(", StatusMatch: %q", so.StatusMatch)


### PR DESCRIPTION
Added explanation that info about FailureMatch is not an error. This has confused engineers who are not working on Daisy directly so it must be confusing to customers.