### PR TITLE
[daisy] Add "RetryHook" to accept retry logic from external

### DIFF
--- a/cli_tools/common/utils/daisy/daisy_utils.go
+++ b/cli_tools/common/utils/daisy/daisy_utils.go
@@ -33,8 +33,8 @@ const (
 	// BuildIDOSEnvVarName is the os env var name to get build id
 	BuildIDOSEnvVarName   = "BUILD_ID"
 	translateFailedPrefix = "TranslateFailed"
-	pdStandard = "pd-standard"
-	pdSsd      = "pd-ssd"
+	pdStandard            = "pd-standard"
+	pdSsd                 = "pd-ssd"
 )
 
 var (
@@ -216,7 +216,7 @@ func SetupRetryHookForCreateInstances(w *daisy.Workflow) {
 				// Fallback to no-external-ip mode to workaround organization policy.
 				if isExternalIPDeniedByOrganizationPolicy(originalErr) {
 					w.LogStepInfo(s.GetName(), "CreateInstances", "Falling back to no-external-ip mode "+
-							"for creating instance %v due to the fact that external IP is denied by organization policy.", ci.Name)
+						"for creating instance %v due to the fact that external IP is denied by organization policy.", ci.Name)
 
 					updateInstanceNoExternalIP(s)
 					if retryErr := w.ComputeClient.CreateInstance(ci.Project, ci.Zone, &ci.Instance); retryErr != nil {
@@ -234,7 +234,7 @@ func SetupRetryHookForCreateInstances(w *daisy.Workflow) {
 				// Fallback to no-external-ip mode to workaround organization policy.
 				if isExternalIPDeniedByOrganizationPolicy(originalErr) {
 					w.LogStepInfo(s.GetName(), "CreateInstances", "Falling back to no-external-ip mode "+
-							"for creating instance %v due to the fact that external IP is denied by organization policy.", ci.Name)
+						"for creating instance %v due to the fact that external IP is denied by organization policy.", ci.Name)
 
 					updateInstanceNoExternalIP(s)
 					if retryErr := w.ComputeClient.CreateInstanceBeta(ci.Project, ci.Zone, &ci.Instance); retryErr != nil {
@@ -247,7 +247,6 @@ func SetupRetryHookForCreateInstances(w *daisy.Workflow) {
 		}
 	})
 }
-
 
 func isExternalIPDeniedByOrganizationPolicy(err error) bool {
 	if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusPreconditionFailed {
@@ -269,8 +268,8 @@ func SetupRetryHookForCreateDisks(w *daisy.Workflow) {
 				// Fallback to pd-standard to avoid quota issue.
 				if strings.HasSuffix(cd.Type, pdSsd) && isQuotaExceeded(originalErr) {
 					w.LogStepInfo(s.GetName(), "CreateDisks", "Falling back to pd-standard for disk %v. "+
-							"It may be caused by insufficient pd-ssd quota. Consider increasing pd-ssd quota to "+
-							"avoid using ps-standard for better performance.", cd.Name)
+						"It may be caused by insufficient pd-ssd quota. Consider increasing pd-ssd quota to "+
+						"avoid using ps-standard for better performance.", cd.Name)
 					cd.Type = strings.TrimRight(cd.Type, pdSsd) + pdStandard
 					if retryErr := w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk); retryErr != nil {
 						return daisy.Errf("failed to create disk: %v", retryErr)

--- a/cli_tools/common/utils/daisy/daisy_utils.go
+++ b/cli_tools/common/utils/daisy/daisy_utils.go
@@ -265,9 +265,12 @@ func SetupRetryHookForCreateDisks(w *daisy.Workflow) {
 
 		for _, cdPtr := range *s.CreateDisks {
 			cd := cdPtr
+			fmt.Println(">>>>Set hook")
 			cd.SetRetryHook(func(s *daisy.Step, err daisy.DError, originalErr error) daisy.DError {
 				// Fallback to pd-standard to avoid quota issue.
+				fmt.Println(">>>>call hook?")
 				if strings.HasSuffix(cd.Type, pdSsd) && isQuotaExceeded(originalErr) {
+					fmt.Println(">>>>Entered!")
 					w.LogStepInfo(s.GetName(), "CreateDisks", "Falling back to pd-standard for disk %v. "+
 							"It may be caused by insufficient pd-ssd quota. Consider increasing pd-ssd quota to "+
 							"avoid using ps-standard for better performance.", cd.Name)

--- a/cli_tools/common/utils/daisy/daisy_utils.go
+++ b/cli_tools/common/utils/daisy/daisy_utils.go
@@ -265,12 +265,9 @@ func SetupRetryHookForCreateDisks(w *daisy.Workflow) {
 
 		for _, cdPtr := range *s.CreateDisks {
 			cd := cdPtr
-			fmt.Println(">>>>Set hook")
 			cd.SetRetryHook(func(s *daisy.Step, err daisy.DError, originalErr error) daisy.DError {
 				// Fallback to pd-standard to avoid quota issue.
-				fmt.Println(">>>>call hook?")
 				if strings.HasSuffix(cd.Type, pdSsd) && isQuotaExceeded(originalErr) {
-					fmt.Println(">>>>Entered!")
 					w.LogStepInfo(s.GetName(), "CreateDisks", "Falling back to pd-standard for disk %v. "+
 							"It may be caused by insufficient pd-ssd quota. Consider increasing pd-ssd quota to "+
 							"avoid using ps-standard for better performance.", cd.Name)

--- a/cli_tools/common/utils/daisy/daisy_utils_test.go
+++ b/cli_tools/common/utils/daisy/daisy_utils_test.go
@@ -252,10 +252,10 @@ func TestSetupRetryHookForCreateInstances(t *testing.T) {
 		t.Errorf("Instance AccessConfigs empty")
 	}
 
-	externalIpAccessErr := &googleapi.Error{Code: http.StatusPreconditionFailed, Message: "Some error caused by constraints/compute.vmExternalIpAccess."}
-	err = ci.GetRetryHook()(s, regularErr, externalIpAccessErr)
+	externalIPAccessErr := &googleapi.Error{Code: http.StatusPreconditionFailed, Message: "Some error caused by constraints/compute.vmExternalIpAccess."}
+	err = ci.GetRetryHook()(s, regularErr, externalIPAccessErr)
 	assert.Nil(t, err)
-	err = ciBeta.GetRetryHook()(s, regularErr, externalIpAccessErr)
+	err = ciBeta.GetRetryHook()(s, regularErr, externalIPAccessErr)
 	assert.Nil(t, err)
 	if len(ci.NetworkInterfaces[0].AccessConfigs) != 0 {
 		t.Errorf("Instance AccessConfigs not empty")

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -54,14 +54,14 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 					Type:        "pd-ssd",
 				},
-				SizeGb:               importerDiskSize,
+				SizeGb: importerDiskSize,
 			},
 			{
 				Disk: compute.Disk{
 					Name: diskNames[i],
 					Type: "pd-ssd",
 				},
-				SizeGb:               "10",
+				SizeGb: "10",
 				Resource: daisy.Resource{
 					ExactName: true,
 					NoCleanup: true,
@@ -72,7 +72,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Name: scratchDiskDiskName,
 					Type: "pd-ssd",
 				},
-				SizeGb:               "10",
+				SizeGb: "10",
 				Resource: daisy.Resource{
 					ExactName: true,
 				},

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -55,7 +55,6 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Type:        "pd-ssd",
 				},
 				SizeGb:               importerDiskSize,
-				FallbackToPdStandard: true,
 			},
 			{
 				Disk: compute.Disk{
@@ -63,7 +62,6 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Type: "pd-ssd",
 				},
 				SizeGb:               "10",
-				FallbackToPdStandard: true,
 				Resource: daisy.Resource{
 					ExactName: true,
 					NoCleanup: true,
@@ -75,7 +73,6 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Type: "pd-ssd",
 				},
 				SizeGb:               "10",
-				FallbackToPdStandard: true,
 				Resource: daisy.Resource{
 					ExactName: true,
 				},

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater_test.go
@@ -68,17 +68,11 @@ func TestAddDiskImportSteps(t *testing.T) {
 	assert.Equal(t, "10", (*w.Steps["setup-data-disk-1"].CreateDisks)[0].SizeGb)
 	assert.Equal(t, "10", (*w.Steps["setup-data-disk-1"].CreateDisks)[1].SizeGb)
 	assert.Equal(t, "10", (*w.Steps["setup-data-disk-1"].CreateDisks)[2].SizeGb)
-	assert.Equal(t, true, (*w.Steps["setup-data-disk-1"].CreateDisks)[0].FallbackToPdStandard)
-	assert.Equal(t, true, (*w.Steps["setup-data-disk-1"].CreateDisks)[1].FallbackToPdStandard)
-	assert.Equal(t, true, (*w.Steps["setup-data-disk-1"].CreateDisks)[2].FallbackToPdStandard)
 
 	assert.Equal(t, 3, len(*w.Steps["setup-data-disk-2"].CreateDisks))
 	assert.Equal(t, "10", (*w.Steps["setup-data-disk-2"].CreateDisks)[0].SizeGb)
 	assert.Equal(t, "10", (*w.Steps["setup-data-disk-2"].CreateDisks)[1].SizeGb)
 	assert.Equal(t, "10", (*w.Steps["setup-data-disk-2"].CreateDisks)[2].SizeGb)
-	assert.Equal(t, true, (*w.Steps["setup-data-disk-2"].CreateDisks)[0].FallbackToPdStandard)
-	assert.Equal(t, true, (*w.Steps["setup-data-disk-2"].CreateDisks)[1].FallbackToPdStandard)
-	assert.Equal(t, true, (*w.Steps["setup-data-disk-2"].CreateDisks)[2].FallbackToPdStandard)
 
 	assert.Equal(t,
 		[]*compute.AttachedDisk{

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -367,6 +367,7 @@ func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
 	if oi.params.UefiCompatible {
 		daisyutils.UpdateToUEFICompatible(w)
 	}
+	daisyutils.SetupRetryHookForCreateDisks(w)
 }
 
 func (oi *OVFImporter) getMachineType(

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -368,6 +368,7 @@ func (oi *OVFImporter) modifyWorkflowPostValidate(w *daisy.Workflow) {
 		daisyutils.UpdateToUEFICompatible(w)
 	}
 	daisyutils.SetupRetryHookForCreateDisks(w)
+	daisyutils.SetupRetryHookForCreateInstances(w)
 }
 
 func (oi *OVFImporter) getMachineType(

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -140,6 +140,8 @@ func runExportWorkflow(ctx context.Context, exportWorkflowPath string, varMap ma
 				return "gce-image-export"
 			}}
 		rl.LabelResources(w)
+		daisyutils.SetupRetryHookForCreateDisks(w)
+		daisyutils.SetupRetryHookForCreateInstances(w)
 	}
 
 	err = workflow.RunWithModifiers(ctx, preValidateWorkflowModifier, postValidateWorkflowModifier)

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -194,7 +194,7 @@ func buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, f
 func runImport(ctx context.Context, varMap map[string]string, importWorkflowPath string, zone string,
 	timeout string, project string, scratchBucketGcsPath string, oauth string, ce string,
 	gcsLogsDisabled bool, cloudLogsDisabled bool, stdoutLogsDisabled bool, kmsKey string,
-	kmsKeyring string, kmsLocation string, kmsProject string, noExternalIP bool,
+	kmsKeyring string, kmsLocation string, kmsProject string,
 	userLabels map[string]string, storageLocation string, uefiCompatible bool) (*daisy.Workflow, error) {
 
 	workflow, err := daisycommon.ParseWorkflow(importWorkflowPath, varMap,
@@ -230,11 +230,11 @@ func runImport(ctx context.Context, varMap map[string]string, importWorkflowPath
 				return imageTypeLabel
 			}}
 		rl.LabelResources(w)
-		daisyutils.UpdateAllInstanceNoExternalIP(w, noExternalIP)
 		if uefiCompatible {
 			daisyutils.UpdateToUEFICompatible(w)
 		}
 		daisyutils.SetupRetryHookForCreateDisks(w)
+		daisyutils.SetupRetryHookForCreateInstances(w)
 	}
 
 	return workflow, workflow.RunWithModifiers(ctx, preValidateWorkflowModifier, postValidateWorkflowModifier)
@@ -246,7 +246,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	network string, subnet string, zone string, timeout string, project *string,
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool, cloudLogsDisabled bool,
 	stdoutLogsDisabled bool, kmsKey string, kmsKeyring string, kmsLocation string, kmsProject string,
-	noExternalIP bool, labels string, currentExecutablePath string, storageLocation string,
+	labels string, currentExecutablePath string, storageLocation string,
 	uefiCompatible bool) (*daisy.Workflow, error) {
 
 	log.SetPrefix(logPrefix + " ")
@@ -296,7 +296,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	var w *daisy.Workflow
 	if w, err = runImport(ctx, varMap, importWorkflowPath, zone, timeout, *project, scratchBucketGcsPath,
 		oauth, ce, gcsLogsDisabled, cloudLogsDisabled, stdoutLogsDisabled, kmsKey, kmsKeyring,
-		kmsLocation, kmsProject, noExternalIP, userLabels, storageLocation, uefiCompatible); err != nil {
+		kmsLocation, kmsProject, userLabels, storageLocation, uefiCompatible); err != nil {
 
 		daisyutils.PostProcessDErrorForNetworkFlag("image import", err, network, w)
 

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -234,6 +234,7 @@ func runImport(ctx context.Context, varMap map[string]string, importWorkflowPath
 		if uefiCompatible {
 			daisyutils.UpdateToUEFICompatible(w)
 		}
+		daisyutils.SetupRetryHookForCreateDisks(w)
 	}
 
 	return workflow, workflow.RunWithModifiers(ctx, preValidateWorkflowModifier, postValidateWorkflowModifier)

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -50,7 +50,6 @@ var (
 	kmsKeyring           = flag.String("kms_keyring", "", "The KMS keyring of the key.")
 	kmsLocation          = flag.String("kms_location", "", "The Cloud location for the key.")
 	kmsProject           = flag.String("kms_project", "", "The Cloud project for the key")
-	noExternalIP         = flag.Bool("no_external_ip", false, "VPC doesn't allow external IPs")
 	labels               = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
 	storageLocation      = flag.String("storage_location", "", "Location for the imported image which can be any GCS location. If the location parameter is not included, images are created in the multi-region associated with the source disk, image, snapshot or GCS bucket.")
 	uefiCompatible       = flag.Bool("uefi_compatible", false, "Enables UEFI booting, which is an alternative system boot method. Most public images use the GRUB bootloader as their primary boot method.")
@@ -61,7 +60,7 @@ func importEntry() (*daisy.Workflow, error) {
 	return importer.Run(*clientID, *imageName, *dataDisk, *osID, *customTranWorkflow, *sourceFile,
 		*sourceImage, *noGuestEnvironment, *family, *description, *network, *subnet, *zone, *timeout,
 		project, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
-		*stdoutLogsDisabled, *kmsKey, *kmsKeyring, *kmsLocation, *kmsProject, *noExternalIP,
+		*stdoutLogsDisabled, *kmsKey, *kmsKeyring, *kmsLocation, *kmsProject,
 		*labels, currentExecutablePath, *storageLocation, *uefiCompatible)
 }
 
@@ -94,7 +93,6 @@ func main() {
 			NoGuestEnvironment: *noGuestEnvironment,
 			Family:             *family,
 			Description:        *description,
-			NoExternalIP:       *noExternalIP,
 			HasKmsKey:          *kmsKey != "",
 			HasKmsKeyring:      *kmsKeyring != "",
 			HasKmsLocation:     *kmsLocation != "",

--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -28,3 +28,5 @@ require (
 	google.golang.org/api v0.17.0
 	google.golang.org/grpc v1.27.1 // indirect
 )
+
+replace github.com/GoogleCloudPlatform/compute-image-tools/daisy => ../daisy

--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go v0.53.0
 	cloud.google.com/go/storage v1.5.0
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200214212030-cdab85f8f241
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200219213738-41e8aea99239
 	github.com/GoogleCloudPlatform/compute-image-tools/mocks v0.0.0-20200206014411-426b6301f679
 	github.com/GoogleCloudPlatform/osconfig v0.0.0-20200211005319-080372593330
 	github.com/dustin/go-humanize v1.0.0
@@ -13,7 +13,7 @@ require (
 	github.com/golang/mock v1.4.0
 	github.com/google/logger v1.0.1
 	github.com/google/uuid v1.1.1
-	github.com/klauspost/compress v1.10.0 // indirect
+	github.com/klauspost/compress v1.10.1 // indirect
 	github.com/klauspost/pgzip v1.2.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/minio/highwayhash v1.0.0
@@ -22,10 +22,11 @@ require (
 	go.opencensus.io v0.22.3 // indirect
 	golang.org/x/exp v0.0.0-20200213203834-85f925bdd4d0 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirecresource_labeler_testt
-	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4
-	golang.org/x/tools v0.0.0-20200214201135-548b770e2dfa // indirect
+	golang.org/x/net v0.0.0-20200219183655-46282727080f // indirecresource_labeler_testt
+	golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c
+	golang.org/x/tools v0.0.0-20200220155224-947cbf191135 // indirect
 	google.golang.org/api v0.17.0
+	google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 // indirect
 	google.golang.org/grpc v1.27.1 // indirect
 )
 

--- a/cli_tools/go.sum
+++ b/cli_tools/go.sum
@@ -137,6 +137,8 @@ github.com/klauspost/compress v1.9.8 h1:VMAMUUOh+gaxKTMk+zqbjsSjsIcUcL/LF4o63i82
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.0 h1:92XGj1AcYzA6UrVdd4qIIBrT8OroryvRvdmg/IfmC7Y=
 github.com/klauspost/compress v1.10.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.1 h1:a/QY0o9S6wCi0XhxaMX/QmusicNUqCqFugR6WKPOSoQ=
+github.com/klauspost/compress v1.10.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM=
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -233,6 +235,8 @@ golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCT
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200219183655-46282727080f h1:dB42wwhNuwPvh8f+5zZWNcU+F2Xs/B9wXXwvUCOH7r8=
+golang.org/x/net v0.0.0-20200219183655-46282727080f/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -273,6 +277,8 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfru
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c h1:jceGD5YNJGgGMkJz79agzOln1K9TaZUjv5ird16qniQ=
+golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -323,6 +329,8 @@ golang.org/x/tools v0.0.0-20200213215053-695c81b9c693 h1:cavpmULeqA05a7O3fsa+45j
 golang.org/x/tools v0.0.0-20200213215053-695c81b9c693/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200214201135-548b770e2dfa h1:BmyblL6HF4UvCacG8vRH/IPhx3pIS4LMNkeqP6+vEwc=
 golang.org/x/tools v0.0.0-20200214201135-548b770e2dfa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200220155224-947cbf191135 h1:kjnuf2YFfn8wNTzKa7cjLZ2D5CRK4tJ4OzLY6uoXsik=
+golang.org/x/tools v0.0.0-20200220155224-947cbf191135/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -370,6 +378,8 @@ google.golang.org/genproto v0.0.0-20200205142000-a86caf926a67 h1:MBO9fkVSrTpJ8vg
 google.golang.org/genproto v0.0.0-20200205142000-a86caf926a67/go.mod h1:GmwEX6Z4W5gMy59cAlVYjN9JhxgbQH6Gn+gFDQe2lzA=
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce h1:1mbrb1tUU+Zmt5C94IGKADBTJZjZXAd+BubWi7r9EiI=
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 h1:jB9+PJSvu5tBfmJHy/OVapFdjDF3WvpkqRhxqrmzoEU=
+google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/cli_tools/go.sum
+++ b/cli_tools/go.sum
@@ -92,6 +92,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.0 h1:Rd1kQnQu0Hq3qvJppYSG0HtP+f5LPPUiDswTLiEegLg=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/daisy/common.go
+++ b/daisy/common.go
@@ -280,26 +280,3 @@ func CombineGuestOSFeaturesBeta(features1 []*computeBeta.GuestOsFeature,
 	})
 	return ret
 }
-
-// UpdateInstanceNoExternalIP updates Create Instance step to operate
-// when no external IP access is allowed by the VPC Daisy workflow is running in.
-func UpdateInstanceNoExternalIP(step *Step) {
-	if step.CreateInstances != nil {
-		for _, instance := range step.CreateInstances.Instances {
-			if instance.Instance.NetworkInterfaces == nil {
-				continue
-			}
-			for _, networkInterface := range instance.Instance.NetworkInterfaces {
-				networkInterface.AccessConfigs = []*compute.AccessConfig{}
-			}
-		}
-		for _, instance := range step.CreateInstances.InstancesBeta {
-			if instance.Instance.NetworkInterfaces == nil {
-				continue
-			}
-			for _, networkInterface := range instance.Instance.NetworkInterfaces {
-				networkInterface.AccessConfigs = []*computeBeta.AccessConfig{}
-			}
-		}
-	}
-}

--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -65,6 +65,7 @@ func diskExists(client daisyCompute.Client, project, zone, disk string) (bool, D
 type Disk struct {
 	compute.Disk
 	Resource
+	fallbackRetryableTask
 
 	// If this is enabled, then WINDOWS will be added to the
 	// disk's guestOsFeatures. This is a string since daisy
@@ -75,9 +76,6 @@ type Disk struct {
 
 	// Size of this disk.
 	SizeGb string `json:"sizeGb,omitempty"`
-
-	// Fallback to pd-standard when quota is not enough for higher-level pd
-	FallbackToPdStandard bool `json:"fallbackToPdStandard,omitempty"`
 }
 
 // MarshalJSON is a hacky workaround to prevent Disk from using compute.Disk's implementation.

--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -78,6 +78,10 @@ type Disk struct {
 	SizeGb string `json:"sizeGb,omitempty"`
 }
 
+func (d *Disk) GetFallbackRetryableTask() fallbackRetryableTask {
+	return d.fallbackRetryableTask
+}
+
 // MarshalJSON is a hacky workaround to prevent Disk from using compute.Disk's implementation.
 func (d *Disk) MarshalJSON() ([]byte, error) {
 	return json.Marshal(*d)

--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -78,7 +78,7 @@ type Disk struct {
 	SizeGb string `json:"sizeGb,omitempty"`
 }
 
-func (d *Disk) GetFallbackRetryableTask() fallbackRetryableTask {
+func (d *Disk) getFallbackRetryableTask() fallbackRetryableTask {
 	return d.fallbackRetryableTask
 }
 

--- a/daisy/instance.go
+++ b/daisy/instance.go
@@ -125,8 +125,8 @@ type InstanceBase struct {
 	StartupScript string `json:",omitempty"`
 }
 
-func (d *InstanceBase) GetFallbackRetryableTask() fallbackRetryableTask {
-	return d.fallbackRetryableTask
+func (ib *InstanceBase) getFallbackRetryableTask() fallbackRetryableTask {
+	return ib.fallbackRetryableTask
 }
 
 // Instance is used to create a GCE instance using GA API.

--- a/daisy/instance.go
+++ b/daisy/instance.go
@@ -125,6 +125,10 @@ type InstanceBase struct {
 	StartupScript string `json:",omitempty"`
 }
 
+func (d *InstanceBase) GetFallbackRetryableTask() fallbackRetryableTask {
+	return d.fallbackRetryableTask
+}
+
 // Instance is used to create a GCE instance using GA API.
 // Output of serial port 1 will be streamed to the daisy logs directory.
 type Instance struct {

--- a/daisy/logger.go
+++ b/daisy/logger.go
@@ -125,7 +125,9 @@ func (w *Workflow) logEntry(e *LogEntry) {
 		rw = rw.parent
 	}
 
-	w.Logger.WriteLogEntry(e)
+	if w.Logger != nil {
+		w.Logger.WriteLogEntry(e)
+	}
 }
 
 // WriteSerialPortLogs writes serial port logs to cloud logging.

--- a/daisy/step.go
+++ b/daisy/step.go
@@ -72,11 +72,8 @@ func runMultiTasksStepImpl(mtsi multiTasksStepImpl, ctx context.Context, s *Step
 			defer wg.Done()
 
 			if err, originalErr := mtsi.runTask(ctx, t, s); err != nil {
-				fmt.Println("has error!!!")
 				if frt, ok := t.(FallbackRetryableTaskGetter); ok {
-					fmt.Println(">>>>Has hook?")
 					if frt.GetFallbackRetryableTask().retryHook != nil {
-						fmt.Println(">>>>Has hook!")
 						err = frt.GetFallbackRetryableTask().retryHook(s, err, originalErr)
 					}
 				}

--- a/daisy/step.go
+++ b/daisy/step.go
@@ -151,7 +151,7 @@ func NewStepDefaultTimeout(name string, w *Workflow) *Step {
 	return NewStep(name, w, 0)
 }
 
-func (s *Step) StepImpl() (stepImpl, DError) {
+func (s *Step) stepImpl() (stepImpl, DError) {
 	var result stepImpl
 	matchCount := 0
 	if s.AttachDisks != nil {
@@ -329,7 +329,7 @@ func (s *Step) getChain() []*Step {
 
 func (s *Step) populate(ctx context.Context) DError {
 	s.w.LogWorkflowInfo("Populating step %q", s.name)
-	impl, err := s.StepImpl()
+	impl, err := s.stepImpl()
 	if err != nil {
 		return s.wrapPopulateError(err)
 	}
@@ -347,7 +347,7 @@ func (s *Step) recordStepTime(startTime time.Time) {
 func (s *Step) run(ctx context.Context) DError {
 	startTime := time.Now()
 	defer s.recordStepTime(startTime)
-	impl, err := s.StepImpl()
+	impl, err := s.stepImpl()
 	if err != nil {
 		return s.wrapRunError(err)
 	}
@@ -374,7 +374,7 @@ func (s *Step) validate(ctx context.Context) DError {
 	if !rfc1035Rgx.MatchString(strings.ToLower(s.name)) {
 		return s.wrapValidateError(Errf("step name must start with a letter and only contain letters, numbers, and hyphens"))
 	}
-	impl, err := s.StepImpl()
+	impl, err := s.stepImpl()
 	if err != nil {
 		return s.wrapValidateError(err)
 	}

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -16,6 +16,7 @@ package daisy
 
 import (
 	"context"
+	"fmt"
 )
 
 // CreateDisks is a Daisy CreateDisks workflow step.
@@ -64,6 +65,7 @@ func (c *CreateDisks) runTask(ctx context.Context, t interface{}, s *Step) (DErr
 
 	w.LogStepInfo(s.name, "CreateDisks", "Creating disk %q.", cd.Name)
 	if err := w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk); err != nil {
+		fmt.Println("has error!")
 		return newErr("failed to create disk", err), err
 	}
 

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -47,27 +47,29 @@ func (c *CreateDisks) iterateAllTasks(ctx context.Context, f func(context.Contex
 	}
 }
 
-func (c *CreateDisks) runTask(ctx context.Context, t interface{}, s *Step) DError {
+func (c *CreateDisks) runTask(ctx context.Context, t interface{}, s *Step) (DError, error) {
 	cd, ok := t.(*Disk)
 	if !ok {
-		return nil
+		return nil, nil
 	}
+
+	w := s.w
 
 	// Get the source image link if using a source image.
 	if cd.SourceImage != "" {
-		if image, ok := s.w.images.get(cd.SourceImage); ok {
+		if image, ok := w.images.get(cd.SourceImage); ok {
 			cd.SourceImage = image.link
 		}
 	}
 
-	s.w.LogStepInfo(s.name, "CreateDisks", "Creating disk %q.", cd.Name)
-	if err := s.w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk); err != nil {
-		return newErr("failed to create disk", err)
+	w.LogStepInfo(s.name, "CreateDisks", "Creating disk %q.", cd.Name)
+	if err := w.ComputeClient.CreateDisk(cd.Project, cd.Zone, &cd.Disk); err != nil {
+		return newErr("failed to create disk", err), err
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (c *CreateDisks) waitAllTasksBeforeCleanup() bool {
-	return false
+	return true
 }

--- a/daisy/step_create_disks.go
+++ b/daisy/step_create_disks.go
@@ -39,7 +39,7 @@ func (c *CreateDisks) validate(ctx context.Context, s *Step) DError {
 }
 
 func (c *CreateDisks) run(ctx context.Context, s *Step) DError {
-	return runMultiTasksStepImpl(c, ctx, s)
+	return runMultiTasksStepImpl(ctx, c, s)
 }
 
 func (c *CreateDisks) iterateAllTasks(ctx context.Context, f func(context.Context, interface{})) {

--- a/daisy/step_create_disks_test.go
+++ b/daisy/step_create_disks_test.go
@@ -31,11 +31,11 @@ func TestCreateDisksRun(t *testing.T) {
 	e := Errf("error")
 	quotaExceededErr := Errf("Some error\nCode: QUOTA_EXCEEDED\nMessage: some message.")
 	tests := []struct {
-		desc                 string
-		d                    compute.Disk
-		wantD                compute.Disk
-		clientErr            error
-		wantErr              DError
+		desc      string
+		d         compute.Disk
+		wantD     compute.Disk
+		clientErr error
+		wantErr   DError
 	}{
 		{"blank case", compute.Disk{}, compute.Disk{}, nil, nil},
 		{"resolve source image case", compute.Disk{SourceImage: "i1"}, compute.Disk{SourceImage: "i1link"}, nil, nil},

--- a/daisy/step_create_disks_test.go
+++ b/daisy/step_create_disks_test.go
@@ -34,30 +34,23 @@ func TestCreateDisksRun(t *testing.T) {
 		desc                 string
 		d                    compute.Disk
 		wantD                compute.Disk
-		clientErr            []error
+		clientErr            error
 		wantErr              DError
-		fallbackToPdStandard bool
 	}{
-		{"blank case", compute.Disk{}, compute.Disk{}, nil, nil, false},
-		{"resolve source image case", compute.Disk{SourceImage: "i1"}, compute.Disk{SourceImage: "i1link"}, nil, nil, false},
-		{"client error case", compute.Disk{}, compute.Disk{}, []error{e}, e, false},
-		{"not fallback to pd-standard case", compute.Disk{Type: "prefix/pd-ssd"}, compute.Disk{Type: "prefix/pd-ssd"}, []error{e}, e, true},
-		{"fallback to pd-standard case", compute.Disk{Type: "prefix/pd-ssd"}, compute.Disk{Type: "prefix/pd-standard"}, []error{quotaExceededErr, nil}, nil, true},
+		{"blank case", compute.Disk{}, compute.Disk{}, nil, nil},
+		{"resolve source image case", compute.Disk{SourceImage: "i1"}, compute.Disk{SourceImage: "i1link"}, nil, nil},
+		{"client error case", compute.Disk{}, compute.Disk{}, e, e},
+		{"not fallback to pd-standard", compute.Disk{Type: "prefix/pd-ssd"}, compute.Disk{Type: "prefix/pd-ssd"}, e, e},
+		{"not fallback to pd-standard without retry hook", compute.Disk{Type: "prefix/pd-ssd"}, compute.Disk{Type: "prefix/pd-ssd"}, quotaExceededErr, quotaExceededErr},
 	}
 	for _, tt := range tests {
 		var gotD compute.Disk
-		var errIndex = 0
 		fake := func(_, _ string, d *compute.Disk) error {
 			gotD = *d
-			if tt.clientErr == nil {
-				return nil
-			}
-			var ret = tt.clientErr[errIndex]
-			errIndex = (errIndex + 1) % len(tt.clientErr)
-			return ret
+			return tt.clientErr
 		}
 		w.ComputeClient = &daisyCompute.TestClient{CreateDiskFn: fake}
-		cds := &CreateDisks{{Disk: tt.d, FallbackToPdStandard: tt.fallbackToPdStandard}}
+		cds := &CreateDisks{{Disk: tt.d}}
 		if err := cds.run(ctx, s); err != tt.wantErr {
 			t.Errorf("%s: unexpected error returned, got: %v, want: %v", tt.desc, err, tt.wantErr)
 		}

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -149,8 +149,8 @@ func (ci *CreateInstances) validate(ctx context.Context, s *Step) DError {
 	return errs
 }
 
-func (c *CreateInstances) run(ctx context.Context, s *Step) DError {
-	return runMultiTasksStepImpl(c, ctx, s)
+func (ci *CreateInstances) run(ctx context.Context, s *Step) DError {
+	return runMultiTasksStepImpl(ctx, ci, s)
 }
 
 func (ci *CreateInstances) iterateAllTasks(ctx context.Context, f func(context.Context, interface{})) {
@@ -165,7 +165,7 @@ func (ci *CreateInstances) iterateAllTasks(ctx context.Context, f func(context.C
 	}
 }
 
-func (c *CreateInstances) runTask(ctx context.Context, t interface{}, s *Step) (DError, error) {
+func (ci *CreateInstances) runTask(ctx context.Context, t interface{}, s *Step) (DError, error) {
 	ii, ok := t.(InstanceInterface)
 	if !ok {
 		return nil, nil
@@ -193,10 +193,9 @@ func (c *CreateInstances) runTask(ctx context.Context, t interface{}, s *Step) (
 	return nil, nil
 }
 
-func (c *CreateInstances) waitAllTasksBeforeCleanup() bool {
+func (ci *CreateInstances) waitAllTasksBeforeCleanup() bool {
 	return true
 }
-
 
 func (ci *CreateInstances) instanceUsesBetaFeatures() bool {
 	for _, instanceBeta := range ci.InstancesBeta {

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -175,7 +175,7 @@ func TestCreateInstancesRun(t *testing.T) {
 		t.Errorf("unexpected error running CreateInstances.run(): %v", err)
 	}
 	if i0.Disks[0].Source != w.disks.m["d"].link {
-		t.Errorf("instance disk link did not resolve properly: want: %q, got: %q", w.disks.m["d0"].link, i0.Disks[0].Source)
+		t.Errorf("instance disk link did not resolve properly: want: %q, got: %q", w.disks.m["d"].link, i0.Disks[0].Source)
 	}
 	if i0.NetworkInterfaces[0].Network != w.networks.m["n"].link {
 		t.Errorf("instance network link did not resolve properly: want: %q, got: %q", w.networks.m["n"].link, i0.NetworkInterfaces[0].Network)

--- a/daisy/step_test.go
+++ b/daisy/step_test.go
@@ -213,7 +213,7 @@ func TestStepImpl(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		st, err := tt.step.StepImpl()
+		st, err := tt.step.stepImpl()
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
@@ -225,7 +225,7 @@ func TestStepImpl(t *testing.T) {
 
 	// Bad. Try empty step.
 	s := Step{}
-	if _, err := s.StepImpl(); err == nil {
+	if _, err := s.stepImpl(); err == nil {
 		t.Fatal("empty step should have thrown an error")
 	}
 	// Bad. Try step with multiple real steps.
@@ -233,7 +233,7 @@ func TestStepImpl(t *testing.T) {
 		CreateDisks:  &CreateDisks{},
 		CreateImages: &CreateImages{},
 	}
-	if _, err := s.StepImpl(); err == nil {
+	if _, err := s.stepImpl(); err == nil {
 		t.Fatal("malformed step should have thrown an error")
 	}
 }

--- a/daisy/step_test.go
+++ b/daisy/step_test.go
@@ -213,7 +213,7 @@ func TestStepImpl(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		st, err := tt.step.stepImpl()
+		st, err := tt.step.StepImpl()
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
@@ -225,7 +225,7 @@ func TestStepImpl(t *testing.T) {
 
 	// Bad. Try empty step.
 	s := Step{}
-	if _, err := s.stepImpl(); err == nil {
+	if _, err := s.StepImpl(); err == nil {
 		t.Fatal("empty step should have thrown an error")
 	}
 	// Bad. Try step with multiple real steps.
@@ -233,7 +233,7 @@ func TestStepImpl(t *testing.T) {
 		CreateDisks:  &CreateDisks{},
 		CreateImages: &CreateImages{},
 	}
-	if _, err := s.stepImpl(); err == nil {
+	if _, err := s.StepImpl(); err == nil {
 		t.Fatal("malformed step should have thrown an error")
 	}
 }

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -412,7 +412,7 @@ func (w *Workflow) populateStep(ctx context.Context, s *Step) DError {
 
 	var derr DError
 	var step stepImpl
-	if step, derr = s.StepImpl(); derr != nil {
+	if step, derr = s.stepImpl(); derr != nil {
 		return derr
 	}
 	return step.populate(ctx, s)

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -412,7 +412,7 @@ func (w *Workflow) populateStep(ctx context.Context, s *Step) DError {
 
 	var derr DError
 	var step stepImpl
-	if step, derr = s.stepImpl(); derr != nil {
+	if step, derr = s.StepImpl(); derr != nil {
 		return derr
 	}
 	return step.populate(ctx, s)

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -44,8 +44,7 @@
           "Name": "disk-${NAME}",
           "SourceImage": "${export_instance_disk_image}",
           "SizeGb": "${export_instance_disk_size}",
-          "Type": "${export_instance_disk_type}",
-          "FallbackToPdStandard": true
+          "Type": "${export_instance_disk_type}"
         }
       ]
     },

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -66,7 +66,6 @@
               "subnetwork": "${export_subnet}"
             }
           ],
-          "RetryWhenExternalIPDenied": true,
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"]
         }
       ]

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -45,15 +45,13 @@
         {
           "Name": "disk-${NAME}-os",
           "SourceImage": "${export_instance_disk_image}",
-          "Type": "${export_instance_disk_type}",
-          "FallbackToPdStandard": true
+          "Type": "${export_instance_disk_type}"
         },
         {
           "Name": "disk-${NAME}-buffer-${ID}",
           "SizeGb": "${export_instance_disk_size}",
           "Type": "${export_instance_disk_type}",
-          "ExactName": true,
-          "FallbackToPdStandard": true
+          "ExactName": true
         }
       ]
     },

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -79,7 +79,6 @@
               "subnetwork": "${export_subnet}"
             }
           ],
-          "RetryWhenExternalIPDenied": true,
           "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/compute"]
         }
       ]

--- a/daisy_workflows/export/image_export.wf.json
+++ b/daisy_workflows/export/image_export.wf.json
@@ -40,8 +40,7 @@
         {
           "Name": "disk-${NAME}",
           "SourceImage": "${source_image}",
-          "Type": "${export_instance_disk_type}",
-          "FallbackToPdStandard": true
+          "Type": "${export_instance_disk_type}"
         }
       ]
     },

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -41,8 +41,7 @@
         {
           "Name": "disk-${NAME}",
           "SourceImage": "${source_image}",
-          "Type": "${export_instance_disk_type}",
-          "FallbackToPdStandard": true
+          "Type": "${export_instance_disk_type}"
         }
       ]
     },

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -36,8 +36,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -37,8 +37,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -44,8 +44,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/freebsd-org-cloud-dev/global/images/family/freebsd-11-2",
           "SizeGb": "32",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -43,8 +43,7 @@
           "Name": "disk-importer",
           "SourceImage": "${import_instance_disk_image}",
           "SizeGb": "${importer_instance_disk_size}",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         },
         {
           "Name": "${disk_name}",
@@ -53,15 +52,13 @@
           "ExactName": true,
           "NoCleanup": true,
           "isWindows": "${is_windows}",
-          "FallbackToPdStandard": true,
           "Licenses": ["${import_license}"]
         },
         {
           "Name": "disk-${NAME}-scratch-${ID}",
           "SizeGb": "10",
           "Type": "pd-ssd",
-          "ExactName": true,
-          "FallbackToPdStandard": true
+          "ExactName": true
         }
       ]
     },

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -48,7 +48,6 @@
         "ExactName": true,
         "SourceImage": "${source_image}",
         "isWindows": "${is_windows}",
-        "FallbackToPdStandard": true,
         "Licenses": ["projects/compute-image-tools/global/licenses/virtual-disk-import"]
       }]
     },

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -44,8 +44,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/debian-cloud/global/images/family/debian-10",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
@@ -44,8 +44,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
@@ -44,8 +44,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -44,8 +44,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -36,8 +36,7 @@
           "Name": "disk-translator",
           "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/windows/translate_windows_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_wf.json
@@ -58,8 +58,7 @@
         {
           "Name": "disk-bootstrap",
           "SourceImage": "projects/windows-cloud/global/images/family/windows-2019-core",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
@@ -69,8 +69,7 @@
         {
           "Name": "disk-bootstrap",
           "SourceImage": "projects/windows-cloud/global/images/family/windows-2019-core",
-          "Type": "pd-ssd",
-          "FallbackToPdStandard": true
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/ovf_import/import_ovf_to_instance.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf_to_instance.wf.json
@@ -80,8 +80,7 @@
           "SourceImage": "${boot_image_name}",
           "Type": "pd-ssd",
           "ExactName": true,
-          "NoCleanup": true,
-          "FallbackToPdStandard": true
+          "NoCleanup": true
         }
       ]
     },

--- a/daisy_workflows/ovf_import/import_ovf_to_machine_image.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf_to_machine_image.wf.json
@@ -81,8 +81,7 @@
           "SourceImage": "${boot_image_name}",
           "Type": "pd-ssd",
           "ExactName": true,
-          "NoCleanup": true,
-          "FallbackToPdStandard": true
+          "NoCleanup": true
         }
       ]
     },


### PR DESCRIPTION
Motivation: currently, there are 2 sections of on-demand retry logic which lives in daisy core. Ideally, we should move them out to keep daisy core clean.
(they are: 1. retry CreteDisks with pd-standard when quota exceeded; 2. retry CreateInstances without external IP when it failed on external ip access limit)

Solution: Add a "RetryHook", which is contained by "fallbackRetryableTask". Any steps who need to handle retry just simply add "fallbackRetryableTask" to its corresponding daisy resources class.

To be able to call that hook function, we need to extract the multi-task logic to a common place. "multiTasksStepImpl" is what we add for that purpose.

All above core logic change is mostly in step.go.

Following above patterns, step_create_instances and step_create_disks are changed accordingly. Retry logic was moved to daisy_utils.go so importer, exporter and ovf_importer can call them.

Many test files and workflow.json files got changed to remove "FallbackToPdStandard" and "RetryWhenExternalIPDenied", which is trivial.

TODO in the future: Most of step_xxx.go have multi-task logic in their run(). We can change them by implementing "multiTasksStepImpl" to save a lot of dup code.