### PR TITLE
[error log] add log prefix to pass gcloud filter

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -17,6 +17,7 @@ package ovfimporter
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -48,6 +49,7 @@ import (
 const (
 	ovfWorkflowDir    = "daisy_workflows/ovf_import/"
 	ovfImportWorkflow = ovfWorkflowDir + "import_ovf.wf.json"
+	logPrefix         = "[import-ovf]"
 )
 
 const (
@@ -86,7 +88,8 @@ type OVFImporter struct {
 // such as compute/storage clients.
 func NewOVFImporter(params *ovfimportparams.OVFImportParams) (*OVFImporter, error) {
 	ctx := context.Background()
-	logger := logging.NewLogger("[import-ovf]")
+	log.SetPrefix(logPrefix)
+	logger := logging.NewLogger(logPrefix)
 	storageClient, err := storageutils.NewStorageClient(ctx, logger, "")
 	if err != nil {
 		return nil, err

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -88,7 +88,7 @@ type OVFImporter struct {
 // such as compute/storage clients.
 func NewOVFImporter(params *ovfimportparams.OVFImportParams) (*OVFImporter, error) {
 	ctx := context.Background()
-	log.SetPrefix(logPrefix)
+	log.SetPrefix(logPrefix + " ")
 	logger := logging.NewLogger(logPrefix)
 	storageClient, err := storageutils.NewStorageClient(ctx, logger, "")
 	if err != nil {

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -157,7 +157,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool,
 	cloudLogsDisabled bool, stdoutLogsDisabled bool, labels string, currentExecutablePath string) (*daisy.Workflow, error) {
 
-	log.SetPrefix(logPrefix)
+	log.SetPrefix(logPrefix + " ")
 
 	userLabels, err := validateAndParseFlags(clientID, destinationURI, sourceImage, labels)
 	if err != nil {

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -18,6 +18,7 @@ package exporter
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -39,11 +40,16 @@ var (
 	ExportAndConvertWorkflow = "image_export_ext.wf.json"
 )
 
-// Parameter key shared with external packages
+// Parameter key shared with other packages
 const (
 	ClientIDFlagKey       = "client_id"
 	DestinationURIFlagKey = "destination_uri"
 	SourceImageFlagKey    = "source_image"
+)
+
+const (
+	logPrefix = "[image-export]"
+
 )
 
 func validateAndParseFlags(clientID string, destinationURI string, sourceImage string, labels string) (
@@ -152,6 +158,8 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool,
 	cloudLogsDisabled bool, stdoutLogsDisabled bool, labels string, currentExecutablePath string) (*daisy.Workflow, error) {
 
+	log.SetPrefix(logPrefix)
+
 	userLabels, err := validateAndParseFlags(clientID, destinationURI, sourceImage, labels)
 	if err != nil {
 		return nil, err
@@ -160,7 +168,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	ctx := context.Background()
 	metadataGCE := &compute.MetadataGCE{}
 	storageClient, err := storage.NewStorageClient(
-		ctx, logging.NewLogger("[image-export]"), oauth)
+		ctx, logging.NewLogger(logPrefix), oauth)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -40,7 +40,7 @@ var (
 	ExportAndConvertWorkflow = "image_export_ext.wf.json"
 )
 
-// Parameter key shared with other packages
+// Parameter key shared with external packages
 const (
 	ClientIDFlagKey       = "client_id"
 	DestinationURIFlagKey = "destination_uri"
@@ -49,7 +49,6 @@ const (
 
 const (
 	logPrefix = "[image-export]"
-
 )
 
 func validateAndParseFlags(clientID string, destinationURI string, sourceImage string, labels string) (

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -235,7 +235,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	stdoutLogsDisabled bool, kmsKey string, kmsKeyring string, kmsLocation string, kmsProject string,
 	noExternalIP bool, labels string, currentExecutablePath string, storageLocation string) (*daisy.Workflow, error) {
 
-	log.SetPrefix(logPrefix)
+	log.SetPrefix(logPrefix + " ")
 
 	sourceBucketName, sourceObjectName, userLabels, err := validateAndParseFlags(clientID, imageName,
 		sourceFile, sourceImage, dataDisk, osID, customTranWorkflow, labels)

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -18,6 +18,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -46,6 +47,10 @@ var (
 const (
 	ImageNameFlagKey = "image_name"
 	ClientIDFlagKey  = "client_id"
+)
+
+const (
+	logPrefix = "[image-import]"
 )
 
 func validateAndParseFlags(clientID string, imageName string, sourceFile string, sourceImage string, dataDisk bool, osID string, customTranWorkflow string, labels string) (
@@ -230,6 +235,8 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	stdoutLogsDisabled bool, kmsKey string, kmsKeyring string, kmsLocation string, kmsProject string,
 	noExternalIP bool, labels string, currentExecutablePath string, storageLocation string) (*daisy.Workflow, error) {
 
+	log.SetPrefix(logPrefix)
+
 	sourceBucketName, sourceObjectName, userLabels, err := validateAndParseFlags(clientID, imageName,
 		sourceFile, sourceImage, dataDisk, osID, customTranWorkflow, labels)
 	if err != nil {
@@ -239,7 +246,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	ctx := context.Background()
 	metadataGCE := &compute.MetadataGCE{}
 	storageClient, err := storage.NewStorageClient(
-		ctx, logging.NewLogger("[image-import]"), oauth)
+		ctx, logging.NewLogger(logPrefix), oauth)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This prefix is required because gcloud filters log based on prefix. Without this prefix, the final error msg won't show up in gcloud console.