### PR TITLE
Add small retry for installing products using SuseConnect.

### DIFF
--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -178,6 +178,7 @@ def _disambiguate_suseconnect_product_error(g, product, error) -> Exception:
     'Unable to find an active SLES subscription. SCC returned: %s' % statuses)
 
 
+@utils.RetryOnFailure(stop_after_seconds=60, initial_delay_seconds=1)
 def _install_product(distro, g):
   """Executes SuseConnect -p for each product on `distro`.
 


### PR DESCRIPTION
We've had some recent errors in tests where `SuseConnect -p` was failing without a message, even though `SUSEConnect --status` says the registration is active.