### PR TITLE
Improve error message for failed EL translation.

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -190,11 +190,11 @@ def yum_install(g, *packages):
   try:
     g.command(['yum', 'install', '-y'] + list(packages))
   except Exception as e:
-    logging.info('Failed to install {}. Detail: {}.'.format(packages, e))
+    logging.debug('Failed to install {}. Details: {}.'.format(packages, e))
     raise RuntimeError(
-        'Ensure that you have the correct --os specified. If this '
-        'is BYOL, also verify that your subscription '
-        'is eligible to be run on GCP.'.format(packages))
+        'Verify that you have specified the correct operating system '
+        'in the `--os` flag.  If you are bringing your own license (BYOL), '
+        'also verify that your subscription is eligible to be run on GCP.')
 
 
 def main():


### PR DESCRIPTION
This improves error messaging for two failure modes, where the user currently sees an error such as 

1. Incorrect `--os` such that EL's translate.py gets executed. Current error message is `TranslateFailed: error: command:`.
2. Correct `--os` using BYOL, but importing a VM that doesn't have a subscription. Current error message is `TranslateFailed: error: command: Importing GPG key 0xA7317B0F`.

Testing
 - Ran:
    - daisy_integration_tests/centos_6_qcow2_translate.wf.json
    - daisy_integration_tests/centos_7_qcow2_translate.wf.json
 - Verified error message by importing a RHEL 6 image that didn't have a subscription as BYOL.
 - Successfully imported same image without using BYOL.