### PR TITLE
Added missing default timeout for import from image workflow

### DIFF
--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -1,5 +1,6 @@
 {
   "Name": "import-from-image",
+  "DefaultTimeout": "90m",
   "Vars": {
     "source_image": {
       "Required": true,


### PR DESCRIPTION
Added missing default timeout for import from image workflow, the same as other import workflows.