### PR TITLE
OVF Import: data disk steps to use workflow default timeout

### DIFF
--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -48,7 +48,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		diskImporterDiskName := fmt.Sprintf("disk-importer-%v", dataDiskIndex)
 		scratchDiskDiskName := fmt.Sprintf("disk-importer-scratch-%v-%v", dataDiskIndex, w.Vars["instance_name"].Value)
 
-		setupDataDiskStep := daisy.NewStep(setupDataDiskStepName, w, 0)
+		setupDataDiskStep := daisy.NewStepDefaultTimeout(setupDataDiskStepName, w, 0)
 		setupDataDiskStep.CreateDisks = &daisy.CreateDisks{
 			{
 				Disk: compute.Disk{
@@ -83,7 +83,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[setupDataDiskStepName] = setupDataDiskStep
 
 		createDiskImporterInstanceStepName := fmt.Sprintf("create-data-disk-import-instance-%v", dataDiskIndex)
-		createDiskImporterInstanceStep := daisy.NewStep(createDiskImporterInstanceStepName, w, 0)
+		createDiskImporterInstanceStep := daisy.NewStepDefaultTimeout(createDiskImporterInstanceStepName, w, 0)
 
 		sTrue := "true"
 		dataDiskImporterInstanceName := fmt.Sprintf("data-disk-importer-%v", dataDiskIndex)
@@ -121,7 +121,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[createDiskImporterInstanceStepName] = createDiskImporterInstanceStep
 
 		waitForDataDiskImportInstanceSignalStepName := fmt.Sprintf("wait-for-data-disk-%v-signal", dataDiskIndex)
-		waitForDataDiskImportInstanceSignalStep := daisy.NewStep(waitForDataDiskImportInstanceSignalStepName, w, 0)
+		waitForDataDiskImportInstanceSignalStep := daisy.NewStepDefaultTimeout(waitForDataDiskImportInstanceSignalStepName, w, 0)
 		waitForDataDiskImportInstanceSignalStep.WaitForInstancesSignal = &daisy.WaitForInstancesSignal{
 			{
 				Name: dataDiskImporterInstanceName,
@@ -136,7 +136,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[waitForDataDiskImportInstanceSignalStepName] = waitForDataDiskImportInstanceSignalStep
 
 		deleteDataDiskImportInstanceSignalStepName := fmt.Sprintf("delete-data-disk-%v-import-instance", dataDiskIndex)
-		deleteDataDiskImportInstanceSignalStep := daisy.NewStep(deleteDataDiskImportInstanceSignalStepName, w, 0)
+		deleteDataDiskImportInstanceSignalStep := daisy.NewStepDefaultTimeout(deleteDataDiskImportInstanceSignalStepName, w, 0)
 		deleteDataDiskImportInstanceSignalStep.DeleteResources = &daisy.DeleteResources{
 			Instances: []string{dataDiskImporterInstanceName},
 		}

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -48,7 +48,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		diskImporterDiskName := fmt.Sprintf("disk-importer-%v", dataDiskIndex)
 		scratchDiskDiskName := fmt.Sprintf("disk-importer-scratch-%v-%v", dataDiskIndex, w.Vars["instance_name"].Value)
 
-		setupDataDiskStep := daisy.NewStepDefaultTimeout(setupDataDiskStepName, w, 0)
+		setupDataDiskStep := daisy.NewStepDefaultTimeout(setupDataDiskStepName, w)
 		setupDataDiskStep.CreateDisks = &daisy.CreateDisks{
 			{
 				Disk: compute.Disk{
@@ -83,7 +83,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[setupDataDiskStepName] = setupDataDiskStep
 
 		createDiskImporterInstanceStepName := fmt.Sprintf("create-data-disk-import-instance-%v", dataDiskIndex)
-		createDiskImporterInstanceStep := daisy.NewStepDefaultTimeout(createDiskImporterInstanceStepName, w, 0)
+		createDiskImporterInstanceStep := daisy.NewStepDefaultTimeout(createDiskImporterInstanceStepName, w)
 
 		sTrue := "true"
 		dataDiskImporterInstanceName := fmt.Sprintf("data-disk-importer-%v", dataDiskIndex)
@@ -121,7 +121,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[createDiskImporterInstanceStepName] = createDiskImporterInstanceStep
 
 		waitForDataDiskImportInstanceSignalStepName := fmt.Sprintf("wait-for-data-disk-%v-signal", dataDiskIndex)
-		waitForDataDiskImportInstanceSignalStep := daisy.NewStepDefaultTimeout(waitForDataDiskImportInstanceSignalStepName, w, 0)
+		waitForDataDiskImportInstanceSignalStep := daisy.NewStepDefaultTimeout(waitForDataDiskImportInstanceSignalStepName, w)
 		waitForDataDiskImportInstanceSignalStep.WaitForInstancesSignal = &daisy.WaitForInstancesSignal{
 			{
 				Name: dataDiskImporterInstanceName,
@@ -136,7 +136,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[waitForDataDiskImportInstanceSignalStepName] = waitForDataDiskImportInstanceSignalStep
 
 		deleteDataDiskImportInstanceSignalStepName := fmt.Sprintf("delete-data-disk-%v-import-instance", dataDiskIndex)
-		deleteDataDiskImportInstanceSignalStep := daisy.NewStepDefaultTimeout(deleteDataDiskImportInstanceSignalStepName, w, 0)
+		deleteDataDiskImportInstanceSignalStep := daisy.NewStepDefaultTimeout(deleteDataDiskImportInstanceSignalStepName, w)
 		deleteDataDiskImportInstanceSignalStep.DeleteResources = &daisy.DeleteResources{
 			Instances: []string{dataDiskImporterInstanceName},
 		}

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -16,7 +16,6 @@ package daisyovfutils
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_utils"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
@@ -26,7 +25,6 @@ import (
 const (
 	createInstanceStepName = "create-instance"
 	importerDiskSize       = "10"
-	dataDiskImportTimeout  = "3600s"
 )
 
 // AddDiskImportSteps adds Daisy steps to OVF import workflow to import disks defined in
@@ -50,7 +48,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		diskImporterDiskName := fmt.Sprintf("disk-importer-%v", dataDiskIndex)
 		scratchDiskDiskName := fmt.Sprintf("disk-importer-scratch-%v-%v", dataDiskIndex, w.Vars["instance_name"].Value)
 
-		setupDataDiskStep := daisy.NewStep(setupDataDiskStepName, w, time.Hour)
+		setupDataDiskStep := daisy.NewStep(setupDataDiskStepName, w, 0)
 		setupDataDiskStep.CreateDisks = &daisy.CreateDisks{
 			{
 				Disk: compute.Disk{
@@ -85,7 +83,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[setupDataDiskStepName] = setupDataDiskStep
 
 		createDiskImporterInstanceStepName := fmt.Sprintf("create-data-disk-import-instance-%v", dataDiskIndex)
-		createDiskImporterInstanceStep := daisy.NewStep(createDiskImporterInstanceStepName, w, time.Hour)
+		createDiskImporterInstanceStep := daisy.NewStep(createDiskImporterInstanceStepName, w, 0)
 
 		sTrue := "true"
 		dataDiskImporterInstanceName := fmt.Sprintf("data-disk-importer-%v", dataDiskIndex)
@@ -123,8 +121,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[createDiskImporterInstanceStepName] = createDiskImporterInstanceStep
 
 		waitForDataDiskImportInstanceSignalStepName := fmt.Sprintf("wait-for-data-disk-%v-signal", dataDiskIndex)
-		waitForDataDiskImportInstanceSignalStep := daisy.NewStep(waitForDataDiskImportInstanceSignalStepName, w, time.Hour)
-		waitForDataDiskImportInstanceSignalStep.Timeout = dataDiskImportTimeout
+		waitForDataDiskImportInstanceSignalStep := daisy.NewStep(waitForDataDiskImportInstanceSignalStepName, w, 0)
 		waitForDataDiskImportInstanceSignalStep.WaitForInstancesSignal = &daisy.WaitForInstancesSignal{
 			{
 				Name: dataDiskImporterInstanceName,
@@ -139,7 +136,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		w.Steps[waitForDataDiskImportInstanceSignalStepName] = waitForDataDiskImportInstanceSignalStep
 
 		deleteDataDiskImportInstanceSignalStepName := fmt.Sprintf("delete-data-disk-%v-import-instance", dataDiskIndex)
-		deleteDataDiskImportInstanceSignalStep := daisy.NewStep(deleteDataDiskImportInstanceSignalStepName, w, time.Hour)
+		deleteDataDiskImportInstanceSignalStep := daisy.NewStep(deleteDataDiskImportInstanceSignalStepName, w, 0)
 		deleteDataDiskImportInstanceSignalStep.DeleteResources = &daisy.DeleteResources{
 			Instances: []string{dataDiskImporterInstanceName},
 		}

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
@@ -27,6 +27,7 @@ func TestAddDiskImportSteps(t *testing.T) {
 
 	w := daisy.New()
 	w.Vars["instance_name"] = daisy.Var{Value: "an_instance"}
+	w.DefaultTimeout = "180m"
 
 	diskInfos := []ovfutils.DiskInfo{
 		{FilePath: "gs://abucket/apath/disk1.vmdk", SizeInGB: 20},
@@ -111,8 +112,15 @@ func TestAddDiskImportSteps(t *testing.T) {
 	assert.Equal(t, diskInfos[0].FilePath, getMetadataValue((*w.Steps["create-data-disk-import-instance-1"].CreateInstances)[0].Instance.Metadata, "source_disk_file"))
 	assert.Equal(t, diskInfos[1].FilePath, getMetadataValue((*w.Steps["create-data-disk-import-instance-2"].CreateInstances)[0].Instance.Metadata, "source_disk_file"))
 
-	//TODO: further assertion to validate the workflow if deemed necessary
+	assert.Equal(t, w.DefaultTimeout, w.Steps["setup-data-disk-1"].Timeout)
+	assert.Equal(t, w.DefaultTimeout, w.Steps["create-data-disk-import-instance-1"].Timeout)
+	assert.Equal(t, w.DefaultTimeout, w.Steps["wait-for-data-disk-1-signal"].Timeout)
+	assert.Equal(t, w.DefaultTimeout, w.Steps["delete-data-disk-1-import-instance"].Timeout)
 
+	assert.Equal(t, w.DefaultTimeout, w.Steps["setup-data-disk-2"].Timeout)
+	assert.Equal(t, w.DefaultTimeout, w.Steps["create-data-disk-import-instance-2"].Timeout)
+	assert.Equal(t, w.DefaultTimeout, w.Steps["wait-for-data-disk-2-signal"].Timeout)
+	assert.Equal(t, w.DefaultTimeout, w.Steps["delete-data-disk-2-import-instance"].Timeout)
 }
 
 func getMetadataValue(metadata *compute.Metadata, key string) string {

--- a/daisy/step.go
+++ b/daisy/step.go
@@ -69,8 +69,12 @@ type Step struct {
 	testType stepImpl
 }
 
-// NewStep creates a Step with given name and timeout  with the specified workflow
+// NewStep creates a Step with given name and timeout  with the specified workflow.
+// If timeout is less or equal to zero, defaultTimeout from the workflow will be used
 func NewStep(name string, w *Workflow, timeout time.Duration) *Step {
+	if timeout <= 0 {
+		return &Step{name: name, w: w, Timeout: w.DefaultTimeout}
+	}
 	return &Step{name: name, w: w, timeout: timeout}
 }
 

--- a/daisy/step.go
+++ b/daisy/step.go
@@ -69,13 +69,18 @@ type Step struct {
 	testType stepImpl
 }
 
-// NewStep creates a Step with given name and timeout  with the specified workflow.
+// NewStep creates a Step with given name and timeout with the specified workflow.
 // If timeout is less or equal to zero, defaultTimeout from the workflow will be used
 func NewStep(name string, w *Workflow, timeout time.Duration) *Step {
 	if timeout <= 0 {
 		return &Step{name: name, w: w, Timeout: w.DefaultTimeout}
 	}
 	return &Step{name: name, w: w, timeout: timeout}
+}
+
+// NewStepDefaultTimeout creates a Step with given name using default timeout from the workflow
+func NewStepDefaultTimeout(name string, w *Workflow, timeout time.Duration) *Step {
+	return NewStep(name, w, 0)
 }
 
 func (s *Step) stepImpl() (stepImpl, DError) {

--- a/daisy/step.go
+++ b/daisy/step.go
@@ -79,7 +79,7 @@ func NewStep(name string, w *Workflow, timeout time.Duration) *Step {
 }
 
 // NewStepDefaultTimeout creates a Step with given name using default timeout from the workflow
-func NewStepDefaultTimeout(name string, w *Workflow, timeout time.Duration) *Step {
+func NewStepDefaultTimeout(name string, w *Workflow) *Step {
 	return NewStep(name, w, 0)
 }
 


### PR DESCRIPTION
OVF Import: data disk steps to use workflow default timeout instead of timeout being hardcoded to 1hr