### PR TITLE
Fixes for handling GCS paths

### DIFF
--- a/cli_tools/common/utils/storage/scratch_bucket_creator.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator.go
@@ -81,7 +81,7 @@ func (c *ScratchBucketCreator) getBucketAttrs(fileGcsPath string, project string
 func (c *ScratchBucketCreator) getBucketAttrsFromInputFile(fileGcsPath string, project string,
 	fallbackZone string) (*storage.BucketAttrs, error) {
 
-	fileBucket, _, err := SplitGCSPath(fileGcsPath)
+	fileBucket, err := GetBucketNameFromGCSPath(fileGcsPath)
 	if err != nil || fileBucket == "" {
 		return nil, daisy.Errf("file GCS path `%v` is invalid: %v", fileGcsPath, err)
 	}

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	bucketNameRegex = `[a-z0-9][-_.a-z0-9]*`
-	gsPathRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://(%s\/?)(.*)$`, bucketNameRegex))
+	gsPathRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://(%s)(\/.*)?$`, bucketNameRegex))
 )
 
 // Client implements domain.StorageClientInterface. It implements main Storage functions
@@ -191,7 +191,7 @@ func (sc *Client) Close() error {
 func SplitGCSPath(p string) (string, string, error) {
 	matches := gsPathRegex.FindStringSubmatch(p)
 	if matches != nil {
-		return strings.TrimRight(matches[1], "/"), matches[2], nil
+		return matches[1], strings.TrimLeft(matches[2], "/"), nil
 	}
 
 	return "", "", daisy.Errf("%q is not a valid Cloud Storage path", p)

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	bucketNameRegex = `([a-z0-9][-_.a-z0-9]*)`
-	gsPathRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://%s/?(.*)$`, bucketNameRegex))
+	bucketNameRegex = `[a-z0-9][-_.a-z0-9]*`
+	gsPathRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://(%s\/?)(.*)$`, bucketNameRegex))
 )
 
 // Client implements domain.StorageClientInterface. It implements main Storage functions
@@ -191,7 +191,7 @@ func (sc *Client) Close() error {
 func SplitGCSPath(p string) (string, string, error) {
 	matches := gsPathRegex.FindStringSubmatch(p)
 	if matches != nil {
-		return matches[1], matches[2], nil
+		return strings.TrimRight(matches[1], "/"), matches[2], nil
 	}
 
 	return "", "", daisy.Errf("%q is not a valid Cloud Storage path", p)

--- a/cli_tools/common/utils/storage/storage_client_test.go
+++ b/cli_tools/common/utils/storage/storage_client_test.go
@@ -268,6 +268,18 @@ func TestSplitGCSPathBucketOnlyNoTrailingSlash(t *testing.T) {
 	assert.Equal(t, "", object)
 }
 
+func TestSplitGCSPathObjectNameNonLetters(t *testing.T) {
+	bucket, object, err := SplitGCSPath("gs://bucket_name/|||")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "|||", object)
+}
+
+func TestSplitGCSPathOErrorOnMissingSlashWhenObjectNameNonLetters(t *testing.T) {
+	_, _, err := SplitGCSPath("gs://bucket_name|||")
+	assert.NotNil(t, err)
+}
+
 func TestSplitGCSPathErrorOnNoBucket(t *testing.T) {
 	_, _, err := SplitGCSPath("gs://")
 	assert.NotNil(t, err)

--- a/cli_tools/common/utils/storage/storage_client_test.go
+++ b/cli_tools/common/utils/storage/storage_client_test.go
@@ -195,3 +195,119 @@ func TestFindGcsFileErrorWhileIteratingThroughFilesInPath(t *testing.T) {
 	assert.Nil(t, objectHandle)
 	assert.NotNil(t, err)
 }
+
+func TestGetBucketNameFromGCSPathObjectInFolderPath(t *testing.T) {
+	result, err := GetBucketNameFromGCSPath("gs://bucket_name/folder_name/object_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", result)
+}
+
+func TestGetBucketNameFromGCSPathObjectPath(t *testing.T) {
+	result, err := GetBucketNameFromGCSPath("gs://bucket_name/object_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", result)
+}
+
+func TestGetBucketNameFromGCSPathBucketOnlyWithTrailingSlash(t *testing.T) {
+	result, err := GetBucketNameFromGCSPath("gs://bucket_name/")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", result)
+}
+
+func TestGetBucketNameFromGCSPathBucketOnlyWithNoTrailingSlash(t *testing.T) {
+	result, err := GetBucketNameFromGCSPath("gs://bucket_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", result)
+}
+
+func TestGetBucketNameFromGCSPathBucketErrorWhenNoBucketName(t *testing.T) {
+	_, err := GetBucketNameFromGCSPath("gs://")
+	assert.NotNil(t, err)
+}
+
+func TestGetBucketNameFromGCSPathBucketErrorWhenNoBucketNameTrailingSlash(t *testing.T) {
+	_, err := GetBucketNameFromGCSPath("gs:///")
+	assert.NotNil(t, err)
+}
+
+func TestGetBucketNameFromGCSPathBucketErrorWhenNoBucketNameWithObjectName(t *testing.T) {
+	_, err := GetBucketNameFromGCSPath("gs:///object_name")
+	assert.NotNil(t, err)
+}
+
+func TestGetBucketNameFromGCSPathBucketErrorOnInvalidPath(t *testing.T) {
+	_, err := GetBucketNameFromGCSPath("NOT_A_GCS_PATH")
+	assert.NotNil(t, err)
+}
+
+func TestSplitGCSPathObjectInFolder(t *testing.T) {
+	bucket, object, err := SplitGCSPath("gs://bucket_name/folder_name/object_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "folder_name/object_name", object)
+}
+
+func TestSplitGCSPathObjectDirectlyInBucket(t *testing.T) {
+	bucket, object, err := SplitGCSPath("gs://bucket_name/object_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "object_name", object)
+}
+
+func TestSplitGCSPathBucketOnlyTrailingSlash(t *testing.T) {
+	bucket, object, err := SplitGCSPath("gs://bucket_name/")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "", object)
+}
+
+func TestSplitGCSPathBucketOnlyNoTrailingSlash(t *testing.T) {
+	bucket, object, err := SplitGCSPath("gs://bucket_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "", object)
+}
+
+func TestSplitGCSPathErrorOnNoBucket(t *testing.T) {
+	_, _, err := SplitGCSPath("gs://")
+	assert.NotNil(t, err)
+}
+
+func TestSplitGCSPathErrorOnNoBucketButObjectPath(t *testing.T) {
+	_, _, err := SplitGCSPath("gs:///object_name")
+	assert.NotNil(t, err)
+}
+
+func TestSplitGCSPathErrorOnInvalidPath(t *testing.T) {
+	_, _, err := SplitGCSPath("NOT_A_GCS_PATH")
+	assert.NotNil(t, err)
+}
+
+func TestGetGCSObjectPathElementsInFolder(t *testing.T) {
+	bucket, object, err := GetGCSObjectPathElements("gs://bucket_name/folder_name/object_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "folder_name/object_name", object)
+}
+
+func TestGetGCSObjectPathElementsNoFolder(t *testing.T) {
+	bucket, object, err := GetGCSObjectPathElements("gs://bucket_name/object_name")
+	assert.Nil(t, err)
+	assert.Equal(t, "bucket_name", bucket)
+	assert.Equal(t, "object_name", object)
+}
+
+func TestGetGCSObjectPathElementsErrorOnBucketOnlyTrailingSlash(t *testing.T) {
+	_, _, err := GetGCSObjectPathElements("gs://bucket_name/")
+	assert.NotNil(t, err)
+}
+
+func TestGetGCSObjectPathElementsErrorOnBucketOnlyNoTrailingSlash(t *testing.T) {
+	_, _, err := GetGCSObjectPathElements("gs://bucket_name")
+	assert.NotNil(t, err)
+}
+
+func TestGetGCSObjectPathElementsErrorOnInvalidPath(t *testing.T) {
+	_, _, err := GetGCSObjectPathElements("NOT_GCS_PATH")
+	assert.NotNil(t, err)
+}

--- a/cli_tools/common/utils/storage/tar_gcs_extractor.go
+++ b/cli_tools/common/utils/storage/tar_gcs_extractor.go
@@ -42,7 +42,7 @@ func NewTarGcsExtractor(ctx context.Context, sc domain.StorageClientInterface, l
 // ExtractTarToGcs extracts a tar file in GCS back into GCS directory
 func (tge *TarGcsExtractor) ExtractTarToGcs(tarGcsPath string, destinationGcsPath string) error {
 
-	tarBucketName, tarPath, err := SplitGCSPath(tarGcsPath)
+	tarBucketName, tarPath, err := GetGCSObjectPathElements(tarGcsPath)
 	if err != nil {
 		return err
 	}

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -443,7 +443,7 @@ func main() {
 		log.Fatal("The flag -disk must be provided")
 	}
 
-	bkt, obj, err := storageutils.SplitGCSPath(*gcsPath)
+	bkt, obj, err := storageutils.GetGCSObjectPathElements(*gcsPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
@@ -56,8 +56,8 @@ func ValidateAndParseParams(params *OVFImportParams) error {
 		return err
 	}
 
-	if _, _, err := storage.SplitGCSPath(params.OvfOvaGcsPath); err != nil {
-		return daisy.Errf("%v should be a path to OVF or OVA package in GCS", OvfGcsPathFlagKey)
+	if _, err := storage.GetBucketNameFromGCSPath(params.OvfOvaGcsPath); err != nil {
+		return daisy.Errf("%v should be a path to OVF or OVA package in Cloud Storage", OvfGcsPathFlagKey)
 	}
 
 	if params.Labels != "" {

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
@@ -54,6 +54,18 @@ func TestFlagsAllValid(t *testing.T) {
 	assert.Nil(t, ValidateAndParseParams(getAllParams()))
 }
 
+func TestFlagsAllValidBucketOnlyPathTrailingSlash(t *testing.T) {
+	params := getAllParams()
+	params.OvfOvaGcsPath = "gs://bucket_name/"
+	assert.Nil(t, ValidateAndParseParams(getAllParams()))
+}
+
+func TestFlagsAllValidBucketOnlyPathNoTrailingSlash(t *testing.T) {
+	params := getAllParams()
+	params.OvfOvaGcsPath = "gs://bucket_name"
+	assert.Nil(t, ValidateAndParseParams(getAllParams()))
+}
+
 func assertErrorOnValidate(t *testing.T, params *OVFImportParams) {
 	assert.NotNil(t, ValidateAndParseParams(params))
 }

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -94,9 +94,9 @@ func validateAndParseFlags(clientID string, imageName string, sourceFile string,
 
 	if sourceFile != "" {
 		var err error
-		sourceBucketName, sourceObjectName, err = storage.SplitGCSPath(sourceFile)
+		sourceBucketName, sourceObjectName, err = storage.GetGCSObjectPathElements(sourceFile)
 		if err != nil {
-			return "", "", nil, daisy.Errf("failed to split source file GCS path: %v", err)
+			return "", "", nil, daisy.Errf("failed to split source file Cloud Storage path: %v", err)
 		}
 	}
 

--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -18,25 +18,56 @@ ping 127.0.0.1 -n 60
 
 echo "Translate: Starting image translate..." > COM1:
 
+echo "Translate: Enable DHCP" > COM1:
+powershell -command "Get-CimInstance Win32_NetworkAdapterConfiguration -Filter IPEnabled=True | Invoke-CimMethod -Name EnableDHCP" > COM1: 2>&1
+powershell -command "Get-CimInstance Win32_NetworkAdapterConfiguration -Filter IPEnabled=True | Invoke-CimMethod -Name SetDNSServerSearchOrder -Arguments @{DNSServerSearchOrder=$null}" > COM1: 2>&1
+
 REM Enable inbound communication from the metadata server.
+echo "Translate: Enable inbound communication from the metadata server." > COM1:
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow
 
 REM Enable outbound communication to the metadata server.
+echo "Translate: Enable outbound communication to the metadata server." > COM1:
 netsh advfirewall firewall add rule name="Allow outgoing to GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=out action=allow
 
 REM This is needed for 2008R2 networking to work, this will fail on post 2008R2 but that's fine.
+echo "Translate: This is needed for 2008R2 networking to work, this will fail on post 2008R2 but that's fine." > COM1:
 for /f "tokens=2 delims=:" %%a in (
   'ipconfig ^| find "Gateway"'
 ) do (
+  echo "Translate: " [%%a] 2>&1 > COM1:
   netsh interface ipv4 set dnsservers "Local Area Connection" static address=%%a primary
   netsh interface ipv4 set dnsservers "Local Area Connection 2" static address=%%a primary
   netsh interface ipv4 set dnsservers "Local Area Connection 3" static address=%%a primary
 )
 
+echo "Translate: tzutil." > COM1: 2>&1
 tzutil /s 'UTC'
+
+echo "Translate: w32tm." > COM1: 2>&1
 w32tm /resync
 
-C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet > COM1:
+echo "Translate: ipconfig." > COM1: 2>&1
+Run ipconfig /all > COM1: 2>&1
+
+echo "Translate: GooGet." > COM1: 2>&1
+C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet 2>&1 > COM1:
 REM Install google-compute-engine-metadata-scripts and then run the task.
 REM This needs to be on one line as this file will get overwritten.
-start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"
+
+echo "Translate: dir GooGet" > COM1: 2>&1
+dir C:\ProgramData\GooGet\ > COM1: 2>&1
+
+echo "Translate: dir c:" > COM1: 2>&1
+dir C:\ > COM1: 2>&1
+
+echo "Translate: available" > COM1: 2>&1
+C:\ProgramData\GooGet\googet.exe available -root C:\ProgramData\GooGet\ > COM1: 2>&1
+echo "Translate: google-compute-engine-metadata-scripts." > COM1: 2>&1
+C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: 2>&1
+
+echo "Translate: GCEStartup." > COM1: 2>&1
+schtasks /run /tn GCEStartup > COM1: 2>&1
+REM start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"
+
+echo "Translate: Done." > COM1: 2>&1

--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -18,56 +18,25 @@ ping 127.0.0.1 -n 60
 
 echo "Translate: Starting image translate..." > COM1:
 
-echo "Translate: Enable DHCP" > COM1:
-powershell -command "Get-CimInstance Win32_NetworkAdapterConfiguration -Filter IPEnabled=True | Invoke-CimMethod -Name EnableDHCP" > COM1: 2>&1
-powershell -command "Get-CimInstance Win32_NetworkAdapterConfiguration -Filter IPEnabled=True | Invoke-CimMethod -Name SetDNSServerSearchOrder -Arguments @{DNSServerSearchOrder=$null}" > COM1: 2>&1
-
 REM Enable inbound communication from the metadata server.
-echo "Translate: Enable inbound communication from the metadata server." > COM1:
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow
 
 REM Enable outbound communication to the metadata server.
-echo "Translate: Enable outbound communication to the metadata server." > COM1:
 netsh advfirewall firewall add rule name="Allow outgoing to GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=out action=allow
 
 REM This is needed for 2008R2 networking to work, this will fail on post 2008R2 but that's fine.
-echo "Translate: This is needed for 2008R2 networking to work, this will fail on post 2008R2 but that's fine." > COM1:
 for /f "tokens=2 delims=:" %%a in (
   'ipconfig ^| find "Gateway"'
 ) do (
-  echo "Translate: " [%%a] 2>&1 > COM1:
   netsh interface ipv4 set dnsservers "Local Area Connection" static address=%%a primary
   netsh interface ipv4 set dnsservers "Local Area Connection 2" static address=%%a primary
   netsh interface ipv4 set dnsservers "Local Area Connection 3" static address=%%a primary
 )
 
-echo "Translate: tzutil." > COM1: 2>&1
 tzutil /s 'UTC'
-
-echo "Translate: w32tm." > COM1: 2>&1
 w32tm /resync
 
-echo "Translate: ipconfig." > COM1: 2>&1
-Run ipconfig /all > COM1: 2>&1
-
-echo "Translate: GooGet." > COM1: 2>&1
-C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet 2>&1 > COM1:
+C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet > COM1:
 REM Install google-compute-engine-metadata-scripts and then run the task.
 REM This needs to be on one line as this file will get overwritten.
-
-echo "Translate: dir GooGet" > COM1: 2>&1
-dir C:\ProgramData\GooGet\ > COM1: 2>&1
-
-echo "Translate: dir c:" > COM1: 2>&1
-dir C:\ > COM1: 2>&1
-
-echo "Translate: available" > COM1: 2>&1
-C:\ProgramData\GooGet\googet.exe available -root C:\ProgramData\GooGet\ > COM1: 2>&1
-echo "Translate: google-compute-engine-metadata-scripts." > COM1: 2>&1
-C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: 2>&1
-
-echo "Translate: GCEStartup." > COM1: 2>&1
-schtasks /run /tn GCEStartup > COM1: 2>&1
-REM start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"
-
-echo "Translate: Done." > COM1: 2>&1
+start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"


### PR DESCRIPTION
Fixes for handling GCS paths where existing code was rejecting valid paths. E.g. gs://bucket-name/ was being rejected from OVF import as it didn't have object name portion, even though it's a valid path to an OVF package if files are directly in the bucket (no folders). Added GetGCSObjectPathElements func to be used when an actual file path is needed