### PR TITLE
test-infra: update FreeBSD images

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -455,8 +455,8 @@ periodics:
           projects/centos-cloud/global/images/family/centos-7,\
           projects/rhel-cloud/global/images/family/rhel-6,\
           projects/rhel-cloud/global/images/family/rhel-7,\
-          projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-2-snap,\
-          projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-0-snap,\
+          projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-3-snap,\
+          projects/freebsd-org-cloud-dev/global/images/family/freebsd-12-1-snap,\
           projects/freebsd-org-cloud-dev/global/images/family/freebsd-13-0-snap"
       - "-var:alias_ips=\
           10.128.3.80,\


### PR DESCRIPTION
Remove obsolete FreeBSD images and replace by the more recent ones.
This fix prow boot tests.