### PR TITLE
Improve stability of import integ tests and enterprise linux installs.

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -51,13 +51,13 @@ function fail {
 # Check network connectivity.
 function check_connectivity {
   status "Checking metadata connection."
-  ping -q -c 2 metadata.google.internal
+  ping -q -w 10 metadata.google.internal
   if [[ $? -ne 0 ]]; then
     fail "Failed to connect to metadata.google.internal."
   fi
 
   status "Checking external connectivity."
-  ping -q -c 2 google.com
+  ping -q -w 10 google.com
   if [[ $? -ne 0 ]]; then
     fail "Failed to ping google.com."
   fi

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -24,6 +24,7 @@ use_rhel_gce_license: True if GCE RHUI package should be installed
 
 import logging
 import os
+import time
 
 import utils
 import utils.diskutils as diskutils
@@ -197,14 +198,18 @@ def yum_install(g, *packages):
   Raises:
       RuntimeError: If there is a failure during installation.
   """
-  try:
-    g.command(['yum', 'install', '-y'] + list(packages))
-  except Exception as e:
-    logging.debug('Failed to install {}. Details: {}.'.format(packages, e))
-    raise RuntimeError(
-        'Verify that you have specified the correct operating system '
-        'in the `--os` flag.  If you are bringing your own license (BYOL), '
-        'also verify that your subscription is eligible to be run on GCP.')
+  for i in range(6):
+    try:
+      # There's no sleep on the first iteration since `i` is zero.
+      time.sleep(i**2)
+      g.command(['yum', 'install', '-y'] + list(packages))
+      return
+    except Exception as e:
+      logging.debug('Failed to install {}. Details: {}.'.format(packages, e))
+  raise RuntimeError(
+      'Verify that you have specified the correct operating system '
+      'in the `--os` flag.  If you are bringing your own license (BYOL), '
+      'also verify that your subscription is eligible to be run on GCP.')
 
 
 def main():


### PR DESCRIPTION
Two fixes:
 1. Tune the `ping` test to allow longer for the response.
 2. Add retries when installing packages using yum.

Testing:
 1. Ran `daisy_integration_tests/centos_6_qcow2_translate.wf.json`
 2. Ran `daisy_integration_tests/ubuntu_1404_img_translate.wf.json`