### PR TITLE
fallback to pd-standard for import/export when failed to create disk

### DIFF
--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -76,6 +76,9 @@ type Disk struct {
 
 	// Size of this disk.
 	SizeGb string `json:"sizeGb,omitempty"`
+
+	// Fallback to pd-standard when quota is not enough for higher-level pd
+	FallbackToPdStandard bool `json:"fallbackToPdStandard,omitempty"`
 }
 
 // MarshalJSON is a hacky workaround to prevent Disk from using compute.Disk's implementation.

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -65,8 +65,8 @@ func (c *CreateDisks) run(ctx context.Context, s *Step) DError {
 				// Fallback to pd-standard to avoid quota issue. There isn't a reliable way
 				// to determine whether it's failed by QUOTA_EXCEEDED, so just simply retry.
 				if cd.FallbackToPdStandard && strings.HasSuffix(cd.Type, pdSsd) {
-					w.LogStepInfo(s.name, "CreateDisks", "Failed on: %v.", err)
-					w.LogStepInfo(s.name, "CreateDisks", "Disk %v falls back to pd-standard due to quota limit. Trying again.", cd.Name)
+					w.LogStepInfo(s.name, "CreateDisks", "Disk %v falls back to pd-standard to workaround quota limit. " +
+						"Trying again. Consider increase pd-ssd quota to avoid fallback to ps-standard for better performance.", cd.Name)
 					cd.Type = strings.TrimRight(cd.Type, pdSsd) + pdStandard
 					err = w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk)
 				}

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -65,8 +65,8 @@ func (c *CreateDisks) run(ctx context.Context, s *Step) DError {
 				// Fallback to pd-standard to avoid quota issue. There isn't a reliable way
 				// to determine whether it's failed by QUOTA_EXCEEDED, so just simply retry.
 				if cd.FallbackToPdStandard && strings.HasSuffix(cd.Type, pdSsd) {
-					w.LogStepInfo(s.name, "CreateDisks", "Disk %v falls back to pd-standard to workaround quota limit. " +
-						"Trying again. Consider increase pd-ssd quota to avoid fallback to ps-standard for better performance.", cd.Name)
+					w.LogStepInfo(s.name, "CreateDisks", "Disk %v falls back to pd-standard to workaround quota limit. "+
+							"Trying again. Consider increase pd-ssd quota to avoid fallback to ps-standard for better performance.", cd.Name)
 					cd.Type = strings.TrimRight(cd.Type, pdSsd) + pdStandard
 					err = w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk)
 				}

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -65,8 +65,9 @@ func (c *CreateDisks) run(ctx context.Context, s *Step) DError {
 				// Fallback to pd-standard to avoid quota issue. There isn't a reliable way
 				// to determine whether it's failed by QUOTA_EXCEEDED, so just simply retry.
 				if cd.FallbackToPdStandard && strings.HasSuffix(cd.Type, pdSsd) {
-					w.LogStepInfo(s.name, "CreateDisks", "Disk %v falls back to pd-standard to workaround quota limit. "+
-							"Trying again. Consider increase pd-ssd quota to avoid fallback to ps-standard for better performance.", cd.Name)
+					w.LogStepInfo(s.name, "CreateDisks", "Falling back to pd-standard for disk %v. "+
+						"It may be caused by insufficient pd-ssd quota. Consider increasing pd-ssd quota to "+
+						"avoid using ps-standard for better performance.", cd.Name)
 					cd.Type = strings.TrimRight(cd.Type, pdSsd) + pdStandard
 					err = w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk)
 				}

--- a/daisy_integration_tests/daisy_e2e_quota_exceeded.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e_quota_exceeded.test.gotmpl
@@ -1,0 +1,9 @@
+{
+  "Name": "daisy-e2e-tests",
+  "TestParallelCount": 1,
+  "Tests": {
+    "ssd quota exceeded": {
+      "Path": "./image_export_ssd_quota_exceeded.wf.json"
+    }
+  }
+}

