### PR TITLE
Default for import_license 

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -28,7 +28,7 @@
       "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
     },
     "import_license": {
-      "Value": "",
+      "Value": "projects/compute-image-tools/global/licenses/virtual-disk-import",
       "Description": "Import License used for tracking migration workflow use."
     }
   },


### PR DESCRIPTION
Default for import_license to avoid create disk API failures if empty string is provided for a license.