### PR TITLE
Use disk file from daisy's scratch path.

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -79,7 +79,6 @@
             "block-project-ssh-keys": "true",
             "disk_name": "${disk_name}",
             "scratch_disk_name": "disk-${NAME}-scratch-${ID}",
-            "source_disk_file": "${source_disk_file}",
             "shutdown-script": "echo 'Worker instance terminated'",
             "startup-script": "${SOURCE:import_image.sh}"
           },

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -29,7 +29,7 @@ fi
 BYTES_1GB=1073741824
 URL="http://metadata/computeMetadata/v1/instance"
 DAISY_SOURCE_URL="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/daisy-sources-path)"
-SOURCE_URL="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/source_disk_file)"
+SOURCE_URL="$DAISY_SOURCE_URL/source_disk_file"
 DISKNAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/disk_name)"
 SCRATCH_DISK_NAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/scratch_disk_name)"
 ME="$(curl -f -H Metadata-Flavor:Google ${URL}/name)"


### PR DESCRIPTION
When an image file contains square brackets ([]), we've observed the error:

`Destination (/daisy-scratch/file-name[stuff-in-brackets].vmdk) must match exactly 1 URL`

The error is thrown from our call to gsutil cp[1], and is a result of gsutil cp's wildcard feature[2]. The following four characters are interpreted as wildcard characters: []?*.

This change utilizes the copy of the image that daisy creates [3], which has a sanitized name.

1. ⁠https://github.com/GoogleCloudPlatform/compute-image-tools/blob/master/daisy_workflows/image_import/import_image.sh#L125
⁠2. https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames
3. https://github.com/GoogleCloudPlatform/compute-image-tools/blob/115ddd50514d903cfc2b2c96b0bad39c369f60f0/daisy_workflows/image_import/import_disk.wf.json#L37

For testing, I ran `daisy_integration_tests/ubuntu_1804_vmware.wf.json`. Also, I read through qemu-img's format detection. It uses magic file numbers, and not the file name's extension.