### PR TITLE
Revert "[Import] Skip bootloader mod when importing GPT boot disk."

### DIFF
--- a/daisy_workflows/image_import/windows/translate_bootstrap.ps1
+++ b/daisy_workflows/image_import/windows/translate_bootstrap.ps1
@@ -147,14 +147,7 @@ try {
   Write-Output 'Copying googet.'
   Copy-Item 'C:\ProgramData\GooGet\googet.exe' "${script:os_drive}\ProgramData\GooGet\googet.exe" -Force -Verbose
 
-  $partition_type = Get-Disk | Select-Object -Expand PartitionStyle
-  if !($partition_type -eq "GPT") {
-    Write-Output 'MBR partition detected. Resetting bootloader.'
-    Run-Command bcdboot "${script:os_drive}\Windows" /s $bcd_drive
-  }
-  else {
-    Write-Output 'GPT partition detected.'
-  }
+  Run-Command bcdboot "${script:os_drive}\Windows" /s $bcd_drive
 
   # Turn off startup animation which breaks headless installation.
   # See http://support.microsoft.com/kb/2955372/en-us


### PR DESCRIPTION
This reverts commit 89fc62638f6db687f7e13fbad29382beeaf7721d.

A syntax error is causing image imports to fail.