### PR TITLE
Update Windows SHA2 precheck to look at KB4474419.

### DIFF
--- a/cli_tools/import_precheck/check_sha2.go
+++ b/cli_tools/import_precheck/check_sha2.go
@@ -20,8 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/packages"
 )
 
-const sha2Windows2008R2KB = "KB3033929"
-const windows2008R2RollupKB = "KB3125574"
+const sha2Windows2008R2KB = "KB4474419"
 
 type sha2DriverSigningCheck struct{}
 
@@ -56,6 +55,6 @@ func (s *sha2DriverSigningCheck) run() (*report, error) {
 			return r, nil
 		}
 	}
-	r.Fatal("SHA2 driver signing support not found.")
+	r.Fatal(fmt.Sprintf("%s is required to support SHA2-signed drivers.", sha2Windows2008R2KB))
 	return r, nil
 }


### PR DESCRIPTION
Updates the precheck tool to mach the guidance on our [help page](https://cloud.google.com/compute/docs/instances/windows/bring-your-own-license/), which links to KB4474419.

## Testing (2008r2):

1. Starting from a vanilla install, confirmed that the image fails to import (hangs while attempting to boot for translation)
2. Added KB4474419, and confirmed that the image can be imported.
3. Ran the precheck tool against (1) and confirmed that it failed, and ran the tool against (2) and confirmed that it passed.