### PR TITLE
SLES 12.x image import fix, not only 12.5

### DIFF
--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -89,7 +89,7 @@ _distros = [
     _SuseRelease(
         flavor='sles',
         major='12',
-        minor='5',
+        minor='*',
         subscriptions=['sle-module-public-cloud/12/x86_64']
     ),
 ]


### PR DESCRIPTION
SLES image import: use 'sle-module-public-cloud/12/x86_64' subscription for any SLES 12.x, not only 12.5.