### PR TITLE
Revert "SLES image import: use 'sle-module-public-cloud/12/x86_64' subscription for any SLES 12.x, not only 12.5. (#1108)"

### DIFF
--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -91,7 +91,7 @@ _distros = [
     _SuseRelease(
         flavor='sles',
         major='12',
-        minor='*',
+        minor='5',
         products=['sle-module-public-cloud/12/x86_64']
     ),
 ]


### PR DESCRIPTION
This reverts commit 9a5cb7b7d72d4f74d65a48e96c9be2ea1d8e3def.

Reverting this while we continue to test versions of SLES 12 below 12.5.