### PR TITLE
Image import: Detect and fail if import worker is terminated.

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -80,6 +80,7 @@
             "disk_name": "${disk_name}",
             "scratch_disk_name": "disk-${NAME}-scratch-${ID}",
             "source_disk_file": "${source_disk_file}",
+            "shutdown-script": "echo 'Worker instance terminated'",
             "startup-script": "${SOURCE:import_image.sh}"
           },
           "networkInterfaces": [
@@ -102,7 +103,11 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "ImportSuccess:",
-            "FailureMatch": ["ImportFailed:", "WARNING Failed to download metadata script"],
+            "FailureMatch": [
+              "ImportFailed:",
+              "WARNING Failed to download metadata script",
+              "Worker instance terminated"
+            ],
             "StatusMatch": "Import:"
           }
         }


### PR DESCRIPTION
### Background:

Importing images depends on worker instances that run with user's GCP project. If the instance is shutdown, then currently then the import workflow fails with 'WaitForInstancesSignal: instance %q: error getting serial port'.

This is a two-fold problem: First, it's a confusing message to users. Second, it adds noise to our metrics.

### Solution

Use `shutdown-script` to send a sentinel message. If this message is detected before `ImportSuccess|ImportFailed`, then we know the worker instance is being terminated prior to the end of the import workflow.

### Testing:

1. For OVF and VMDK import, started an import, killed the worker, and observed that daisy correctly identified the shutdown worker and started the cleanup process.
2. Running `gce_ovf_import_tests`; I'll wait for these to finish prior to pushing.