### PR TITLE
Fix flakiness for image storage location retrieving

### DIFF
--- a/cli_tools/common/utils/storage/resource_location_retriever_test.go
+++ b/cli_tools/common/utils/storage/resource_location_retriever_test.go
@@ -372,3 +372,16 @@ func TestGetLargestStorageLocationForRegionNotInMultiRegion(t *testing.T) {
 	location := rlr.GetLargestStorageLocation("australia-southeast1")
 	assert.Equal(t, "australia-southeast1", location)
 }
+
+func TestGetLargestStorageLocationForMultiRegionNoDualRegions(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockMetadataGce := mocks.NewMockMetadataGCEInterface(mockCtrl)
+	mockComputeService := mocks.NewMockClient(mockCtrl)
+	rlr := ResourceLocationRetriever{mockMetadataGce, mockComputeService}
+
+	location := rlr.GetLargestStorageLocation("us-central1")
+	// We don't want NAM4 here
+	assert.Equal(t, "US", location)
+}


### PR DESCRIPTION
Fix occasional flakiness for image storage location retrieving where dual regions (NAM4/EUR4) are returned instead of multi-regions (US/EU) for regions belonging to both.