### PR TITLE
CentOS 6: Wait until network is ready.

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -18,6 +18,25 @@
 FAIL=0
 FAILURES=""
 
+function wait_for_connectivity {
+  if [[ $(cat /etc/centos-release) =~ "CentOS release 6" ]]; then
+    status "CentOS 6: Waiting for network connectivity."
+  else
+    return
+  fi
+
+  for i in {0..60}; do
+    if [[ $(nmcli -t -f STATE nm) == "connected" ]]; then
+      status "Network ready."
+      return
+    fi
+    sleep 5s
+  done
+
+  echo "FAILED: Unable to initialize network connection."
+  exit 1
+}
+
 function status {
   local message="${1}"
   echo "STATUS: ${message}"
@@ -158,6 +177,9 @@ function check_package_install {
     fi
   fi
 }
+
+# Ensure there's network connectivity before running the tests.
+wait_for_connectivity
 
 # Run tests.
 check_google_services

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -361,7 +361,7 @@ func runOvfImportTest(
 	logger.Printf("[%v] Waiting for `%v` in instance serial console.", testSetup.name,
 		testSetup.expectedStartupOutput)
 	if err := instanceWrapper.WaitForSerialOutput(
-		testSetup.expectedStartupOutput, 1, 5*time.Second, 7*time.Minute); err != nil {
+		testSetup.expectedStartupOutput, 1, 5*time.Second, 15*time.Minute); err != nil {
 		testCase.WriteFailure("Error during VM validation: %v", err)
 		return
 	}


### PR DESCRIPTION
Testing: Ran `go run gce_ovf_import_tests/main.go -test_project_id edens-test -test_zone us-central1-a`