### PR TITLE
[image-import] windows: bring disks online before translate

### DIFF
--- a/daisy_workflows/image_import/windows/translate_bootstrap.ps1
+++ b/daisy_workflows/image_import/windows/translate_bootstrap.ps1
@@ -120,6 +120,7 @@ try {
   $script:is_x86 = Get-MetadataValue -key 'is_x86'
 
   $partition_style = Get-Disk 1 | Select-Object -Expand PartitionStyle
+  Get-Disk | Where-Object -Property OperationalStatus -EQ "Offline" | Set-Disk -IsOffline $false
   Get-Disk 1 | Get-Partition | ForEach-Object {
     if (-not $_.DriveLetter) {
       # Ensure all available partitions on the import disk are accessible via drive letter.


### PR DESCRIPTION
This happened when importing a non-uefi windows-2019 image: the secondary disk was offline, so it failed.

Just simply bring all offlined disk online to fix. Manually tested and it passed.