### PR TITLE
Update IO scheduler settings

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el6-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el6-post.cfg
@@ -168,7 +168,9 @@ dracut -f
 # timeout.
 sed -e 's/^timeout=.*$/timeout=0/' \
     -e '/^terminal /s/--timeout=\w\+/--timeout=0/' \
-    -i /boot/grub/grub.conf
+    -i"" /boot/grub/grub.conf
+
+sed -e '/kernel \/boot/s/$/ elevator=noop' -i"" /boot/grub/grub.conf
 
 # Create device.map. This is a config file used by grub to specify the boot
 # partition.

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
@@ -95,7 +95,8 @@ echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
 restorecon /etc/modprobe.d/blacklist-floppy.conf
 
 # Set the default timeout to 0 and update grub2.
-sed -i 's:GRUB_TIMEOUT=.*:GRUB_TIMEOUT=0:' /etc/default/grub
+sed -i"" 's:GRUB_TIMEOUT=.*:GRUB_TIMEOUT=0:' /etc/default/grub
+sed -i"" '/GRUB_CMDLINE_LINUX/s:"$: elevator=noop":'
 restorecon /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 echo "Running dracut."

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-options.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-options.cfg
@@ -11,7 +11,7 @@ network --bootproto=dhcp --hostname=localhost --device=link --mtu=1460
 
 ### Disk configuration.
 # The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y elevator=noop"
+bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 clearpart --drives=sdb --all
 part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
 

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-uefi-options.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-uefi-options.cfg
@@ -12,7 +12,7 @@ network --bootproto=dhcp --hostname=localhost --device=link --mtu=1460
 
 ### Disk configuration.
 # The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y elevator=noop"
+bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
 clearpart --drives=sdb --all
 part /boot/efi --size=200 --fstype=efi --ondrive=sdb

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -77,8 +77,8 @@ def DistroSpecific(g):
 
   # Update grub config to log to console.
   g.command(
-      ['sed', '-i',
-      r's#^\(GRUB_CMDLINE_LINUX=".*\)"$#\1 console=ttyS0,38400n8"#',
+      ['sed', '-i""',
+      r'/GRUB_CMDLINE_LINUX/s#"$# console=ttyS0,38400n8"#',
       '/etc/default/grub'])
 
   # Disable predictive network interface naming in Stretch.

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -73,7 +73,7 @@ GRUB_DEFAULT=saved
 GRUB_DISABLE_SUBMENU=true
 GRUB_TERMINAL="serial console"
 GRUB_SERIAL_COMMAND="serial --speed=38400"
-GRUB_CMDLINE_LINUX="crashkernel=auto console=ttyS0,38400n8"
+GRUB_CMDLINE_LINUX="crashkernel=auto console=ttyS0,38400n8 elevator=noop"
 GRUB_DISABLE_RECOVERY="true"
 '''
 

--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -72,10 +72,11 @@ def DistroSpecific(g):
   # Update grub config to log to console, remove quiet and timeouts.
   g.command(
       ['sed', '-i',
-      '-e', r's#^\(GRUB_CMDLINE_LINUX=".*\)"$#\1 console=ttyS0,38400n8"#',
-      '-e', r's#^\(GRUB_CMDLINE_LINUX[^=]*=".*\)quiet\(.*"\)$#\1\2#',
-      '-e', r's#^\(GRUB_[^=]*TIMEOUT\)=.*$#\1=0#',
-      '/etc/default/grub'])
+       '-e', r'/GRUB_CMDLINE_LINUX/s#"$# console=ttyS0,38400n8'
+       ' scsi_mod.use_blk_mq=Y"#',
+       '-e', r'/GRUB_CMDLINE_LINUX/s#quiet##',
+       '-e', r'/GRUB_[^=]*TIMEOUT=/s#=.*#=0',
+       '/etc/default/grub'])
 
   g.command(['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'])
 


### PR DESCRIPTION
* set IO scheduler to `noop` on older kernels (EL6,7)
* use blk-mq on newer kernels (Debian9,10,SLES12,15)
* update sed command to use matches instead of capture groups

Currently we don't set a consistent value for the IO scheduler, and we set the incompatible `elevator` and `scsi_mod.use_blk_mq` parameters on some distros. This PR updates the image creation and import workflows to set appropriate kernel command line parameters. Instance setup must be updated to set the scheduler to none, as there's currently no option to set this on the command line.