### PR TITLE
Allow post-translate test to wait until cloud-init finishes its startup work.

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -142,10 +142,12 @@ function check_google_cloud_sdk {
 function check_cloud_init {
   if [[ -x /usr/bin/cloud-init ]]; then
     status "Checking if cloud-init runs."
-    cloud-init init
-    if [[ $? -ne 0 ]]; then
-      fail "cloud-init failed to run."
-    fi
+    for i in $(seq 1 20) ; do
+      cloud-init init && return 0
+      status "Waiting until cloud-init finishes its startup run."
+      sleep $((i**2))
+    done
+    fail "cloud-init failed to run."
   fi
 }
 


### PR DESCRIPTION
The Linux post-translate test assumes that cloud-init has already run (and finished) by the time the test runs, which isn't always true. 

## Testing: 

1. Ran `daisy_integration_tests/centos_6_qcow2_translate.wf.json`, which passed.
2. Created an instance using the translated cent6 image as the boot disk, and `post_translate_test.sh` as the startup script
3. Cycled the instance about 20 times and verified that the test passed each time.