### PR TITLE
Transfrom Application & System event logs from evtx files to plain text files

### DIFF
--- a/cli_tools/diagnostics/main_windows_test.go
+++ b/cli_tools/diagnostics/main_windows_test.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,10 +25,12 @@ import (
 )
 
 const (
-	pathNotExistErr    = "The system cannot find the path specified."
-	fileNotExistErr    = "The system cannot find the file specified."
-	systemLogPath      = `C:\Windows\System32\winevt\Logs\System.evtx`
-	kubeletLogFileName = "kubelet.log"
+	pathNotExistErr            = "The system cannot find the path specified."
+	fileNotExistErr            = "The system cannot find the file specified."
+	systemLogPath              = `C:\Windows\System32\winevt\Logs\System.evtx`
+	kubeletLogFileName         = "kubelet.log"
+	applicationTextLogFileName = "Application.log"
+	systemTextLogFileName      = "System.log"
 )
 
 func pathNonExist(e error) bool {
@@ -42,6 +45,50 @@ func fileNonExist(e error) bool {
 		return true
 	}
 	return false
+}
+
+func TestGetPlainEventLogs(t *testing.T) {
+	// Test setup: create temp test folder for test, clean it up afterwards
+	var err error
+	tmpFolder, err = ioutil.TempDir("", "getPlainEventLogsTest")
+	if err != nil {
+		t.Errorf("Error creating a temporary test folder:\n%v", err.Error())
+	}
+	defer os.RemoveAll(tmpFolder)
+
+	tests := []struct {
+		name         string
+		args         []winEvt
+		want         []string
+		expectErrStr string
+	}{
+		{name: "Nil events", args: nil, want: []string{}, expectErrStr: ""},
+		{name: "Empty events", args: []winEvt{}, want: []string{}, expectErrStr: ""},
+		{name: "Existing events logName", args: []winEvt{{"Application", false}}, want: []string{filepath.Join(tmpFolder, applicationTextLogFileName)}, expectErrStr: ""},
+		{name: "Non-Existing events logName", args: []winEvt{{"xxx", false}}, want: []string{}, expectErrStr: "xxx"},
+		{name: "Existing events providerName", args: []winEvt{{"GCEWindowsAgent", true}}, want: []string{}, expectErrStr: ""},
+		{name: "Non-Existing events providerName", args: []winEvt{{"System", true}}, want: []string{}, expectErrStr: "System"},
+	}
+	errCh := make(chan error)
+	gotFilesCh := make(chan []string)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			go func() {
+				gotFilesCh <- getPlainEventLogs(tt.args, errCh)
+			}()
+			select {
+			case e := <-errCh:
+				if tt.expectErrStr == "" || !strings.Contains(e.Error(), tt.expectErrStr) {
+					t.Errorf("unexpected err, want %v, got %v", tt.expectErrStr, e.Error())
+				}
+			case gotFiles := <-gotFilesCh:
+				if !reflect.DeepEqual(gotFiles, tt.want) {
+					t.Errorf("unexpected filepaths, want %v, got %v", tt.want, gotFiles)
+				}
+			}
+		})
+	}
 }
 
 func TestCollectFilePaths(t *testing.T) {
@@ -84,7 +131,7 @@ func TestCollectFilePaths(t *testing.T) {
 
 func stringArrayIncludesString(stringArray []string, target string) bool {
 	for _, s := range stringArray {
-		if s == target {
+		if strings.Contains(s, target) {
 			return true
 		}
 	}
@@ -94,13 +141,16 @@ func stringArrayIncludesString(stringArray []string, target string) bool {
 func TestGatherEventLogs(t *testing.T) {
 	logFolderCh := make(chan logFolder, 2)
 	errCh := make(chan error)
+	expectedFiles := []string{systemLogPath, applicationTextLogFileName, systemTextLogFileName}
 
 	t.Run("Gathers Expected SystemLog File", func(t *testing.T) {
 		go gatherEventLogs(logFolderCh, errCh)
 		select {
 		case l := <-logFolderCh:
-			if !stringArrayIncludesString(l.files, systemLogPath) {
-				t.Errorf("Expect %s, but it's missing", systemLogPath)
+			for _, expectFile := range expectedFiles {
+				if !stringArrayIncludesString(l.files, expectFile) {
+					t.Errorf("Expect %s, but it's missing", expectFile)
+				}
 			}
 		case e := <-errCh:
 			t.Errorf(e.Error())


### PR DESCRIPTION
Evtx file is compressed binary xml format, not readable on Linux/Mac without any tools. 
If transformed all evtx files, it would take around 20mins.
So just transfrom Application,System which are most valuable logs, to plain text files. 