### PR TITLE
Allow time for SLES integ tests to create PD from image.

### DIFF
--- a/daisy_integration_tests/opensuse_15_1.wf.json
+++ b/daisy_integration_tests/opensuse_15_1.wf.json
@@ -24,6 +24,7 @@
       }
     },
     "test-the-image": {
+      "Timeout": "30m",
       "CreateInstances": [
         {
           "disks": [

--- a/daisy_integration_tests/sles_12_5_byol.wf.json
+++ b/daisy_integration_tests/sles_12_5_byol.wf.json
@@ -24,6 +24,7 @@
       }
     },
     "test-the-image": {
+      "Timeout": "30m",
       "CreateInstances": [
         {
           "disks": [

--- a/daisy_integration_tests/sles_15_1_byol.wf.json
+++ b/daisy_integration_tests/sles_15_1_byol.wf.json
@@ -24,6 +24,7 @@
       }
     },
     "test-the-image": {
+      "Timeout": "30m",
       "CreateInstances": [
         {
           "disks": [


### PR DESCRIPTION
This PR sets the timeout to 30 minutes (which I think was my intent in the first place, since I put a timeout of 30 minutes on `WaitForInstancesSignal`)

The SUSE/SLES tests are a bit different, in the `CreateInstance` step starts with the translated image, rather than the intermediate PD. As such, it takes a bit longer than the other integration tests, since we have to create the PD, and hence we're occasionally running into the 10 minute default step limit.

*In draft mode while the three tests run*