### PR TITLE
Fixed OVF import e2e tests failing

### DIFF
--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -66,6 +66,7 @@ var (
 	uefiCompatible              = flag.Bool("uefi-compatible", false, "Enables UEFI booting, which is an alternative system boot method. Most public images use the GRUB bootloader as their primary boot method.")
 	hostname                    = flag.String(ovfimportparams.HostnameFlagKey, "", "Specify the hostname of the instance to be created. The specified hostname must be RFC1035 compliant.")
 	machineImageStorageLocation = flag.String(ovfimportparams.MachineImageStorageLocationFlagKey, "", "GCS bucket storage location of the machine image being imported (regional or multi-regional)")
+	buildID                     = flag.String("build-id", "", "Cloud Build ID override. This flag should be used if auto-generated or build ID provided by Cloud Build is not appropriate. For example, if running multiple imports in parallel in a single Cloud Build run, sharing build ID could cause premature temporary resource clean-up resulting in import failures.")
 
 	nodeAffinityLabelsFlag flags.StringArrayFlag
 	currentExecutablePath  string
@@ -94,7 +95,7 @@ func buildImportParams() *ovfimportparams.OVFImportParams {
 		StdoutLogsDisabled: *stdoutLogsDisabled, NodeAffinityLabelsFlag: nodeAffinityLabelsFlag,
 		CurrentExecutablePath: currentExecutablePath, ReleaseTrack: *releaseTrack,
 		UefiCompatible: *uefiCompatible, Hostname: *hostname,
-		MachineImageStorageLocation: *machineImageStorageLocation,
+		MachineImageStorageLocation: *machineImageStorageLocation, BuildID: *buildID,
 	}
 }
 

--- a/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/ovf_import_params/ovf_import_params.go
@@ -68,6 +68,7 @@ type OVFImportParams struct {
 	ReleaseTrack                string
 	UefiCompatible              bool
 	Hostname                    string
+	BuildID                     string
 
 	// Non-flags
 	UserLabels            map[string]string

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -100,20 +100,26 @@ func NewOVFImporter(params *ovfimportparams.OVFImportParams) (*OVFImporter, erro
 		return nil, err
 	}
 	tarGcsExtractor := storageutils.NewTarGcsExtractor(ctx, storageClient, logger)
-	buildID := os.Getenv("BUILD_ID")
-
-	if buildID == "" {
-		buildID = pathutils.RandString(5)
-	}
 	workingDirOVFImportWorkflow := toWorkingDir(getImportWorkflowPath(params), params)
 	bic := &storageutils.BucketIteratorCreator{}
 
 	ovfImporter := &OVFImporter{ctx: ctx, storageClient: storageClient, computeClient: computeClient,
-		tarGcsExtractor: tarGcsExtractor, workflowPath: workingDirOVFImportWorkflow, BuildID: buildID,
+		tarGcsExtractor: tarGcsExtractor, workflowPath: workingDirOVFImportWorkflow, BuildID: getBuildID(params),
 		ovfDescriptorLoader: ovfutils.NewOvfDescriptorLoader(storageClient),
 		mgce:                &computeutils.MetadataGCE{}, bucketIteratorCreator: bic, Logger: logger,
 		zoneValidator: &computeutils.ZoneValidator{ComputeClient: computeClient}, params: params}
 	return ovfImporter, nil
+}
+
+func getBuildID(params *ovfimportparams.OVFImportParams) string {
+	if params != nil && params.BuildID != "" {
+		return params.BuildID
+	}
+	buildID := os.Getenv("BUILD_ID")
+	if buildID == "" {
+		buildID = pathutils.RandString(5)
+	}
+	return buildID
 }
 
 func getImportWorkflowPath(params *ovfimportparams.OVFImportParams) string {

--- a/gce_ovf_import_tests/test_suites/ovf_instance_import/ovf_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_instance_import/ovf_import_test_suite.go
@@ -309,6 +309,7 @@ func buildTestArgs(props *ovfImportTestProperties, testProjectConfig *testconfig
 		fmt.Sprintf("-instance-names=%s", props.instanceName),
 		fmt.Sprintf("-ovf-gcs-path=%v", props.sourceURI),
 		fmt.Sprintf("-zone=%v", testProjectConfig.TestZone),
+		fmt.Sprintf("-build-id=%v", path.RandString(10)),
 	}
 
 	if props.os != "" {


### PR DESCRIPTION
Fixed OVF import e2e tests failing due to multiple tests sharing single Cloud Build and temporary resources getting cleaned up by shorter running tests thus failing longer running tests. The fix was to provide buildID override that can be utilized by E2E tests.