### PR TITLE
Only check for CentOS6 network readiness if NetworkManager is available.

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -19,7 +19,7 @@ FAIL=0
 FAILURES=""
 
 function wait_for_connectivity {
-  if [[ $(cat /etc/centos-release) =~ "CentOS release 6" && $(command -v nmcli) ]]; then
+  if grep -q 'CentOS release 6' /etc/centos-release && command -v nmcli; then
     status "CentOS 6: Waiting for network connectivity using nmcli."
   else
     return

--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -19,8 +19,8 @@ FAIL=0
 FAILURES=""
 
 function wait_for_connectivity {
-  if [[ $(cat /etc/centos-release) =~ "CentOS release 6" ]]; then
-    status "CentOS 6: Waiting for network connectivity."
+  if [[ $(cat /etc/centos-release) =~ "CentOS release 6" && $(command -v nmcli) ]]; then
+    status "CentOS 6: Waiting for network connectivity using nmcli."
   else
     return
   fi


### PR DESCRIPTION
The daisy_integration_tests/centos_6_qcow2_translate.wf.json test also uses post_translate_test.sh, but its base CentOS6 image doesn't have NetworkManager. I haven't observed any of its tests failing due to network race conditions; if we see that, then we can tweak this network detection.

## Testing

- Ran `daisy_integration_tests/centos_6_qcow2_translate.wf.json `
- Ran `go run gce_ovf_import_tests/main.go -test_project_id edens-test -test_zone us-central1-a`