### PR TITLE
Save serial logs if there's an import failure.

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -171,6 +171,9 @@ type OutputInfo struct {
 	FailureMessageWithoutPrivacyInfo string `json:"failure_message_without_privacy_info,omitempty"`
 	// ImportFileFormat shows what is the actual image format of the imported file
 	ImportFileFormat string `json:"import_file_format,omitempty"`
+	// Serial output from worker instances; only populated
+	// if workflow failed.
+	SerialOutputs []string `json:"serial_outputs,omitempty"`
 }
 
 func (l *Logger) updateParams(projectPointer *string) {

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -181,6 +181,9 @@ func (l *Logger) getOutputInfo(w *daisy.Workflow, err error) *OutputInfo {
 	if err != nil {
 		o.FailureMessage = getFailureReason(err)
 		o.FailureMessageWithoutPrivacyInfo = getAnonymizedFailureReason(err)
+		if w != nil && w.Logger != nil {
+			o.SerialOutputs = w.Logger.ReadSerialPortLogs()
+		}
 	}
 
 	return &o

--- a/cli_tools/daisy_test_runner/main.go
+++ b/cli_tools/daisy_test_runner/main.go
@@ -150,6 +150,10 @@ func (l *logger) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf byt
 	return
 }
 
+func (l *logger) ReadSerialPortLogs() []string {
+	return nil
+}
+
 func (l *logger) Flush() { return }
 
 func createTestCase(ctx context.Context, testLogger *logger, path, project, zone, oauthPath, ce string, varMap map[string]string) (*daisy.Workflow, error) {

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -775,3 +775,4 @@ type DummyLogger struct{}
 func (dl DummyLogger) WriteLogEntry(e *daisy.LogEntry)                                          {}
 func (dl DummyLogger) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {}
 func (dl DummyLogger) Flush()                                                                   {}
+func (dl DummyLogger) ReadSerialPortLogs() []string                                             { return nil }

--- a/daisy/logger.go
+++ b/daisy/logger.go
@@ -171,11 +171,11 @@ func (l *daisyLog) WriteSerialPortLogs(w *Workflow, instance string, buf bytes.B
 }
 
 func (l *daisyLog) ReadSerialPortLogs() []string {
-	logs := make([]string, 0, len(l.serialLogs))
-	for _, v := range l.serialLogs {
-		logs = append(logs, v)
+	allLogs := make([]string, 0, len(l.serialLogs))
+	for instance, log := range l.serialLogs {
+		allLogs = append(allLogs, fmt.Sprintf("Serial logs for instance: %s\n%s", instance, log))
 	}
-	return logs
+	return allLogs
 }
 
 // Flush flushes all loggers.

--- a/daisy/logger.go
+++ b/daisy/logger.go
@@ -33,6 +33,7 @@ import (
 type Logger interface {
 	WriteLogEntry(e *LogEntry)
 	WriteSerialPortLogs(w *Workflow, instance string, buf bytes.Buffer)
+	ReadSerialPortLogs() []string
 	Flush()
 }
 
@@ -47,13 +48,13 @@ type daisyLog struct {
 	cloudLogger     cloudLogWriter
 	stdoutLogging   bool
 	logCleanupRegex *regexp.Regexp
+	// A map of instance name to its serial logs.
+	serialLogs map[string]string
 }
 
 // createLogger builds a Logger.
 func (w *Workflow) createLogger(ctx context.Context) {
-	l := &daisyLog{
-		stdoutLogging: !w.stdoutLoggingDisabled,
-	}
+	l := newDaisyLogger(!w.stdoutLoggingDisabled)
 
 	w.addCleanupHook(func() DError {
 		w.logWait.Wait()
@@ -88,6 +89,13 @@ func (w *Workflow) createLogger(ctx context.Context) {
 		w.Logger.Flush()
 		return nil
 	})
+}
+
+func newDaisyLogger(stdOutLoggingEnabled bool) *daisyLog {
+	return &daisyLog{
+		stdoutLogging: stdOutLoggingEnabled,
+		serialLogs:    map[string]string{},
+	}
 }
 
 // LogStepInfo logs information for the workflow step.
@@ -132,6 +140,9 @@ func (l *daisyLog) WriteSerialPortLogs(w *Workflow, instance string, buf bytes.B
 		return
 	}
 
+	logs := buf.String()
+	l.serialLogs[instance] = logs
+
 	writeLog := func(str string) {
 		entry := &LogEntry{
 			LocalTimestamp: time.Now(),
@@ -146,7 +157,7 @@ func (l *daisyLog) WriteSerialPortLogs(w *Workflow, instance string, buf bytes.B
 	// Write the output to cloud logging only after instance has stopped.
 	// Type assertion check is needed for tests not to panic.
 	// Split if output is too long for log entry (100K max, we leave a 2K buffer).
-	ss := strings.SplitAfter(buf.String(), "\n")
+	ss := strings.SplitAfter(logs, "\n")
 	var str string
 	for _, s := range ss {
 		if len(str)+len(s) > 98*1024 {
@@ -157,6 +168,14 @@ func (l *daisyLog) WriteSerialPortLogs(w *Workflow, instance string, buf bytes.B
 		}
 	}
 	writeLog(str)
+}
+
+func (l *daisyLog) ReadSerialPortLogs() []string {
+	logs := make([]string, 0, len(l.serialLogs))
+	for _, v := range l.serialLogs {
+		logs = append(logs, v)
+	}
+	return logs
 }
 
 // Flush flushes all loggers.

--- a/daisy/logger_test.go
+++ b/daisy/logger_test.go
@@ -17,11 +17,13 @@ package daisy
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"regexp"
 	"sync"
 	"testing"
 
 	"cloud.google.com/go/logging"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockLogger struct {
@@ -31,6 +33,10 @@ type MockLogger struct {
 
 func (l *MockLogger) WriteSerialPortLogs(w *Workflow, instance string, buf bytes.Buffer) {
 	// nop
+}
+
+func (l *MockLogger) ReadSerialPortLogs() []string {
+	return nil
 }
 
 func (l *MockLogger) WriteLogEntry(e *LogEntry) {
@@ -51,7 +57,7 @@ func (l *MockLogger) getEntries() []*LogEntry {
 func TestWriteWorkflowInfo(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.Logger = &daisyLog{}
+	w.Logger = newDaisyLogger(false)
 
 	var b bytes.Buffer
 	w.Logger.(*daisyLog).gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&b)}
@@ -73,7 +79,7 @@ func TestWriteWorkflowInfo(t *testing.T) {
 func TestWriteStepInfo(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.Logger = &daisyLog{}
+	w.Logger = newDaisyLogger(false)
 
 	var b bytes.Buffer
 	w.Logger.(*daisyLog).gcsLogWriter = &syncedWriter{buf: bufio.NewWriter(&b)}
@@ -107,7 +113,7 @@ func (cl *MockCloudLogWriter) Flush() error {
 func TestSendSerialPortLogsToCloud(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.Logger = &daisyLog{}
+	w.Logger = newDaisyLogger(false)
 	cl := &MockCloudLogWriter{}
 	w.Logger.(*daisyLog).cloudLogger = cl
 	var buf bytes.Buffer
@@ -120,16 +126,51 @@ func TestSendSerialPortLogsToCloud(t *testing.T) {
 	if len(cl.entries) != 14 {
 		t.Errorf("Wanted %d", len(cl.entries))
 	}
+
+	assertLogOutput(t, w.Logger.ReadSerialPortLogs(), []string{buf.String()})
+}
+
+func TestSendSerialPortLogsToCloudMultipleInstances(t *testing.T) {
+	w := New()
+	w.Name = "Test"
+	w.Logger = newDaisyLogger(false)
+	cl := &MockCloudLogWriter{}
+	w.Logger.(*daisyLog).cloudLogger = cl
+
+	actualLogs := []string{
+		"line1\nline2",
+		"more log info\t",
+	}
+
+	for i, log := range actualLogs {
+		var buf bytes.Buffer
+		buf.WriteString(log)
+		w.Logger.WriteSerialPortLogs(w, fmt.Sprintf("instance-%d", i), buf)
+	}
+
+	assertLogOutput(t, w.Logger.ReadSerialPortLogs(), actualLogs)
 }
 
 func TestSendSerialPortLogsToCloudDisabled(t *testing.T) {
 	w := New()
 	w.Name = "Test"
-	w.Logger = &daisyLog{}
+	w.Logger = newDaisyLogger(false)
 	var buf bytes.Buffer
 	buf.WriteString("Serial output\n")
 
 	w.Logger.WriteSerialPortLogs(w, "instance-name", buf)
 
-	// Nothing to verify. Nothing happened.
+	assert.Equal(t, len(w.Logger.ReadSerialPortLogs()), 0,
+		"Don't retain logs if cloud logging disabled.")
+}
+
+func assertLogOutput(t *testing.T, actualLogs []string, expectedLogs []string) {
+	if len(actualLogs) != len(expectedLogs) {
+		t.Errorf("Expected %d serial logs. Found %d",
+			len(expectedLogs), len(actualLogs))
+	}
+
+	for _, log := range expectedLogs {
+		assert.Contains(t, actualLogs, log)
+	}
 }

--- a/daisy/logger_test.go
+++ b/daisy/logger_test.go
@@ -127,7 +127,8 @@ func TestSendSerialPortLogsToCloud(t *testing.T) {
 		t.Errorf("Wanted %d", len(cl.entries))
 	}
 
-	assertLogOutput(t, w.Logger.ReadSerialPortLogs(), []string{buf.String()})
+	assertLogOutput(t, w.Logger.ReadSerialPortLogs(),
+		[]string{"Serial logs for instance: instance-name\n" + buf.String()})
 }
 
 func TestSendSerialPortLogsToCloudMultipleInstances(t *testing.T) {
@@ -137,18 +138,23 @@ func TestSendSerialPortLogsToCloudMultipleInstances(t *testing.T) {
 	cl := &MockCloudLogWriter{}
 	w.Logger.(*daisyLog).cloudLogger = cl
 
-	actualLogs := []string{
+	contentOfLogs := []string{
 		"line1\nline2",
 		"more log info\t",
 	}
 
-	for i, log := range actualLogs {
+	instanceAnnotatedLogs := []string{
+		"Serial logs for instance: instance-0\nline1\nline2",
+		"Serial logs for instance: instance-1\nmore log info\t",
+	}
+
+	for i, log := range contentOfLogs {
 		var buf bytes.Buffer
 		buf.WriteString(log)
 		w.Logger.WriteSerialPortLogs(w, fmt.Sprintf("instance-%d", i), buf)
 	}
 
-	assertLogOutput(t, w.Logger.ReadSerialPortLogs(), actualLogs)
+	assertLogOutput(t, w.Logger.ReadSerialPortLogs(), instanceAnnotatedLogs)
 }
 
 func TestSendSerialPortLogsToCloudDisabled(t *testing.T) {


### PR DESCRIPTION
Notes:
- I've piggy-backed on Daisy's `DisableCloudLogging` flag; if the user specifies that flag, then we won't keep the serial output.
- Logs are only retained if there's a workflow error.

Testing:
 - In addition to unit tests, I ran OVF's import integration tests.