### PR TITLE
Allow EL import to continue if image's HTTP proxy is unreachable.

### DIFF
--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -47,6 +47,9 @@
     "centos8 translate": {
       "Path": "./centos_8_translate.wf.json"
     },
+    "Enterprise Linux - Don't use proxy": {
+      "Path": "./el_import_dont_use_proxy.wf.json"
+    },
     "Image export latest": {
       "Path": "./image_export_latest.wf.json"
     },

--- a/daisy_integration_tests/el_import_dont_use_proxy.wf.json
+++ b/daisy_integration_tests/el_import_dont_use_proxy.wf.json
@@ -1,0 +1,96 @@
+{
+  "Name": "el-dont-use-proxy",
+  "Vars": {
+    "image_name": {
+      "Value": "el-dont-use-proxy-${ID}"
+    },
+    "source_image": {
+      "Value": "projects/compute-image-tools-test/global/images/cent-7-http-proxy"
+    },
+    "test-id": {
+      "Value": "",
+      "Description": "The ID of this test run."
+    }
+  },
+  "Steps": {
+    "create-disk-from-image": {
+      "CreateDisks": [
+        {
+          "name": "translate-me",
+          "sourceImage": "${source_image}"
+        }
+      ]
+    },
+    "create-test-disk": {
+      "CreateDisks": [
+        {
+          "name": "disk-import-test",
+          "sourceImage": "${image_name}",
+          "type": "pd-ssd"
+        }
+      ]
+    },
+    "create-test-instance": {
+      "CreateInstances": [
+        {
+          "disks": [
+            {
+              "source": "disk-import-test"
+            }
+          ],
+          "machineType": "n1-standard-4",
+          "name": "inst-import-test",
+          "metadata": {
+            "startup-script": "echo 'SUCCESS el-dont-use-proxy'"
+          }
+        }
+      ]
+    },
+    "delete-image": {
+      "DeleteResources": {
+        "Images": [
+          "${image_name}"
+        ]
+      }
+    },
+    "translate-disk": {
+      "Timeout": "30m",
+      "IncludeWorkflow": {
+        "Path": "../daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json",
+        "Vars": {
+          "image_name": "${image_name}",
+          "source_disk": "translate-me"
+        }
+      }
+    },
+    "wait-for-test-instance": {
+      "Timeout": "30m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-import-test",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "SUCCESS el-dont-use-proxy"
+          }
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-test-disk": [
+      "translate-disk"
+    ],
+    "create-test-instance": [
+      "create-test-disk"
+    ],
+    "delete-image": [
+      "create-test-disk"
+    ],
+    "translate-disk": [
+      "create-disk-from-image"
+    ],
+    "wait-for-test-instance": [
+      "create-test-instance"
+    ]
+  }
+}

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -202,7 +202,13 @@ def yum_install(g, *packages):
     try:
       # There's no sleep on the first iteration since `i` is zero.
       time.sleep(i**2)
-      g.command(['yum', 'install', '-y'] + list(packages))
+      # Bypass HTTP proxies configured in the guest image to allow
+      # import to continue when the proxy is unreachable.
+      #   no_proxy="*": Disables proxies set by using the `http_proxy`
+      #                 environment variable.
+      #   proxy=_none_: Disables proxies set in /etc/yum.conf.
+      g.sh('no_proxy="*" yum install --setopt=proxy=_none_ -y ' + ' '.join(
+          '"{0}"'.format(p) for p in packages))
       return
     except Exception as e:
       logging.debug('Failed to install {}. Details: {}.'.format(packages, e))


### PR DESCRIPTION
The test image `cent-7-http-proxy` specifies HTTP proxies in two ways:
1. Sets an HTTP proxy using the environment variable `http_proxy` in `/etc/profile`
2. Sets an HTTP proxy within `/etc/yum.conf`.

Testing:
- Ran new integration test
- Ran `centos_8_translate.wf.json` integration test