--- a/daisy_integration_tests/image_export_ssd_quota_exceeded.wf.json
+++ b/daisy_integration_tests/image_export_ssd_quota_exceeded.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "about-this-test": {
       "Value": "",
-      "Description": "This test checks that the workflow still works when ssd quota exceeded."
+      "Description": "This test checks that the workflow still works when ssd quota exceeded by fallback to pd-standard."
     },
     "gcs_export": {
       "Value": "${SCRATCHPATH}/created-by-export-test-latest.tar.gz"

--- a/daisy_integration_tests/image_export_ssd_quota_exceeded.wf.json
+++ b/daisy_integration_tests/image_export_ssd_quota_exceeded.wf.json
@@ -1,0 +1,79 @@
+{
+  "Name": "image-export-ssd-quota-exceeded",
+  "Vars": {
+    "about-this-test": {
+      "Value": "",
+      "Description": "This test checks that the workflow still works when ssd quota exceeded."
+    },
+    "gcs_export": {
+      "Value": "${SCRATCHPATH}/created-by-export-test-latest.tar.gz"
+    },
+    "image_name": "from-export"
+  },
+  "Steps": {
+    "create-image": {
+      "CreateImages": [
+        {
+          "name": "${image_name}",
+          "rawDisk": {
+            "source": "${gcs_export}"
+          }
+        }
+      ]
+    },
+    "create-tester": {
+      "CreateInstances": [
+        {
+          "disks": [
+            {
+              "initializeParams": {
+                "sourceImage": "${image_name}"
+              }
+            }
+          ],
+          "name": "tester",
+          "metadata": {
+            "startup-script": "echo 'SUCCESS wVnWw3a41CVe3mBVvTMn'"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write"
+          ]
+        }
+      ]
+    },
+    "image-export": {
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/export/image_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_export}",
+          "export_instance_disk_image": "projects/compute-image-tools-test/global/images/family/debian-9-worker",
+          "source_image": "projects/debian-cloud/global/images/family/debian-9",
+          "export_instance_disk_size": "20490"
+        }
+      }
+    },
+    "verify-output": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "tester",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "SUCCESS wVnWw3a41CVe3mBVvTMn",
+            "FailureMatch": "FAILURE wVnWw3a41CVe3mBVvTMn"
+          }
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "image-export"
+    ],
+    "create-tester": [
+      "create-image"
+    ],
+    "verify-output": [
+      "create-tester"
+    ]
+  }
+}

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -44,7 +44,8 @@
           "Name": "disk-${NAME}",
           "SourceImage": "${export_instance_disk_image}",
           "SizeGb": "${export_instance_disk_size}",
