### PR TITLE
OVF Import: limit disk names to 63 characters

### DIFF
--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -22,7 +22,9 @@ import (
 )
 
 var (
-	fqdnRegexp = regexp.MustCompile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$")
+	rfc1035LabelRegexpStr = "[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]"
+	rfc1035LabelRegexp    = regexp.MustCompile(rfc1035LabelRegexpStr)
+	fqdnRegexp            = regexp.MustCompile(fmt.Sprintf("^((%v)\\.)+(%v)$", rfc1035LabelRegexpStr, rfc1035LabelRegexpStr))
 )
 
 // ValidateStringFlagNotEmpty returns error with error message stating field must be provided if
@@ -41,6 +43,13 @@ func ValidateFqdn(flagValue string, flagKey string) error {
 		return daisy.Errf(fmt.Sprintf("The flag `%v` must conform to RFC 1035 requirements for valid hostnames. "+
 			"To meet this requirement, the value must contain a series of labels and each label is concatenated with a dot."+
 			"Each label can be 1-63 characters long, and the entire sequence must not exceed 253 characters.", flagKey))
+	}
+	return nil
+}
+
+func ValidateRfc1035Label(value string) error {
+	if len(value) > 63 || !rfc1035LabelRegexp.MatchString(value) {
+		return daisy.Errf(fmt.Sprintf("Value `%v` must conform to RFC 1035 requirements for valid labels.", value))
 	}
 	return nil
 }

--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -47,6 +47,7 @@ func ValidateFqdn(flagValue string, flagKey string) error {
 	return nil
 }
 
