### PR TITLE
Image import: Support OVAs where enclosed vmdk has spaces.

### DIFF
--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -137,8 +137,8 @@
     "Image import and translate ova": {
       "Path": "./image_import_and_translate_ova.wf.json"
     },
-    "Image import and translate ova with spaces in VMDK": {
-      "Path": "./image_import_and_translate_ova_with_spaces_in_vmdk.wf.json"
+    "Image import and translate ova with spaces in VMDK filename.": {
+      "Path": "./image_import_and_translate_ova_with_spaces_in_vmdk_filename.wf.json"
     },
     "Image import and translate no extension": {
       "Path": "./image_import_and_translate_no_extension.wf.json"

--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -137,6 +137,9 @@
     "Image import and translate ova": {
       "Path": "./image_import_and_translate_ova.wf.json"
     },
+    "Image import and translate ova with spaces in VMDK": {
+      "Path": "./image_import_and_translate_ova_with_spaces_in_vmdk.wf.json"
+    },
     "Image import and translate no extension": {
       "Path": "./image_import_and_translate_no_extension.wf.json"
     },

--- a/daisy_integration_tests/image_import_and_translate_ova_with_spaces_in_vmdk.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_ova_with_spaces_in_vmdk.wf.json
@@ -1,0 +1,78 @@
+{
+  "Name": "image-import-and-translate-ova-with-spaces-in-vmdk",
+  "Sources": {
+    "post_translate_test.sh": "./scripts/post_translate_test.sh"
+  },
+  "Vars": {
+    "image": {
+      "Value": "image-${ID}"
+    },
+    "file": {
+      "Value": "gs://compute-image-tools-test-resources/ubuntu-1804-vmdk-spaces.ova"
+    }
+  },
+  "Steps": {
+    "import-image": {
+      "Timeout": "2h",
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/image_import/import_and_translate.wf.json",
+        "Vars": {
+          "image_name": "${image}",
+          "source_disk_file": "${file}",
+          "translate_workflow": "ubuntu/translate_ubuntu_1804.wf.json"
+        }
+      }
+    },
+    "test-the-image": {
+      "CreateInstances": [
+        {
+          "disks": [
+            {
+              "initializeParams": {
+                "sourceImage": "${image}"
+              }
+            }
+          ],
+          "machineType": "n1-standard-4",
+          "name": "test-the-image-instance",
+          "StartupScript": "post_translate_test.sh"
+        }
+      ]
+    },
+    "wait-for-test": {
+      "Timeout": "30m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "test-the-image-instance",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "PASSED:",
+            "FailureMatch": "FAILED:",
+            "StatusMatch": "STATUS:"
+          }
+        }
+      ]
+    },
+    "cleanup": {
+      "DeleteResources": {
+        "Images": [
+          "${image}"
+        ],
+        "Instances": [
+          "test-the-image-instance"
+        ]
+      }
+    }
+  },
+  "Dependencies": {
+    "cleanup": [
+      "wait-for-test"
+    ],
+    "wait-for-test": [
+      "test-the-image"
+    ],
+    "test-the-image": [
+      "import-image"
+    ]
+  }
+}

--- a/daisy_integration_tests/image_import_and_translate_ova_with_spaces_in_vmdk_filename.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_ova_with_spaces_in_vmdk_filename.wf.json
@@ -8,7 +8,7 @@
       "Value": "image-${ID}"
     },
     "file": {
-      "Value": "gs://compute-image-tools-test-resources/ubuntu-1804-vmdk-spaces.ova"
+      "Value": "gs://compute-image-tools-test-resources/ubuntu-1804-ova-vmdk-spaces-in-filename.ova"
     }
   },
   "Steps": {
@@ -65,14 +65,14 @@
     }
   },
   "Dependencies": {
-    "cleanup": [
-      "wait-for-test"
+    "test-the-image": [
+      "import-image"
     ],
     "wait-for-test": [
       "test-the-image"
     ],
-    "test-the-image": [
-      "import-image"
+    "cleanup": [
+      "wait-for-test"
     ]
   }
 }

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -147,7 +147,7 @@ copyImageToScratchDisk
 if [[ "${IMAGE_PATH}" =~ \.ova$ ]]; then
   echo "Import: Unpacking VMDK files from ova."
   VMDK="$(tar --list -f "${IMAGE_PATH}" | grep -m1 vmdk)"
-  tar -C /daisy-scratch -xf "${IMAGE_PATH}" ${VMDK}
+  tar -C /daisy-scratch -xf "${IMAGE_PATH}" "${VMDK}"
   IMAGE_PATH="/daisy-scratch/${VMDK}"
   echo "Import: New source file is ${VMDK}"
 fi


### PR DESCRIPTION
Prior to this fix, if a user imported an OVA that contained "The Image Name.vmdk", they'd see the following logs and errors:

```
Import: Unpacking VMDK files from ova.
tar: The: Not found in archive
tar: Image: Not found in archive
tar: Name.vmdk: Not found in archive
tar: Exiting with failure status due to previous errors
Import: New source file is The Image Name.vmdk
...
Could not open '/daisy-scratch/The Image Name.vmdk': No such file or directory
```

## Testing
 - Ran the new integration test