### PR TITLE
Fixed OVF instance import E2E tests not being reported

### DIFF
--- a/gce_ovf_import_tests/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	testSuiteName = "OVFImportTests"
+	testSuiteName = "OVFInstanceImportTests"
 	ovaBucket     = "compute-image-tools-test-resources"
 )
 

--- a/gce_ovf_import_tests/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/gce_ovf_import_tests/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	testSuiteName = "OVFImportTests"
+	testSuiteName = "OVFMachineImageImportTests"
 	ovaBucket     = "compute-image-tools-test-resources"
 )
 


### PR DESCRIPTION
Fixed OVF instance import E2E tests not being reported in the test grid due to machine image import overwriting the test results (due to the shared testSuiteName)