-          "Type": "${export_instance_disk_type}"
+          "Type": "${export_instance_disk_type}",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -45,13 +45,15 @@
         {
           "Name": "disk-${NAME}-os",
           "SourceImage": "${export_instance_disk_image}",
-          "Type": "${export_instance_disk_type}"
+          "Type": "${export_instance_disk_type}",
+          "FallbackToPdStandard": true
         },
         {
           "Name": "disk-${NAME}-buffer-${ID}",
           "SizeGb": "${export_instance_disk_size}",
           "Type": "${export_instance_disk_type}",
-	  "ExactName": true
+          "ExactName": true,
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -36,7 +36,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -37,7 +37,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -37,7 +37,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -37,7 +37,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -37,7 +37,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -37,7 +37,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -37,7 +37,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -44,7 +44,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-2",
           "SizeGb": "32",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -39,7 +39,8 @@
           "Name": "disk-importer",
           "SourceImage": "${import_instance_disk_image}",
           "SizeGb": "${importer_instance_disk_size}",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         },
         {
           "Name": "${disk_name}",
@@ -47,13 +48,15 @@
           "Type": "pd-ssd",
           "ExactName": true,
           "NoCleanup": true,
-          "isWindows": "${is_windows}"
+          "isWindows": "${is_windows}",
+          "FallbackToPdStandard": true
         },
         {
           "Name": "disk-${NAME}-scratch-${ID}",
           "SizeGb": "10",
           "Type": "pd-ssd",
-          "ExactName": true
+          "ExactName": true,
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -46,7 +46,8 @@
         "Type": "pd-ssd",
         "ExactName": true,
         "SourceImage": "${source_image}",
-        "isWindows": "${is_windows}"
+        "isWindows": "${is_windows}",
+        "FallbackToPdStandard": true
       }]
     },
     "translate-disk": {

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -44,7 +44,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -36,7 +36,8 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/image_import/windows/translate_windows_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_wf.json
@@ -51,7 +51,8 @@
         {
           "Name": "disk-bootstrap",
           "SourceImage": "projects/windows-cloud/global/images/family/windows-2019-core",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/daisy_workflows/ovf_import/import_ovf.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf.wf.json
@@ -79,7 +79,8 @@
           "SourceImage": "${boot_image_name}",
           "Type": "pd-ssd",
           "ExactName": true,
-          "NoCleanup": true
+          "NoCleanup": true,
+          "FallbackToPdStandard": true
         }
       ]
     },

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -137,24 +137,42 @@ periodics:
    agent: kubernetes
    spec:
     containers:
-    - image: gcr.io/compute-image-tools-test/test-runner:latest
-      args:
-      - "-out_path=/artifacts/junit.xml"
-      # One project is enough for daisy tests, no test requires a write lock.
-      - "-projects=compute-image-test-pool-001"
-      - "-zone=us-central1-c"
-      - "daisy_integration_tests/daisy_e2e.test.gotmpl"
-      env:
-      - name: REPO_OWNER
-        value: GoogleCloudPlatform
-      - name: REPO_NAME
-        value: compute-image-tools
-      - name: ARTIFACTS
-        value: /artifacts
-      volumeMounts:
-      - name: compute-image-tools-test-service-account
-        mountPath: /etc/compute-image-tools-test-service-account
-        readOnly: true
+      - image: gcr.io/compute-image-tools-test/test-runner:latest
+        args:
+          - "-out_path=/artifacts/junit.xml"
+          # One project is enough for daisy tests, no test requires a write lock.
+          - "-projects=compute-image-test-pool-001"
+          - "-zone=us-central1-c"
+          - "daisy_integration_tests/daisy_e2e.test.gotmpl"
+        env:
+          - name: REPO_OWNER
+            value: GoogleCloudPlatform
+          - name: REPO_NAME
+            value: compute-image-tools
+          - name: ARTIFACTS
+            value: /artifacts
+        volumeMounts:
+          - name: compute-image-tools-test-service-account
+            mountPath: /etc/compute-image-tools-test-service-account
+            readOnly: true
+      - image: gcr.io/compute-image-tools-test/test-runner:latest
+        args:
+          - "-out_path=/artifacts/junit.xml"
+          # One project is enough for daisy tests, no test requires a write lock.
+          - "-projects=compute-image-test-pool-006"
+          - "-zone=us-central1-c"
+          - "daisy_integration_tests/daisy_e2e_quota_exceeded.test.gotmpl"
+        env:
+          - name: REPO_OWNER
+            value: GoogleCloudPlatform
+          - name: REPO_NAME
+            value: compute-image-tools
+          - name: ARTIFACTS
+            value: /artifacts
+        volumeMounts:
+          - name: compute-image-tools-test-service-account
+            mountPath: /etc/compute-image-tools-test-service-account
+            readOnly: true
     volumes:
     - name: compute-image-tools-test-service-account
       secret:


### PR DESCRIPTION
Fallback to pd-standard for import/export when failed to create disk
It resolved the problem that import/export failed due to quota exceeded error.

This PR includes:
1. code change to handle fallback logic
2. workflow change to enable FallbackToPdStandard flag
3. unit test
4. e2e test