### PR TITLE
[logging] v2 - abstracts class for cli tool with logging

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -175,7 +175,7 @@ type CommonParams struct {
 	DisableCloudLogging     bool   `json:"disable_cloud_logging"`
 	DisableStdoutLogging    bool   `json:"disable_stdout_logging"`
 
-	UpdatableProject *param.UpdatableParam
+	UpdatableProject *param.UpdatableParam `json:"-"`
 }
 
 // OutputInfo contains output values from the tools execution

--- a/cli_tools/common/utils/logging/service/logger_test.go
+++ b/cli_tools/common/utils/logging/service/logger_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
@@ -121,7 +122,7 @@ func TestRunWithServerLoggingSuccess(t *testing.T) {
 	logExtension, _ := logger.runWithServerLogging(
 		func() (*daisy.Workflow, error) {
 			return &daisy.Workflow{}, nil
-		}, nil)
+		})
 	if logExtension.Status != statusSuccess {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusSuccess)
 	}
@@ -133,7 +134,7 @@ func TestRunWithServerLoggingFailed(t *testing.T) {
 	logExtension, _ := logger.runWithServerLogging(
 		func() (*daisy.Workflow, error) {
 			return &daisy.Workflow{}, fmt.Errorf("test msg - failure by purpose")
-		}, nil)
+		})
 	if logExtension.Status != statusFailure {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusFailure)
 	}
@@ -143,10 +144,13 @@ func TestRunWithServerLoggingSuccessWithUpdatedProject(t *testing.T) {
 	prepareTestLogger(t, nil, buildLogResponses(deleteRequest, deleteRequest))
 
 	project := "dummy-project"
+	updatableProject := param.CreateUpdatableParam(project)
+	logger.Params.commonParams().UpdatableProject = updatableProject
 	logExtension, _ := logger.runWithServerLogging(
 		func() (*daisy.Workflow, error) {
+			updatableProject.Update(project)
 			return &daisy.Workflow{}, nil
-		}, &project)
+		})
 	if logExtension.Status != statusSuccess {
 		t.Errorf("Unexpected Status: %v, expect: %v", logExtension.Status, statusSuccess)
 	}
