### PR TITLE
Add SQL Server 2019 builds.

### DIFF
--- a/daisy_workflows/image_build/sqlserver/configs/sql_server_2019.ini
+++ b/daisy_workflows/image_build/sqlserver/configs/sql_server_2019.ini
@@ -1,0 +1,267 @@
+;SQL Server 2019 Configuration File
+[OPTIONS]
+
+; Accept SQL Server License terms.
+
+IACCEPTSQLSERVERLICENSETERMS="True"
+
+; By specifying this parameter and accepting Microsoft R Open and Microsoft R Server terms, you acknowledge that you have read and understood the terms of use. 
+
+IACCEPTPYTHONLICENSETERMS="False"
+
+; Specifies a Setup work flow, like INSTALL, UNINSTALL, or UPGRADE. This is a required parameter. 
+
+ACTION="Install"
+
+; By specifying this parameter and accepting Microsoft R Open and Microsoft R Server terms, you acknowledge that you have read and understood the terms of use. 
+
+IACCEPTROPENLICENSETERMS="False"
+
+; Specifies that SQL Server Setup should not display the privacy statement when ran from the command line. 
+
+SUPPRESSPRIVACYSTATEMENTNOTICE="True"
+
+; Use the /ENU parameter to install the English version of SQL Server on your localized Windows operating system. 
+
+ENU="True"
+
+; Setup will not display any user interface. 
+
+QUIET="True"
+
+; Setup will display progress only, without any user interaction. 
+
+QUIETSIMPLE="False"
+
+; Parameter that controls the user interface behavior. Valid values are Normal for the full UI,AutoAdvance for a simplied UI, and EnableUIOnServerCore for bypassing Server Core setup GUI block. 
+
+; UIMODE="Normal"
+
+; Specify whether SQL Server Setup should discover and include product updates. The valid values are True and False or 1 and 0. By default SQL Server Setup will include updates that are found. 
+
+UpdateEnabled="True"
+
+; If this parameter is provided, then this computer will use Microsoft Update to check for updates. 
+
+USEMICROSOFTUPDATE="True"
+
+; Specifies that SQL Server Setup should not display the paid edition notice when ran from the command line. 
+
+SUPPRESSPAIDEDITIONNOTICE="True"
+
+; Specify the location where SQL Server Setup will obtain product updates. The valid values are "MU" to search Microsoft Update, a valid folder path, a relative path such as .\MyUpdates or a UNC share. By default SQL Server Setup will search Microsoft Update or a Windows Update service through the Window Server Update Services. 
+
+UpdateSource="MU"
+
+; Specifies features to install, uninstall, or upgrade. The list of top-level features include SQL, AS, IS, MDS, and Tools. The SQL feature will install the Database Engine, Replication, Full-Text, and Data Quality Services (DQS) server. The Tools feature will install shared components. 
+
+FEATURES=SQLENGINE,REPLICATION,DQ,AS,CONN,IS,BC,SDK,SNAC_SDK
+
+; Displays the command line parameters usage 
+
+HELP="False"
+
+; Specifies that the detailed Setup log should be piped to the console. 
+
+INDICATEPROGRESS="False"
+
+; Specifies that Setup should install into WOW64. This command line argument is not supported on an IA64 or a 32-bit system. 
+
+X86="False"
+
+; Specify a default or named instance. MSSQLSERVER is the default instance for non-Express editions and SQLExpress for Express editions. This parameter is required when installing the SQL Server Database Engine (SQL), or Analysis Services (AS). 
+
+INSTANCENAME="MSSQLSERVER"
+
+; Specify the root installation directory for shared components.  This directory remains unchanged after shared components are already installed. 
+
+INSTALLSHAREDDIR="C:\Program Files\Microsoft SQL Server"
+
+; Specify the root installation directory for the WOW64 shared components.  This directory remains unchanged after WOW64 shared components are already installed. 
+
+INSTALLSHAREDWOWDIR="C:\Program Files (x86)\Microsoft SQL Server"
+
+; Specify the Instance ID for the SQL Server features you have specified. SQL Server directory structure, registry structure, and service names will incorporate the instance ID of the SQL Server instance. 
+
+INSTANCEID="MSSQLSERVER"
+
+; TelemetryUserNameConfigDescription 
+
+SQLTELSVCACCT="NT Service\SQLTELEMETRY"
+
+; TelemetryStartupConfigDescription 
+
+SQLTELSVCSTARTUPTYPE="Automatic"
+
+; ASTelemetryStartupConfigDescription 
+
+ASTELSVCSTARTUPTYPE="Automatic"
+
+; ASTelemetryUserNameConfigDescription 
+
+ASTELSVCACCT="NT Service\SSASTELEMETRY"
+
+; TelemetryStartupConfigDescription 
+
+ISTELSVCSTARTUPTYPE="Automatic"
+
+; TelemetryUserNameConfigDescription 
+
+ISTELSVCACCT="NT Service\SSISTELEMETRY150"
+
+; Specify the installation directory. 
+
+INSTANCEDIR="C:\Program Files\Microsoft SQL Server"
+
+; Agent account name 
+
+AGTSVCACCOUNT="NT Service\SQLSERVERAGENT"
+
+; Auto-start service after installation.  
+
+AGTSVCSTARTUPTYPE="Manual"
+
+; Startup type for Integration Services. 
+
+ISSVCSTARTUPTYPE="Automatic"
+
+; Account for Integration Services: Domain\User or system account. 
+
+ISSVCACCOUNT="NT Service\MsDtsServer150"
+
+; The name of the account that the Analysis Services service runs under. 
+
+ASSVCACCOUNT="NT Service\MSSQLServerOLAPService"
+
+; Controls the service startup type setting after the service has been created. 
+
+ASSVCSTARTUPTYPE="Automatic"
+
+; The collation to be used by Analysis Services. 
+
+ASCOLLATION="Latin1_General_CI_AS"
+
+; The location for the Analysis Services data files. 
+
+ASDATADIR="C:\Program Files\Microsoft SQL Server\MSAS15.MSSQLSERVER\OLAP\Data"
+
+; The location for the Analysis Services log files. 
+
+ASLOGDIR="C:\Program Files\Microsoft SQL Server\MSAS15.MSSQLSERVER\OLAP\Log"
+
+; The location for the Analysis Services backup files. 
+
+ASBACKUPDIR="C:\Program Files\Microsoft SQL Server\MSAS15.MSSQLSERVER\OLAP\Backup"
+
+; The location for the Analysis Services temporary files. 
+
+ASTEMPDIR="C:\Program Files\Microsoft SQL Server\MSAS15.MSSQLSERVER\OLAP\Temp"
+
+; The location for the Analysis Services configuration files. 
+
+ASCONFIGDIR="C:\Program Files\Microsoft SQL Server\MSAS15.MSSQLSERVER\OLAP\Config"
+
+; Specifies whether or not the MSOLAP provider is allowed to run in process. 
+
+ASPROVIDERMSOLAP="1"
+
+; Specifies the list of administrator accounts that need to be provisioned. 
+
+ASSYSADMINACCOUNTS="BUILTIN\Users"
+
+; Specifies the server mode of the Analysis Services instance. Valid values are MULTIDIMENSIONAL and TABULAR. The default value is TABULAR. 
+
+ASSERVERMODE="MULTIDIMENSIONAL"
+
+; CM brick TCP communication port 
+
+COMMFABRICPORT="0"
+
+; How matrix will use private networks 
+
+COMMFABRICNETWORKLEVEL="0"
+
+; How inter brick communication will be protected 
+
+COMMFABRICENCRYPTION="0"
+
+; TCP port used by the CM brick 
+
+MATRIXCMBRICKCOMMPORT="0"
+
+; Startup type for the SQL Server service. 
+
+SQLSVCSTARTUPTYPE="Automatic"
+
+; Level to enable FILESTREAM feature at (0, 1, 2 or 3). 
+
+FILESTREAMLEVEL="0"
+
+; The max degree of parallelism (MAXDOP) server configuration option. 
+
+SQLMAXDOP="4"
+
+; Set to "1" to enable RANU for SQL Server Express. 
+
+ENABLERANU="False"
+
+; Specifies a Windows collation or an SQL collation to use for the Database Engine. 
+
+SQLCOLLATION="SQL_Latin1_General_CP1_CI_AS"
+
+; Account for SQL Server service: Domain\User or system account. 
+
+SQLSVCACCOUNT="NT Service\MSSQLSERVER"
+
+; Set to "True" to enable instant file initialization for SQL Server service. If enabled, Setup will grant Perform Volume Maintenance Task privilege to the Database Engine Service SID. This may lead to information disclosure as it could allow deleted content to be accessed by an unauthorized principal. 
+
+SQLSVCINSTANTFILEINIT="False"
+
+; Windows account(s) to provision as SQL Server system administrators. 
+
+SQLSYSADMINACCOUNTS="BUILTIN\Users"
+
+; The number of Database Engine TempDB files. 
+
+SQLTEMPDBFILECOUNT="4"
+
+; Specifies the initial size of a Database Engine TempDB data file in MB. 
+
+SQLTEMPDBFILESIZE="8"
+
+; Specifies the automatic growth increment of each Database Engine TempDB data file in MB. 
+
+SQLTEMPDBFILEGROWTH="64"
+
+; Specifies the initial size of the Database Engine TempDB log file in MB. 
+
+SQLTEMPDBLOGFILESIZE="8"
+
+; Specifies the automatic growth increment of the Database Engine TempDB log file in MB. 
+
+SQLTEMPDBLOGFILEGROWTH="64"
+
+; Provision current user as a Database Engine system administrator for %SQL_PRODUCT_SHORT_NAME% Express. 
+
+ADDCURRENTUSERASSQLADMIN="False"
+
+; Specify 0 to disable or 1 to enable the TCP/IP protocol. 
+
+TCPENABLED="1"
+
+; Specify 0 to disable or 1 to enable the Named Pipes protocol. 
+
+NPENABLED="0"
+
+; Startup type for Browser Service. 
+
+BROWSERSVCSTARTUPTYPE="Disabled"
+
+; Use SQLMAXMEMORY to minimize the risk of the OS experiencing detrimental memory pressure. 
+
+SQLMAXMEMORY="2147483647"
+
+; Use SQLMINMEMORY to reserve a minimum amount of memory available to the SQL Server Memory Manager. 
+
+SQLMINMEMORY="0"
+

--- a/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2019-enterprise-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2019.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2019-enterprise-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2019-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
+          "Family": "sql-ent-2019-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2019-standard-windows-2019-dc-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2019.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2019-standard-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2019-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
+          "Family": "sql-std-2019-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019-dc.wf.json
@@ -1,0 +1,46 @@
+{
+  "Name": "sql-2019-web-windows-2019-dc-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "70m",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2019.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2019-web-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2019-web"
+          ],
+          "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2019, x64 built on ${build_date}",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
+          "Family": "sql-web-2019-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}


### PR DESCRIPTION
- Enterprise, Standard, and Web versions, all on Windows Server 2019.
- Attempt to match the SQL Server config for our 2017 builds.