### PR TITLE
OVF import e2e test directly from a bucket

### DIFF
--- a/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_import_test_suite.go
@@ -112,7 +112,7 @@ func TestSuite(
 			importParams: &ovfimportparams.OVFImportParams{
 				ClientID:      "test",
 				InstanceNames: fmt.Sprintf("test-instance-centos-6-%v", suffix),
-				OvfOvaGcsPath: fmt.Sprintf("gs://%v/ova/centos-6.8", ovaBucket),
+				OvfOvaGcsPath: fmt.Sprintf("gs://%v/", ovaBucket),
 				OsID:          "centos-6",
 				Labels:        "lk1=lv1,lk2=kv2",
 				Project:       &testProjectConfig.TestProjectID,


### PR DESCRIPTION
Changed CentOS 6 OVF import e2e test to cover importing directly from a bucket (no sub-directories) as customers are performing this type of import from time to time.