### PR TITLE
prow: Remove deprecated Ubuntu 1810 from linux image list

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -326,7 +326,6 @@ periodics:
           projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-1604-lts,\
           projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts,\
           projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-1804-lts,\
-          projects/ubuntu-os-cloud/global/images/family/ubuntu-1810,\
           projects/ubuntu-os-cloud-image-proposed/global/images/family/ubuntu-1404-lts,\
           projects/ubuntu-os-cloud-image-proposed/global/images/family/ubuntu-1604-lts,\
           projects/ubuntu-os-cloud-image-proposed/global/images/family/ubuntu-1804-lts,\


### PR DESCRIPTION
Ubuntu 1810 is not available anymore in project `ubuntu-os-cloud`