### PR TITLE
image_test: oslogin: fix test for FreeBSD images with bash sym link

### DIFF
--- a/image_test/oslogin-ssh/oslogin-ssh.wf.json
+++ b/image_test/oslogin-ssh/oslogin-ssh.wf.json
@@ -137,7 +137,7 @@
           "RealName": "inst-oslogin-ssh-testee-${DATETIME}-${ID}",
           "Disks": [{"Source": "disk-testee"}],
           "metadata": {
-            "startup-script": "service sshguard stop; logger -p daemon.info BOOTED"
+            "startup-script": "service sshguard stop; ln -s /bin/sh /bin/bash; logger -p daemon.info BOOTED; echo BOOTED > /dev/console"
           }
         }
       ]


### PR DESCRIPTION
FreeBSD doesn't have /bin/bash, and usually oslogin accounts are
configured with /bin/bash by default, causing the test to fail, so add a
link to force the test.

This doesn't affect the test to other images, because if /bin/bash
exists, the ln command will fail.

With this change, the oslogin tests passes in all FreeBSD images, which are:
projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-3-snap
projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-1-snap
projects/freebsd-org-cloud-dev/global/images/family/freebsd-13-0-snap