@@ -248,7 +252,7 @@ func buildComputeImageToolsLogExtension() *ComputeImageToolsLogExtension {
 	logExtension := &ComputeImageToolsLogExtension{
 		ID:           "dummy-id",
 		CloudBuildID: "dummy-cloud-build-id",
-		ToolAction:   ImageImportAction,
+		ToolAction:   string(ImageImportAction),
 		Status:       statusStart,
 		InputParams: &InputParams{
 			ImageImportParams: &ImageImportParams{

--- a/cli_tools/common/utils/param/param_utils_test.go
+++ b/cli_tools/common/utils/param/param_utils_test.go
@@ -91,7 +91,7 @@ func TestPopulateMissingParametersReturnsErrorWhenZoneCantBeRetrieved(t *testing
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: "us-west2"}, nil).Times(1)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -113,7 +113,7 @@ func TestPopulateMissingParametersReturnsErrorWhenProjectNotProvidedAndNotRunnin
 	mockZoneRetriever := mocks.NewMockZoneRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -136,7 +136,7 @@ func TestPopulateMissingParametersReturnsErrorWhenProjectNotProvidedAndGCEProjec
 	mockZoneRetriever := mocks.NewMockZoneRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -159,7 +159,7 @@ func TestPopulateMissingParametersReturnsErrorWhenProjectNotProvidedAndMetadataR
 	mockZoneRetriever := mocks.NewMockZoneRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -182,7 +182,7 @@ func TestPopulateMissingParametersReturnsErrorWhenScratchBucketCreationError(t *
 	mockZoneRetriever := mocks.NewMockZoneRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -203,7 +203,7 @@ func TestPopulateMissingParametersReturnsErrorWhenScratchBucketInvalidFormat(t *
 	mockZoneRetriever := mocks.NewMockZoneRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -225,7 +225,7 @@ func TestPopulateMissingParametersReturnsErrorWhenPopulateRegionFails(t *testing
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: region}, nil)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath,
 		file, mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.NotNil(t, err)
@@ -252,7 +252,7 @@ func TestPopulateMissingParametersDoesNotChangeProvidedScratchBucketAndUsesItsRe
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 	mockStorageClient.EXPECT().GetBucketAttrs(expectedBucketName).Return(&storage.BucketAttrs{Location: expectedRegion}, nil)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath, file,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath, file,
 		mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.Nil(t, err)
@@ -288,7 +288,7 @@ func TestPopulateMissingParametersCreatesScratchBucketIfNotProvided(t *testing.T
 	mockZoneRetriever.EXPECT().GetZone(expectedRegion, project).Return(expectedZone, nil).Times(1)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath, file,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath, file,
 		mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.Nil(t, err)
@@ -325,7 +325,7 @@ func TestPopulateMissingParametersCreatesScratchBucketIfNotProvidedOnGCE(t *test
 	mockZoneRetriever.EXPECT().GetZone(expectedRegion, project).Return(expectedZone, nil).Times(1)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 
-	err := PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath, file,
+	err := PopulateMissingParameters(CreateUpdatableParam(project), &zone, &region, &scratchBucketGcsPath, file,
 		mockMetadataGce, mockScratchBucketCreator, mockZoneRetriever, mockStorageClient)
 
 	assert.Nil(t, err)
@@ -336,7 +336,7 @@ func TestPopulateMissingParametersCreatesScratchBucketIfNotProvidedOnGCE(t *test
 }
 
 func TestPopulateProjectIfMissingProjectPopulatedFromGCE(t *testing.T) {
-	project := ""
+	updatableProject := CreateUpdatableParam("")
 	expectedProject := "gce_project"
 
 	mockCtrl := gomock.NewController(t)
@@ -346,10 +346,10 @@ func TestPopulateProjectIfMissingProjectPopulatedFromGCE(t *testing.T) {
 	mockMetadataGce.EXPECT().OnGCE().Return(true)
 	mockMetadataGce.EXPECT().ProjectID().Return(expectedProject, nil)
 
-	err := PopulateProjectIfMissing(mockMetadataGce, &project)
+	err := PopulateProjectIfMissing(mockMetadataGce, updatableProject)
 
 	assert.Nil(t, err)
-	assert.Equal(t, expectedProject, project)
+	assert.Equal(t, expectedProject, updatableProject.StringValue())
 }
 
 func TestPopulateProjectIfMissingProjectNotOnGCE(t *testing.T) {
@@ -362,7 +362,7 @@ func TestPopulateProjectIfMissingProjectNotOnGCE(t *testing.T) {
 	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
 	mockMetadataGce.EXPECT().OnGCE().Return(false)
 
-	err := PopulateProjectIfMissing(mockMetadataGce, &project)
+	err := PopulateProjectIfMissing(mockMetadataGce, CreateUpdatableParam(project))
 
 	assert.NotNil(t, err)
 	assert.Equal(t, expectedProject, project)
@@ -377,7 +377,7 @@ func TestPopulateProjectIfNotMissingProject(t *testing.T) {
 
 	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
 
-	err := PopulateProjectIfMissing(mockMetadataGce, &project)
+	err := PopulateProjectIfMissing(mockMetadataGce, CreateUpdatableParam(project))
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedProject, project)
@@ -394,7 +394,7 @@ func TestPopulateProjectIfMissingProjectWithErrorRetrievingFromGCE(t *testing.T)
 	mockMetadataGce.EXPECT().OnGCE().Return(true)
 	mockMetadataGce.EXPECT().ProjectID().Return("", daisy.Errf("gce error"))
 
-	err := PopulateProjectIfMissing(mockMetadataGce, &project)
+	err := PopulateProjectIfMissing(mockMetadataGce, CreateUpdatableParam(project))
 
 	assert.NotNil(t, err)
 	assert.Equal(t, expectedProject, project)

--- a/cli_tools/gce_ovf_import/main_test.go
+++ b/cli_tools/gce_ovf_import/main_test.go
@@ -56,7 +56,7 @@ func TestBuildParams(t *testing.T) {
 	assert.Equal(t, cliArgs["boot-disk-kms-location"], params.BootDiskKmsLocation)
 	assert.Equal(t, cliArgs["boot-disk-kms-project"], params.BootDiskKmsProject)
 	assert.Equal(t, cliArgs["timeout"], params.Timeout)
-	assert.Equal(t, cliArgs["project"], *params.Project)
+	assert.Equal(t, cliArgs["project"], params.Project.StringValue())
 	assert.Equal(t, cliArgs["scratch-bucket-gcs-path"], params.ScratchBucketGcsPath)
 	assert.Equal(t, cliArgs["oauth"], params.Oauth)
 	assert.Equal(t, cliArgs["compute-endpoint-override"], params.Ce)

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -49,7 +50,7 @@ type OVFImportParams struct {
 	BootDiskKmsLocation         string
 	BootDiskKmsProject          string
 	Timeout                     string
-	Project                     *string
+	Project                     *param.UpdatableParam
 	ScratchBucketGcsPath        string
 	Oauth                       string
 	Ce                          string

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
@@ -17,6 +17,7 @@ package ovfimportparams
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -87,7 +88,7 @@ func getAllParams() *OVFImportParams {
 		BootDiskKmsLocation:         "aKmsLocation",
 		BootDiskKmsProject:          "aKmsProject",
 		Timeout:                     "3h",
-		Project:                     &project,
+		Project:                     param.CreateUpdatableParam(project),
 		ScratchBucketGcsPath:        "gs://bucket/folder",
 		Oauth:                       "oAuthFilePath",
 		Ce:                          "us-east1-c",

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -340,10 +340,10 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, error) {
 		region  string
 		err     error
 	)
-	if project, err = param.GetProjectID(oi.mgce, *oi.params.Project); err != nil {
+	if err = param.PopulateProjectIfMissing(oi.mgce, oi.params.Project); err != nil {
 		return nil, err
 	}
-	*oi.params.Project = project
+	project = oi.params.Project.StringValue()
 	if zone, err = oi.getZone(project); err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/ovf"
@@ -37,8 +38,7 @@ import (
 
 func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
 	params := GetAllParams()
-	projectParam := ""
-	params.Project = &projectParam
+	params.Project = param.CreateUpdatableParam("")
 	params.Zone = ""
 	params.MachineType = ""
 	params.ScratchBucketGcsPath = ""
@@ -131,8 +131,7 @@ func TestSetUpWorkflowHappyPathFromOVANoExtraFlags(t *testing.T) {
 
 func TestSetUpWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneAsFlags(t *testing.T) {
 	params := GetAllParams()
-	project := "aProject"
-	params.Project = &project
+	params.Project = param.CreateUpdatableParam("aProject")
 	params.Zone = "europe-west2-b"
 	params.UefiCompatible = true
 	params.MachineType = ""
@@ -282,8 +281,7 @@ func TestSetUpWorkflowInvalidReleaseTrack(t *testing.T) {
 
 func TestSetUpWorkflowPopulateMissingParametersError(t *testing.T) {
 	params := GetAllParams()
-	project := ""
-	params.Project = &project
+	params.Project = param.CreateUpdatableParam("")
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -317,8 +315,7 @@ func TestSetUpWorkflowPopulateFlagValidationFailed(t *testing.T) {
 
 func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
 	params := GetAllParams()
-	project := "aProject"
-	params.Project = &project
+	params.Project = param.CreateUpdatableParam("aProject")
 	params.Zone = "europe-north1-b"
 	params.MachineType = ""
 
@@ -351,8 +348,7 @@ func TestSetUpWorkflowErrorUnpackingOVA(t *testing.T) {
 
 func TestSetUpWorkflowErrorLoadingDescriptor(t *testing.T) {
 	params := GetAllParams()
-	project := "aProject"
-	params.Project = &project
+	params.Project = param.CreateUpdatableParam("aProject")
 	params.Zone = "europe-north1-b"
 	params.OvfOvaGcsPath = "gs://ovfbucket/ovffolder/"
 	params.MachineType = ""
@@ -708,7 +704,6 @@ func createMemoryItem(instanceID string, quantityMB uint) ovf.ResourceAllocation
 }
 
 func GetAllParams() *ovfimportparams.OVFImportParams {
-	project := "aProject"
 	return &ovfimportparams.OVFImportParams{
 		InstanceNames:               "instance1",
 		ClientID:                    "aClient",
@@ -736,7 +731,7 @@ func GetAllParams() *ovfimportparams.OVFImportParams {
 		BootDiskKmsLocation:         "aKmsLocation",
 		BootDiskKmsProject:          "aKmsProject",
 		Timeout:                     "3h",
-		Project:                     &project,
+		Project:                     param.CreateUpdatableParam("aProject"),
 		ScratchBucketGcsPath:        "gs://bucket/folder",
 		Oauth:                       "oAuthFilePath",
 		Ce:                          "us-east1-c",

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -153,9 +153,10 @@ func runExportWorkflow(ctx context.Context, exportWorkflowPath string, varMap ma
 
 // Run runs export workflow.
 func Run(clientID string, destinationURI string, sourceImage string, format string,
-	project *string, network string, subnet string, zone string, timeout string,
+	project *param.UpdatableParam, network string, subnet string, zone string, timeout string,
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool,
-	cloudLogsDisabled bool, stdoutLogsDisabled bool, labels string, currentExecutablePath string) (*daisy.Workflow, error) {
+	cloudLogsDisabled bool, stdoutLogsDisabled bool, labels string,
+	currentExecutablePath string) (*daisy.Workflow, error) {
 
 	log.SetPrefix(logPrefix + " ")
 
@@ -190,7 +191,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 	varMap := buildDaisyVars(destinationURI, sourceImage, format, network, subnet, *region)
 
 	var w *daisy.Workflow
-	if w, err = runExportWorkflow(ctx, getWorkflowPath(format, currentExecutablePath), varMap, *project,
+	if w, err = runExportWorkflow(ctx, getWorkflowPath(format, currentExecutablePath), varMap, project.StringValue(),
 		zone, timeout, scratchBucketGcsPath, oauth, ce, gcsLogsDisabled, cloudLogsDisabled,
 		stdoutLogsDisabled, userLabels); err != nil {
 		return w, err

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -275,7 +275,6 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	region := new(string)
 	err = param.PopulateMissingParameters(project, &zone, region, &scratchBucketGcsPath,
 		sourceFile, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
-	project.Update(project)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -242,7 +242,7 @@ func runImport(ctx context.Context, varMap map[string]string, importWorkflowPath
 // Run runs import workflow.
 func Run(clientID string, imageName string, dataDisk bool, osID string, customTranWorkflow string,
 	sourceFile string, sourceImage string, noGuestEnvironment bool, family string, description string,
-	network string, subnet string, zone string, timeout string, project *string,
+	network string, subnet string, zone string, timeout string, project *param.UpdatableParam,
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool, cloudLogsDisabled bool,
 	stdoutLogsDisabled bool, kmsKey string, kmsKeyring string, kmsLocation string, kmsProject string,
 	noExternalIP bool, labels string, currentExecutablePath string, storageLocation string,
@@ -275,6 +275,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	region := new(string)
 	err = param.PopulateMissingParameters(project, &zone, region, &scratchBucketGcsPath,
 		sourceFile, metadataGCE, scratchBucketCreator, zoneRetriever, storageClient)
+	project.Update(project)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 		description, *region, subnet, network, noGuestEnvironment)
 
 	var w *daisy.Workflow
-	if w, err = runImport(ctx, varMap, importWorkflowPath, zone, timeout, *project, scratchBucketGcsPath,
+	if w, err = runImport(ctx, varMap, importWorkflowPath, zone, timeout, project.StringValue(), scratchBucketGcsPath,
 		oauth, ce, gcsLogsDisabled, cloudLogsDisabled, stdoutLogsDisabled, kmsKey, kmsKeyring,
 		kmsLocation, kmsProject, noExternalIP, userLabels, storageLocation, uefiCompatible); err != nil {
 

--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_import_params"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_importer"
@@ -98,7 +99,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/Ubuntu_for_Horizon_three_disks_mounted.ova", ovaBucket),
 				OsID:          "ubuntu-1404",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-1",
 			},
@@ -117,7 +118,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/centos-6.8", ovaBucket),
 				OsID:          "centos-6",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -136,7 +137,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/w2k12-r2", ovaBucket),
 				OsID:          "windows-2012r2",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-8",
 			},
@@ -156,7 +157,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/w2k16/w2k16.ovf", ovaBucket),
 				OsID:          "windows-2016",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 			},
 			name:        fmt.Sprintf("ovf-import-test-w2k16-%s", suffix),
@@ -174,7 +175,7 @@ func TestSuite(
 				InstanceNames: fmt.Sprintf("test-instance-w2k8r2-%v", suffix),
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/win2008r2-all-updates-four-nic.ova", ovaBucket),
 				OsID:          "windows-2008r2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 			},
 			name:        fmt.Sprintf("ovf-import-test-w2k8r2-%s", suffix),
@@ -192,7 +193,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/bitnami-tomcat-8.5.43-0-linux-debian-9-x86_64.ova", ovaBucket),
 				OsID:          "debian-9",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -210,7 +211,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
 				OsID:          "ubuntu-1604",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},
@@ -229,7 +230,7 @@ func TestSuite(
 				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/aws-ova-ubuntu-1604.ova", ovaBucket),
 				OsID:          "ubuntu-1604",
 				Labels:        "lk1=lv1,lk2=kv2",
-				Project:       &testProjectConfig.TestProjectID,
+				Project:       param.CreateUpdatableParam(testProjectConfig.TestProjectID),
 				Zone:          testProjectConfig.TestZone,
 				MachineType:   "n1-standard-4",
 			},


### PR DESCRIPTION
This is a different implementation of https://github.com/GoogleCloudPlatform/compute-image-tools/pull/983

Similarly, it tries to resolve the problem that some parameters have to be updated during the tool is executed.
When I try to adopt some feedbacks from Eric and Zoran, the whole solution became closer to the Eric's proposed one - it's like a mixture of my last implementation and Eric's. Since the shape of the design is quite different from 983, I created a new PR so you can compare them.

1. I removed the abstract class in this version due that it's harder to get a common top-level common code, as well as the abstract class shared pretty few common logic.
2. The key is that I added a "UpdatableParam" (maybe MutableParam is a better name), which replaces param pointer that needs to be updated during the tool's executed. 
3. The "UpdatableParam" is registered in InputParams, so logger.Update can consume.
4. Logically, it collects most of the params at the beginning for "Start" log, while it reflects updatable params after the execution and before "Success/Failure" log.
5. "UpdatableParam" is updated by core importer/exporter.