### PR TITLE
Add sysprep_windows param to image import wrapper.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -159,7 +159,7 @@ func getTranslateWorkflowPath(customTranslateWorkflow, osID string) string {
 }
 
 func buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, family, description,
-	region, subnet, network string, noGuestEnvironment bool) map[string]string {
+	region, subnet, network string, noGuestEnvironment bool, sysprepWindows bool) map[string]string {
 
 	varMap := map[string]string{}
 
@@ -168,6 +168,7 @@ func buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, f
 		varMap["translate_workflow"] = translateWorkflowPath
 		varMap["install_gce_packages"] = strconv.FormatBool(!noGuestEnvironment)
 		varMap["is_windows"] = strconv.FormatBool(strings.Contains(translateWorkflowPath, "windows"))
+		varMap["sysprep_windows"] = strconv.FormatBool(sysprepWindows)
 	}
 	if strings.TrimSpace(sourceFile) != "" {
 		varMap["source_disk_file"] = strings.TrimSpace(sourceFile)
@@ -246,7 +247,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 	scratchBucketGcsPath string, oauth string, ce string, gcsLogsDisabled bool, cloudLogsDisabled bool,
 	stdoutLogsDisabled bool, kmsKey string, kmsKeyring string, kmsLocation string, kmsProject string,
 	noExternalIP bool, labels string, currentExecutablePath string, storageLocation string,
-	uefiCompatible bool) (*daisy.Workflow, error) {
+	uefiCompatible bool, sysprepWindows bool) (*daisy.Workflow, error) {
 
 	log.SetPrefix(logPrefix + " ")
 
@@ -290,7 +291,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 		customTranWorkflow, currentExecutablePath)
 
 	varMap := buildDaisyVars(translateWorkflowPath, imageName, sourceFile, sourceImage, family,
-		description, *region, subnet, network, noGuestEnvironment)
+		description, *region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	var w *daisy.Workflow
 	if w, err = runImport(ctx, varMap, importWorkflowPath, zone, timeout, *project, scratchBucketGcsPath,

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -30,7 +30,7 @@ import (
 var (
 	currentExecutablePath, clientID, imageName, osID, customTranWorkflow, sourceFile, sourceImage,
 	family, description, network, subnet, labels string
-	dataDisk, noGuestEnvironment bool
+	dataDisk, noGuestEnvironment, sysprepWindows bool
 )
 
 func TestGetWorkflowPathsFromImage(t *testing.T) {
@@ -274,7 +274,7 @@ func TestBuildDaisyVarsFromDisk(t *testing.T) {
 	region := ws + "a-region" + ws
 
 	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
+		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "image-a", got["image_name"])
 	assert.Equal(t, "translate/workflow/path", got["translate_workflow"])
@@ -285,7 +285,8 @@ func TestBuildDaisyVarsFromDisk(t *testing.T) {
 	assert.Equal(t, "global/networks/a-network", got["import_network"])
 	assert.Equal(t, "regions/a-region/subnetworks/a-subnet", got["import_subnet"])
 	assert.Equal(t, "false", got["is_windows"])
-	assert.Equal(t, 9, len(got))
+	assert.Equal(t, "false", got["sysprep_windows"])
+	assert.Equal(t, 10, len(got))
 }
 
 func TestBuildDaisyVarsFromImage(t *testing.T) {
@@ -302,7 +303,7 @@ func TestBuildDaisyVarsFromImage(t *testing.T) {
 	region := ws + "a-region" + ws
 
 	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
+		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "image-a", got["image_name"])
 	assert.Equal(t, "translate/workflow/path", got["translate_workflow"])
@@ -313,16 +314,35 @@ func TestBuildDaisyVarsFromImage(t *testing.T) {
 	assert.Equal(t, "global/networks/a-network", got["import_network"])
 	assert.Equal(t, "regions/a-region/subnetworks/a-subnet", got["import_subnet"])
 	assert.Equal(t, "false", got["is_windows"])
-	assert.Equal(t, 9, len(got))
+	assert.Equal(t, "false", got["sysprep_windows"])
+	assert.Equal(t, 10, len(got))
 }
 
-func TestBuildDaisyVarsWindow(t *testing.T) {
+func TestBuildDaisyVarsWindowsSysprepEnabled(t *testing.T) {
+	resetArgs()
+	sysprepWindows = true
+	got := buildDaisyVars("translate/workflow/path/windows", "image-a",
+		sourceFile, sourceImage, family, description, "", subnet, network, noGuestEnvironment, sysprepWindows)
+
+	assert.Equal(t, "true", got["sysprep_windows"])
+}
+
+func TestBuildDaisyVarsWindowsSysprepDisabled(t *testing.T) {
+	resetArgs()
+	sysprepWindows = false
+	got := buildDaisyVars("translate/workflow/path/windows", "image-a",
+		sourceFile, sourceImage, family, description, "", subnet, network, noGuestEnvironment, sysprepWindows)
+
+	assert.Equal(t, "false", got["sysprep_windows"])
+}
+
+func TestBuildDaisyVarsIsWindows(t *testing.T) {
 	resetArgs()
 	imageName = "image-a"
 
 	region := ""
 	got := buildDaisyVars("translate/workflow/path/windows", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
+		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "true", got["is_windows"])
 }
@@ -333,7 +353,7 @@ func TestBuildDaisyVarsImageNameLowercase(t *testing.T) {
 
 	region := ""
 	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment)
+		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, got["image_name"], "image-a")
 }
@@ -353,6 +373,7 @@ func resetArgs() {
 	sourceImage = "anImage"
 	osID = "ubuntu-1404"
 	dataDisk = false
+	sysprepWindows = false
 	imageName = "img"
 	clientID = "aClient"
 	customTranWorkflow = ""

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -54,7 +54,7 @@ var (
 	labels               = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
 	storageLocation      = flag.String("storage_location", "", "Location for the imported image which can be any GCS location. If the location parameter is not included, images are created in the multi-region associated with the source disk, image, snapshot or GCS bucket.")
 	uefiCompatible       = flag.Bool("uefi_compatible", false, "Enables UEFI booting, which is an alternative system boot method. Most public images use the GRUB bootloader as their primary boot method.")
-	sysprepWindows       = flag.Bool("sysprep_windows", false, "Whether to generalize image using Windows Sysprep.")
+	sysprepWindows       = flag.Bool("sysprep_windows", false, "Whether to generalize image using Windows Sysprep. Only applicable to Windows.")
 )
 
 func importEntry() (*daisy.Workflow, error) {

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -54,6 +54,7 @@ var (
 	labels               = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
 	storageLocation      = flag.String("storage_location", "", "Location for the imported image which can be any GCS location. If the location parameter is not included, images are created in the multi-region associated with the source disk, image, snapshot or GCS bucket.")
 	uefiCompatible       = flag.Bool("uefi_compatible", false, "Enables UEFI booting, which is an alternative system boot method. Most public images use the GRUB bootloader as their primary boot method.")
+	sysprepWindows       = flag.Bool("sysprep_windows", false, "Whether to generalize image using Windows Sysprep.")
 )
 
 func importEntry() (*daisy.Workflow, error) {
@@ -62,7 +63,7 @@ func importEntry() (*daisy.Workflow, error) {
 		*sourceImage, *noGuestEnvironment, *family, *description, *network, *subnet, *zone, *timeout,
 		project, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
 		*stdoutLogsDisabled, *kmsKey, *kmsKeyring, *kmsLocation, *kmsProject, *noExternalIP,
-		*labels, currentExecutablePath, *storageLocation, *uefiCompatible)
+		*labels, currentExecutablePath, *storageLocation, *uefiCompatible, *sysprepWindows)
 }
 
 func main() {

--- a/daisy_workflows/image_import/debian/translate_debian_8.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_8.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The Debian 8 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/debian/translate_debian_8.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_8.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/debian/translate_debian_9.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_9.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The Debian 9 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/debian/translate_debian_9.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_9.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The CentOS 6 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The CentOS 7 GCE image to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The CentOS 8 GCE image to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The RHEL 6 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The RHEL 6 GCE image to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The RHEL 7 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The RHEL 7 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The RHEL 8 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The RHEL 8 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "translate-freebsd",
   "Vars": {
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/import_and_translate.wf.json
+++ b/daisy_workflows/image_import/import_and_translate.wf.json
@@ -38,6 +38,10 @@
     "is_windows": {
       "Value": "false",
       "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
+    },
+    "sysprep_windows": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
     }
   },
   "Steps": {
@@ -61,6 +65,7 @@
           "source_disk": "${translation-disk-name}",
           "image_name": "${image_name}",
           "install_gce_packages": "${install_gce_packages}",
+          "sysprep": "${sysprep_windows}",
           "family": "${family}",
           "description": "${description}",
           "import_network": "${import_network}",

--- a/daisy_workflows/image_import/import_and_translate.wf.json
+++ b/daisy_workflows/image_import/import_and_translate.wf.json
@@ -41,7 +41,7 @@
     },
     "sysprep_windows": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -38,6 +38,10 @@
     "is_windows": {
       "Value": "false",
       "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
+    },
+    "sysprep_windows": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
     }
   },
   "Steps": {
@@ -59,6 +63,7 @@
           "source_disk": "${disk_name}",
           "image_name": "${image_name}",
           "install_gce_packages": "${install_gce_packages}",
+          "sysprep": "${sysprep_windows}",
           "family": "${family}",
           "description": "${description}",
           "import_network": "${import_network}",

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -41,7 +41,7 @@
     },
     "sysprep_windows": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     }
   },
   "Steps": {

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "translate-suse",
   "Vars": {
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "translate-suse",
   "Vars": {
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "translate-suse",
   "Vars": {
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/suse/translate_sles_sap_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_sap_12_byol.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/suse/translate_sles_sap_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_sap_12_byol.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "translate-suse",
   "Vars": {
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The Ubuntu 14.04 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The Ubuntu 16.04 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
@@ -7,7 +7,7 @@
     },
     "sysprep": {
       "Value": "false",
-      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
     },
     "install_gce_packages": {
       "Value": "true",

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
@@ -5,6 +5,10 @@
       "Required": true,
       "Description": "The Ubuntu 18.04 GCE disk to translate."
     },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run Windows Sysprep. Only applicable to Windows instances."
+    },
     "install_gce_packages": {
       "Value": "true",
       "Description": "Whether to install GCE packages."


### PR DESCRIPTION
Testing:

Ran four imports, and confirmed that sysprep ran on (1).
1. Windows 2019, `-sysprep_windows=true`
2. Windows 2019, no `-sysprep_windows` specified
3. Ubuntu 16.04, `-sysprep_windows=true`
4. Ubuntu 16.04, no `-sysprep_windows` specified