### PR TITLE
Update Debian 9 build to pull from branched bootstrap-vz.

### DIFF
--- a/daisy_workflows/image_build/debian/build.py
+++ b/daisy_workflows/image_build/debian/build.py
@@ -67,7 +67,7 @@ def main():
   logging.info('Google Cloud repo: %s' % repo)
 
   # Download and setup bootstrap_vz.
-  bvz_url = 'https://github.com/andsens/bootstrap-vz/archive/%s.zip'
+  bvz_url = 'https://github.com/zmarano/bootstrap-vz/archive/%s.zip'
   bvz_url %= bvz_version
   bvz_zip_dir = 'bvz_zip'
   logging.info('Downloading bootstrap-vz at commit %s' % bvz_version)

--- a/daisy_workflows/image_build/debian/debian.wf.json
+++ b/daisy_workflows/image_build/debian/debian.wf.json
@@ -5,7 +5,7 @@
     "bootstrap_vz_manifest": {"Required": true, "Description": "The bootstrap-vz manifest to build."},
     "bootstrap_vz_version": {"Required": true, "Description": "The bootstrap-vz github commit ID to use."},
     "builder_source_image": {
-      "Value": "projects/debian-cloud/global/images/family/debian-9",
+      "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "The image used to run bootstrap-vz."
     },
     "google_cloud_repo": {"Required": true, "Description": "The Google Cloud Repo branch to use."},

--- a/daisy_workflows/image_build/debian/debian_9.wf.json
+++ b/daisy_workflows/image_build/debian/debian_9.wf.json
@@ -4,7 +4,7 @@
     "google_cloud_repo": {"Value": "stable", "Description": "The Google Cloud Repo branch to use."},
     "image_dest": {"Required": true, "Description": "The GCS path for the destination image tar.gz."},
     "bootstrap_vz_version": {
-      "Value": "8715d5e969e9452d0c975c1d1949535fa60b71fe",
+      "Value": "9b81ff0858fceb9ec2b635ddcc7b79f6d5af650c",
       "Description": "The bootstrap-vz github commit ID to use."
     }
   },
@@ -16,7 +16,7 @@
         "Vars": {
           "bootstrap_vz_manifest": "official/gce/stretch.yml",
           "bootstrap_vz_version": "${bootstrap_vz_version}",
-          "builder_source_image": "projects/debian-cloud/global/images/family/debian-9",
+          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "google_cloud_repo": "${google_cloud_repo}",
           "image_dest": "${image_dest}"
         }


### PR DESCRIPTION
This goes with https://github.com/zmarano/bootstrap-vz/commit/9b81ff0858fceb9ec2b635ddcc7b79f6d5af650c to install the OS Config agent.

The upstream project is locked and no longer accepting changes.