### PR TITLE
Build SQL Server on Windows Server UEFI

### DIFF
--- a/daisy_workflows/image_build/sqlserver/sql-2012-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-enterprise-windows-2012-r2-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2012.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2012-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2012-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2012-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-standard-windows-2012-r2-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2012.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2012-standard"
           ],
-          "Description": "Microsoft, SQL Server 2012 Standard, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2012 Standard, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2012-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2012-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-web-windows-2012-r2-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2012.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2012-web"
           ],
-          "Description": "Microsoft, SQL Server 2012 Web, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2012 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2012-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2012-r2-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2014.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2014-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2014-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2016-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2014.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2014-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2014-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2014-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-standard-windows-2012-r2-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2014.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2014-standard"
           ],
-          "Description": "Microsoft, SQL Server 2014 Standard, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2014 Standard, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2014-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2014-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-web-windows-2012-r2-dc.wf.json
@@ -5,7 +5,8 @@
     "install_disk": "disk-install",
     "publish_project": "${PROJECT}",
     "sql_server_media": {"Required": true, "Description": "GCS or local path to Windows installer media"},
-    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."}
+    "source_image_project": {"Value": "windows-cloud", "Description": "Project to source base image from."},
+    "ssms_exe": {"Required": true, "Description": "GCS or local path to SSMS installer"}
   },
   "Steps": {
     "build-sql-image": {
@@ -16,7 +17,8 @@
           "sql_server_config": "./configs/sql_server_2014.ini",
           "sql_server_media": "${sql_server_media}",
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
-          "install_disk": "${install_disk}"
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}"
         }
       }
     },
@@ -28,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2014-web"
           ],
-          "Description": "Microsoft, SQL Server 2014 Web, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2014 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2014-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2012-r2-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2016-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2016-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2016-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2012-r2-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-standard"
           ],
-          "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2016-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-standard"
           ],
-          "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2016-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2012-r2-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-web"
           ],
-          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2016-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-web"
           ],
-          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2016-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2016-web"
           ],
-          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2016-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2017-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2017-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2012-r2-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-express"
           ],
-          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2012 R2, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-exp-2017-win-2012-r2",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-express"
           ],
-          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-exp-2017-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-express"
           ],
-          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-exp-2017-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-standard"
           ],
-          "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2017-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-standard"
           ],
-          "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2017-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2016-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-web"
           ],
-          "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2016, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2017-win-2016",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2017-web"
           ],
-          "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "MULTI_IP_SUBNET"],
+          "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2017-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2019-enterprise"
           ],
-          "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["MULTI_IP_SUBNET", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
+          "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-ent-2019-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2019-standard"
           ],
-          "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["MULTI_IP_SUBNET", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
+          "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-std-2019-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019-dc.wf.json
@@ -30,8 +30,8 @@
           "Licenses": [
             "projects/windows-sql-cloud/global/licenses/sql-server-2019-web"
           ],
-          "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2019, x64 built on ${build_date}",
-          "GuestOsFeatures": ["MULTI_IP_SUBNET", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
+          "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
           "Family": "sql-web-2019-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/sqlserver/sql_install.ps1
+++ b/daisy_workflows/image_build/sqlserver/sql_install.ps1
@@ -218,7 +218,7 @@ function Install-SqlServer {
 
 function Install-SSMS {
   $sql_server_config = Get-MetadataValue -key 'sql-server-config'
-  if ($sql_server_config -notlike '*2016*' -and $sql_server_config -notlike '*2017*' -or $sql_server_config -like '*core*') {
+  if ($sql_server_config -like '*core*') {
     Write-Host "Not installing SSMS for config ${sql_server_config}"
     return
   }


### PR DESCRIPTION
- Install SQL Server Management studio on all Windows Server base images, except Core
- Update description and Guest OS features to expect UEFI firmware
- Test that images build and run successfully on UEFI firmware