### PR TITLE
Python rhel8

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el6-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el6-post.cfg
@@ -69,7 +69,7 @@ rpm --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpm --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages.
-yum install -y  google-compute-engine google-osconfig-agent gce-disk-expand python27 __PACKAGES__
+yum install -y  google-compute-engine google-osconfig-agent gce-disk-expand __PACKAGES__
 
 # Install python 2.7 SCL
 if [ -f /etc/centos-release ]; then
@@ -80,6 +80,8 @@ if [ -f /etc/centos-release ]; then
   rm -f /etc/yum.repos.d/CentOS-SCL.repo
   yum -y install centos-release-scl
 fi
+
+yum install -y python27
 
 # Enable python 2.7 SCL for Cloud SDK.
 scl enable python27 "pip2.7 install --upgrade google_compute_engine"

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el6-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el6-post.cfg
@@ -69,7 +69,7 @@ rpm --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpm --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages.
-yum install -y  __PACKAGES__
+yum install -y  google-compute-engine google-osconfig-agent gce-disk-expand python27 __PACKAGES__
 
 # Install python 2.7 SCL
 if [ -f /etc/centos-release ]; then
@@ -80,8 +80,6 @@ if [ -f /etc/centos-release ]; then
   rm -f /etc/yum.repos.d/CentOS-SCL.repo
   yum -y install centos-release-scl
 fi
-
-yum install -y python27
 
 # Enable python 2.7 SCL for Cloud SDK.
 scl enable python27 "pip2.7 install --upgrade google_compute_engine"

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
@@ -38,7 +38,7 @@ rpmkeys --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpmkeys --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages and CloudSDK.
-yum install -y __PACKAGES__
+yum install -y google-compute-engine google-osconfig-agent google-cloud-sdk gce-disk-expand __PACKAGES__
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
@@ -37,7 +37,7 @@ rpmkeys --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpmkeys --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages.
-dnf install -y google-compute-engine google-osconfig-agent google-cloud-sdk python27 python36 __PACKAGES__
+dnf install -y google-compute-engine google-osconfig-agent google-cloud-sdk gce-disk-expand python27 python36 __PACKAGES__
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
@@ -37,7 +37,7 @@ rpmkeys --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpmkeys --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages.
-dnf install -y google-compute-engine google-osconfig-agent google-cloud-sdk gce-disk-expand python27 python36 __PACKAGES__
+dnf install -y google-compute-engine google-osconfig-agent google-cloud-sdk gce-disk-expand python2 python36 __PACKAGES__
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
@@ -37,7 +37,7 @@ rpmkeys --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpmkeys --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages.
-dnf install -y google-compute-engine google-osconfig-agent python27 python36 __PACKAGES__
+dnf install -y google-compute-engine google-osconfig-agent google-cloud-sdk python27 python36 __PACKAGES__
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
@@ -37,7 +37,7 @@ rpmkeys --import /etc/pki/rpm-gpg/google-rpm-package-key.gpg
 rpmkeys --import /etc/pki/rpm-gpg/google-key.gpg
 
 # Install GCE guest packages.
-dnf install -y __PACKAGES__ python27
+dnf install -y google-compute-engine google-osconfig-agent python27 python36 __PACKAGES__
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
+++ b/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
@@ -179,15 +179,9 @@ def BuildKsConfig(release, google_cloud_repo, byol, sap, uefi, nge):
   # pre and post
   # Each section must be in a specific order, but items in that section do not
   # have to be.
-  packages = "google-compute-engine google-osconfig-agent"
+  packages = ""
   if nge:
-    packages += " google-guest-agent"
-  if release != "rhel6" and release != "centos6":
-    # SDK installed manually on EL6
-    packages += " google-cloud-sdk"
-  if not release.endswith("8"):
-    # TODO: disk-expand not yet working on EL8
-    packages += " gce-disk-expand"
+    packages = "google-guest-agent"
 
   # Common
   pre = ''


### PR DESCRIPTION
these files are already being used as templates, so might as well declare packages there to be obvious. keep the replacement for packages that vary, but don't vary based on distro.

after removing legacy guest we find that python packages need to be explicitly installed. start doing that now.