### PR TITLE
Allow instances to attempt repair.

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -1246,7 +1246,7 @@ func (c *client) InstanceStopped(project, zone, name string) (bool, error) {
 		return false, err
 	}
 	switch status {
-	case "PROVISIONING", "RUNNING", "STAGING", "STOPPING":
+	case "PROVISIONING", "REPAIRING", "RUNNING", "STAGING", "STOPPING":
 		return false, nil
 	case "TERMINATED", "STOPPED":
 		return true, nil


### PR DESCRIPTION
We observed a recent failure of `APIError: step "wait-for-translate" run error: APIError: unexpected instance status "REPAIRING"`. Based on GCE's [instance lifecycle](https://cloud.google.com/compute/docs/instances/instance-life-cycle), an instance is able to recover from the repairing step.