### PR TITLE
Image Import: Allow spaces in disk's filename.

### DIFF
--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -112,6 +112,9 @@
     },
     "Image import and translate no extension": {
       "Path": "./image_import_and_translate_no_extension.wf.json"
+    },
+    "Image import allow spaces in disk's filename.": {
+     "Path": "./image_import_allow_spaces_in_disk_filename.wf.json"
     }
   }
 }

--- a/daisy_integration_tests/image_import_allow_spaces_in_disk_filename.wf.json
+++ b/daisy_integration_tests/image_import_allow_spaces_in_disk_filename.wf.json
@@ -1,0 +1,36 @@
+{
+  "Name": "image-import-allows-spaces",
+  "Vars": {
+    "image_name": {
+      "Value": "image-import-allows-spaces-test-${ID}"
+    },
+    "source_disk_file": {
+      "Value": "gs://compute-image-tools-test-resources/ubuntu 1604 name image with spaces.vmdk"
+    }
+  },
+  "Steps": {
+    "delete-image": {
+      "DeleteResources": {
+        "Images": [
+          "${image_name}"
+        ]
+      }
+    },
+    "import-and-translate-image": {
+      "Timeout": "45m",
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/image_import/import_and_translate.wf.json",
+        "Vars": {
+          "image_name": "${image_name}",
+          "source_disk_file": "${source_disk_file}",
+          "translate_workflow": "ubuntu/translate_ubuntu_1604.wf.json"
+        }
+      }
+    }
+  },
+  "Dependencies": {
+    "delete-image": [
+      "import-and-translate-image"
+    ]
+  }
+}

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -28,9 +28,9 @@ SCRATCH_DISK_NAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/scratch
 ME="$(curl -f -H Metadata-Flavor:Google ${URL}/name)"
 ZONE=$(curl -f -H Metadata-Flavor:Google ${URL}/zone)
 
-SOURCE_SIZE_BYTES="$(gsutil du ${SOURCE_URL} | grep -o '^[0-9]\+')"
+SOURCE_SIZE_BYTES="$(gsutil du "${SOURCE_URL}" | grep -o '^[0-9]\+')"
 SOURCE_SIZE_GB=$(awk "BEGIN {print int(((${SOURCE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
-IMAGE_PATH="/daisy-scratch/$(basename ${SOURCE_URL})"
+IMAGE_PATH="/daisy-scratch/$(basename "${SOURCE_URL}")"
 
 # Print info.
 echo "#################" 2> /dev/null
@@ -131,15 +131,15 @@ copyImageToScratchDisk
 # If the image is an OVA, then copy out its VMDK.
 if [[ "${IMAGE_PATH}" =~ \.ova$ ]]; then
   echo "Import: Unpacking VMDK files from ova."
-  VMDK="$(tar --list -f ${IMAGE_PATH} | grep -m1 vmdk)"
-  tar -C /daisy-scratch -xf ${IMAGE_PATH} ${VMDK}
+  VMDK="$(tar --list -f "${IMAGE_PATH}" | grep -m1 vmdk)"
+  tar -C /daisy-scratch -xf "${IMAGE_PATH}" ${VMDK}
   IMAGE_PATH="/daisy-scratch/${VMDK}"
   echo "Import: New source file is ${VMDK}"
 fi
 
 # Ensure the output disk has sufficient space to accept the disk image.
 # Disk image size info.
-SIZE_BYTES=$(qemu-img info --output "json" ${IMAGE_PATH} | grep -m1 "virtual-size" | grep -o '[0-9]\+')
+SIZE_BYTES=$(qemu-img info --output "json" "${IMAGE_PATH}" | grep -m1 "virtual-size" | grep -o '[0-9]\+')
  # Round up to the next GB.
 SIZE_GB=$(awk "BEGIN {print int(((${SIZE_BYTES} - 1)/${BYTES_1GB}) + 1)}")
 echo "Import: Importing ${IMAGE_PATH} of size ${SIZE_GB}GB to ${DISKNAME} in ${ZONE}." 2> /dev/null
@@ -159,7 +159,7 @@ fi
 
 # Convert the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdc is used since it's the third disk that's attached in import_disk.wf.json.
-if ! out=$(qemu-img convert ${IMAGE_PATH} -p -O raw -S 512b /dev/sdc 2>&1); then
+if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); then
   echo "ImportFailed: Failed to convert source to raw. [Privacy-> error: ${out} <-Privacy]"
   exit
 fi


### PR DESCRIPTION
This change allows the filename of a disk to have a space in it, and includes an integration test. 

Prior to this fix, import if you tried to import an image with spaces in its name, you'd see an error from qemu-img of "Could not read image for determining its format: File too large "