### PR TITLE
[daisy] fix unit test: some tests failed in specific time zones; some failed without default credential

### DIFF
--- a/daisy/logger_test.go
+++ b/daisy/logger_test.go
@@ -67,7 +67,7 @@ func TestWriteWorkflowInfo(t *testing.T) {
 	w.Logger.(*daisyLog).gcsLogWriter.Flush()
 
 	got := b.String()
-	want := "\\[Test\\]: \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(-\\d{2}:\\d{2})|Z test a"
+	want := "\\[Test\\]: \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}([+-]\\d{2}:\\d{2})|Z test a"
 	match, err := regexp.MatchString(want, got)
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +89,7 @@ func TestWriteStepInfo(t *testing.T) {
 	w.Logger.Flush()
 
 	got := b.String()
-	want := "\\[Test.StepName\\]: \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(-\\d{2}:\\d{2})|Z StepType: test a"
+	want := "\\[Test.StepName\\]: \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}([+-]\\d{2}:\\d{2})|Z StepType: test a"
 	match, _ := regexp.MatchString(want, got)
 	if !match {
 		t.Errorf("Wanted to match %s, got %s", want, got)

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -884,46 +884,52 @@ func TestPopulateClients(t *testing.T) {
 	w := testWorkflow()
 
 	initialComputeClient := w.ComputeClient
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.ComputeClient != initialComputeClient {
 		t.Errorf("Should not repopulate compute client.")
 	}
 
 	w.ComputeClient = nil
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.ComputeClient == nil {
 		t.Errorf("Did not populate compute client.")
 	}
 
 	initialStorageClient := w.StorageClient
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.StorageClient != initialStorageClient {
 		t.Errorf("Should not repopulate storage client.")
 	}
 
 	w.StorageClient = nil
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.StorageClient == nil {
 		t.Errorf("Did not populate storage client.")
 	}
 
 	initialCloudLoggingClient := w.cloudLoggingClient
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.cloudLoggingClient != initialCloudLoggingClient {
 		t.Errorf("Should not repopulate logging client.")
 	}
 
 	w.cloudLoggingClient = nil
 	w.externalLogging = false
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.cloudLoggingClient != nil {
 		t.Errorf("Should not populate Cloud Logging client.")
 	}
 
 	w.cloudLoggingClient = nil
 	w.externalLogging = true
-	w.PopulateClients(context.Background())
+	tryPopulateClients(t, w)
 	if w.cloudLoggingClient == nil {
 		t.Errorf("Did not populate Cloud Logging client.")
+	}
+}
+
+func tryPopulateClients(t *testing.T, w *Workflow) {
+	if err := w.PopulateClients(context.Background()); err != nil {
+		t.Errorf("Failed to populate clients for workflow: %v", err)
 	}
 }


### PR DESCRIPTION
[daisy] fix unit test
Some tests failed in specific time zones. The "expect" regex expect a GMT-x time zone, but, for example, China is in GMT+8, which doesn't match the regex.

Some failed without default credential. So, especially on a new setup machine, the test will fail without a meaningful hint message. I added the output for the error so developer can hae an idea what's going on.