### PR TITLE
Fixes for dumping RDP settings and Testgrid failure

### DIFF
--- a/cli_tools/diagnostics/google-compute-engine-diagnostics.goospec
+++ b/cli_tools/diagnostics/google-compute-engine-diagnostics.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-diagnostics",
-  "version": "1.1.0@0",
+  "version": "1.2.0@0",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -11,7 +11,8 @@
   },
   "releaseNotes": [
     "1.0.0 - GCE diagnostics tool for Windows instances",
-    "1.1.0 - Dump RDP settings"
+    "1.1.0 - Dump RDP settings",
+    "1.2.0 - Dump Docker image list and fixes for dumping RDP settings"
   ],
   "sources": [{
     "include": [

--- a/cli_tools/diagnostics/main_windows_test.go
+++ b/cli_tools/diagnostics/main_windows_test.go
@@ -62,13 +62,21 @@ func TestGetDockerImagesList(t *testing.T) {
 func TestGatherRDPSettings(t *testing.T) {
 	logFolderCh := make(chan logFolder, 2)
 	errCh := make(chan error)
-	// Test setup: create temp folder for test, clean it up afterwards
+
+	// Test setup: use the temp test build package folder for test
 	var err error
-	tmpFolder, err = ioutil.TempDir("", "gatherRDPSettingsTest")
+	tmpFolder, err = filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
-		t.Errorf("Error creating a temporary test folder:\n%v", err.Error())
+		t.Errorf("Error getting the temp test build folder:\n%v", err.Error())
 	}
-	defer os.RemoveAll(tmpFolder)
+
+	// Copy the rdp_status.ps1 over to temp test build folder for execution
+	rdpScriptFilePath := filepath.Join(tmpFolder, rdpScriptFileName)
+	input, err := ioutil.ReadFile(rdpScriptFileName)
+	if err != nil {
+		t.Errorf("Error loading the rdp_status.ps1 file:\n%v", err.Error())
+	}
+	ioutil.WriteFile(rdpScriptFilePath, input, 0644)
 
 	t.Run("Gathers Expected RDP Status File", func(t *testing.T) {
 		go gatherRDPSettings(logFolderCh, errCh)


### PR DESCRIPTION
There's test failure on [testgrid](https://testgrid.corp.google.com/windows-image#win-prod), seems due to surfacing the trivial errors, so change it to log.Printf instead of log.Fatalf.

Also Ning found the dumping RDP setting is not working, so figured out that GCE Agent was not running diagnostics.exe inside the `C:\Program Files\Google\Compute Engine\diagnostics\`  folder, so need to get the diagnostics.exe runtime directory path and pass it.