### PR TITLE
Mitigate race condition between createInstance and waitForInstanceSignal

### DIFF
--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -41,8 +41,6 @@ func logSerialOutput(ctx context.Context, s *Step, i *Instance, port int64, inte
 Loop:
 	for {
 		select {
-		case <-w.Cancel:
-			break Loop
 		case <-tick:
 			resp, err := w.ComputeClient.GetSerialPortOutput(path.Base(i.Project), path.Base(i.Zone), i.Name, port, start)
 			if err != nil {
@@ -72,6 +70,10 @@ Loop:
 				gcsErr = true
 				w.LogStepInfo(s.name, "CreateInstances", "Instance %q: error saving log to GCS: %v", i.Name, err)
 				continue
+			}
+
+			if w.isCanceled() {
+				break Loop
 			}
 		}
 	}

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -319,6 +319,11 @@ func (w *Workflow) cleanup() {
 	default:
 		close(w.Cancel)
 	}
+
+	// Allow goroutines that are watching w.Cancel an opportunity
+	// to detect that the workflow was cancelled and to cleanup.
+	time.Sleep(4 * time.Second)
+
 	for _, hook := range w.cleanupHooks {
 		if err := hook(); err != nil {
 			w.LogWorkflowInfo("Error returned from cleanup hook: %s", err)

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -713,6 +713,15 @@ func (w *Workflow) traverseDAG(f func(*Step) DError) DError {
 	return nil
 }
 
+func (w *Workflow) isCanceled() bool {
+	select {
+	case <-w.Cancel:
+		return true
+	default:
+		return false
+	}
+}
+
 // New instantiates a new workflow.
 func New() *Workflow {
 	// We can't use context.WithCancel as we use the context even after cancel for cleanup.


### PR DESCRIPTION
waitForInstanceSignal is able to kill an instance depending on its serial output, while createInstance is responsible for archiving serial output. Typically these steps run in parallel, leading to situations where an instance is killed prior to archiving the latest batch of logs. 

This commit adds a couple of mitigations:
 1. Always get the latest batch of logs when a workflow is canceled.
 2. Delay the return of createInstance by 20 seconds.

Testing:
 - Ran the OVF import integ tests.