### PR TITLE
Image import: Add hint for when VMDK decoding fails.

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -178,9 +178,19 @@ fi
 # /dev/sdc is used since it's the third disk that's attached in import_disk.wf.json.
 if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); then
   if [[ "${IMAGE_PATH}" =~ \.vmdk$ ]]; then
-    hint="Verify that you have a monolithic VMDK with an embedded descriptor file."
+    if file "${IMAGE_PATH}" | grep -qiP ascii; then
+      hint="When importing a VMDK disk image, ensure that you specify the VMDK disk "
+      hint+="image file, rather than its text descriptor file. In some virtual "
+      hint+="machine managers, given a text descriptor called <disk.vmdk>, "
+      hint+="the disk image file would be called <disk-flat.vmdk>."
+    else
+      hint="When preparing a VM import, ensure that you create a monolithic "
+      hint+="image file, where the disk is contained in a single VMDK file, as "
+      hint+="opposed to a split file, where the disk is spread across multiple files."
+    fi
   fi
-  echo "ImportFailed: Failed to decode image file. $hint [Privacy-> error: ${out} <-Privacy]"
+  echo "Import: [Privacy-> error: ${out} <-Privacy] "
+  echo "ImportFailed: Failed to decode image file. $hint"
   exit
 fi
 echo "${out}"

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -177,10 +177,13 @@ fi
 # Convert the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdc is used since it's the third disk that's attached in import_disk.wf.json.
 if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); then
-  echo "ImportFailed: Failed to convert source to raw. [Privacy-> error: ${out} <-Privacy]"
+  if [[ "${IMAGE_PATH}" =~ \.vmdk$ ]]; then
+    hint="Verify that you have a monolithic VMDK with an embedded descriptor file."
+  fi
+  echo "ImportFailed: Failed to decode image file. $hint [Privacy-> error: ${out} <-Privacy]"
   exit
 fi
-echo ${out}
+echo "${out}"
 
 sync
 


### PR DESCRIPTION
The message is intended to help with two common failures in VMDK decoding:
1. The user uploads the descriptor file, but not the image itself
2. The user uploads one VMDK from a set of split VMDKs

