### PR TITLE
[logging] fix log race condition

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -171,15 +171,15 @@ type OutputInfo struct {
 	FailureMessageWithoutPrivacyInfo string `json:"failure_message_without_privacy_info,omitempty"`
 }
 
-func (i *InputParams) updateParams(p *string) {
+func (i *InputParams) updateParams(projectPointer *string) {
 	logParamsMutex.Lock()
 	defer logParamsMutex.Unlock()
 
-	if p == nil {
+	if projectPointer == nil {
 		return
 	}
 
-	project := *p
+	project := *projectPointer
 	obfuscatedProject := Hash(project)
 
 	if i.ImageImportParams != nil {

--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -172,6 +172,9 @@ type OutputInfo struct {
 }
 
 func (i *InputParams) updateParams(p *string) {
+	logParamsMutex.Lock()
+	defer logParamsMutex.Unlock()
+
 	if p == nil {
 		return
 	}

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -40,6 +40,7 @@ var (
 	key                                       = deinterleave(keyP1, keyP2)
 	serverLogEnabled                          = true
 	logMutex                                  = sync.Mutex{}
+	logParamsMutex                            = sync.Mutex{}
 	nextRequestWaitMillis int64
 )
 
@@ -134,6 +135,9 @@ func (l *Logger) logFailure(err error, w *daisy.Workflow) (*ComputeImageToolsLog
 }
 
 func (l *Logger) createComputeImageToolsLogExtension(status string, outputInfo *OutputInfo) *ComputeImageToolsLogExtension {
+	logParamsMutex.Lock()
+	defer logParamsMutex.Unlock()
+
 	return &ComputeImageToolsLogExtension{
 		ID:            l.ID,
 		CloudBuildID:  os.Getenv(daisyutils.BuildIDOSEnvVarName),


### PR DESCRIPTION
It guards "logParams". The "logParams" has a chance to be updated while another thread is trying to send it to log server.