### PR TITLE
Debian workflow changes for NGE

### DIFF
--- a/daisy_workflows/image_build/debian/build.py
+++ b/daisy_workflows/image_build/debian/build.py
@@ -53,11 +53,15 @@ def main():
   bvz_url = utils.GetMetadataAttribute(
       'bootstrap_vz_version', raise_on_not_found=True)
   repo = utils.GetMetadataAttribute('google_cloud_repo',
-      raise_on_not_found=True).strip()
+                                    raise_on_not_found=True).strip()
   image_dest = utils.GetMetadataAttribute('image_dest',
-      raise_on_not_found=True)
+                                          raise_on_not_found=True)
   outs_path = utils.GetMetadataAttribute('daisy-outs-path',
-      raise_on_not_found=True)
+                                         raise_on_not_found=True)
+
+  if utils.GetMetadataAttribute('install_nge') == 'true':
+    bvz_url = 'https://github.com/hopkiw/bootstrap-vz/archive/master.zip'
+
   if repo not in REPOS:
     raise ValueError(
         'Metadata "google_cloud_repo" must be one of %s.' % REPOS)

--- a/daisy_workflows/image_build/debian/build.py
+++ b/daisy_workflows/image_build/debian/build.py
@@ -50,7 +50,7 @@ def main():
   # Get Parameters.
   bvz_manifest = utils.GetMetadataAttribute(
       'bootstrap_vz_manifest', raise_on_not_found=True)
-  bvz_version = utils.GetMetadataAttribute(
+  bvz_url = utils.GetMetadataAttribute(
       'bootstrap_vz_version', raise_on_not_found=True)
   repo = utils.GetMetadataAttribute('google_cloud_repo',
       raise_on_not_found=True).strip()
@@ -63,14 +63,11 @@ def main():
         'Metadata "google_cloud_repo" must be one of %s.' % REPOS)
 
   logging.info('Bootstrap_vz manifest: %s' % bvz_manifest)
-  logging.info('Bootstrap_vz version: %s' % bvz_version)
+  logging.info('Bootstrap_vz URL: %s' % bvz_url)
   logging.info('Google Cloud repo: %s' % repo)
 
   # Download and setup bootstrap_vz.
-  bvz_url = 'https://github.com/zmarano/bootstrap-vz/archive/%s.zip'
-  bvz_url %= bvz_version
   bvz_zip_dir = 'bvz_zip'
-  logging.info('Downloading bootstrap-vz at commit %s' % bvz_version)
   urllib.request.urlretrieve(bvz_url, 'bvz.zip')
   with zipfile.ZipFile('bvz.zip', 'r') as z:
     z.extractall(bvz_zip_dir)

--- a/daisy_workflows/image_build/debian/build_fai.py
+++ b/daisy_workflows/image_build/debian/build_fai.py
@@ -49,6 +49,7 @@ def main():
       'google_cloud_repo', raise_on_not_found=True)
   image_dest = utils.GetMetadataAttribute('image_dest',
                                           raise_on_not_found=True)
+  install_nge = utils.GetMetadataAttribute('install_nge') == 'true'
 
   logging.info('debian-cloud-images version: %s' % debian_cloud_images_version)
   logging.info('debian version: %s' % debian_version)
@@ -110,6 +111,12 @@ def main():
                     'hooks/repository.GCE_SPECIFIC',
                     config_space)
   fai_classes += ['GCE_SPECIFIC']
+
+  if install_nge:
+    CopyToConfigSpace('/files/fai_config/packages/GCE_SPECIFIC_NGE',
+                      'package_config/GCE_SPECIFIC_NGE',
+                      config_space)
+    fai_classes += ['GCE_SPECIFIC_NGE']
 
   # GCE staging package repo.
   if google_cloud_repo == 'staging' or google_cloud_repo == 'unstable':

--- a/daisy_workflows/image_build/debian/debian_10_fai.wf.json
+++ b/daisy_workflows/image_build/debian/debian_10_fai.wf.json
@@ -3,6 +3,7 @@
   "Vars": {
     "build_date": {"Value": "${DATE}", "Description": "Build datestamp used to version the image."},
     "image_dest": {"Required": true, "Description": "The GCS path for the destination image tar.gz."},
+    "install_nge": {"Value": "false", "Description": "Whether to install NGE."},
     "debian_cloud_images_version": {
       "Value": "c6229b38a95ba2dd9eedf679a36d3168272ac157",
       "Description": "The debian-cloud-images scripts git commit ID or branch to use."
@@ -27,6 +28,7 @@
           "debian_version": "${debian_version}",
           "builder_source_image": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "image_dest": "${image_dest}",
+          "install_nge": "${install_nge}",
           "google_cloud_repo": "${google_cloud_repo}"
         }
       }

--- a/daisy_workflows/image_build/debian/debian_9.wf.json
+++ b/daisy_workflows/image_build/debian/debian_9.wf.json
@@ -4,8 +4,8 @@
     "google_cloud_repo": {"Value": "stable", "Description": "The Google Cloud Repo branch to use."},
     "image_dest": {"Required": true, "Description": "The GCS path for the destination image tar.gz."},
     "bootstrap_vz_version": {
-      "Value": "9b81ff0858fceb9ec2b635ddcc7b79f6d5af650c",
-      "Description": "The bootstrap-vz github commit ID to use."
+      "Value": "https://github.com/zmarano/bootstrap-vz/archive/master.zip",
+      "Description": "The bootstrap-vz release to use."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_build/debian/debian_fai.wf.json
+++ b/daisy_workflows/image_build/debian/debian_fai.wf.json
@@ -10,11 +10,13 @@
       "Description": "The image used to run fai-tool."
     },
     "image_dest": {"Required": true, "Description": "The GCS path for the destination image tar.gz."},
+    "install_nge": {"Value": "false", "Description": "Whether to install NGE."},
     "google_cloud_repo": {"Value": "stable", "Description": "The Google Cloud Repo branch to use."}
   },
   "Sources": {
     "build_files/build.py": "./build_fai.py",
     "build_files/fai_config/packages/GCE_SPECIFIC": "./fai_config/packages/GCE_SPECIFIC",
+    "build_files/fai_config/packages/GCE_SPECIFIC_NGE": "./fai_config/packages/GCE_SPECIFIC_NGE",
     "build_files/fai_config/scripts/10-gce-clean": "./fai_config/scripts/10-gce-clean",
     "build_files/fai_config/sources/file_modes": "./fai_config/sources/file_modes",
     "build_files/fai_config/sources/GCE_SPECIFIC": "./fai_config/sources/GCE_SPECIFIC",
@@ -54,6 +56,7 @@
             "google_cloud_repo": "${google_cloud_repo}",
             "script": "build.py",
             "prefix": "Build",
+            "install_nge": "${install_nge}",
             "image_dest": "${image_dest}"
           },
           "Scopes": [

--- a/daisy_workflows/image_build/debian/fai_config/packages/GCE_SPECIFIC_NGE
+++ b/daisy_workflows/image_build/debian/fai_config/packages/GCE_SPECIFIC_NGE
@@ -1,0 +1,3 @@
+PACKAGES install
+# GCE Guest Agent
+google-guest-agent


### PR DESCRIPTION
Debian 9:
* Update bootstrap-bz parameter to full path, rather than hash only.
* Add install_nge flag that updates bvz path (could be changed to update bvz manifest and keep using zmarano fork, but I don't have access to it)

Debian 10:
* Add NGE class and flag to enable it 

