### PR TITLE
Add support for importing CentOS-8.

### DIFF
--- a/cli_tools/common/utils/daisy/daisy_utils.go
+++ b/cli_tools/common/utils/daisy/daisy_utils.go
@@ -37,6 +37,7 @@ var (
 		"debian-9":            "debian/translate_debian_9.wf.json",
 		"centos-6":            "enterprise_linux/translate_centos_6.wf.json",
 		"centos-7":            "enterprise_linux/translate_centos_7.wf.json",
+		"centos-8":            "enterprise_linux/translate_centos_8.wf.json",
 		"opensuse-15":         "suse/translate_opensuse_15.wf.json",
 		"sles-12-byol":        "suse/translate_sles_12_byol.wf.json",
 		"sles-15-byol":        "suse/translate_sles_15_byol.wf.json",

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -47,6 +47,8 @@ var ovfOSTypeToOSID = map[string]string{
 	"centos6_64Guest":       "centos-6",
 	"centos7Guest":          "centos-7",
 	"centos7_64Guest":       "centos-7",
+	"centos8Guest":          "centos-8",
+	"centos8_64Guest":       "centos-8",
 	"rhel6Guest":            "rhel-6",
 	"rhel6_64Guest":         "rhel-6",
 	"rhel7Guest":            "rhel-7",

--- a/daisy_integration_tests/centos_8_translate.wf.json
+++ b/daisy_integration_tests/centos_8_translate.wf.json
@@ -1,0 +1,99 @@
+{
+  "Name": "centos-8-translate-test",
+  "Sources": {
+    "post_translate_test.sh": "./scripts/post_translate_test.sh"
+  },
+  "Vars": {
+    "image_name": {
+      "Value": "centos-8-translate-test-${ID}"
+    },
+    "source_image": {
+      "Value": "projects/compute-image-tools-test/global/images/centos-8-import"
+    },
+    "test-id": {
+      "Value": "",
+      "Description": "The ID of this test run."
+    }
+  },
+  "Steps": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "name": "translate-me",
+          "sourceImage": "${source_image}"
+        }
+      ]
+    },
+    "create-test-disk": {
+      "CreateDisks": [
+        {
+          "name": "disk-import-test",
+          "sourceImage": "${image_name}",
+          "type": "pd-ssd"
+        }
+      ]
+    },
+    "create-test-instance": {
+      "CreateInstances": [
+        {
+          "disks": [
+            {
+              "source": "disk-import-test"
+            }
+          ],
+          "machineType": "n1-standard-4",
+          "name": "inst-import-test",
+          "StartupScript": "post_translate_test.sh"
+        }
+      ]
+    },
+    "delete-image": {
+      "DeleteResources": {
+        "Images": [
+          "${image_name}"
+        ]
+      }
+    },
+    "translate-disk": {
+      "Timeout": "90m",
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json",
+        "Vars": {
+          "image_name": "${image_name}",
+          "source_disk": "translate-me"
+        }
+      }
+    },
+    "wait-for-test-instance": {
+      "Timeout": "30m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-import-test",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "PASSED:",
+            "FailureMatch": "FAILED:",
+            "StatusMatch": "STATUS:"
+          }
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-test-disk": [
+      "translate-disk"
+    ],
+    "create-test-instance": [
+      "create-test-disk"
+    ],
+    "delete-image": [
+      "create-test-disk"
+    ],
+    "translate-disk": [
+      "create-disk-from-image"
+    ],
+    "wait-for-test-instance": [
+      "create-test-instance"
+    ]
+  }
+}

--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -44,6 +44,9 @@
     "centos7 qcow2 translate": {
       "Path": "./centos_7_qcow2_translate.wf.json"
     },
+    "centos8 translate": {
+      "Path": "./centos_8_translate.wf.json"
+    },
     "Image export latest": {
       "Path": "./image_export_latest.wf.json"
     },

--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -165,7 +165,11 @@ function check_package_install {
   # Yum
   if [[ -d /etc/yum ]]; then
     status "Checking if yum can install a package."
-    yum -y update make
+    if rpm -q make; then
+      yum -y update make
+    else
+      yum -y install make
+    fi
     yum -y reinstall make
     if [[ $? -ne 0 ]]; then
       fail "yum cannot install make."

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -1,0 +1,77 @@
+{
+  "Name": "translate-centos-8",
+  "Vars": {
+    "source_disk": {
+      "Required": true,
+      "Description": "The CentOS 8 GCE image to translate."
+    },
+    "install_gce_packages": {
+      "Value": "true",
+      "Description": "Whether to install GCE packages."
+    },
+    "image_name": {
+      "Value": "centos-8-${ID}",
+      "Description": "The name of the translated CentOS 8 image."
+    },
+    "family": {
+      "Value": "",
+      "Description": "Optional family to set for the translated image"
+    },
+    "description": {
+      "Value": "",
+      "Description": "Optional description to set for the translated image"
+    },
+    "import_network": {
+      "Value": "global/networks/default",
+      "Description": "Network to use for the import instance"
+    },
+    "import_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the import instance"
+    }
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-translator",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SizeGb": "10",
+          "Type": "pd-ssd",
+          "FallbackToPdStandard": true
+        }
+      ]
+    },
+    "translate-disk": {
+      "Timeout": "2h",
+      "IncludeWorkflow": {
+        "Path": "./translate_el.wf.json",
+        "Vars": {
+          "el_release": "8",
+          "install_gce_packages": "${install_gce_packages}",
+          "translator_disk": "disk-translator",
+          "imported_disk": "${source_disk}",
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "${image_name}",
+          "SourceDisk": "${source_disk}",
+          "Family": "${family}",
+          "Licenses": ["projects/centos-cloud/global/licenses/centos-8"],
+          "Description": "${description}",
+          "ExactName": true,
+          "NoCleanup": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "translate-disk": ["setup-disks"],
+    "create-image": ["translate-disk"]
+  }
+}


### PR DESCRIPTION
## Overview

Adds a workflow for importing CentOS-8, and wires the workflow through the OVF wrapper and the image import wrapper. 

## Testing

* Created a VM using vmware, and imported as a VMDK and OVF.
* Ran the new integration test.
* Ran the existing CentOS tests: centos_6_qcow2_translate.wf.json and centos_7_qcow2_translate.wf.json