+// ValidateRfc1035Label validates a single label per RFC 1035
 func ValidateRfc1035Label(value string) error {
 	if len(value) > 63 || !rfc1035LabelRegexp.MatchString(value) {
 		return daisy.Errf(fmt.Sprintf("Value `%v` must conform to RFC 1035 requirements for valid labels.", value))

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
@@ -17,6 +17,7 @@ package daisyovfutils
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/validation"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_import/ovf_utils"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/stretchr/testify/assert"
@@ -24,46 +25,10 @@ import (
 )
 
 func TestAddDiskImportSteps(t *testing.T) {
-
-	w := daisy.New()
-	w.Vars["instance_name"] = daisy.Var{Value: "an_instance"}
-	w.DefaultTimeout = "180m"
-
+	w := createBaseImportWorkflow("an_instance")
 	diskInfos := []ovfutils.DiskInfo{
 		{FilePath: "gs://abucket/apath/disk1.vmdk", SizeInGB: 20},
 		{FilePath: "gs://abucket/apath/disk2.vmdk", SizeInGB: 1},
-	}
-
-	w.Steps = map[string]*daisy.Step{
-		"create-boot-disk": {
-			CreateDisks: &daisy.CreateDisks{
-				{
-					Disk: compute.Disk{
-						Name:        "instance-boot-disk",
-						SourceImage: "source_image",
-						Type:        "pd-ssd",
-					},
-				},
-			},
-		},
-		"create-instance": {
-			CreateInstances: &daisy.CreateInstances{
-				{
-					Instance: compute.Instance{
-						Disks:  []*compute.AttachedDisk{{Source: "boot_disk", Boot: true}},
-						Labels: map[string]string{"labelKey": "labelValue"},
-					},
-				},
-				{
-					Instance: compute.Instance{
-						Disks: []*compute.AttachedDisk{{Source: "key2"}},
-					},
-				},
-			},
-		},
-	}
-	w.Dependencies = map[string][]string{
-		"create-instance": {"create-boot-disk"},
 	}
 
 	AddDiskImportSteps(w, diskInfos)
@@ -104,8 +69,8 @@ func TestAddDiskImportSteps(t *testing.T) {
 	assert.Equal(t,
 		[]*compute.AttachedDisk{
 			{Source: "boot_disk", Boot: true},
-			{Source: "an_instance-data-disk-1", AutoDelete: true},
-			{Source: "an_instance-data-disk-2", AutoDelete: true},
+			{Source: "an_instance-1", AutoDelete: true},
+			{Source: "an_instance-2", AutoDelete: true},
 		},
 		(*w.Steps[createInstanceStepName].CreateInstances)[0].Disks)
 
@@ -122,6 +87,29 @@ func TestAddDiskImportSteps(t *testing.T) {
 	assert.Equal(t, w.DefaultTimeout, w.Steps["wait-for-data-disk-2-signal"].Timeout)
 	assert.Equal(t, w.DefaultTimeout, w.Steps["delete-data-disk-2-import-instance"].Timeout)
 }
+func TestAddDiskImportStepsLongInstanceName(t *testing.T) {
+	w := createBaseImportWorkflow("a-very-long-instance-name-that-is-at-the-limit-of-allowed-leng")
+
+	diskInfos := []ovfutils.DiskInfo{
+		{FilePath: "gs://abucket/apath/disk1.vmdk", SizeInGB: 20},
+		{FilePath: "gs://abucket/apath/disk2.vmdk", SizeInGB: 1},
+	}
+	AddDiskImportSteps(w, diskInfos)
+
+	assert.NotNil(t, w)
+	assert.Equal(t, 2+4*len(diskInfos), len(w.Steps))
+
+	assert.NotNil(t, w.Steps["setup-data-disk-1"])
+	assert.NotNil(t, w.Steps["setup-data-disk-2"])
+
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-1"].CreateDisks)[0].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-1"].CreateDisks)[1].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-1"].CreateDisks)[2].Name))
+
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-2"].CreateDisks)[0].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-2"].CreateDisks)[1].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-2"].CreateDisks)[2].Name))
+}
 
 func getMetadataValue(metadata *compute.Metadata, key string) string {
 	for _, metadataItem := range metadata.Items {
@@ -130,4 +118,43 @@ func getMetadataValue(metadata *compute.Metadata, key string) string {
 		}
 	}
 	return ""
+}
+
+func createBaseImportWorkflow(instanceName string) *daisy.Workflow {
+	w := daisy.New()
+	w.Vars["instance_name"] = daisy.Var{Value: instanceName}
+	w.DefaultTimeout = "180m"
+
+	w.Steps = map[string]*daisy.Step{
+		"create-boot-disk": {
+			CreateDisks: &daisy.CreateDisks{
+				{
+					Disk: compute.Disk{
+						Name:        "instance-boot-disk",
+						SourceImage: "source_image",
+						Type:        "pd-ssd",
+					},
+				},
+			},
+		},
+		"create-instance": {
+			CreateInstances: &daisy.CreateInstances{
+				{
+					Instance: compute.Instance{
+						Disks:  []*compute.AttachedDisk{{Source: "boot_disk", Boot: true}},
+						Labels: map[string]string{"labelKey": "labelValue"},
+					},
+				},
+				{
+					Instance: compute.Instance{
+						Disks: []*compute.AttachedDisk{{Source: "key2"}},
+					},
+				},
+			},
+		},
+	}
+	w.Dependencies = map[string][]string{
+		"create-instance": {"create-boot-disk"},
+	}
+	return w
 }

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
@@ -34,6 +34,10 @@ func TestAddDiskImportSteps(t *testing.T) {
 	AddDiskImportSteps(w, diskInfos)
 
 	assert.NotNil(t, w)
+
+	// 2 for create boot disk step and create instance from the base workflow
+	// 4 for each disk (setup-data-disk, create-data-disk-import-instance,
+	// wait-for-data-disk-signal and delete-data-disk-import-instance)
 	assert.Equal(t, 2+4*len(diskInfos), len(w.Steps))
 
 	assert.NotNil(t, w.Steps["setup-data-disk-1"])
@@ -86,8 +90,17 @@ func TestAddDiskImportSteps(t *testing.T) {
 	assert.Equal(t, w.DefaultTimeout, w.Steps["create-data-disk-import-instance-2"].Timeout)
 	assert.Equal(t, w.DefaultTimeout, w.Steps["wait-for-data-disk-2-signal"].Timeout)
 	assert.Equal(t, w.DefaultTimeout, w.Steps["delete-data-disk-2-import-instance"].Timeout)
+
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-1"].CreateDisks)[0].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-1"].CreateDisks)[1].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-1"].CreateDisks)[2].Name))
+
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-2"].CreateDisks)[0].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-2"].CreateDisks)[1].Name))
+	assert.NoError(t, validation.ValidateRfc1035Label((*w.Steps["setup-data-disk-2"].CreateDisks)[2].Name))
 }
-func TestAddDiskImportStepsLongInstanceName(t *testing.T) {
+
+func TestAddDiskImportStepsDiskNamesValidWhenInstanceNameLong(t *testing.T) {
 	w := createBaseImportWorkflow("a-very-long-instance-name-that-is-at-the-limit-of-allowed-leng")
 
 	diskInfos := []ovfutils.DiskInfo{

--- a/daisy_workflows/ovf_import/import_ovf.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf.wf.json
@@ -76,7 +76,7 @@
     "create-boot-disk": {
       "CreateDisks": [
         {
-          "Name": "${instance_name}-boot-disk",
+          "Name": "${instance_name}",
           "SourceImage": "${boot_image_name}",
           "Type": "pd-ssd",
           "ExactName": true,
@@ -91,7 +91,7 @@
           "Name": "${instance_name}",
           "Disks": [
             {
-              "Source": "${instance_name}-boot-disk",
+              "Source": "${instance_name}",
               "AutoDelete": true,
               "boot": true
             }


### PR DESCRIPTION
OVF Import: limit disk names to 63 characters to prevent failures when long instance name is provided.