### PR TITLE
Ensure that pyguestf surfaces dracut's error message.

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -162,7 +162,7 @@ def DistroSpecific(g):
       # Version 6 doesn't have option --kver
       g.command(['dracut', '-v', '-f', kver])
     else:
-      g.command(['dracut', '-v', '-f', '--kver', kver])
+      g.command(['dracut', '--stdlog=1', '-f', '--kver', kver])
 
   logging.info('Update grub configuration')
   if el_release == '6':


### PR DESCRIPTION
Fixes #1143.

When there's a command error, pyguestfs surfaces the first line of stderr.  Since `dracut` is set to verbose logging, the information surfaced to the user is not necessarily relevant to the underlying error.

This change reduces dracut's logging from verbose to fatal-only. In doing so, it ensures that the surfaced error message is relevant to the actual failure.



### Old message:

```
TranslateFailed: error: command: No '/dev/log' or 'logger' included for syslog logging
```

### New message:

```
TranslateFailed: error: command: /lib/modules/3.10.0-1062.el7.x86_64//modules.dep is missing. Did you run depmod?
```

## FAQ

### Two slashes in the /lib/modules path? 
 - The error message [comes from dracut](https://github.com/dracutdevs/dracut/blob/master/dracut.sh#L1074) 

### Make the change for EL6 as well?
 - The modules.dep error isn't reproducible on EL6, and the signature of `dracut` doesn't have the same `--stdlog=1` flag.