### PR TITLE
Support both POST URLs for object insert.

### DIFF
--- a/daisy/step_copy_gcs_objects_test.go
+++ b/daisy/step_copy_gcs_objects_test.go
@@ -55,9 +55,11 @@ func TestCopyGCSObjectsValidate(t *testing.T) {
 			fmt.Fprint(w, `{}`)
 		} else if m == "GET" && u == "/b/bucket2?alt=json&prettyPrint=false&projection=full" {
 			fmt.Fprint(w, `{}`)
-		} else if m == "POST" && u == "/b/bucket1/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart" {
+		} else if m == "POST" && (u == "/b/bucket1/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart" ||
+			u == "/upload/storage/v1/b/bucket1/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart") {
 			fmt.Fprint(w, `{}`)
-		} else if m == "POST" && u == "/b/bucket2/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart" {
+		} else if m == "POST" && (u == "/b/bucket2/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart" ||
+			u == "/upload/storage/v1/b/bucket2/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart") {
 			fmt.Fprint(w, `{}`)
 		} else if m == "DELETE" && u == "/b/bucket1/o/abcdef?alt=json&prettyPrint=false" {
 			fmt.Fprint(w, `{}`)


### PR DESCRIPTION
This fixes the presubmit errors that we started seeing yesterday such as [this one](https://k8s-gubernator.appspot.com/build/compute-image-tools-test/pr-logs/pull/GoogleCloudPlatform_compute-image-tools/984/presubmit-unittests/1189191560273596416/).

According to https://cloud.google.com/storage/docs/json_api/v1/ both
URL formats are valid for object insertion.