### PR TITLE
[logging] abstracts class for cli tool with logging

### DIFF
--- a/cli_tools/common/utils/logging/service/cli_tool_with_log.go
+++ b/cli_tools/common/utils/logging/service/cli_tool_with_log.go
@@ -1,0 +1,44 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package service
+
+import (
+	"flag"
+	"os"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+// CliToolWithLogging abstracts the interface of a cli tool with logging
+type CliToolWithLogging interface {
+	// ActionType indicates the action type of the tool
+	ActionType() ActionType
+
+	// InitParamLog initialize tool params in the log
+	InitParamLog() InputParams
+
+	// MainFunc is the main function of the tool
+	MainFunc() (*daisy.Workflow, map[string]string, error)
+}
+
+// RunCliToolWithLogging runs the cli tool with server logging
+func RunCliToolWithLogging(t CliToolWithLogging) {
+	flag.Parse()
+	paramLog := t.InitParamLog()
+	l := NewLoggingServiceLogger(t.ActionType(), paramLog)
+	if _, err := l.runWithServerLogging(t.MainFunc); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cli_tools/common/utils/logging/service/cli_tool_with_log.go
+++ b/cli_tools/common/utils/logging/service/cli_tool_with_log.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
@@ -32,7 +33,7 @@ type CliToolWithLogging interface {
 	InitParamLog() InputParams
 
 	// Run is the entry function of the tool
-	Run() (*daisy.Workflow, map[string]string, error)
+	Run() (*daisy.Workflow, *param.UpdatedParams, error)
 }
 
 // RunCliToolWithLogging runs the cli tool with server logging

--- a/cli_tools/common/utils/logging/service/cli_tool_with_log.go
+++ b/cli_tools/common/utils/logging/service/cli_tool_with_log.go
@@ -21,16 +21,17 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
-// CliToolWithLogging abstracts the interface of a cli tool with logging
+// CliToolWithLogging abstracts the interface of a cli tool with logging. A tool
+// which implemented this interface adopts log service automatically.
 type CliToolWithLogging interface {
 	// ActionType indicates the action type of the tool
 	ActionType() ActionType
 
-	// InitParamLog initialize tool params in the log
+	// InitParamLog initializes tool's input params in order to be logged
 	InitParamLog() InputParams
 
-	// MainFunc is the main function of the tool
-	MainFunc() (*daisy.Workflow, map[string]string, error)
+	// Run is the entry function of the tool
+	Run() (*daisy.Workflow, map[string]string, error)
 }
 
 // RunCliToolWithLogging runs the cli tool with server logging
@@ -38,7 +39,7 @@ func RunCliToolWithLogging(t CliToolWithLogging) {
 	flag.Parse()
 	paramLog := t.InitParamLog()
 	l := NewLoggingServiceLogger(t.ActionType(), paramLog)
-	if _, err := l.runWithServerLogging(t.MainFunc); err != nil {
+	if _, err := l.runWithServerLogging(t.Run); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cli_tools/common/utils/logging/service/cli_tool_with_log.go
+++ b/cli_tools/common/utils/logging/service/cli_tool_with_log.go
@@ -24,7 +24,8 @@ import (
 // CliToolWithLogging abstracts the interface of a cli tool with logging. A tool
 // which implemented this interface adopts log service automatically.
 type CliToolWithLogging interface {
-	// ActionType indicates the action type of the tool
+	// ActionType indicates the action type of the tool. It represents which tool
+	// function this log line is about. "ImageImport" is an example.
 	ActionType() ActionType
 
 	// InitParamLog initializes tool's input params in order to be logged

--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -85,6 +85,19 @@ type InputParams struct {
 	InstanceImportParams *InstanceImportParams `json:"instance_import_input_params,omitempty"`
 }
 
+func (p *InputParams) commonParams() *CommonParams {
+	if p.ImageImportParams != nil {
+		return p.ImageImportParams.CommonParams
+	}
+	if p.ImageExportParams != nil {
+		return p.ImageExportParams.CommonParams
+	}
+	if p.InstanceImportParams != nil {
+		return p.InstanceImportParams.CommonParams
+	}
+	return nil
+}
+
 // ImageImportParams contains all input params for image import
 type ImageImportParams struct {
 	*CommonParams
@@ -171,27 +184,23 @@ type OutputInfo struct {
 	FailureMessageWithoutPrivacyInfo string `json:"failure_message_without_privacy_info,omitempty"`
 }
 
-func (l *Logger) updateParams(projectPointer *string) {
+func (l *Logger) updateParams(params map[string]string) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if projectPointer == nil {
+	l.updateProject(params)
+}
+
+func (l *Logger) updateProject(params map[string]string) {
+	project, ok := params["project"]
+	if !ok {
 		return
 	}
 
-	project := *projectPointer
 	obfuscatedProject := Hash(project)
 
-	if l.Params.ImageImportParams != nil {
-		l.Params.ImageImportParams.CommonParams.Project = project
-		l.Params.ImageImportParams.CommonParams.ObfuscatedProject = obfuscatedProject
-	}
-	if l.Params.ImageExportParams != nil {
-		l.Params.ImageExportParams.CommonParams.Project = project
-		l.Params.ImageExportParams.CommonParams.ObfuscatedProject = obfuscatedProject
-	}
-	if l.Params.InstanceImportParams != nil {
-		l.Params.InstanceImportParams.CommonParams.Project = project
-		l.Params.InstanceImportParams.CommonParams.ObfuscatedProject = obfuscatedProject
+	if commonParams := l.Params.commonParams(); commonParams != nil {
+		commonParams.Project = project
+		commonParams.ObfuscatedProject = obfuscatedProject
 	}
 }

--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -14,6 +14,10 @@
 
 package service
 
+import (
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
+)
+
 // logRequest is a server-side pre-defined data structure
 type logRequest struct {
 	ClientInfo    clientInfo `json:"client_info"`
@@ -192,7 +196,7 @@ func (l *Logger) updateParams(params map[string]string) {
 }
 
 func (l *Logger) updateProject(params map[string]string) {
-	project, ok := params["project"]
+	project, ok := params[param.UpdatedParamProject]
 	if !ok {
 		return
 	}

--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -188,19 +188,21 @@ type OutputInfo struct {
 	FailureMessageWithoutPrivacyInfo string `json:"failure_message_without_privacy_info,omitempty"`
 }
 
-func (l *Logger) updateParams(params map[string]string) {
+func (l *Logger) updateParams(updatedParams *param.UpdatedParams) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	l.updateProject(params)
-}
-
-func (l *Logger) updateProject(params map[string]string) {
-	project, ok := params[param.UpdatedParamProject]
-	if !ok {
+	if updatedParams == nil {
 		return
 	}
+	l.updateProject(updatedParams)
+}
 
+func (l *Logger) updateProject(updatedParams *param.UpdatedParams) {
+	if updatedParams.Project == nil {
+		return
+	}
+	project := *updatedParams.Project
 	obfuscatedProject := Hash(project)
 
 	if commonParams := l.Params.commonParams(); commonParams != nil {

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/google/uuid"
 	"github.com/minio/highwayhash"
@@ -199,7 +200,7 @@ func getInt64Values(s string) []int64 {
 }
 
 func (l *Logger) runWithServerLogging(function func() (*daisy.Workflow,
-	map[string]string, error)) (*ComputeImageToolsLogExtension, error) {
+		*param.UpdatedParams, error)) (*ComputeImageToolsLogExtension, error) {
 
 	var logExtension *ComputeImageToolsLogExtension
 

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -43,11 +43,14 @@ var (
 	nextRequestWaitMillis int64
 )
 
+// ActionType of the tool
+type ActionType string
+
 // constants used by logging
 const (
-	ImageImportAction    = "ImageImport"
-	ImageExportAction    = "ImageExport"
-	InstanceImportAction = "InstanceImport"
+	ImageImportAction    ActionType = "ImageImport"
+	ImageExportAction    ActionType = "ImageExport"
+	InstanceImportAction ActionType = "InstanceImport"
 
 	// These strings should be interleaved to construct the real URL. This is just to (hopefully)
 	// fool github URL scanning bots.
@@ -106,11 +109,11 @@ type Logger struct {
 }
 
 // NewLoggingServiceLogger creates a new server logger
-func NewLoggingServiceLogger(action string, params InputParams) *Logger {
+func NewLoggingServiceLogger(action ActionType, params InputParams) *Logger {
 	return &Logger{
 		ServerURL: serverURL,
 		ID:        uuid.New().String(),
-		Action:    action,
+		Action:    string(action),
 		TimeStart: time.Now(),
 		Params:    params,
 		mutex:     sync.Mutex{},
@@ -195,8 +198,8 @@ func getInt64Values(s string) []int64 {
 	return r
 }
 
-func (l *Logger) runWithServerLogging(function func() (*daisy.Workflow, error),
-	projectPointer *string) (*ComputeImageToolsLogExtension, error) {
+func (l *Logger) runWithServerLogging(function func() (*daisy.Workflow,
+	map[string]string, error)) (*ComputeImageToolsLogExtension, error) {
 
 	var logExtension *ComputeImageToolsLogExtension
 
@@ -210,8 +213,8 @@ func (l *Logger) runWithServerLogging(function func() (*daisy.Workflow, error),
 		l.logStart()
 	}()
 
-	w, err := function()
-	l.updateParams(projectPointer)
+	w, updatedParams, err := function()
+	l.updateParams(updatedParams)
 	if err != nil {
 		wg.Add(1)
 		go func() {
@@ -231,14 +234,6 @@ func (l *Logger) runWithServerLogging(function func() (*daisy.Workflow, error),
 	return logExtension, err
 }
 
-// RunWithServerLogging runs the function with server logging
-func RunWithServerLogging(action string, params InputParams, projectPointer *string,
-	function func() (*daisy.Workflow, error)) error {
-	l := NewLoggingServiceLogger(action, params)
-	_, err := l.runWithServerLogging(function, projectPointer)
-	return err
-}
-
 func (l *Logger) sendLogToServer(logExtension *ComputeImageToolsLogExtension) logResult {
 	r := l.sendLogToServerWithRetry(logExtension, 3)
 	return r
@@ -251,8 +246,8 @@ func (l *Logger) sendLogToServerWithRetry(logExtension *ComputeImageToolsLogExte
 	for i := 0; i < maxRetry; i++ {
 		// Before sending a new request, wait for a while if server asked to do so
 		if nextRequestWaitMillis > 0 {
-			nextRequestWaitMillis = 0
 			time.Sleep(time.Duration(nextRequestWaitMillis) * time.Millisecond)
+			nextRequestWaitMillis = 0
 		}
 
 		logRequestJSON, err := l.constructLogRequest(logExtension)

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -200,7 +200,7 @@ func getInt64Values(s string) []int64 {
 }
 
 func (l *Logger) runWithServerLogging(function func() (*daisy.Workflow,
-		*param.UpdatedParams, error)) (*ComputeImageToolsLogExtension, error) {
+	*param.UpdatedParams, error)) (*ComputeImageToolsLogExtension, error) {
 
 	var logExtension *ComputeImageToolsLogExtension
 

--- a/cli_tools/common/utils/logging/service/logger_test.go
+++ b/cli_tools/common/utils/logging/service/logger_test.go
@@ -119,9 +119,9 @@ func TestRunWithServerLoggingSuccess(t *testing.T) {
 	prepareTestLogger(t, nil, buildLogResponses(deleteRequest, deleteRequest))
 
 	logExtension, _ := logger.runWithServerLogging(
-		func() (*daisy.Workflow, error) {
-			return &daisy.Workflow{}, nil
-		}, nil)
+		func() (*daisy.Workflow, map[string]string, error) {
+			return &daisy.Workflow{}, nil, nil
+		})
 	if logExtension.Status != statusSuccess {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusSuccess)
 	}
@@ -131,9 +131,9 @@ func TestRunWithServerLoggingFailed(t *testing.T) {
 	prepareTestLogger(t, nil, buildLogResponses(deleteRequest, deleteRequest))
 
 	logExtension, _ := logger.runWithServerLogging(
-		func() (*daisy.Workflow, error) {
-			return &daisy.Workflow{}, fmt.Errorf("test msg - failure by purpose")
-		}, nil)
+		func() (*daisy.Workflow, map[string]string, error) {
+			return &daisy.Workflow{}, nil, fmt.Errorf("test msg - failure by purpose")
+		})
 	if logExtension.Status != statusFailure {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusFailure)
 	}
@@ -144,9 +144,9 @@ func TestRunWithServerLoggingSuccessWithUpdatedProject(t *testing.T) {
 
 	project := "dummy-project"
 	logExtension, _ := logger.runWithServerLogging(
-		func() (*daisy.Workflow, error) {
-			return &daisy.Workflow{}, nil
-		}, &project)
+		func() (*daisy.Workflow, map[string]string, error) {
+			return &daisy.Workflow{}, map[string]string{"project": project}, nil
+		})
 	if logExtension.Status != statusSuccess {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusSuccess)
 	}
@@ -248,7 +248,7 @@ func buildComputeImageToolsLogExtension() *ComputeImageToolsLogExtension {
 	logExtension := &ComputeImageToolsLogExtension{
 		ID:           "dummy-id",
 		CloudBuildID: "dummy-cloud-build-id",
-		ToolAction:   ImageImportAction,
+		ToolAction:   string(ImageImportAction),
 		Status:       statusStart,
 		InputParams: &InputParams{
 			ImageImportParams: &ImageImportParams{

--- a/cli_tools/common/utils/logging/service/logger_test.go
+++ b/cli_tools/common/utils/logging/service/logger_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
@@ -119,7 +120,7 @@ func TestRunWithServerLoggingSuccess(t *testing.T) {
 	prepareTestLogger(t, nil, buildLogResponses(deleteRequest, deleteRequest))
 
 	logExtension, _ := logger.runWithServerLogging(
-		func() (*daisy.Workflow, map[string]string, error) {
+		func() (*daisy.Workflow, *param.UpdatedParams, error) {
 			return &daisy.Workflow{}, nil, nil
 		})
 	if logExtension.Status != statusSuccess {
@@ -131,7 +132,7 @@ func TestRunWithServerLoggingFailed(t *testing.T) {
 	prepareTestLogger(t, nil, buildLogResponses(deleteRequest, deleteRequest))
 
 	logExtension, _ := logger.runWithServerLogging(
-		func() (*daisy.Workflow, map[string]string, error) {
+		func() (*daisy.Workflow, *param.UpdatedParams, error) {
 			return &daisy.Workflow{}, nil, fmt.Errorf("test msg - failure by purpose")
 		})
 	if logExtension.Status != statusFailure {
@@ -144,8 +145,8 @@ func TestRunWithServerLoggingSuccessWithUpdatedProject(t *testing.T) {
 
 	project := "dummy-project"
 	logExtension, _ := logger.runWithServerLogging(
-		func() (*daisy.Workflow, map[string]string, error) {
-			return &daisy.Workflow{}, map[string]string{"project": project}, nil
+		func() (*daisy.Workflow, *param.UpdatedParams, error) {
+			return &daisy.Workflow{}, &param.UpdatedParams{Project: &project}, nil
 		})
 	if logExtension.Status != statusSuccess {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusSuccess)

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -27,11 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
-// List name of updated params here
-const (
-	UpdatedParamProject = "project"
-)
-
+// UpdatedParams represents parameters that will be updated in the preparation stage
 type UpdatedParams struct {
 	Project *string
 }

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -32,6 +32,10 @@ const (
 	UpdatedParamProject = "project"
 )
 
+type UpdatedParams struct {
+	Project *string
+}
+
 // GetProjectID gets project id from flag if exists; otherwise, try to retrieve from GCE metadata.
 func GetProjectID(mgce domain.MetadataGCEInterface, projectFlag string) (string, error) {
 	if projectFlag == "" {

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -27,6 +27,11 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
+// List name of updated params here
+const (
+	UpdatedParamProject = "project"
+)
+
 // GetProjectID gets project id from flag if exists; otherwise, try to retrieve from GCE metadata.
 func GetProjectID(mgce domain.MetadataGCEInterface, projectFlag string) (string, error) {
 	if projectFlag == "" {

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -93,18 +93,18 @@ func buildImportParams() *ovfimportparams.OVFImportParams {
 	}
 }
 
-// InstanceExportTool is the tool for instance import
-type InstanceExportTool struct {
+// InstanceImportTool is the tool for instance import
+type InstanceImportTool struct {
 	service.CliToolWithLogging
 }
 
 // ActionType implements CliToolWithLogging
-func (t *InstanceExportTool) ActionType() service.ActionType {
+func (t *InstanceImportTool) ActionType() service.ActionType {
 	return service.InstanceImportAction
 }
 
-// MainFunc implements CliToolWithLogging
-func (t *InstanceExportTool) MainFunc() (*daisy.Workflow, map[string]string, error) {
+// Run implements CliToolWithLogging
+func (t *InstanceImportTool) Run() (*daisy.Workflow, map[string]string, error) {
 	var ovfImporter *ovfimporter.OVFImporter
 	var err error
 	defer func() {
@@ -121,7 +121,7 @@ func (t *InstanceExportTool) MainFunc() (*daisy.Workflow, map[string]string, err
 }
 
 // InitParamLog implements CliToolWithLogging
-func (t *InstanceExportTool) InitParamLog() service.InputParams {
+func (t *InstanceImportTool) InitParamLog() service.InputParams {
 	return service.InputParams{
 		InstanceImportParams: &service.InstanceImportParams{
 			CommonParams: &service.CommonParams{
@@ -167,5 +167,5 @@ func (t *InstanceExportTool) InitParamLog() service.InputParams {
 }
 
 func main() {
-	service.RunCliToolWithLogging(&InstanceExportTool{})
+	service.RunCliToolWithLogging(&InstanceImportTool{})
 }

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_importer"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
@@ -104,7 +105,7 @@ func (t *InstanceImportTool) ActionType() service.ActionType {
 }
 
 // Run implements CliToolWithLogging
-func (t *InstanceImportTool) Run() (*daisy.Workflow, map[string]string, error) {
+func (t *InstanceImportTool) Run() (*daisy.Workflow, *param.UpdatedParams, error) {
 	var ovfImporter *ovfimporter.OVFImporter
 	var err error
 	defer func() {

--- a/cli_tools/gce_ovf_import/main_test.go
+++ b/cli_tools/gce_ovf_import/main_test.go
@@ -56,7 +56,7 @@ func TestBuildParams(t *testing.T) {
 	assert.Equal(t, cliArgs["boot-disk-kms-location"], params.BootDiskKmsLocation)
 	assert.Equal(t, cliArgs["boot-disk-kms-project"], params.BootDiskKmsProject)
 	assert.Equal(t, cliArgs["timeout"], params.Timeout)
-	assert.Equal(t, cliArgs["project"], *params.Project)
+	assert.Equal(t, cliArgs["project"], params.Project)
 	assert.Equal(t, cliArgs["scratch-bucket-gcs-path"], params.ScratchBucketGcsPath)
 	assert.Equal(t, cliArgs["oauth"], params.Oauth)
 	assert.Equal(t, cliArgs["compute-endpoint-override"], params.Ce)

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
@@ -49,7 +49,7 @@ type OVFImportParams struct {
 	BootDiskKmsLocation         string
 	BootDiskKmsProject          string
 	Timeout                     string
-	Project                     *string
+	Project                     string
 	ScratchBucketGcsPath        string
 	Oauth                       string
 	Ce                          string

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
@@ -87,7 +87,7 @@ func getAllParams() *OVFImportParams {
 		BootDiskKmsLocation:         "aKmsLocation",
 		BootDiskKmsProject:          "aKmsProject",
 		Timeout:                     "3h",
-		Project:                     &project,
+		Project:                     project,
 		ScratchBucketGcsPath:        "gs://bucket/folder",
 		Oauth:                       "oAuthFilePath",
 		Ce:                          "us-east1-c",

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -344,7 +344,7 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, map[string]string
 	if project, err = param.GetProjectID(oi.mgce, oi.params.Project); err != nil {
 		return nil, updatedParams, err
 	}
-	updatedParams["project"] = project
+	updatedParams[param.UpdatedParamProject] = project
 	if zone, err = oi.getZone(project); err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -344,7 +344,7 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, *param.UpdatedPar
 	if project, err = param.GetProjectID(oi.mgce, oi.params.Project); err != nil {
 		return nil, updatedParams, err
 	}
-	*updatedParams.Project = project
+	updatedParams.Project = &project
 	if zone, err = oi.getZone(project); err != nil {
 		return nil, updatedParams, err
 	}
@@ -421,7 +421,7 @@ func validateReleaseTrack(releaseTrack string) error {
 }
 
 // Import runs OVF import
-func (oi *OVFImporter) Import() (*daisy.Workflow, map[string]string, error) {
+func (oi *OVFImporter) Import() (*daisy.Workflow, *param.UpdatedParams, error) {
 	oi.Logger.Log("Starting OVF import workflow.")
 	w, updatedParams, err := oi.setUpImportWorkflow()
 	if err != nil {

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -330,8 +330,8 @@ func (oi *OVFImporter) getMachineType(
 	return machineTypeProvider.GetMachineType()
 }
 
-func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, map[string]string, error) {
-	updatedParams := map[string]string{}
+func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, *param.UpdatedParams, error) {
+	updatedParams := &param.UpdatedParams{}
 	if err := ovfimportparams.ValidateAndParseParams(oi.params); err != nil {
 		return nil, updatedParams, err
 	}
@@ -344,7 +344,7 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, map[string]string
 	if project, err = param.GetProjectID(oi.mgce, oi.params.Project); err != nil {
 		return nil, updatedParams, err
 	}
-	updatedParams[param.UpdatedParamProject] = project
+	*updatedParams.Project = project
 	if zone, err = oi.getZone(project); err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -37,8 +37,7 @@ import (
 
 func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
 	params := GetAllParams()
-	projectParam := ""
-	params.Project = &projectParam
+	params.Project = ""
 	params.Zone = ""
 	params.MachineType = ""
 	params.ScratchBucketGcsPath = ""
@@ -96,7 +95,7 @@ func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
 		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
 		ctx: ctx, bucketIteratorCreator: mockBucketIteratorCreator,
 		Logger: logging.NewLogger("test"), params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
@@ -131,8 +130,7 @@ func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
 
 func TestSetUpWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneAsFlags(t *testing.T) {
 	params := GetAllParams()
-	project := "aProject"
-	params.Project = &project
+	params.Project = "aProject"
 	params.Zone = "europe-west2-b"
 	params.UefiCompatible = true
 	params.MachineType = ""
@@ -166,7 +164,7 @@ func TestSetUpWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneAsFlags(t 
 		storageClient: mockStorageClient, computeClient: mockComputeClient, BuildID: "build123",
 		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
 		Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator, params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
@@ -234,7 +232,7 @@ func doTestSetUpWorkflowUsesImageLocationForReleaseTrack(
 		storageClient: mockStorageClient, computeClient: mockComputeClient, BuildID: "build123",
 		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
 		Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator, params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
@@ -274,7 +272,7 @@ func TestSetUpWorkflowInvalidReleaseTrack(t *testing.T) {
 		storageClient: mockStorageClient, computeClient: mockComputeClient, BuildID: "build123",
 		ovfDescriptorLoader: mockOvfDescriptorLoader, tarGcsExtractor: mockMockTarGcsExtractorInterface,
 		Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator, params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.NotNil(t, err)
 	assert.Nil(t, w)
@@ -282,8 +280,7 @@ func TestSetUpWorkflowInvalidReleaseTrack(t *testing.T) {
 
 func TestSetUpWorkflowPopulateMissingParametersError(t *testing.T) {
 	params := GetAllParams()
-	project := ""
-	params.Project = &project
+	params.Project = ""
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -292,7 +289,7 @@ func TestSetUpWorkflowPopulateMissingParametersError(t *testing.T) {
 	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
 
 	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.NotNil(t, err)
 	assert.Nil(t, w)
@@ -309,7 +306,7 @@ func TestSetUpWorkflowPopulateFlagValidationFailed(t *testing.T) {
 	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
 
 	oi := OVFImporter{mgce: mockMetadataGce, Logger: logging.NewLogger("test"), params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.NotNil(t, err)
 	assert.Nil(t, w)
@@ -317,8 +314,7 @@ func TestSetUpWorkflowPopulateFlagValidationFailed(t *testing.T) {
 
 func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
 	params := GetAllParams()
-	project := "aProject"
-	params.Project = &project
+	params.Project = "aProject"
 	params.Zone = "europe-north1-b"
 	params.MachineType = ""
 
@@ -343,7 +339,7 @@ func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
 		storageClient: mockStorageClient, BuildID: "build123",
 		tarGcsExtractor: mockMockTarGcsExtractorInterface, Logger: logging.NewLogger("test"),
 		zoneValidator: mockZoneValidator, params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.NotNil(t, err)
 	assert.Nil(t, w)
@@ -351,8 +347,7 @@ func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
 
 func TestSetUpWorkflowErrorLoadingDescriptor(t *testing.T) {
 	params := GetAllParams()
-	project := "aProject"
-	params.Project = &project
+	params.Project = "aProject"
 	params.Zone = "europe-north1-b"
 	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
 	params.MachineType = ""
@@ -374,7 +369,7 @@ func TestSetUpWorkflowErrorLoadingDescriptor(t *testing.T) {
 	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
 		BuildID: "build123", ovfDescriptorLoader: mockOvfDescriptorLoader,
 		Logger: logging.NewLogger("test"), zoneValidator: mockZoneValidator, params: params}
-	w, err := oi.setUpImportWorkflow()
+	w, _, err := oi.setUpImportWorkflow()
 
 	assert.NotNil(t, err)
 	assert.Nil(t, w)
@@ -436,6 +431,33 @@ func TestSetUpWorkOSFlagInvalid(t *testing.T) {
 
 	assert.Nil(t, w)
 	assert.NotNil(t, err)
+}
+
+func setupMocksForOSIdTesting(mockCtrl *gomock.Controller, osType string,
+	params *ovfimportparams.OVFImportParams) (*daisy.Workflow, error) {
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
+
+	descriptor := createOVFDescriptor()
+	if osType != "" {
+		descriptor.VirtualSystem.OperatingSystem = []ovf.OperatingSystemSection{{OSType: &osType}}
+	}
+	mockOvfDescriptorLoader.EXPECT().Load("gs://ovfbucket/ovffolder/").Return(
+		descriptor, nil)
+
+	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
+	mockZoneValidator.EXPECT().
+		ZoneValid("aProject", "us-central1-c").Return(nil)
+
+	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
+		storageClient: mockStorageClient, BuildID: "build123",
+		ovfDescriptorLoader: mockOvfDescriptorLoader, Logger: logging.NewLogger("test"),
+		zoneValidator: mockZoneValidator, params: params}
+	w, _, err := oi.setUpImportWorkflow()
+	return w, err
 }
 
 func TestCleanUp(t *testing.T) {
@@ -594,32 +616,6 @@ func TestPopulateMissingParametersInvalidZone(t *testing.T) {
 	assert.Equal(t, "europe-north1-b", params.Zone)
 }
 
-func setupMocksForOSIdTesting(mockCtrl *gomock.Controller, osType string,
-	params *ovfimportparams.OVFImportParams) (*daisy.Workflow, error) {
-	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
-	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
-
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	mockOvfDescriptorLoader := mocks.NewMockOvfDescriptorLoaderInterface(mockCtrl)
-
-	descriptor := createOVFDescriptor()
-	if osType != "" {
-		descriptor.VirtualSystem.OperatingSystem = []ovf.OperatingSystemSection{{OSType: &osType}}
-	}
-	mockOvfDescriptorLoader.EXPECT().Load("gs://ovfbucket/ovffolder/").Return(
-		descriptor, nil)
-
-	mockZoneValidator := mocks.NewMockZoneValidatorInterface(mockCtrl)
-	mockZoneValidator.EXPECT().
-		ZoneValid("aProject", "us-central1-c").Return(nil)
-
-	oi := OVFImporter{mgce: mockMetadataGce, workflowPath: "../../test_data/test_import_ovf.wf.json",
-		storageClient: mockStorageClient, BuildID: "build123",
-		ovfDescriptorLoader: mockOvfDescriptorLoader, Logger: logging.NewLogger("test"),
-		zoneValidator: mockZoneValidator, params: params}
-	return oi.setUpImportWorkflow()
-}
-
 func createControllerItem(instanceID string, resourceType uint16) ovf.ResourceAllocationSettingData {
 	return ovf.ResourceAllocationSettingData{
 		CIMResourceAllocationSettingData: ovf.CIMResourceAllocationSettingData{
@@ -708,7 +704,6 @@ func createMemoryItem(instanceID string, quantityMB uint) ovf.ResourceAllocation
 }
 
 func GetAllParams() *ovfimportparams.OVFImportParams {
-	project := "aProject"
 	return &ovfimportparams.OVFImportParams{
 		InstanceNames:               "instance1",
 		ClientID:                    "aClient",
@@ -736,7 +731,7 @@ func GetAllParams() *ovfimportparams.OVFImportParams {
 		BootDiskKmsLocation:         "aKmsLocation",
 		BootDiskKmsProject:          "aKmsProject",
 		Timeout:                     "3h",
-		Project:                     &project,
+		Project:                     "aProject",
 		ScratchBucketGcsPath:        "gs://bucket/folder",
 		Oauth:                       "oAuthFilePath",
 		Ce:                          "us-east1-c",

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/ovf"
@@ -590,7 +591,7 @@ func TestPopulateMissingParametersInvalidZone(t *testing.T) {
 }
 
 func setupMocksForOSIdTesting(mockCtrl *gomock.Controller, osType string,
-	params *ovfimportparams.OVFImportParams) (*daisy.Workflow, map[string]string, error) {
+	params *ovfimportparams.OVFImportParams) (*daisy.Workflow, *param.UpdatedParams, error) {
 	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
 	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
 

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -384,7 +384,7 @@ func TestSetUpWorkOSIdFromOVFDescriptor(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	w, err := setupMocksForOSIdTesting(mockCtrl, "rhel7_64Guest", params)
+	w, _, err := setupMocksForOSIdTesting(mockCtrl, "rhel7_64Guest", params)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, w)
@@ -399,7 +399,7 @@ func TestSetUpWorkOSIdFromDescriptorInvalidAndOSFlagNotSpecified(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	w, err := setupMocksForOSIdTesting(mockCtrl, "no-OS-ID", params)
+	w, _, err := setupMocksForOSIdTesting(mockCtrl, "no-OS-ID", params)
 
 	assert.Nil(t, w)
 	assert.NotNil(t, err)
@@ -413,7 +413,7 @@ func TestSetUpWorkOSIdFromDescriptorNonDeterministicAndOSFlagNotSpecified(t *tes
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	w, err := setupMocksForOSIdTesting(mockCtrl, "ubuntu64Guest", params)
+	w, _, err := setupMocksForOSIdTesting(mockCtrl, "ubuntu64Guest", params)
 
 	assert.Nil(t, w)
 	assert.NotNil(t, err)
@@ -427,7 +427,7 @@ func TestSetUpWorkOSFlagInvalid(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	w, err := setupMocksForOSIdTesting(mockCtrl, "", params)
+	w, _, err := setupMocksForOSIdTesting(mockCtrl, "", params)
 
 	assert.Nil(t, w)
 	assert.NotNil(t, err)
@@ -590,7 +590,7 @@ func TestPopulateMissingParametersInvalidZone(t *testing.T) {
 }
 
 func setupMocksForOSIdTesting(mockCtrl *gomock.Controller, osType string,
-		params *ovfimportparams.OVFImportParams) (*daisy.Workflow, error) {
+	params *ovfimportparams.OVFImportParams) (*daisy.Workflow, map[string]string, error) {
 	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
 	mockMetadataGce.EXPECT().OnGCE().Return(false).AnyTimes()
 

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -186,7 +186,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	region := new(string)
 	err = param.PopulateMissingParameters(&project, &zone, region, &scratchBucketGcsPath,
 		destinationURI, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	*updatedParams.Project = project
+	updatedParams.Project = &project
 	if err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -186,7 +186,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	region := new(string)
 	err = param.PopulateMissingParameters(&project, &zone, region, &scratchBucketGcsPath,
 		destinationURI, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	updatedParams["project"] = project
+	updatedParams[param.UpdatedParamProject] = project
 	if err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -156,9 +156,9 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	project string, network string, subnet string, zone string, timeout string,
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool,
 	cloudLogsDisabled bool, stdoutLogsDisabled bool, labels string,
-	currentExecutablePath string) (*daisy.Workflow, map[string]string, error) {
+	currentExecutablePath string) (*daisy.Workflow, *param.UpdatedParams, error) {
 
-	updatedParams := map[string]string{}
+	updatedParams := &param.UpdatedParams{}
 
 	log.SetPrefix(logPrefix + " ")
 
@@ -186,7 +186,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	region := new(string)
 	err = param.PopulateMissingParameters(&project, &zone, region, &scratchBucketGcsPath,
 		destinationURI, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	updatedParams[param.UpdatedParamProject] = project
+	*updatedParams.Project = project
 	if err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_export/exporter"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
@@ -54,7 +55,7 @@ func (t *ImageExportTool) ActionType() service.ActionType {
 }
 
 // Run implements CliToolWithLogging
-func (t *ImageExportTool) Run() (*daisy.Workflow, map[string]string, error) {
+func (t *ImageExportTool) Run() (*daisy.Workflow, *param.UpdatedParams, error) {
 	currentExecutablePath := string(os.Args[0])
 	return exporter.Run(*clientID, *destinationURI, *sourceImage, *format, *project,
 		*network, *subnet, *zone, *timeout, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled,

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -53,8 +53,8 @@ func (t *ImageExportTool) ActionType() service.ActionType {
 	return service.ImageExportAction
 }
 
-// MainFunc implements CliToolWithLogging
-func (t *ImageExportTool) MainFunc() (*daisy.Workflow, map[string]string, error) {
+// Run implements CliToolWithLogging
+func (t *ImageExportTool) Run() (*daisy.Workflow, map[string]string, error) {
 	currentExecutablePath := string(os.Args[0])
 	return exporter.Run(*clientID, *destinationURI, *sourceImage, *format, *project,
 		*network, *subnet, *zone, *timeout, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled,

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -43,17 +43,27 @@ var (
 	labels               = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
 )
 
-func exportEntry() (*daisy.Workflow, error) {
+// ImageExportTool is the tool for image export
+type ImageExportTool struct {
+	service.CliToolWithLogging
+}
+
+// ActionType implements CliToolWithLogging
+func (t *ImageExportTool) ActionType() service.ActionType {
+	return service.ImageExportAction
+}
+
+// MainFunc implements CliToolWithLogging
+func (t *ImageExportTool) MainFunc() (*daisy.Workflow, map[string]string, error) {
 	currentExecutablePath := string(os.Args[0])
-	return exporter.Run(*clientID, *destinationURI, *sourceImage, *format, project,
+	return exporter.Run(*clientID, *destinationURI, *sourceImage, *format, *project,
 		*network, *subnet, *zone, *timeout, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled,
 		*cloudLogsDisabled, *stdoutLogsDisabled, *labels, currentExecutablePath)
 }
 
-func main() {
-	flag.Parse()
-
-	paramLog := service.InputParams{
+// InitParamLog implements CliToolWithLogging
+func (t *ImageExportTool) InitParamLog() service.InputParams {
+	return service.InputParams{
 		ImageExportParams: &service.ImageExportParams{
 			CommonParams: &service.CommonParams{
 				ClientID:                *clientID,
@@ -76,8 +86,8 @@ func main() {
 			Format:         *format,
 		},
 	}
+}
 
-	if err := service.RunWithServerLogging(service.ImageExportAction, paramLog, project, exportEntry); err != nil {
-		os.Exit(1)
-	}
+func main() {
+	service.RunCliToolWithLogging(&ImageExportTool{})
 }

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -277,7 +277,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	region := new(string)
 	err = param.PopulateMissingParameters(&project, &zone, region, &scratchBucketGcsPath,
 		sourceFile, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	*updatedParams.Project = project
+	updatedParams.Project = &project
 	if err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -277,7 +277,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	region := new(string)
 	err = param.PopulateMissingParameters(&project, &zone, region, &scratchBucketGcsPath,
 		sourceFile, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	updatedParams["project"] = project
+	updatedParams[param.UpdatedParamProject] = project
 	if err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -246,9 +246,9 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool, cloudLogsDisabled bool,
 	stdoutLogsDisabled bool, kmsKey string, kmsKeyring string, kmsLocation string, kmsProject string,
 	noExternalIP bool, labels string, currentExecutablePath string, storageLocation string,
-	uefiCompatible bool) (*daisy.Workflow, map[string]string, error) {
+	uefiCompatible bool) (*daisy.Workflow, *param.UpdatedParams, error) {
 
-	updatedParams := map[string]string{}
+	updatedParams := &param.UpdatedParams{}
 
 	log.SetPrefix(logPrefix + " ")
 
@@ -277,7 +277,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	region := new(string)
 	err = param.PopulateMissingParameters(&project, &zone, region, &scratchBucketGcsPath,
 		sourceFile, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	updatedParams[param.UpdatedParamProject] = project
+	*updatedParams.Project = project
 	if err != nil {
 		return nil, updatedParams, err
 	}

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -66,8 +66,8 @@ func (t *ImageImportTool) ActionType() service.ActionType {
 	return service.ImageImportAction
 }
 
-// MainFunc implements CliToolWithLogging
-func (t *ImageImportTool) MainFunc() (*daisy.Workflow, map[string]string, error) {
+// Run implements CliToolWithLogging
+func (t *ImageImportTool) Run() (*daisy.Workflow, map[string]string, error) {
 	currentExecutablePath := string(os.Args[0])
 	return importer.Run(*clientID, *imageName, *dataDisk, *osID, *customTranWorkflow, *sourceFile,
 		*sourceImage, *noGuestEnvironment, *family, *description, *network, *subnet, *zone, *timeout,

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -56,19 +56,29 @@ var (
 	uefiCompatible       = flag.Bool("uefi_compatible", false, "Enables UEFI booting, which is an alternative system boot method. Most public images use the GRUB bootloader as their primary boot method.")
 )
 
-func importEntry() (*daisy.Workflow, error) {
+// ImageImportTool is the tool for image import
+type ImageImportTool struct {
+	service.CliToolWithLogging
+}
+
+// ActionType implements CliToolWithLogging
+func (t *ImageImportTool) ActionType() service.ActionType {
+	return service.ImageImportAction
+}
+
+// MainFunc implements CliToolWithLogging
+func (t *ImageImportTool) MainFunc() (*daisy.Workflow, map[string]string, error) {
 	currentExecutablePath := string(os.Args[0])
 	return importer.Run(*clientID, *imageName, *dataDisk, *osID, *customTranWorkflow, *sourceFile,
 		*sourceImage, *noGuestEnvironment, *family, *description, *network, *subnet, *zone, *timeout,
-		project, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
+		*project, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
 		*stdoutLogsDisabled, *kmsKey, *kmsKeyring, *kmsLocation, *kmsProject, *noExternalIP,
 		*labels, currentExecutablePath, *storageLocation, *uefiCompatible)
 }
 
-func main() {
-	flag.Parse()
-
-	paramLog := service.InputParams{
+// InitParamLog implements CliToolWithLogging
+func (t *ImageImportTool) InitParamLog() service.InputParams {
+	return service.InputParams{
 		ImageImportParams: &service.ImageImportParams{
 			CommonParams: &service.CommonParams{
 				ClientID:                *clientID,
@@ -102,8 +112,8 @@ func main() {
 			StorageLocation:    *storageLocation,
 		},
 	}
+}
 
-	if err := service.RunWithServerLogging(service.ImageImportAction, paramLog, project, importEntry); err != nil {
-		os.Exit(1)
-	}
+func main() {
+	service.RunCliToolWithLogging(&ImageImportTool{})
 }

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/importer"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
@@ -67,7 +68,7 @@ func (t *ImageImportTool) ActionType() service.ActionType {
 }
 
 // Run implements CliToolWithLogging
-func (t *ImageImportTool) Run() (*daisy.Workflow, map[string]string, error) {
+func (t *ImageImportTool) Run() (*daisy.Workflow, *param.UpdatedParams, error) {
 	currentExecutablePath := string(os.Args[0])
 	return importer.Run(*clientID, *imageName, *dataDisk, *osID, *customTranWorkflow, *sourceFile,
 		*sourceImage, *noGuestEnvironment, *family, *description, *network, *subnet, *zone, *timeout,

--- a/daisy/step_includeworkflow.go
+++ b/daisy/step_includeworkflow.go
@@ -65,7 +65,6 @@ func (i *IncludeWorkflow) populate(ctx context.Context, s *Step) DError {
 	i.Workflow.Logger = i.Workflow.parent.Logger
 	i.Workflow.Name = s.name
 	i.Workflow.DefaultTimeout = s.Timeout
-	fmt.Println("incldued_wf name:", i.Workflow.Name, " timeout:", i.Workflow.DefaultTimeout)
 
 	var errs DError
 Loop:

--- a/daisy/step_includeworkflow.go
+++ b/daisy/step_includeworkflow.go
@@ -65,6 +65,7 @@ func (i *IncludeWorkflow) populate(ctx context.Context, s *Step) DError {
 	i.Workflow.Logger = i.Workflow.parent.Logger
 	i.Workflow.Name = s.name
 	i.Workflow.DefaultTimeout = s.Timeout
+	fmt.Println("incldued_wf name:", i.Workflow.Name, " timeout:", i.Workflow.DefaultTimeout)
 
 	var errs DError
 Loop:

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -671,7 +671,7 @@ func (w *Workflow) traverseDAG(f func(*Step) DError) DError {
 		}(name, s)
 	}
 
-	// Main signaling logic.
+	// Run signaling logic.
 	for len(waiting) != 0 || len(running) != 0 {
 		// If we got a Cancel signal, kill all waiting steps.
 		// Let running steps finish.

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -98,7 +98,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/Ubuntu_for_Horizon_three_disks_mounted.ova", ovaBucket),
 				OsID:          "ubuntu-1404",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-1",
 			},
@@ -117,7 +117,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/centos-6.8", ovaBucket),
 				OsID:          "centos-6",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -136,7 +136,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/w2k12-r2", ovaBucket),
 				OsID:          "windows-2012r2",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-8",
 			},
@@ -156,7 +156,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/w2k16/w2k16.ovf", ovaBucket),
 				OsID:          "windows-2016",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 			},
 			name:        fmt.Sprintf("ovf-import-test-w2k16-%s", suffix),
@@ -174,7 +174,7 @@ func TestSuite(
 				InstanceNames: fmt.Sprintf("test-instance-w2k8r2-%v", suffix),
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/win2008r2-all-updates-four-nic.ova", ovaBucket),
 				OsID:          "windows-2008r2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 			},
 			name:        fmt.Sprintf("ovf-import-test-w2k8r2-%s", suffix),
@@ -192,7 +192,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/bitnami-tomcat-8.5.43-0-linux-debian-9-x86_64.ova", ovaBucket),
 				OsID:          "debian-9",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -210,7 +210,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
 				OsID:          "ubuntu-1604",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -229,7 +229,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/aws-ova-ubuntu-1604.ova", ovaBucket),
 				OsID:          "ubuntu-1604",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       testProjectConfig.TestProjectID,
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -297,7 +297,7 @@ func runOvfImportTest(
 	}
 
 	logger.Printf("[%v] Starting OVF import", testSetup.name)
-	_, err = ovfImporter.Import()
+	_, _, err = ovfImporter.Import()
 	if err != nil {
 		logger.Printf("[%v] error while performing OVF import: %v", testSetup.name, err)
 		testCase.WriteFailure("error while performing OVF import: %v", err)

--- a/test-infra/prowjobs/wrapper/main.go
+++ b/test-infra/prowjobs/wrapper/main.go
@@ -197,7 +197,7 @@ func main() {
 		buffered.Flush()
 		os.Exit(1)
 	}
-	buildLog.Printf("Main logic finished with result %q.", result)
+	buildLog.Printf("Run logic finished with result %q.", result)
 
 	// Copy artifacts.
 	buildLog.Println("Writing artifacts to GCS.")


### PR DESCRIPTION
Use CliToolWithLogging as the abstract class of all cli tools with logging.
ImageImport/ImageExport/InstanceImport follows the pattern.
In the future, new tool (e.g. InstanceExport?) can just follow the pattern to support logging by simply implementing CliToolWithLogging.

This new abstracts avoided implicitly update input params by pointer. It forced tool's MainFunc to return a "updatedParams map[string]string", which is adopted by CliToolWithLogging to update log.

"updatedParams" is used to update 'project', and can be used for other params as well in the future.