### PR TITLE
Don't allow empty disk images to be imported.

### DIFF
--- a/cli_tools/daisycommon/io.go
+++ b/cli_tools/daisycommon/io.go
@@ -10,6 +10,7 @@ type ByteCountingReader struct {
 	BytesRead int64
 }
 
+// NewByteCountingReader is a contructor for ByteCountingReader.
 func NewByteCountingReader(r io.Reader) *ByteCountingReader {
 	return &ByteCountingReader{r, 0}
 }

--- a/cli_tools/daisycommon/io.go
+++ b/cli_tools/daisycommon/io.go
@@ -1,0 +1,21 @@
+package daisycommon
+
+import "io"
+
+// ByteCountingReader forwards calls to a delegate reader, keeping
+// track of the number bytes that have been read in `BytesRead`.
+// Errors are propagated unchanged.
+type ByteCountingReader struct {
+	r         io.Reader
+	BytesRead int64
+}
+
+func NewByteCountingReader(r io.Reader) *ByteCountingReader {
+	return &ByteCountingReader{r, 0}
+}
+
+func (l *ByteCountingReader) Read(p []byte) (n int, err error) {
+	n, err = l.r.Read(p)
+	l.BytesRead += int64(n)
+	return n, err
+}

--- a/cli_tools/daisycommon/io.go
+++ b/cli_tools/daisycommon/io.go
@@ -1,3 +1,17 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package daisycommon
 
 import "io"

--- a/cli_tools/daisycommon/io_test.go
+++ b/cli_tools/daisycommon/io_test.go
@@ -1,0 +1,35 @@
+package daisycommon
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestByteCountingReader(t *testing.T) {
+	data := []byte{100, 101, 102, 103, 104, 105}
+	reader := NewByteCountingReader(bytes.NewReader(data))
+	buff := make([]byte, 2)
+
+	// Read one byte at a time, checking that our accounting of
+	// BytesRead is correct and that we forward the correct
+	// byte to the caller
+	for i := 0; i < 6; i += 2 {
+		assert.Equal(t, int64(i), reader.BytesRead)
+		n, err := reader.Read(buff)
+		assert.Equal(t, data[i], buff[0])
+		assert.Equal(t, data[i+1], buff[1])
+		assert.Equal(t, 2, n)
+		assert.Nil(t, err)
+	}
+
+	// Once exhausted, the facade should forward the error from the underlying
+	// reader, and it should not change increment BytesRead.
+	assert.Equal(t, int64(6), reader.BytesRead)
+	n, err := reader.Read(buff)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, int64(6), reader.BytesRead)
+}

--- a/cli_tools/daisycommon/io_test.go
+++ b/cli_tools/daisycommon/io_test.go
@@ -1,3 +1,17 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package daisycommon
 
 import (

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -127,9 +127,9 @@ func validateSourceFile(storageClient domain.StorageClientInterface, sourceBucke
 	// an empty file, then BytesRead will be zero.
 	if byteCountingReader.BytesRead <= 0 {
 		return errors.New("cannot import an image from an empty file")
-	} else {
-		return nil
 	}
+
+	return nil
 }
 
 // Returns main workflow and translate workflow paths (if any)

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -17,6 +17,7 @@ package importer
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -115,12 +116,20 @@ func validateSourceFile(storageClient domain.StorageClientInterface, sourceBucke
 	}
 	defer rc.Close()
 
+	byteCountingReader := daisycommon.NewByteCountingReader(rc)
 	// Detect whether it's a compressed file by extracting compressed file header
-	if _, err = gzip.NewReader(rc); err == nil {
+	if _, err = gzip.NewReader(byteCountingReader); err == nil {
 		return daisy.Errf("cannot import an image from a compressed file. Please provide a path to an uncompressed image file. If the compressed file is an image exported from Google Compute Engine, please use 'images create' instead")
 	}
 
-	return nil
+	// By calling gzip.NewReader above, a few bytes were read from the Reader in
+	// an attempt to decode the compression header. If the Reader represents
+	// an empty file, then BytesRead will be zero.
+	if byteCountingReader.BytesRead <= 0 {
+		return errors.New("cannot import an image from an empty file")
+	} else {
+		return nil
+	}
 }
 
 // Returns main workflow and translate workflow paths (if any)

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -177,6 +177,19 @@ func TestFlagsSourceFile(t *testing.T) {
 	}
 }
 
+func TestFlagSourceFileEmpty(t *testing.T) {
+	emptyReader := ioutil.NopCloser(strings.NewReader(""))
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().GetObjectReader(gomock.Any(), gomock.Any()).Return(emptyReader, nil)
+
+	err := validateSourceFile(mockStorageClient, "", "")
+	assert.NotNil(t, err, "Expected error")
+	assert.Contains(t, err.Error(), "cannot import an image from an empty file")
+}
+
 func TestFlagSourceFileCompressed(t *testing.T) {
 	fileString := test.CreateCompressedFile()
 


### PR DESCRIPTION
We've seen some errors lately where an import was run against an empty file. This will help to catch the error earlier, and to give more helpful debug information.