### PR TITLE
[ovf import / daisy] avoid undesired deletion

### DIFF
--- a/daisy/image.go
+++ b/daisy/image.go
@@ -116,6 +116,7 @@ type ImageInterface interface {
 	getRawDiskSource() string
 	setRawDiskSource(rawDiskSource string)
 	create(cc daisyCompute.Client) error
+	markCreatedInWorkflow()
 	delete(cc daisyCompute.Client) error
 	appendGuestOsFeatures(featureType string)
 	getGuestOsFeatures() guestOsFeatures
@@ -190,6 +191,10 @@ func (i *Image) create(cc daisyCompute.Client) error {
 	return cc.CreateImage(i.Project, &i.Image)
 }
 
+func (i *Image) markCreatedInWorkflow() {
+	i.createdInWorkflow = true
+}
+
 func (i *Image) delete(cc daisyCompute.Client) error {
 	return cc.DeleteImage(i.Project, i.Name)
 }
@@ -258,6 +263,10 @@ func (i *ImageBeta) setRawDiskSource(rawDiskSource string) {
 
 func (i *ImageBeta) create(cc daisyCompute.Client) error {
 	return cc.CreateImageBeta(i.Project, &i.Image)
+}
+
+func (i *ImageBeta) markCreatedInWorkflow() {
+	i.createdInWorkflow = true
 }
 
 func (i *ImageBeta) delete(cc daisyCompute.Client) error {

--- a/daisy/resource.go
+++ b/daisy/resource.go
@@ -43,8 +43,9 @@ type Resource struct {
 	stopped  bool
 	deleteMx *sync.Mutex
 
-	creator, deleter *Step
-	users            []*Step
+	creator, deleter  *Step
+	createdInWorkflow bool
+	users             []*Step
 }
 
 func (r *Resource) populateWithGlobal(ctx context.Context, s *Step, name string) (string, DError) {

--- a/daisy/resource_registry.go
+++ b/daisy/resource_registry.go
@@ -40,7 +40,10 @@ func (r *baseResourceRegistry) init() {
 func (r *baseResourceRegistry) cleanup() {
 	var wg sync.WaitGroup
 	for name, res := range r.m {
-		if (res.NoCleanup && !r.w.forceCleanup) || res.deleted {
+		if res.creator == nil || // placeholder resource
+			(res.creator != nil && !res.createdInWorkflow) || // resource isn‘t created successfully
+			(res.NoCleanup && !r.w.forceCleanup) || // resource is flagged to avoid cleanup
+			res.deleted { // resource has been deleted
 			continue
 		}
 		wg.Add(1)

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -77,8 +77,10 @@ func (c *CreateDisks) run(ctx context.Context, s *Step) DError {
 
 				if err != nil {
 					e <- newErr("failed to create disk", err)
+					return
 				}
 			}
+			cd.createdInWorkflow = true
 		}(d)
 	}
 

--- a/daisy/step_create_firewall_rule.go
+++ b/daisy/step_create_firewall_rule.go
@@ -56,6 +56,7 @@ func (c *CreateFirewallRules) run(ctx context.Context, s *Step) DError {
 				e <- newErr("failed to create firewall", err)
 				return
 			}
+			fir.createdInWorkflow = true
 		}(fir)
 	}
 

--- a/daisy/step_create_forwarding_rule.go
+++ b/daisy/step_create_forwarding_rule.go
@@ -52,6 +52,7 @@ func (c *CreateForwardingRules) run(ctx context.Context, s *Step) DError {
 				e <- newErr("failed to create forwarding rules", err)
 				return
 			}
+			fr.createdInWorkflow = true
 		}(fr)
 	}
 

--- a/daisy/step_create_images.go
+++ b/daisy/step_create_images.go
@@ -113,6 +113,7 @@ func (ci *CreateImages) run(ctx context.Context, s *Step) DError {
 			e <- newErr("failed to create images", err)
 			return
 		}
+		ci.markCreatedInWorkflow()
 	}
 
 	if usesBetaFeatures(ci.ImagesBeta) {

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -148,6 +148,7 @@ func (c *CreateInstances) run(ctx context.Context, s *Step) DError {
 				eChan <- newErr("failed to create instances", err)
 				return
 			}
+			i.createdInWorkflow = true
 			go logSerialOutput(ctx, s, i, 1, 3*time.Second)
 		}(ci)
 	}

--- a/daisy/step_create_machine_images.go
+++ b/daisy/step_create_machine_images.go
@@ -74,6 +74,7 @@ func (c *CreateMachineImages) run(ctx context.Context, s *Step) DError {
 				eChan <- newErr("failed to create machine image", err)
 				return
 			}
+			mi.createdInWorkflow = true
 		}(ci)
 	}
 

--- a/daisy/step_create_networks.go
+++ b/daisy/step_create_networks.go
@@ -52,6 +52,7 @@ func (c *CreateNetworks) run(ctx context.Context, s *Step) DError {
 				e <- newErr("failed to create networks", err)
 				return
 			}
+			n.createdInWorkflow = true
 		}(n)
 	}
 

--- a/daisy/step_create_subnetworks.go
+++ b/daisy/step_create_subnetworks.go
@@ -56,6 +56,7 @@ func (c *CreateSubnetworks) run(ctx context.Context, s *Step) DError {
 				e <- newErr("failed to create subnetworks", err)
 				return
 			}
+			sn.createdInWorkflow = true
 		}(sn)
 	}
 

--- a/daisy/step_create_target_instance.go
+++ b/daisy/step_create_target_instance.go
@@ -52,6 +52,7 @@ func (c *CreateTargetInstances) run(ctx context.Context, s *Step) DError {
 				e <- newErr("failed to create target instances", err)
 				return
 			}
+			ti.createdInWorkflow = true
 		}(ti)
 	}
 


### PR DESCRIPTION
A resource should be deleted by cleanup only when it's created by the workflow.
Now, there are 2 bugs which can lead to undesired deletion:
1. ovf import: ovf import set "forceCleanup" to "True". It conflicts with original design of "NoCleanup", which is used by regURL to mark placeholder resource as skipping cleanup. The problem: when ovf import failed, it will try deleting all used resources, including subnet, network, etc. We need to avoid this by distinguish whether the resource is a placeholder resource. The correct way is to check "resource.creator == nil".
2. daisy: for any daisy workflow, the create_resource step (for example, CreateDisks) will delete the created resource when the workflow failed on it. The problem is, when multiple workflows run in parallel to create a resource with the same name, one of them can fail on "resource exists", and delete it ultimately. To fix this issue, we need to set a flag to indicate whether creation succeeded; if not, the deletion should be skipped.
