### PR TITLE
[image-import] windows translation: reinstall google-compute-engine-metadata-scripts to prevent dead loop

### DIFF
--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -39,4 +39,4 @@ w32tm /resync
 C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet > COM1:
 REM Install google-compute-engine-metadata-scripts and then run the task.
 REM This needs to be on one line as this file will get overwritten.
-start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"
+start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm verify -reinstall google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"

--- a/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
@@ -42,4 +42,4 @@ w32tm /resync
 echo "Translate: Installing GooGet." > COM1:
 C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\googet-x86.x86_32.2.16.3@1.goo
 echo "Translate: Installing metadata scripts runner." > COM1:
-start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: && schtasks /run /tn GCEStartup > COM1:"
+start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: && C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm verify -reinstall C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: && schtasks /run /tn GCEStartup > COM1:"


### PR DESCRIPTION
When installing google-compute-engine-metadata-scripts, script "run_startup_scripts.cmd" will be replaced.
Enforce a verify & reinstall to prevent skipping installing it. That bug happened when google-compute-engine-metadata-scripts exists.

The bug leads to a infinite loop of calling old run_startup_scripts.cmd.