### PR TITLE
[export] fix gce_export result usage

### DIFF
--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -42,12 +42,12 @@ if [[ -n $LICENSES ]]; then
 else
   gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -y
 fi
-if [[ $? -eq 2 ]]; then
+GCE_EXPORT_RESULT=$?
+if [[ GCE_EXPORT_RESULT -eq 2 ]]; then
   echo "ExportFailed: Failed to export disk source to GCS because default Compute Engine Service account does not have storage.objects.create permission for [Privacy-> ${GCS_PATH}. <-Privacy]."
   exit 1
 fi
-
-if [[ $? -ne 0 ]]; then
+if [[ GCE_EXPORT_RESULT -ne 0 ]]; then
   echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GCS_PATH}. <-Privacy]."
   exit 1
 fi

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -43,11 +43,11 @@ else
   gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -y
 fi
 GCE_EXPORT_RESULT=$?
-if [[ GCE_EXPORT_RESULT -eq 2 ]]; then
+if [[ ${GCE_EXPORT_RESULT} -eq 2 ]]; then
   echo "ExportFailed: Failed to export disk source to GCS because default Compute Engine Service account does not have storage.objects.create permission for [Privacy-> ${GCS_PATH}. <-Privacy]."
   exit 1
 fi
-if [[ GCE_EXPORT_RESULT -ne 0 ]]; then
+if [[ ${GCE_EXPORT_RESULT} -ne 0 ]]; then
   echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GCS_PATH}. <-Privacy]."
   exit 1
 fi


### PR DESCRIPTION
Problem: gce_export failure was not detected in an e2e test because "$?" was used twice in script.
Resolve: Store it in a var to use twice.