### PR TITLE
[daisy] Put resource cache inside workflow to avoid race condition

### DIFF
--- a/daisy/common.go
+++ b/daisy/common.go
@@ -98,15 +98,6 @@ func strIn(s string, ss []string) bool {
 	return false
 }
 
-func strInSlice(s string, ss []interface{}) bool {
-	for _, x := range ss {
-		if s == x {
-			return true
-		}
-	}
-	return false
-}
-
 func strLitPtr(s string) *string {
 	return &s
 }

--- a/daisy/compute/test_client.go
+++ b/daisy/compute/test_client.go
@@ -92,6 +92,7 @@ type TestClient struct {
 	GetImageFromFamilyFn        func(project, family string) (*compute.Image, error)
 	ListImagesFn                func(project string, opts ...ListCallOption) ([]*compute.Image, error)
 	GetLicenseFn                func(project, name string) (*compute.License, error)
+	ListLicensesFn              func(project string, opts ...ListCallOption) ([]*compute.License, error)
 	GetNetworkFn                func(project, name string) (*compute.Network, error)
 	AggregatedListSubnetworksFn func(project string, opts ...ListCallOption) ([]*compute.Subnetwork, error)
 	ListNetworksFn              func(project string, opts ...ListCallOption) ([]*compute.Network, error)
@@ -469,6 +470,14 @@ func (c *TestClient) GetLicense(project, name string) (*compute.License, error) 
 		return c.GetLicenseFn(project, name)
 	}
 	return c.client.GetLicense(project, name)
+}
+
+// ListLicenses uses the override method ListLicensesFn or the real implementation.
+func (c *TestClient) ListLicenses(project string, opts ...ListCallOption) ([]*compute.License, error) {
+	if c.ListLicensesFn != nil {
+		return c.ListLicensesFn(project)
+	}
+	return c.client.ListLicenses(project)
 }
 
 // GetNetwork uses the override method GetNetworkFn or the real implementation.

--- a/daisy/instance_test.go
+++ b/daisy/instance_test.go
@@ -656,7 +656,7 @@ func TestInstanceValidateMachineType(t *testing.T) {
 		if mt != "custom" {
 			return nil, errors.New("bad machine type")
 		}
-		return nil, nil
+		return &compute.MachineType{Name: "custom"}, nil
 	}
 
 	c.GetMachineTypeFn = getMachineTypeFn
@@ -682,11 +682,12 @@ func TestInstanceValidateMachineType(t *testing.T) {
 		}
 	}
 	for _, tt := range tests {
+		w := &Workflow{ComputeClient: c}
 		ci := &Instance{Instance: compute.Instance{MachineType: tt.mt, Zone: testZone}, InstanceBase: InstanceBase{Resource: Resource{Project: testProject}}}
-		assertTest(tt.shouldErr, (&ci.InstanceBase).validateMachineType(ci, c), tt.desc)
+		assertTest(tt.shouldErr, (&ci.InstanceBase).validateMachineType(ci, w), tt.desc)
 
 		ciBeta := &InstanceBeta{Instance: computeBeta.Instance{MachineType: tt.mt, Zone: testZone}, InstanceBase: InstanceBase{Resource: Resource{Project: testProject}}}
-		assertTest(tt.shouldErr, (&ciBeta.InstanceBase).validateMachineType(ciBeta, c), tt.desc+" beta")
+		assertTest(tt.shouldErr, (&ciBeta.InstanceBase).validateMachineType(ciBeta, w), tt.desc+" beta")
 	}
 }
 

--- a/daisy/license.go
+++ b/daisy/license.go
@@ -18,24 +18,13 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
 var licenseURLRegex = regexp.MustCompile(fmt.Sprintf(`^(projects/(?P<project>%[1]s)/)?global/licenses/(?P<license>%[2]s)$`, projectRgxStr, rfc1035))
 
