### PR TITLE
OVF import: validate hostname flag

### DIFF
--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -40,9 +40,9 @@ func ValidateStringFlagNotEmpty(flagValue string, flagKey string) error {
 func ValidateFqdn(flagValue string, flagKey string) error {
 	flagValueLen := len(flagValue)
 	if flagValueLen < 1 || flagValueLen > 253 || !fqdnRegexp.MatchString(flagValue) {
-		return daisy.Errf(fmt.Sprintf("The flag `%v` must conform to RFC 1035 requirements for valid hostnames. " +
-			"To meet this requirement, the value must contain a series of labels and each label is concatenated with a dot. " +
-			"Each label can be 1-63 characters long where each character can be a letter, a digit or a dash (`-`). The " +
+		return daisy.Errf(fmt.Sprintf("The flag `%v` must conform to RFC 1035 requirements for valid hostnames. "+
+			"To meet this requirement, the value must contain a series of labels and each label is concatenated with a dot. "+
+			"Each label can be 1-63 characters long where each character can be a letter, a digit or a dash (`-`). The "+
 			"entire sequence must not exceed 253 characters.", flagKey))
 	}
 	return nil

--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -40,9 +40,10 @@ func ValidateStringFlagNotEmpty(flagValue string, flagKey string) error {
 func ValidateFqdn(flagValue string, flagKey string) error {
 	flagValueLen := len(flagValue)
 	if flagValueLen < 1 || flagValueLen > 253 || !fqdnRegexp.MatchString(flagValue) {
-		return daisy.Errf(fmt.Sprintf("The flag `%v` must conform to RFC 1035 requirements for valid hostnames. "+
-			"To meet this requirement, the value must contain a series of labels and each label is concatenated with a dot."+
-			"Each label can be 1-63 characters long, and the entire sequence must not exceed 253 characters.", flagKey))
+		return daisy.Errf(fmt.Sprintf("The flag `%v` must conform to RFC 1035 requirements for valid hostnames. " +
+			"To meet this requirement, the value must contain a series of labels and each label is concatenated with a dot. " +
+			"Each label can be 1-63 characters long where each character can be a letter, a digit or a dash (`-`). The " +
+			"entire sequence must not exceed 253 characters.", flagKey))
 	}
 	return nil
 }

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -64,7 +64,7 @@ var (
 	stdoutLogsDisabled          = flag.Bool("disable-stdout-logging", false, "do not display individual workflow logs on stdout")
 	releaseTrack                = flag.String("release-track", ovfimporter.GA, fmt.Sprintf("Release track of OVF import. One of: %s, %s or %s. Impacts which compute API release track is used by the import tool.", ovfimporter.Alpha, ovfimporter.Beta, ovfimporter.GA))
 	uefiCompatible              = flag.Bool("uefi-compatible", false, "Enables UEFI booting, which is an alternative system boot method. Most public images use the GRUB bootloader as their primary boot method.")
-	hostname                    = flag.String("hostname", "", "Specify the hostname of the instance to be created. The specified hostname must be RFC1035 compliant.")
+	hostname                    = flag.String(ovfimportparams.HostnameFlagKey, "", "Specify the hostname of the instance to be created. The specified hostname must be RFC1035 compliant.")
 	machineImageStorageLocation = flag.String(ovfimportparams.MachineImageStorageLocationFlagKey, "", "GCS bucket storage location of the machine image being imported (regional or multi-regional)")
 
 	nodeAffinityLabelsFlag flags.StringArrayFlag

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator.go
@@ -39,6 +39,9 @@ const (
 
 	// OvfGcsPathFlagKey is key for OVF/OVA GCS path CLI flag
 	OvfGcsPathFlagKey = "ovf-gcs-path"
+
+	// HostnameFlagKey is key for hostname CLI flag
+	HostnameFlagKey = "hostname"
 )
 
 // ValidateAndParseParams validates and parses OVFImportParams. It returns an error if params are
@@ -88,6 +91,13 @@ func ValidateAndParseParams(params *OVFImportParams) error {
 	if params.NodeAffinityLabelsFlag != nil {
 		var err error
 		params.NodeAffinities, err = compute.ParseNodeAffinityLabels(params.NodeAffinityLabelsFlag)
+		if err != nil {
+			return err
+		}
+	}
+
+	if params.Hostname != "" {
+		err := validation.ValidateFqdn(params.Hostname, HostnameFlagKey)
 		if err != nil {
 			return err
 		}

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params_validator_test.go
@@ -78,6 +78,18 @@ func TestInstanceImportFlagsAllValidBucketOnlyPathNoTrailingSlash(t *testing.T) 
 	assert.Nil(t, ValidateAndParseParams(getAllInstanceImportParams()))
 }
 
+func TestInstanceImportHostnameInvalid(t *testing.T) {
+	params := getAllInstanceImportParams()
+	params.Hostname = "an_invalid_host_name.an_invalid_domain"
+	assertErrorOnValidate(t, params)
+}
+
+func TestInstanceImportHostnameTooLong(t *testing.T) {
+	params := getAllInstanceImportParams()
+	params.Hostname = "a-host.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain"
+	assertErrorOnValidate(t, params)
+}
+
 func TestMachineImageImportFlagsAllValid(t *testing.T) {
 	assert.Nil(t, ValidateAndParseParams(getAllMachineImageImportParams()))
 }
@@ -124,6 +136,18 @@ func TestMachineImageImportFlagsAllValidBucketOnlyPathNoTrailingSlash(t *testing
 	assert.Nil(t, ValidateAndParseParams(getAllMachineImageImportParams()))
 }
 
+func TestMachineImageImportHostnameInvalid(t *testing.T) {
+	params := getAllInstanceImportParams()
+	params.Hostname = "an_invalid_host_name.an_invalid_domain"
+	assertErrorOnValidate(t, params)
+}
+
+func TestMachineImageImportHostnameTooLong(t *testing.T) {
+	params := getAllInstanceImportParams()
+	params.Hostname = "a-host.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain.a-domain"
+	assertErrorOnValidate(t, params)
+}
+
 func assertErrorOnValidate(t *testing.T, params *OVFImportParams) {
 	assert.NotNil(t, ValidateAndParseParams(params))
 }
@@ -165,6 +189,7 @@ func getAllInstanceImportParams() *OVFImportParams {
 		CloudLogsDisabled:           true,
 		StdoutLogsDisabled:          true,
 		NodeAffinityLabelsFlag:      []string{"env,IN,prod,test"},
+		Hostname:                    "a-host.a-domain",
 	}
 }
 
@@ -206,5 +231,6 @@ func getAllMachineImageImportParams() *OVFImportParams {
 		CloudLogsDisabled:           true,
 		StdoutLogsDisabled:          true,
 		NodeAffinityLabelsFlag:      []string{"env,IN,prod,test"},
+		Hostname:                    "a-host.a-domain",
 	}
 }

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -137,7 +137,7 @@ func TestSetUpInstanceWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneHo
 	project := "aProject"
 	params.Project = &project
 	params.Zone = "europe-west2-b"
-	params.Hostname = "ahost"
+	params.Hostname = "a-host.a-domain"
 	params.UefiCompatible = true
 	params.MachineType = ""
 
@@ -192,7 +192,7 @@ func TestSetUpInstanceWorkflowHappyPathFromOVAExistingScratchBucketProjectZoneHo
 		Instance.Labels["userkey1"])
 	assert.Equal(t, "uservalue2", (*w.Steps["create-instance"].CreateInstances)[0].
 		Instance.Labels["userkey2"])
-	assert.Equal(t, "ahost", (*w.Steps["create-instance"].CreateInstances)[0].Hostname)
+	assert.Equal(t, "a-host.a-domain", (*w.Steps["create-instance"].CreateInstances)[0].Hostname)
 
 	assert.Equal(t, "UEFI_COMPATIBLE", (*w.Steps["create-boot-disk"].CreateDisks)[0].Disk.GuestOsFeatures[0].Type)
 	assert.Equal(t, "UEFI_COMPATIBLE", (*w.Steps["create-image"].CreateImages).Images[0].GuestOsFeatures[0])


### PR DESCRIPTION
The original PR that introduced the hostname flag somehow failed to call validateFqnd on params.Hostname in ovf_import_params_validator