### PR TITLE
Wrap Compute API error in Daisy error to prevent exposing PII data

### DIFF
--- a/cli_tools/common/utils/compute/zone_validator.go
+++ b/cli_tools/common/utils/compute/zone_validator.go
@@ -32,7 +32,7 @@ func (zv *ZoneValidator) ZoneValid(project string, zone string) error {
 	if err != nil {
 		// Check for Compute Engine API disabled
 		gAPIErr, isGAPIErr := err.(*googleapi.Error)
-		if isGAPIErr && gAPIErr.Code == 403 && gAPIErr.Errors[0].Reason == "accessNotConfigured" {
+		if isGAPIErr && gAPIErr.Code == 403 && len(gAPIErr.Errors) > 0 && gAPIErr.Errors[0].Reason == "accessNotConfigured" {
 			return daisy.Errf("Compute Engine API not configured: %v", gAPIErr)
 		}
 		return daisy.Errf("Couldn't validate zone `%v`: %v", zone, gAPIErr)

--- a/cli_tools/common/utils/compute/zone_validator.go
+++ b/cli_tools/common/utils/compute/zone_validator.go
@@ -17,6 +17,7 @@ package compute
 import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"google.golang.org/api/googleapi"
 )
 
 // ZoneValidator is responsible for validating zone name corresponds to a valid zone in a given
@@ -29,7 +30,12 @@ type ZoneValidator struct {
 func (zv *ZoneValidator) ZoneValid(project string, zone string) error {
 	zl, err := zv.ComputeClient.ListZones(project)
 	if err != nil {
-		return err
+		// Check for Compute Engine API disabled
+		gAPIErr, isGAPIErr := err.(*googleapi.Error)
+		if isGAPIErr && gAPIErr.Code == 403 && gAPIErr.Errors[0].Reason == "accessNotConfigured" {
+			return daisy.Errf("Compute Engine API not configured: %v", gAPIErr)
+		}
+		return daisy.Errf("Couldn't validate zone `%v`: %v", zone, gAPIErr)
 	}
 	for _, z := range zl {
 		if z.Name == zone {


### PR DESCRIPTION
Wrap Compute API error in Daisy error to prevent exposing PII data. Also, check if it's Compute Engine API disabled and report it as such.