### PR TITLE
fix gce_image_import_export_test docker permission

### DIFF
--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -21,20 +21,16 @@ RUN CGO_ENABLED=0 go build -o /gce_image_import_export_test_runner
 RUN chmod +x /gce_image_import_export_test_runner
 
 # Build binaries to test
-WORKDIR /gce_vm_image_import
-COPY cli_tools/gce_vm_image_import/ .
-RUN go get -d ./...
-RUN CGO_ENABLED=0 go build -o /gce_vm_image_import
+WORKDIR /
+RUN go get -d github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import
+RUN CGO_ENABLED=0 go build -o /gce_vm_image_import github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import
 RUN chmod +x /gce_vm_image_import
-
-WORKDIR /gce_vm_image_export
-COPY cli_tools/gce_vm_image_export/ .
-RUN go get -d ./...
-RUN CGO_ENABLED=0 go build -o /gce_vm_image_export
+RUN go get -d github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_export
+RUN CGO_ENABLED=0 go build -o /gce_vm_image_export github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_export
 RUN chmod +x /gce_vm_image_export
 
-# Build test container
-FROM gcr.io/$PROJECT_ID/wrapper-with-gcloud:latest
+# Prepare content of docker
+FROM gcr.io/compute-image-tools-test/wrapper-with-gcloud:latest
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_image_import_export_test_runner gce_image_import_export_test_runner

--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -29,8 +29,8 @@ RUN go get -d github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_v
 RUN CGO_ENABLED=0 go build -o /gce_vm_image_export github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_export
 RUN chmod +x /gce_vm_image_export
 
-# Prepare content of docker
-FROM gcr.io/compute-image-tools-test/wrapper-with-gcloud:latest
+# Build test container
+FROM gcr.io/$PROJECT_ID/wrapper-with-gcloud:latest
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_image_import_export_test_runner gce_image_import_export_test_runner


### PR DESCRIPTION
e2e now is failing. Error:

Error running cmd: fork/exec ./gce_vm_image_export: permission denied

WORKDIR should be "/" in this docker build file. Fixing it.
