### PR TITLE
Fix the all goroutines asleep - deadlock

### DIFF
--- a/cli_tools/diagnostics/main_windows.go
+++ b/cli_tools/diagnostics/main_windows.go
@@ -274,15 +274,17 @@ func getPlainEventLogs(evts []winEvt, errs chan error) []string {
 
 // getDockerImagesList put docker images list file in logFolder channel and errors in error channel.
 func getDockerImagesList(logs chan logFolder, errs chan error) {
+	dockerImageFilePath := make([]string, 0, 1)
 	dockerPath, err := exec.LookPath("docker")
 	if err != nil {
 		log.Printf("Docker not installed, couldn't get docker images list.\n")
-		return
+	} else {
+		var commands = []runner{
+			cmd{dockerPath, "image list", dockerImageListFileName, false},
+		}
+		dockerImageFilePath = runAll(commands, errs)
 	}
-	var commands = []runner{
-		cmd{dockerPath, "image list", dockerImageListFileName, false},
-	}
-	logs <- logFolder{"Kubernetes", runAll(commands, errs)}
+	logs <- logFolder{"Kubernetes", dockerImageFilePath}
 }
 
 // gatherEventLogs put all the event log file paths in logFolder channel


### PR DESCRIPTION
In the `gatherLogs()` function, it expects each log collector put either logFilePaths in logFolder channel or errors in errCh channel. So shouldn't have done nothing and return, as it caused the goroutines sleeping and failing the [tests](https://g3c.corp.google.com/results/invocations/0f83dcc3-3b68-4893-9b5d-d052b448b92b/targets/%2F%2Fcloud%2Fcluster%2Ftesting%2Fwindows:export_logs_test/tests;group=__main__.ExtractLogsTest;test=testGatherLogsCorrectly_WithOrWithoutKubernetesLog;row=3).