-var licenseCache oneDResourceCache
-
-func licenseExists(client compute.Client, project, license string) (bool, DError) {
-	licenseCache.mu.Lock()
-	defer licenseCache.mu.Unlock()
-	if licenseCache.exists == nil {
-		licenseCache.exists = map[string][]interface{}{}
-	}
-	if _, ok := licenseCache.exists[project]; !ok || !strInSlice(license, licenseCache.exists[project]) {
-		if _, err := client.GetLicense(project, license); err != nil {
-			return false, typedErr(apiError, "failed to get license", err)
-		}
-		licenseCache.exists[project] = append(licenseCache.exists[project], license)
-	}
-	return true, nil
+func (w *Workflow) licenseExists(project, license string) (bool, DError) {
+	return w.licenseCache.resourceExists(func(project string, opts ...daisyCompute.ListCallOption) (interface{}, error) {
+		return w.ComputeClient.ListLicenses(project)
+	}, project, license)
 }

--- a/daisy/machinetype.go
+++ b/daisy/machinetype.go
@@ -28,7 +28,7 @@ func (w *Workflow) machineTypeExists(project, zone, machineType string) (bool, D
 		return w.ComputeClient.ListMachineTypes(project, zone)
 	}, project, zone, machineType)
 	if err != nil {
-		return predefinedMachineTypeExists, err
+		return false, err
 	}
 	if predefinedMachineTypeExists {
 		return true, nil

--- a/daisy/machinetype.go
+++ b/daisy/machinetype.go
@@ -18,40 +18,29 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
 var machineTypeURLRegex = regexp.MustCompile(fmt.Sprintf(`^(projects/(?P<project>%[1]s)/)?zones/(?P<zone>%[2]s)/machineTypes/(?P<machinetype>%[2]s)$`, projectRgxStr, rfc1035))
 
-var machineTypeCache twoDResourceCache
-
-func machineTypeExists(client compute.Client, project, zone, machineType string) (bool, DError) {
-	machineTypeCache.mu.Lock()
-	defer machineTypeCache.mu.Unlock()
-	if machineTypeCache.exists == nil {
-		machineTypeCache.exists = map[string]map[string][]interface{}{}
+func (w *Workflow) machineTypeExists(project, zone, machineType string) (bool, DError) {
+	predefinedMachineTypeExists, err := w.machineTypeCache.resourceExists(func(project, zone string, opts ...daisyCompute.ListCallOption) (interface{}, error) {
+		return w.ComputeClient.ListMachineTypes(project, zone)
+	}, project, zone, machineType)
+	if err != nil {
+		return predefinedMachineTypeExists, err
 	}
-	if _, ok := machineTypeCache.exists[project]; !ok {
-		machineTypeCache.exists[project] = map[string][]interface{}{}
-	}
-	if _, ok := machineTypeCache.exists[project][zone]; !ok {
-		mtl, err := client.ListMachineTypes(project, zone)
-		if err != nil {
-			return false, Errf("error listing machine types for project %q: %v", project, err)
-		}
-		var mts []interface{}
-		for _, mt := range mtl {
-			mts = append(mts, mt.Name)
-		}
-		machineTypeCache.exists[project][zone] = mts
-	}
-	if strInSlice(machineType, machineTypeCache.exists[project][zone]) {
+	if predefinedMachineTypeExists {
 		return true, nil
 	}
+
 	// Check for custom machine types.
-	if _, err := client.GetMachineType(project, zone, machineType); err != nil {
-		return false, typedErr(apiError, "failed to get machine type", err)
+	w.machineTypeCache.mu.Lock()
+	defer w.machineTypeCache.mu.Unlock()
+	mt, cerr := w.ComputeClient.GetMachineType(project, zone, machineType)
+	if cerr != nil {
+		return false, typedErr(apiError, "failed to get machine type", cerr)
 	}
-	machineTypeCache.exists[project][zone] = append(machineTypeCache.exists[project][zone], machineType)
+	w.machineTypeCache.exists[project][zone][mt.Name] = mt
 	return true, nil
 }

--- a/daisy/region.go
+++ b/daisy/region.go
@@ -15,27 +15,11 @@
 package daisy
 
 import (
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
-var regionsCache oneDResourceCache
-
-func regionExists(client compute.Client, project, region string) (bool, DError) {
-	regionsCache.mu.Lock()
-	defer regionsCache.mu.Unlock()
-	if regionsCache.exists == nil {
-		regionsCache.exists = map[string][]interface{}{}
-	}
-	if _, ok := regionsCache.exists[project]; !ok {
-		rl, err := client.ListRegions(project)
-		if err != nil {
-			return false, typedErr(apiError, "failed to list regions", err)
-		}
-		var regions []interface{}
-		for _, r := range rl {
-			regions = append(regions, r.Name)
-		}
-		regionsCache.exists[project] = regions
-	}
-	return strInSlice(region, regionsCache.exists[project]), nil
+func (w *Workflow) regionExists(project, region string) (bool, DError) {
+	return w.zonesCache.resourceExists(func(project string, opts ...daisyCompute.ListCallOption) (interface{}, error) {
+		return w.ComputeClient.ListRegions(project)
+	}, project, region)
 }

--- a/daisy/resource.go
+++ b/daisy/resource.go
@@ -17,6 +17,7 @@ package daisy
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -98,7 +99,7 @@ func (r *Resource) validateWithZone(ctx context.Context, s *Step, z, errPrefix s
 	if z == "" {
 		errs = addErrs(errs, Errf("%s: no zone provided in step or workflow", errPrefix))
 	}
-	if exists, err := zoneExists(s.w.ComputeClient, r.Project, z); err != nil {
+	if exists, err := s.w.zoneExists(r.Project, z); err != nil {
 		errs = addErrs(errs, Errf("%s: bad zone lookup: %q, error: %v", errPrefix, z, err))
 	} else if !exists {
 		errs = addErrs(errs, Errf("%s: zone does not exist: %q", errPrefix, z))
@@ -111,7 +112,7 @@ func (r *Resource) validateWithRegion(ctx context.Context, s *Step, re, errPrefi
 	if re == "" {
 		errs = addErrs(errs, Errf("%s: no region provided in step or workflow", errPrefix))
 	}
-	if exists, err := regionExists(s.w.ComputeClient, r.Project, re); err != nil {
+	if exists, err := s.w.regionExists(r.Project, re); err != nil {
 		errs = addErrs(errs, Errf("%s: bad region lookup: %q, error: %v", errPrefix, re, err))
 	} else if !exists {
 		errs = addErrs(errs, Errf("%s: region does not exist: %q", errPrefix, re))
@@ -130,41 +131,41 @@ func extendPartialURL(url, project string) string {
 	return fmt.Sprintf("projects/%s/%s", project, url)
 }
 
-func resourceExists(client compute.Client, url string) (bool, DError) {
+func (w *Workflow) resourceExists(url string) (bool, DError) {
 	if !strings.HasPrefix(url, "projects/") {
 		return false, Errf("partial GCE resource URL %q needs leading \"projects/PROJECT/\"", url)
 	}
 	switch {
 	case machineTypeURLRegex.MatchString(url):
 		result := NamedSubexp(machineTypeURLRegex, url)
-		return machineTypeExists(client, result["project"], result["zone"], result["machinetype"])
+		return w.machineTypeExists(result["project"], result["zone"], result["machinetype"])
 	case instanceURLRgx.MatchString(url):
 		result := NamedSubexp(instanceURLRgx, url)
-		return instanceExists(client, result["project"], result["zone"], result["instance"])
+		return w.instanceExists(result["project"], result["zone"], result["instance"])
 	case diskURLRgx.MatchString(url):
 		result := NamedSubexp(diskURLRgx, url)
-		return diskExists(client, result["project"], result["zone"], result["disk"])
+		return w.diskExists(result["project"], result["zone"], result["disk"])
 	case imageURLRgx.MatchString(url):
 		result := NamedSubexp(imageURLRgx, url)
-		return imageExists(client, result["project"], result["family"], result["image"])
+		return w.imageExists(result["project"], result["family"], result["image"])
 	case machineImageURLRgx.MatchString(url):
 		result := NamedSubexp(machineImageURLRgx, url)
-		return machineImageExists(client, result["project"], result["machineImage"])
+		return w.machineImageExists(result["project"], result["machineImage"])
 	case networkURLRegex.MatchString(url):
 		result := NamedSubexp(networkURLRegex, url)
-		return networkExists(client, result["project"], result["network"])
+		return w.networkExists(result["project"], result["network"])
 	case subnetworkURLRegex.MatchString(url):
 		result := NamedSubexp(subnetworkURLRegex, url)
-		return subnetworkExists(client, result["project"], result["region"], result["subnetwork"])
+		return w.subnetworkExists(result["project"], result["region"], result["subnetwork"])
 	case targetInstanceURLRegex.MatchString(url):
 		result := NamedSubexp(targetInstanceURLRegex, url)
-		return targetInstanceExists(client, result["project"], result["zone"], result["targetInstance"])
+		return w.targetInstanceExists(result["project"], result["zone"], result["targetInstance"])
 	case forwardingRuleURLRegex.MatchString(url):
 		result := NamedSubexp(forwardingRuleURLRegex, url)
-		return forwardingRuleExists(client, result["project"], result["region"], result["forwardingRule"])
+		return w.forwardingRuleExists(result["project"], result["region"], result["forwardingRule"])
 	case firewallRuleURLRegex.MatchString(url):
 		result := NamedSubexp(firewallRuleURLRegex, url)
-		return firewallRuleExists(client, result["project"], result["firewallRule"])
+		return w.firewallRuleExists(result["project"], result["firewallRule"])
 	}
 	return false, Errf("unknown resource type: %q", url)
 }
@@ -177,23 +178,97 @@ func resourceNameHelper(name string, w *Workflow, exactName bool) string {
 }
 
 type twoDResourceCache struct {
-	exists map[string]map[string][]interface{}
+	exists map[string]map[string]map[string]interface{}
 	mu     sync.Mutex
-}
-
-func (rc *twoDResourceCache) cleanup() {
-	rc.mu.Lock()
-	defer rc.mu.Unlock()
-	rc.exists = nil
 }
 
 type oneDResourceCache struct {
-	exists map[string][]interface{}
+	exists map[string]map[string]interface{}
 	mu     sync.Mutex
 }
 
-func (rc *oneDResourceCache) cleanup() {
-	rc.mu.Lock()
-	defer rc.mu.Unlock()
-	rc.exists = nil
+// resourceExists should only be used during validation for existing GCE
+// resources and should not be relied or populated for daisy created resources.
+func (c *twoDResourceCache) resourceExists(listResourceFunc func(project, regionOrZone string, opts ...compute.ListCallOption) (interface{}, error),
+	project, regionOrZone, resourceName string) (bool, DError) {
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	err := c.loadCache(listResourceFunc, project, regionOrZone, resourceName)
+	if err != nil {
+		return false, err
+	}
+	return nameInResourceMap(resourceName, c.exists[project][regionOrZone]), nil
+}
+
+func (c *twoDResourceCache) loadCache(listResourceFunc func(project string, regionOrZone string, opts ...compute.ListCallOption) (interface{}, error),
+	project string, regionOrZone string, resourceName string) DError {
+
+	if resourceName == "" {
+		return Errf("must provide resource name")
+	}
+	if c.exists == nil {
+		c.exists = map[string]map[string]map[string]interface{}{}
+	}
+	if _, ok := c.exists[project]; !ok {
+		c.exists[project] = map[string]map[string]interface{}{}
+	}
+	if _, ok := c.exists[project][regionOrZone]; !ok {
+		ri, err := listResourceFunc(project, regionOrZone)
+		if err != nil {
+			return Errf("error listing resource for project %q: %v", project, err)
+		}
+		c.exists[project][regionOrZone] = toMap(ri)
+	}
+	return nil
+}
+
+// resourceExists should only be used during validation for existing GCE
+// resources and should not be relied or populated for daisy created resources.
+func (c *oneDResourceCache) resourceExists(listResourceFunc func(project string, opts ...compute.ListCallOption) (interface{}, error),
+	project, resourceName string) (bool, DError) {
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	err := c.loadCache(listResourceFunc, project, resourceName)
+	if err != nil {
+		return false, err
+	}
+
+	return nameInResourceMap(resourceName, c.exists[project]), nil
+}
+
+func (c *oneDResourceCache) loadCache(listResourceFunc func(project string, opts ...compute.ListCallOption) (interface{}, error), project string, resourceName string) DError {
+	if resourceName == "" {
+		return Errf("must provide resource name")
+	}
+	if c.exists == nil {
+		c.exists = map[string]map[string]interface{}{}
+	}
+	if _, ok := c.exists[project]; !ok {
+		ri, err := listResourceFunc(project)
+		if err != nil {
+			return Errf("error listing resource for project %q: %v", project, err)
+		}
+		c.exists[project] = toMap(ri)
+	}
+	return nil
+}
+
+func toMap(slice interface{}) map[string]interface{} {
+	s := reflect.ValueOf(slice)
+	ret := make(map[string]interface{}, s.Len())
+	for i := 0; i < s.Len(); i++ {
+		r := s.Index(i).Interface()
+		v := reflect.ValueOf(r)
+		name := reflect.Indirect(v).FieldByName("Name").String()
+		ret[name] = r
+	}
+	return ret
+}
+
+func nameInResourceMap(name string, m map[string]interface{}) bool {
+	_, ok := m[name]
+	return ok
 }

--- a/daisy/resource_registry.go
+++ b/daisy/resource_registry.go
@@ -135,7 +135,7 @@ func (r *baseResourceRegistry) regCreate(name string, res *Resource, s *Step, ov
 	}
 
 	if !overWrite {
-		if exists, err := resourceExists(r.w.ComputeClient, res.link); err != nil {
+		if exists, err := r.w.resourceExists(res.link); err != nil {
 			return Errf("cannot create %s %q; resource lookup error: %v", r.typeName, name, err)
 		} else if exists {
 			return Errf("cannot create %s %q; resource already exists", r.typeName, name)
@@ -195,7 +195,7 @@ func (r *baseResourceRegistry) regURL(url string, checkExist bool) (*Resource, D
 		return r, nil
 	}
 	if checkExist {
-		exists, err := resourceExists(r.w.ComputeClient, url)
+		exists, err := r.w.resourceExists(url)
 		if !exists {
 			if err != nil {
 				return nil, err

--- a/daisy/step_deprecate_images_test.go
+++ b/daisy/step_deprecate_images_test.go
@@ -146,5 +146,4 @@ func TestDeprecateImagesRun(t *testing.T) {
 			t.Errorf("%s: unexpected error returned, got: %v, want: %v", tt.desc, err, tt.wantErr)
 		}
 	}
-
 }

--- a/daisy/test_common_test.go
+++ b/daisy/test_common_test.go
@@ -207,14 +207,11 @@ func newTestGCEClient() (*daisyCompute.TestClient, error) {
 		}
 		return []*compute.ForwardingRule{{Name: testForwardingRule}}, nil
 	}
-	c.GetLicenseFn = func(p, l string) (*compute.License, error) {
+	c.ListLicensesFn = func(p string, _ ...daisyCompute.ListCallOption) ([]*compute.License, error) {
 		if p != testProject {
 			return nil, errors.New("bad project: " + p)
 		}
-		if l != testLicense {
-			return nil, errors.New("bad license: " + l)
-		}
-		return nil, nil
+		return []*compute.License{{Name: testLicense}}, nil
 	}
 	c.ListNetworksFn = func(p string, _ ...daisyCompute.ListCallOption) ([]*compute.Network, error) {
 		if p != testProject {

--- a/daisy/validate.go
+++ b/daisy/validate.go
@@ -48,7 +48,7 @@ func (w *Workflow) validateRequiredFields() DError {
 		return Errf("project does not exist: %q", w.Project)
 	}
 	if w.Zone != "" {
-		if exists, err := zoneExists(w.ComputeClient, w.Project, w.Zone); err != nil {
+		if exists, err := w.zoneExists(w.Project, w.Zone); err != nil {
 			return Errf("bad zone lookup: %q, error: %v", w.Zone, err)
 		} else if !exists {
 			return Errf("zone does not exist: %q", w.Zone)

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -154,6 +154,22 @@ type Workflow struct {
 	targetInstances *targetInstanceRegistry
 	objects         *objectRegistry
 
+	// Cache of resources
+	machineTypeCache    twoDResourceCache
+	instanceCache       twoDResourceCache
+	diskCache           twoDResourceCache
+	subnetworkCache     twoDResourceCache
+	targetInstanceCache twoDResourceCache
+	forwardingRuleCache twoDResourceCache
+	imageCache          oneDResourceCache
+	imageFamilyCache    oneDResourceCache
+	machineImageCache   oneDResourceCache
+	networkCache        oneDResourceCache
+	firewallRuleCache   oneDResourceCache
+	zonesCache          oneDResourceCache
+	regionsCache        oneDResourceCache
+	licenseCache        oneDResourceCache
+
 	stepTimeRecords             []TimeRecord
 	serialControlOutputValues   map[string]string
 	serialControlOutputValuesMx sync.Mutex
@@ -312,9 +328,6 @@ func (w *Workflow) GetStepTimeRecords() []TimeRecord {
 }
 
 func (w *Workflow) cleanup() {
-	// cleanup cache so the next workflow can have a clean env
-	defer cleanupCache()
-
 	startTime := time.Now()
 	w.LogWorkflowInfo("Workflow %q cleaning up (this may take up to 2 minutes).", w.Name)
 
@@ -343,22 +356,6 @@ func (w *Workflow) cleanup() {
 	}
 	w.LogWorkflowInfo("Workflow %q finished cleanup.", w.Name)
 	w.recordStepTime("workflow cleanup", startTime, time.Now())
-}
-
-func cleanupCache() {
-	diskCache.cleanup()
-	instanceCache.cleanup()
-	imageCache.cleanup()
-	networkCache.cleanup()
-	machineImageCache.cleanup()
-	machineTypeCache.cleanup()
-	licenseCache.cleanup()
-	targetInstanceCache.cleanup()
-	regionsCache.cleanup()
-	subnetworkCache.cleanup()
-	zonesCache.cleanup()
-	forwardingRuleCache.cleanup()
-	firewallRuleCache.cleanup()
 }
 
 func (w *Workflow) genName(n string) string {

--- a/daisy/zone.go
+++ b/daisy/zone.go
@@ -15,27 +15,11 @@
 package daisy
 
 import (
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
-var zonesCache oneDResourceCache
-
-func zoneExists(client compute.Client, project, zone string) (bool, DError) {
-	zonesCache.mu.Lock()
-	defer zonesCache.mu.Unlock()
-	if zonesCache.exists == nil {
-		zonesCache.exists = map[string][]interface{}{}
-	}
-	if _, ok := zonesCache.exists[project]; !ok {
-		zl, err := client.ListZones(project)
-		if err != nil {
-			return false, typedErr(apiError, "failed to list zones", err)
-		}
-		var zones []interface{}
-		for _, z := range zl {
-			zones = append(zones, z.Name)
-		}
-		zonesCache.exists[project] = zones
-	}
-	return strInSlice(zone, zonesCache.exists[project]), nil
+func (w *Workflow) zoneExists(project, zone string) (bool, DError) {
+	return w.zonesCache.resourceExists(func(project string, opts ...daisyCompute.ListCallOption) (interface{}, error) {
+		return w.ComputeClient.ListZones(project)
+	}, project, zone)
 }

--- a/mocks/mock_compute_client.go
+++ b/mocks/mock_compute_client.go
@@ -861,6 +861,26 @@ func (mr *MockClientMockRecorder) ListInstances(arg0, arg1 interface{}, arg2 ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstances", reflect.TypeOf((*MockClient)(nil).ListInstances), varargs...)
 }
 
+// ListLicenses mocks base method
+func (m *MockClient) ListLicenses(arg0 string, arg1 ...compute.ListCallOption) ([]*v1.License, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListLicenses", varargs...)
+	ret0, _ := ret[0].([]*v1.License)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLicenses indicates an expected call of ListLicenses
+func (mr *MockClientMockRecorder) ListLicenses(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLicenses", reflect.TypeOf((*MockClient)(nil).ListLicenses), varargs...)
+}
+
 // ListMachineImages mocks base method
 func (m *MockClient) ListMachineImages(arg0 string, arg1 ...compute.ListCallOption) ([]*v0_beta.MachineImage, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Put resource cache inside workflow to avoid race condition.

This problem breaks tests which run workflows in parallel.

If somebody run workflow in parallel in one program, it can also happen, even though there isn't a case so far.