### PR TITLE
Test cleanup: Delete exported disk image if export is successful.

### DIFF
--- a/daisy_integration_tests/image_export_vmdk_given_size.subwf.json
+++ b/daisy_integration_tests/image_export_vmdk_given_size.subwf.json
@@ -27,11 +27,22 @@
           "gcs_export": "${gcs_export}"
         }
       }
+    },
+    "cleanup": {
+      "DeleteResources": {
+        "GCSPaths": [
+          "${SCRATCHPATH}/created-by-export-test-given-size.vmdk",
+          "${SCRATCHPATH}/outs/"
+        ]
+      }
     }
   },
   "Dependencies": {
     "verify": [
       "export"
+    ],
+    "cleanup": [
+      "verify"
     ]
   }
 }


### PR DESCRIPTION
## Background

The image export tests create terabyte-sized files, which are costly for storage, and are not required when the test was successful. This change deletes the image files if the test passed. 

## Testing
 - Ran `daisy_integration_tests/image_export_vmdk_given_size_10gb.wf.json` and verified that the two image files were removed. (created-by-export-test-given-size.vmdk and the image in outs)