### PR TITLE
Allow import to initiate when worker instance doesn't have access to cloud storage.

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -74,7 +74,8 @@
             "block-project-ssh-keys": "true",
             "disk_name": "${disk_name}",
             "scratch_disk_name": "disk-${NAME}-scratch-${ID}",
-            "source_disk_file": "${source_disk_file}"
+            "source_disk_file": "${source_disk_file}",
+            "startup-script": "${SOURCE:import_image.sh}"
           },
           "networkInterfaces": [
             {
@@ -85,8 +86,7 @@
           "Scopes": [
             "https://www.googleapis.com/auth/devstorage.read_write",
             "https://www.googleapis.com/auth/compute"
-          ],
-          "StartupScript": "import_image.sh"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Prior to this, if the default GCE service account didn't have access to GCS, then the user would see "WARNING Failed to download metadata script". With this change, they'll start seeing the customized error messages that we're creating, such as that in #996.

Testing:

1. Disabled GCS access, ran an instance of `import_and_translate.wf.json` with Daisy, and observed that the startup script executed. The import failed at the point of resizing the disk.
2. Re-enabled GCS and confirmed that the import worked as before.
3. Ran OVF import integration tests.