### PR TITLE
Clarify how to import a disk image that is contained within a gzip compressed file.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -123,11 +123,11 @@ func validateSourceFile(storageClient domain.StorageClientInterface, sourceBucke
 	byteCountingReader := daisycommon.NewByteCountingReader(rc)
 	// Detect whether it's a compressed file by extracting compressed file header
 	if _, err = gzip.NewReader(byteCountingReader); err == nil {
-		return daisy.Errf("the input file is a gzip file, which is not supported by " +
-			"'gcloud compute images import'. To import a file that was exported from " +
-			"Google Compute Engine, please use 'gcloud compute images create'. " +
-			"To import a file that was exported from a different system, decompress it " +
-			"and run 'gcloud compute images import' on the disk image file directly ")
+		return daisy.Errf("the input file is a gzip file, which is not supported by" +
+			"image import. To import a file that was exported from Google Compute " +
+			"Engine, please use image create. To import a file that was exported " +
+			"from a different system, decompress it and run image import on the " +
+			"disk image file directly")
 	}
 
 	// By calling gzip.NewReader above, a few bytes were read from the Reader in

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -123,7 +123,11 @@ func validateSourceFile(storageClient domain.StorageClientInterface, sourceBucke
 	byteCountingReader := daisycommon.NewByteCountingReader(rc)
 	// Detect whether it's a compressed file by extracting compressed file header
 	if _, err = gzip.NewReader(byteCountingReader); err == nil {
-		return daisy.Errf("the input file is a gzip file, which is not supported by 'gcloud compute images import'. To import a file that was exported from Google Compute Engine, please use 'gcloud compute images create' instead")
+		return daisy.Errf("the input file is a gzip file, which is not supported by " +
+			"'gcloud compute images import'. To import a file that was exported from " +
+			"Google Compute Engine, please use 'gcloud compute images create'. " +
+			"To import a file that was exported from a different system, decompress it " +
+			"and run 'gcloud compute images import' on the disk image file directly ")
 	}
 
 	// By calling gzip.NewReader above, a few bytes were read from the Reader in


### PR DESCRIPTION
Currently we tell users how to import a file that was exported from GCP. This adds a hint for gzip files that contain disk images from other systems.