### PR TITLE
Improve error message when 'cloud-init init' fails.

### DIFF
--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -141,9 +141,15 @@ def DistroSpecific(g):
         cfg.write(tinyproxy_cfg)
     utils.Execute(['/etc/init.d/tinyproxy', 'restart'])
     default_gw = g.sh("ip route | awk '/default/ { printf $3 }'")
-    logging.debug(
-        g.sh('http_proxy="http://%s:8888" cloud-init -d init' % default_gw))
-
+    try:
+      logging.debug(
+          g.sh('http_proxy="http://%s:8888" cloud-init -d init' % default_gw))
+    except Exception as e:
+      logging.debug('Failed to run cloud-init. Details: {}.'.format(e))
+      raise RuntimeError(
+        'Failed to run cloud-init. Connect to a shell in the original VM '
+        'and ensure that the following command executes successfully: '
+        'apt-get install -y --no-install-recommends cloud-init && cloud-init -d init')
     logging.info('Installing GCE packages.')
     g.command(['apt-get', 'update'])
     g.sh(

--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -149,7 +149,8 @@ def DistroSpecific(g):
       raise RuntimeError(
         'Failed to run cloud-init. Connect to a shell in the original VM '
         'and ensure that the following command executes successfully: '
-        'apt-get install -y --no-install-recommends cloud-init && cloud-init -d init')
+        'apt-get install -y --no-install-recommends cloud-init '
+        '&& cloud-init -d init')
     logging.info('Installing GCE packages.')
     g.command(['apt-get', 'update'])
     g.sh(


### PR DESCRIPTION
Currently, if `cloud-init init` fails, the user sees "error: "sh: Traceback (most recent call last):". 

I'm currently running the following test and will ensure that it passes before I push the change:

`daisy -zone=us-central1-b -project=compute-image-tools-test daisy_integration_tests/ubuntu_1604_import_and_translate.wf.json`
