### PR TITLE
Trim import parameters of leading and trailing whitespace before sending to Daisy.

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -147,18 +147,18 @@ func (oi *OVFImporter) buildDaisyVars(
 	}
 
 	// common vars
-	if strings.TrimSpace(translateWorkflowPath) != "" {
-		varMap["translate_workflow"] = strings.TrimSpace(translateWorkflowPath)
+	if translateWorkflowPath != "" {
+		varMap["translate_workflow"] = translateWorkflowPath
 		varMap["install_gce_packages"] = strconv.FormatBool(!oi.params.NoGuestEnvironment)
 		varMap["is_windows"] = strconv.FormatBool(
 			strings.Contains(strings.ToLower(translateWorkflowPath), "windows"))
 	}
-	if strings.TrimSpace(bootDiskGcsPath) != "" {
-		varMap["boot_disk_file"] = strings.TrimSpace(bootDiskGcsPath)
+	if bootDiskGcsPath != "" {
+		varMap["boot_disk_file"] = bootDiskGcsPath
 	}
 	if strings.TrimSpace(oi.params.Subnet) != "" {
 		varMap["subnet"] = param.GetRegionalResourcePath(
-			strings.TrimSpace(region), "subnetworks", strings.TrimSpace(oi.params.Subnet))
+			region, "subnetworks", strings.TrimSpace(oi.params.Subnet))
 		// When subnet is set, we need to grant a value to network to avoid fallback to default
 		if oi.params.Network == "" {
 			varMap["network"] = ""
@@ -168,8 +168,8 @@ func (oi *OVFImporter) buildDaisyVars(
 		varMap["network"] = param.GetGlobalResourcePath(
 			"networks", strings.TrimSpace(oi.params.Network))
 	}
-	if strings.TrimSpace(machineType) != "" {
-		varMap["machine_type"] = strings.TrimSpace(machineType)
+	if machineType != "" {
+		varMap["machine_type"] = machineType
 	}
 	if strings.TrimSpace(oi.params.Description) != "" {
 		varMap["description"] = strings.TrimSpace(oi.params.Description)

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -139,45 +139,47 @@ func (oi *OVFImporter) buildDaisyVars(
 	varMap := map[string]string{}
 	if oi.params.IsInstanceImport() {
 		// instance import specific vars
-		varMap["instance_name"] = strings.ToLower(oi.params.InstanceNames)
+		varMap["instance_name"] = strings.ToLower(strings.TrimSpace(oi.params.InstanceNames))
 
 	} else {
 		// machine image import specific vars
-		varMap["machine_image_name"] = strings.ToLower(oi.params.MachineImageName)
+		varMap["machine_image_name"] = strings.ToLower(strings.TrimSpace(oi.params.MachineImageName))
 	}
 
 	// common vars
-	if translateWorkflowPath != "" {
-		varMap["translate_workflow"] = translateWorkflowPath
+	if strings.TrimSpace(translateWorkflowPath) != "" {
+		varMap["translate_workflow"] = strings.TrimSpace(translateWorkflowPath)
 		varMap["install_gce_packages"] = strconv.FormatBool(!oi.params.NoGuestEnvironment)
 		varMap["is_windows"] = strconv.FormatBool(
 			strings.Contains(strings.ToLower(translateWorkflowPath), "windows"))
 	}
-	if bootDiskGcsPath != "" {
-		varMap["boot_disk_file"] = bootDiskGcsPath
+	if strings.TrimSpace(bootDiskGcsPath) != "" {
+		varMap["boot_disk_file"] = strings.TrimSpace(bootDiskGcsPath)
 	}
-	if oi.params.Subnet != "" {
-		varMap["subnet"] = param.GetRegionalResourcePath(region, "subnetworks", oi.params.Subnet)
+	if strings.TrimSpace(oi.params.Subnet) != "" {
+		varMap["subnet"] = param.GetRegionalResourcePath(
+			strings.TrimSpace(region), "subnetworks", strings.TrimSpace(oi.params.Subnet))
 		// When subnet is set, we need to grant a value to network to avoid fallback to default
 		if oi.params.Network == "" {
 			varMap["network"] = ""
 		}
 	}
-	if oi.params.Network != "" {
-		varMap["network"] = param.GetGlobalResourcePath("networks", oi.params.Network)
+	if strings.TrimSpace(oi.params.Network) != "" {
+		varMap["network"] = param.GetGlobalResourcePath(
+			"networks", strings.TrimSpace(oi.params.Network))
 	}
-	if machineType != "" {
-		varMap["machine_type"] = machineType
+	if strings.TrimSpace(machineType) != "" {
+		varMap["machine_type"] = strings.TrimSpace(machineType)
 	}
-	if oi.params.Description != "" {
-		varMap["description"] = oi.params.Description
+	if strings.TrimSpace(oi.params.Description) != "" {
+		varMap["description"] = strings.TrimSpace(oi.params.Description)
 	}
-	if oi.params.PrivateNetworkIP != "" {
-		varMap["private_network_ip"] = oi.params.PrivateNetworkIP
+	if strings.TrimSpace(oi.params.PrivateNetworkIP) != "" {
+		varMap["private_network_ip"] = strings.TrimSpace(oi.params.PrivateNetworkIP)
 	}
 
-	if oi.params.NetworkTier != "" {
-		varMap["network_tier"] = oi.params.NetworkTier
+	if strings.TrimSpace(oi.params.NetworkTier) != "" {
+		varMap["network_tier"] = strings.TrimSpace(oi.params.NetworkTier)
 	}
 	return varMap
 }

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -585,8 +585,22 @@ func TestCleanUp(t *testing.T) {
 }
 
 func TestBuildDaisyVarsFromDisk(t *testing.T) {
-	oi := OVFImporter{params: getAllInstanceImportParams()}
-	varMap := oi.buildDaisyVars("translateworkflow.wf.json", "gs://abucket/apath/bootdisk.vmdk", "n1-standard-2", "aRegion")
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
+
+	params := getAllInstanceImportParams()
+	params.InstanceNames = ws + params.InstanceNames + ws
+	params.Network = ws + params.Network + ws
+	params.Subnet = ws + params.Subnet + ws
+	params.Description = ws + params.Description + ws
+	params.PrivateNetworkIP = ws + params.PrivateNetworkIP + ws
+	params.NetworkTier = ws + params.NetworkTier + ws
+
+	oi := OVFImporter{params: params}
+	varMap := oi.buildDaisyVars(
+		ws+"translateworkflow.wf.json"+ws,
+		ws+"gs://abucket/apath/bootdisk.vmdk"+ws,
+		ws+"n1-standard-2"+ws,
+		ws+"aRegion"+ws)
 
 	assert.Equal(t, "instance1", varMap["instance_name"])
 	assert.Equal(t, "translateworkflow.wf.json", varMap["translate_workflow"])

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -597,10 +597,10 @@ func TestBuildDaisyVarsFromDisk(t *testing.T) {
 
 	oi := OVFImporter{params: params}
 	varMap := oi.buildDaisyVars(
-		ws+"translateworkflow.wf.json"+ws,
-		ws+"gs://abucket/apath/bootdisk.vmdk"+ws,
-		ws+"n1-standard-2"+ws,
-		ws+"aRegion"+ws)
+		"translateworkflow.wf.json",
+		"gs://abucket/apath/bootdisk.vmdk",
+		"n1-standard-2",
+		"aRegion")
 
 	assert.Equal(t, "instance1", varMap["instance_name"])
 	assert.Equal(t, "translateworkflow.wf.json", varMap["translate_workflow"])

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
@@ -85,23 +86,26 @@ func buildDaisyVars(destinationURI string, sourceImage string, format string, ne
 
 	varMap := map[string]string{}
 
-	varMap["destination"] = destinationURI
+	varMap["destination"] = strings.TrimSpace(destinationURI)
 
-	varMap["source_image"] = param.GetGlobalResourcePath("images", sourceImage)
+	varMap["source_image"] = param.GetGlobalResourcePath(
+		"images", strings.TrimSpace(sourceImage))
 
-	if format != "" {
-		varMap["format"] = format
+	if strings.TrimSpace(format) != "" {
+		varMap["format"] = strings.TrimSpace(format)
 	}
-	if subnet != "" {
-		varMap["export_subnet"] = param.GetRegionalResourcePath(region, "subnetworks", subnet)
+	if strings.TrimSpace(subnet) != "" {
+		varMap["export_subnet"] = param.GetRegionalResourcePath(
+			strings.TrimSpace(region), "subnetworks", strings.TrimSpace(subnet))
 
 		// When subnet is set, we need to grant a value to network to avoid fallback to default
-		if network == "" {
+		if strings.TrimSpace(network) == "" {
 			varMap["export_network"] = ""
 		}
 	}
-	if network != "" {
-		varMap["export_network"] = param.GetGlobalResourcePath("networks", network)
+	if strings.TrimSpace(network) != "" {
+		varMap["export_network"] = param.GetGlobalResourcePath(
+			"networks", strings.TrimSpace(network))
 	}
 	return varMap
 }

--- a/cli_tools/gce_vm_image_export/exporter/exporter_test.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter_test.go
@@ -69,7 +69,14 @@ func assertErrorOnValidate(errorMsg string, t *testing.T) {
 
 func TestBuildDaisyVarsWithoutFormatConversion(t *testing.T) {
 	resetArgs()
-	got := buildDaisyVars(destinationURI, sourceImage, format, network, subnet, "aRegion")
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
+	got := buildDaisyVars(
+		ws+destinationURI+ws,
+		ws+sourceImage+ws,
+		ws+format+ws,
+		ws+network+ws,
+		ws+subnet+ws,
+		ws+"aRegion"+ws)
 
 	assert.Equal(t, "global/images/anImage", got["source_image"])
 	assert.Equal(t, "gs://bucket/exported_image", got["destination"])
@@ -80,8 +87,14 @@ func TestBuildDaisyVarsWithoutFormatConversion(t *testing.T) {
 
 func TestBuildDaisyVarsWithFormatConversion(t *testing.T) {
 	resetArgs()
-	format = "vmdk"
-	got := buildDaisyVars(destinationURI, sourceImage, format, network, subnet, "aRegion")
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
+	got := buildDaisyVars(
+		ws+destinationURI+ws,
+		ws+sourceImage+ws,
+		ws+"vmdk"+ws,
+		ws+network+ws,
+		ws+subnet+ws,
+		ws+"aRegion"+ws)
 
 	assert.Equal(t, "global/images/anImage", got["source_image"])
 	assert.Equal(t, "gs://bucket/exported_image", got["destination"])
@@ -93,8 +106,14 @@ func TestBuildDaisyVarsWithFormatConversion(t *testing.T) {
 
 func TestBuildDaisyVarsWithSimpleImageName(t *testing.T) {
 	resetArgs()
-	sourceImage = "anImage"
-	got := buildDaisyVars(destinationURI, sourceImage, format, network, subnet, "aRegion")
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
+	got := buildDaisyVars(
+		ws+destinationURI+ws,
+		ws+"anImage"+ws,
+		ws+format+ws,
+		ws+network+ws,
+		ws+subnet+ws,
+		ws+"aRegion"+ws)
 
 	assert.Equal(t, "global/images/anImage", got["source_image"])
 }

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -165,7 +165,7 @@ func buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, f
 
 	varMap["image_name"] = strings.ToLower(strings.TrimSpace(imageName))
 	if translateWorkflowPath != "" {
-		varMap["translate_workflow"] = strings.TrimSpace(translateWorkflowPath)
+		varMap["translate_workflow"] = translateWorkflowPath
 		varMap["install_gce_packages"] = strconv.FormatBool(!noGuestEnvironment)
 		varMap["is_windows"] = strconv.FormatBool(strings.Contains(translateWorkflowPath, "windows"))
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -163,29 +163,30 @@ func buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, f
 
 	varMap := map[string]string{}
 
-	varMap["image_name"] = strings.ToLower(imageName)
+	varMap["image_name"] = strings.ToLower(strings.TrimSpace(imageName))
 	if translateWorkflowPath != "" {
-		varMap["translate_workflow"] = translateWorkflowPath
+		varMap["translate_workflow"] = strings.TrimSpace(translateWorkflowPath)
 		varMap["install_gce_packages"] = strconv.FormatBool(!noGuestEnvironment)
 		varMap["is_windows"] = strconv.FormatBool(strings.Contains(translateWorkflowPath, "windows"))
 	}
-	if sourceFile != "" {
-		varMap["source_disk_file"] = sourceFile
+	if strings.TrimSpace(sourceFile) != "" {
+		varMap["source_disk_file"] = strings.TrimSpace(sourceFile)
 	}
-	if sourceImage != "" {
-		varMap["source_image"] = param.GetGlobalResourcePath("images", sourceImage)
+	if strings.TrimSpace(sourceImage) != "" {
+		varMap["source_image"] = param.GetGlobalResourcePath("images", strings.TrimSpace(sourceImage))
 	}
-	varMap["family"] = family
-	varMap["description"] = description
+	varMap["family"] = strings.TrimSpace(family)
+	varMap["description"] = strings.TrimSpace(description)
 	if subnet != "" {
-		varMap["import_subnet"] = param.GetRegionalResourcePath(region, "subnetworks", subnet)
+		varMap["import_subnet"] = param.GetRegionalResourcePath(strings.TrimSpace(region),
+			"subnetworks", strings.TrimSpace(subnet))
 		// When subnet is set, we need to grant a value to network to avoid fallback to default
 		if network == "" {
 			varMap["import_network"] = ""
 		}
 	}
 	if network != "" {
-		varMap["import_network"] = param.GetGlobalResourcePath("networks", network)
+		varMap["import_network"] = param.GetGlobalResourcePath("networks", strings.TrimSpace(network))
 	}
 	return varMap
 }

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -262,56 +262,58 @@ func TestFlagsInvalidOS(t *testing.T) {
 
 func TestBuildDaisyVarsFromDisk(t *testing.T) {
 	resetArgs()
-	imageName = "image-a"
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000\uFEFF"
+	imageName = ws + "image-a" + ws
 	noGuestEnvironment = true
-	sourceFile = "source-file-path"
-	sourceImage = ""
-	family = "a-family"
-	description = "a-description"
-	network = "a-network"
-	subnet = "a-subnet"
-	region := "a-region"
+	sourceFile = ws + "source-file-path" + ws
+	sourceImage = ws
+	family = ws + "a-family" + ws
+	description = ws + "a-description" + ws
+	network = ws + "a-network" + ws
+	subnet = ws + "a-subnet" + ws
+	region := ws + "a-region" + ws
 
 	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
 		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
 
-	assert.Equal(t, got["image_name"], "image-a")
-	assert.Equal(t, got["translate_workflow"], "translate/workflow/path")
-	assert.Equal(t, got["install_gce_packages"], "false")
-	assert.Equal(t, got["source_disk_file"], "source-file-path")
-	assert.Equal(t, got["family"], "a-family")
-	assert.Equal(t, got["description"], "a-description")
-	assert.Equal(t, got["import_network"], "global/networks/a-network")
-	assert.Equal(t, got["import_subnet"], "regions/a-region/subnetworks/a-subnet")
-	assert.Equal(t, got["is_windows"], "false")
-	assert.Equal(t, len(got), 9)
+	assert.Equal(t, "image-a", got["image_name"])
+	assert.Equal(t, "translate/workflow/path", got["translate_workflow"])
+	assert.Equal(t, "false", got["install_gce_packages"])
+	assert.Equal(t, "source-file-path", got["source_disk_file"])
+	assert.Equal(t, "a-family", got["family"])
+	assert.Equal(t, "a-description", got["description"])
+	assert.Equal(t, "global/networks/a-network", got["import_network"])
+	assert.Equal(t, "regions/a-region/subnetworks/a-subnet", got["import_subnet"])
+	assert.Equal(t, "false", got["is_windows"])
+	assert.Equal(t, 9, len(got))
 }
 
 func TestBuildDaisyVarsFromImage(t *testing.T) {
 	resetArgs()
-	imageName = "image-a"
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
+	imageName = ws + "image-a" + ws
 	noGuestEnvironment = true
-	sourceFile = ""
-	sourceImage = "source-image"
-	family = "a-family"
-	description = "a-description"
-	network = "a-network"
-	subnet = "a-subnet"
-	region := "a-region"
+	sourceFile = ws
+	sourceImage = ws + "global/images/source-image" + ws
+	family = ws + "a-family" + ws
+	description = ws + "a-description" + ws
+	network = ws + "a-network" + ws
+	subnet = ws + "a-subnet" + ws
+	region := ws + "a-region" + ws
 
 	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
 		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
 
-	assert.Equal(t, got["image_name"], "image-a")
-	assert.Equal(t, got["translate_workflow"], "translate/workflow/path")
-	assert.Equal(t, got["install_gce_packages"], "false")
-	assert.Equal(t, got["source_image"], "global/images/source-image")
-	assert.Equal(t, got["family"], "a-family")
-	assert.Equal(t, got["description"], "a-description")
-	assert.Equal(t, got["import_network"], "global/networks/a-network")
-	assert.Equal(t, got["import_subnet"], "regions/a-region/subnetworks/a-subnet")
-	assert.Equal(t, got["is_windows"], "false")
-	assert.Equal(t, len(got), 9)
+	assert.Equal(t, "image-a", got["image_name"])
+	assert.Equal(t, "translate/workflow/path", got["translate_workflow"])
+	assert.Equal(t, "false", got["install_gce_packages"])
+	assert.Equal(t, "global/images/source-image", got["source_image"])
+	assert.Equal(t, "a-family", got["family"])
+	assert.Equal(t, "a-description", got["description"])
+	assert.Equal(t, "global/networks/a-network", got["import_network"])
+	assert.Equal(t, "regions/a-region/subnetworks/a-subnet", got["import_subnet"])
+	assert.Equal(t, "false", got["is_windows"])
+	assert.Equal(t, 9, len(got))
 }
 
 func TestBuildDaisyVarsWindow(t *testing.T) {

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -262,7 +262,7 @@ func TestFlagsInvalidOS(t *testing.T) {
 
 func TestBuildDaisyVarsFromDisk(t *testing.T) {
 	resetArgs()
-	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000\uFEFF"
+	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
 	imageName = ws + "image-a" + ws
 	noGuestEnvironment = true
 	sourceFile = ws + "source-file-path" + ws


### PR DESCRIPTION
This was motivated by imports that failed when the subnetwork paramater
reached daisy still having a leading space character.

In addition, this updates the usage of assert.Equal, which expects the first parameter to the be the expected value.