### PR TITLE
Add clarifying message if SUSE version is not supported.

### DIFF
--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -108,8 +108,12 @@ def _get_distro(g) -> _SuseRelease:
       if d.major == g.gcp_image_major or d.major == '*':
         if d.minor == g.gcp_image_minor or d.minor == '*':
           return d
-  raise ValueError('Import script not defined for {} {}.{}'.format(
-      g.gcp_image_distro, g.gcp_image_major, g.gcp_image_minor))
+  supported = ', '.join(
+      ['{}-{}.{}'.format(d.flavor, d.major, d.minor) for d in _distros])
+  raise ValueError(
+      'Import of {}-{}.{} is not supported. '
+      'The following versions are supported: [{}]'.format(
+          g.gcp_image_distro, g.gcp_image_major, g.gcp_image_minor, supported))
 
 
 def _disambiguate_suseconnect_product_error(g, product, error) -> Exception:


### PR DESCRIPTION
Here's the output when I ran an import with opensuse-15:

`TranslateFailed: error: Import of opensuse-15.0 is not supported. The following versions are supported: [opensuse-15.1, sles-15.1, sles-12.5]`