### PR TITLE
fix typo in ks_helpers

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
+++ b/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
@@ -184,7 +184,7 @@ def BuildKsConfig(release, google_cloud_repo, byol, sap, uefi, nge):
     packages += " google-guest-agent"
   if release != "rhel6" and release != "centos6":
     # SDK installed manually on EL6
-    packages += "google-cloud-sdk"
+    packages += " google-cloud-sdk"
   if not release.endswith("8"):
     # TODO: disk-expand not yet working on EL8
     packages += " gce-disk-expand"


### PR DESCRIPTION
Turns out google-osconfig-agentgoogle-cloud-sdk is not a real package.
Fixes installed packages test.