### PR TITLE
Make image import translate step use Daisy Workflow default timeout

### DIFF
--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -394,7 +394,6 @@ func (w *Workflow) PopulateClients(ctx context.Context) error {
 func (w *Workflow) populateStep(ctx context.Context, s *Step) DError {
 	if s.Timeout == "" {
 		s.Timeout = w.DefaultTimeout
-
 	}
 	timeout, err := time.ParseDuration(s.Timeout)
 	if err != nil {

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -78,7 +78,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/debian/translate_debian_8.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_8.wf.json
@@ -41,8 +41,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/debian/translate_debian_9.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_9.wf.json
@@ -41,8 +41,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -53,8 +53,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -53,8 +53,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -76,7 +76,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -53,8 +53,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -54,8 +54,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -53,8 +53,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -54,8 +54,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [
@@ -67,7 +66,6 @@
           "Description": "${description}",
           "ExactName": true,
           "NoCleanup": true
-
         }
       ]
     }

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -85,7 +85,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -63,8 +63,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "1h"
+      }
     }
   },
   "Dependencies": {

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -85,7 +85,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
@@ -86,7 +86,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
@@ -86,7 +86,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -85,7 +85,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -78,7 +78,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-instance": {

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
@@ -41,8 +41,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
@@ -41,8 +41,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
@@ -41,8 +41,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_10_x64_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_10_x64_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_10_x86_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_10_x86_byol.wf.json
@@ -52,8 +52,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2008_r2.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2008_r2.wf.json
@@ -49,8 +49,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2008_r2_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2008_r2_byol.wf.json
@@ -50,8 +50,7 @@
           "is_byol": "true",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2012.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012.wf.json
@@ -49,8 +49,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2012_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2012_r2.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_r2.wf.json
@@ -49,8 +49,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2012_r2_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_r2_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2016.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2016.wf.json
@@ -49,8 +49,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2016_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2016_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2019.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2019.wf.json
@@ -49,8 +49,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_2019_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2019_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_7_x64_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_7_x64_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_7_x86_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_7_x86_byol.wf.json
@@ -52,8 +52,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_8_x64_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_8_x64_byol.wf.json
@@ -50,8 +50,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_8_x86_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_8_x86_byol.wf.json
@@ -52,8 +52,7 @@
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}"
         }
-      },
-      "Timeout": "60m"
+      }
     },
     "create-image": {
       "CreateImages": [

--- a/daisy_workflows/image_import/windows/translate_windows_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_wf.json
@@ -144,7 +144,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-inst-translate": {

--- a/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
@@ -156,7 +156,6 @@
           }
         }
       ],
-      "Timeout": "60m",
       "TimeoutDescription": "Ensure that the disk is bootable on Google Compute Engine. For more information about disk requirements for import, see [Importing virtual disks](https://cloud.google.com/compute/docs/import/importing-virtual-disks)."
     },
     "delete-inst-translate": {


### PR DESCRIPTION
Make image import translate step use Daisy Workflow default timeout (configurable) instead of it being hardcoded to 1hr. This is to allow for longer image translates as there have been examples where translate run successfully for more than 1hr.