### PR TITLE
Don't allow sourceImage to be a GCS path.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -16,28 +16,24 @@ package importer
 
 import (
 	"fmt"
-	"io/ioutil"
-	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/test"
-	"github.com/GoogleCloudPlatform/compute-image-tools/mocks"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	currentExecutablePath, clientID, imageName, osID, customTranWorkflow, sourceFile, sourceImage,
+	currentExecutablePath, clientID, imageName, osID, customTranWorkflow,
 	family, description, network, subnet, labels string
 	dataDisk, noGuestEnvironment, sysprepWindows bool
+	source                                       resource
 )
 
 func TestGetWorkflowPathsFromImage(t *testing.T) {
 	resetArgs()
-	sourceImage = "image-1"
+	source = imageSource{uri: "uri"}
 	osID = "ubuntu-1404"
-	workflow, translate := getWorkflowPaths(dataDisk, osID, sourceImage, customTranWorkflow, currentExecutablePath)
+	workflow, translate := getWorkflowPaths(source, dataDisk, osID, customTranWorkflow, currentExecutablePath)
 	if workflow != path.ToWorkingDir(WorkflowDir+ImportFromImageWorkflow, currentExecutablePath) || translate != "ubuntu/translate_ubuntu_1404.wf.json" {
 		t.Errorf("%v != %v and/or translate not empty", workflow, WorkflowDir+ImportFromImageWorkflow)
 	}
@@ -47,8 +43,8 @@ func TestGetWorkflowPathsDataDisk(t *testing.T) {
 	resetArgs()
 	dataDisk = true
 	osID = ""
-	sourceImage = ""
-	workflow, translate := getWorkflowPaths(dataDisk, osID, sourceImage, customTranWorkflow, currentExecutablePath)
+	source = fileSource{}
+	workflow, translate := getWorkflowPaths(source, dataDisk, osID, customTranWorkflow, currentExecutablePath)
 	if workflow != path.ToWorkingDir(WorkflowDir+ImportWorkflow, currentExecutablePath) || translate != "" {
 		t.Errorf("%v != %v and/or translate not empty", workflow, WorkflowDir+ImportWorkflow)
 	}
@@ -57,19 +53,18 @@ func TestGetWorkflowPathsDataDisk(t *testing.T) {
 func TestGetWorkflowPathsWithCustomTranslateWorkflow(t *testing.T) {
 	resetArgs()
 	imageName = "image-a"
-	sourceImage = "image-1"
+	source = imageSource{}
 	customTranWorkflow = "custom.wf"
 	osID = ""
 
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	if _, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels); err != nil {
 
 		t.Errorf("Unexpected flags error: %v", err)
 	}
-	workflow, translate := getWorkflowPaths(dataDisk, osID, sourceImage, customTranWorkflow, currentExecutablePath)
-	if workflow != path.ToWorkingDir(WorkflowDir+ImportFromImageWorkflow, currentExecutablePath) || translate != customTranWorkflow {
-		t.Errorf("%v != %v and/or translate not empty", workflow, WorkflowDir+ImportFromImageWorkflow)
-	}
+	workflow, translate := getWorkflowPaths(source, dataDisk, osID, customTranWorkflow, currentExecutablePath)
+	assert.Equal(t, path.ToWorkingDir(WorkflowDir+ImportFromImageWorkflow, currentExecutablePath), workflow)
+	assert.Equal(t, translate, customTranWorkflow)
 }
 
 func TestFlagsUnexpectedCustomTranslateWorkflowWithOs(t *testing.T) {
@@ -77,7 +72,7 @@ func TestFlagsUnexpectedCustomTranslateWorkflowWithOs(t *testing.T) {
 	imageName = "image-a"
 	customTranWorkflow = "custom.wf"
 
-	_, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	_, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels)
 	expected := fmt.Errorf("-os and -custom_translate_workflow can't be both specified")
 	validateExpectedError(err, expected, t)
@@ -90,7 +85,7 @@ func TestFlagsUnexpectedCustomTranslateWorkflowWithDataDisk(t *testing.T) {
 	osID = ""
 	customTranWorkflow = "custom.wf"
 
-	_, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	_, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels)
 	expected := fmt.Errorf("when -data_disk is specified, -os and -custom_translate_workflow should be empty")
 	validateExpectedError(err, expected, t)
@@ -101,10 +96,10 @@ func TestGetWorkflowPathsFromFile(t *testing.T) {
 
 	resetArgs()
 	imageName = "image-a"
-	sourceImage = ""
+	source = fileSource{}
 	currentExecutablePath = homeDir + "executable"
 
-	workflow, translate := getWorkflowPaths(dataDisk, osID, sourceImage, customTranWorkflow, currentExecutablePath)
+	workflow, translate := getWorkflowPaths(source, dataDisk, osID, customTranWorkflow, currentExecutablePath)
 
 	if workflow != homeDir+WorkflowDir+ImportAndTranslateWorkflow {
 		t.Errorf("resulting workflow path `%v` does not match expected `%v`", workflow, homeDir+WorkflowDir+ImportAndTranslateWorkflow)
@@ -118,14 +113,14 @@ func TestGetWorkflowPathsFromFile(t *testing.T) {
 func TestFlagsImageNameNotProvided(t *testing.T) {
 	resetArgs()
 	imageName = ""
-	_, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	_, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels)
 	expected := fmt.Errorf("The flag -image_name must be provided")
 	validateExpectedError(err, expected, t)
 }
 
 func assertErrorOnValidate(errorMsg string, t *testing.T) {
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	if _, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels); err == nil {
 		t.Error(errorMsg)
 	}
@@ -150,86 +145,11 @@ func TestFlagsDataDiskAndOSFlagsBothProvided(t *testing.T) {
 	assertErrorOnValidate("Expected error for both os and data_disk set at the same time", t)
 }
 
-func TestFlagsSourceFileOrSourceImageNotProvided(t *testing.T) {
-	resetArgs()
-	sourceFile = ""
-	sourceImage = ""
-	dataDisk = false
-	assertErrorOnValidate("Expected error for missing source_file or source_image flag", t)
-}
-
-func TestFlagsSourceFileAndSourceImageBothProvided(t *testing.T) {
-	resetArgs()
-	sourceFile = "gs://source_bucket/source_file"
-	dataDisk = false
-	assertErrorOnValidate("Expected error for both source_file and source_image flags set", t)
-}
-
 func TestFlagsSourceFile(t *testing.T) {
 	resetArgs()
-	sourceFile = "gs://source_bucket/source_file"
-	sourceImage = ""
 	dataDisk = false
 
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
-		osID, customTranWorkflow, labels); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-}
-
-func TestFlagSourceFileEmpty(t *testing.T) {
-	emptyReader := ioutil.NopCloser(strings.NewReader(""))
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	mockStorageClient.EXPECT().GetObjectReader(gomock.Any(), gomock.Any()).Return(emptyReader, nil)
-
-	err := validateSourceFile(mockStorageClient, "", "")
-	assert.NotNil(t, err, "Expected error")
-	assert.Contains(t, err.Error(), "cannot import an image from an empty file")
-}
-
-func TestFlagSourceFileCompressed(t *testing.T) {
-	fileString := test.CreateCompressedFile()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	mockStorageClient.EXPECT().GetObjectReader(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(fileString)), nil)
-
-	err := validateSourceFile(mockStorageClient, "", "")
-	assert.NotNil(t, err, "Expected error")
-}
-
-func TestFlagSourceFileUncompressed(t *testing.T) {
-	fileString := "random content"
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	mockStorageClient.EXPECT().GetObjectReader(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(fileString)), nil)
-
-	err := validateSourceFile(mockStorageClient, "", "")
-	assert.Nil(t, err, "Unexpected error")
-}
-
-func TestFlagsInvalidSourceFile(t *testing.T) {
-	resetArgs()
-	sourceFile = "invalidSourceFile"
-	sourceImage = ""
-
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
-		osID, customTranWorkflow, labels); err == nil {
-		t.Errorf("Expected error")
-	}
-}
-
-func TestFlagsSourceImage(t *testing.T) {
-	resetArgs()
-	sourceFile = ""
-
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	if _, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -237,12 +157,10 @@ func TestFlagsSourceImage(t *testing.T) {
 
 func TestFlagsDataDisk(t *testing.T) {
 	resetArgs()
-	sourceFile = "gs://source_bucket/source_file"
-	sourceImage = ""
 	osID = ""
 	dataDisk = true
 
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	if _, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -250,11 +168,9 @@ func TestFlagsDataDisk(t *testing.T) {
 
 func TestFlagsInvalidOS(t *testing.T) {
 	resetArgs()
-	sourceFile = "gs://source_bucket/source_file"
-	sourceImage = ""
 	osID = "invalidOs"
 
-	if _, _, _, err := validateAndParseFlags(clientID, imageName, sourceFile, sourceImage, dataDisk,
+	if _, err := validateAndParseFlags(clientID, imageName, dataDisk,
 		osID, customTranWorkflow, labels); err == nil {
 		t.Errorf("Expected error")
 	}
@@ -265,16 +181,15 @@ func TestBuildDaisyVarsFromDisk(t *testing.T) {
 	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
 	imageName = ws + "image-a" + ws
 	noGuestEnvironment = true
-	sourceFile = ws + "source-file-path" + ws
-	sourceImage = ws
+	source = fileSource{gcsPath: "source-file-path"}
 	family = ws + "a-family" + ws
 	description = ws + "a-description" + ws
 	network = ws + "a-network" + ws
 	subnet = ws + "a-subnet" + ws
 	region := ws + "a-region" + ws
 
-	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
+	got := buildDaisyVars(source, "translate/workflow/path", imageName,
+		family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "image-a", got["image_name"])
 	assert.Equal(t, "translate/workflow/path", got["translate_workflow"])
@@ -294,16 +209,15 @@ func TestBuildDaisyVarsFromImage(t *testing.T) {
 	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
 	imageName = ws + "image-a" + ws
 	noGuestEnvironment = true
-	sourceFile = ws
-	sourceImage = ws + "global/images/source-image" + ws
+	source = imageSource{uri: "global/images/source-image"}
 	family = ws + "a-family" + ws
 	description = ws + "a-description" + ws
 	network = ws + "a-network" + ws
 	subnet = ws + "a-subnet" + ws
 	region := ws + "a-region" + ws
 
-	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
+	got := buildDaisyVars(source, "translate/workflow/path", imageName,
+		family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "image-a", got["image_name"])
 	assert.Equal(t, "translate/workflow/path", got["translate_workflow"])
@@ -321,8 +235,8 @@ func TestBuildDaisyVarsFromImage(t *testing.T) {
 func TestBuildDaisyVarsWindowsSysprepEnabled(t *testing.T) {
 	resetArgs()
 	sysprepWindows = true
-	got := buildDaisyVars("translate/workflow/path/windows", "image-a",
-		sourceFile, sourceImage, family, description, "", subnet, network, noGuestEnvironment, sysprepWindows)
+	got := buildDaisyVars(source, "translate/workflow/path/windows", "image-a",
+		family, description, "", subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "true", got["sysprep_windows"])
 }
@@ -330,8 +244,8 @@ func TestBuildDaisyVarsWindowsSysprepEnabled(t *testing.T) {
 func TestBuildDaisyVarsWindowsSysprepDisabled(t *testing.T) {
 	resetArgs()
 	sysprepWindows = false
-	got := buildDaisyVars("translate/workflow/path/windows", "image-a",
-		sourceFile, sourceImage, family, description, "", subnet, network, noGuestEnvironment, sysprepWindows)
+	got := buildDaisyVars(source, "translate/workflow/path/windows", "image-a",
+		family, description, "", subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "false", got["sysprep_windows"])
 }
@@ -341,8 +255,8 @@ func TestBuildDaisyVarsIsWindows(t *testing.T) {
 	imageName = "image-a"
 
 	region := ""
-	got := buildDaisyVars("translate/workflow/path/windows", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
+	got := buildDaisyVars(source, "translate/workflow/path/windows", imageName,
+		family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, "true", got["is_windows"])
 }
@@ -352,8 +266,8 @@ func TestBuildDaisyVarsImageNameLowercase(t *testing.T) {
 	imageName = "IMAGE-a"
 
 	region := ""
-	got := buildDaisyVars("translate/workflow/path", imageName, sourceFile,
-		sourceImage, family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
+	got := buildDaisyVars(source, "translate/workflow/path", imageName,
+		family, description, region, subnet, network, noGuestEnvironment, sysprepWindows)
 
 	assert.Equal(t, got["image_name"], "image-a")
 }
@@ -369,8 +283,7 @@ func validateExpectedError(err error, expected error, t *testing.T) {
 }
 
 func resetArgs() {
-	sourceFile = ""
-	sourceImage = "anImage"
+	source = imageSource{uri: "global/images/source-image"}
 	osID = "ubuntu-1404"
 	dataDisk = false
 	sysprepWindows = false

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -145,16 +145,6 @@ func TestFlagsDataDiskAndOSFlagsBothProvided(t *testing.T) {
 	assertErrorOnValidate("Expected error for both os and data_disk set at the same time", t)
 }
 
-func TestFlagsSourceFile(t *testing.T) {
-	resetArgs()
-	dataDisk = false
-
-	if _, err := validateAndParseFlags(clientID, imageName, dataDisk,
-		osID, customTranWorkflow, labels); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-}
-
 func TestFlagsDataDisk(t *testing.T) {
 	resetArgs()
 	osID = ""

--- a/cli_tools/gce_vm_image_import/importer/source.go
+++ b/cli_tools/gce_vm_image_import/importer/source.go
@@ -1,0 +1,198 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"compress/gzip"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+// A resource that can be imported to GCE disk images. If an instance of this
+// interface exists, it is expected that validation has already occurred,
+// and that the caller can safely use the resource.
+type resource interface {
+	path() string
+}
+
+// initAndValidateSource takes the sourceFile and sourceImage specified by the user
+// and determines which, if any, is importable. It is an error if both sourceFile and
+// sourceImage are specified.
+func initAndValidateSource(sourceFile, sourceImage string,
+	storageClient domain.StorageClientInterface) (resource, error) {
+	sourceFile = strings.TrimSpace(sourceFile)
+	sourceImage = strings.TrimSpace(sourceImage)
+
+	if sourceFile == "" && sourceImage == "" {
+		return nil, daisy.Errf(
+			"either -source_file or -source_image has to be specified")
+	} else if sourceFile != "" && sourceImage != "" {
+		return nil, daisy.Errf(
+			"either -source_file or -source_image has to be specified, but not both %v %v",
+			sourceFile, sourceImage)
+	}
+
+	if sourceFile != "" {
+		return newFileSource(sourceFile, storageClient)
+	}
+
+	return newImageSource(sourceImage)
+}
+
+// Whether the resource is a file in GCS.
+func isFile(s resource) bool {
+	_, ok := s.(fileSource)
+	return ok
+}
+
+// Whether the resource is a GCE image.
+func isImage(s resource) bool {
+	_, ok := s.(imageSource)
+	return ok
+}
+
+// An importable source backed by a GCS object.
+type fileSource struct {
+	gcsPath string
+	bucket  string
+	object  string
+}
+
+// Create a fileSource from a gcsPath to a disk image. This method uses storageClient
+// to read a few bytes from the file. It is an error if the file is empty, or if
+// the file is compressed with gzip.
+func newFileSource(gcsPath string, storageClient domain.StorageClientInterface) (resource, error) {
+	sourceBucketName, sourceObjectName, err := storage.GetGCSObjectPathElements(gcsPath)
+	if err != nil {
+		return nil, err
+	}
+	source := fileSource{
+		gcsPath: gcsPath,
+		bucket:  sourceBucketName,
+		object:  sourceObjectName,
+	}
+	return source, source.validate(storageClient)
+}
+
+// The resource path for fileSource is its GCS path.
+func (s fileSource) path() string {
+	return s.gcsPath
+}
+
+// Performs basic validation, focusing on error cases that we've seen in the past.
+// This reads a few bytes from the file in GCS. It is an error if the file
+// is empty, or if the file is compressed with gzip.
+func (s fileSource) validate(storageClient domain.StorageClientInterface) error {
+	rc, err := storageClient.GetObjectReader(s.bucket, s.object)
+	if err != nil {
+		return daisy.Errf("failed to read GCS file when validating resource file: unable to open "+
+			"file from bucket %q, file %q: %v", s.bucket, s.object, err)
+	}
+	defer rc.Close()
+
+	byteCountingReader := daisycommon.NewByteCountingReader(rc)
+	// Detect whether it's a compressed file by extracting compressed file header
+	if _, err = gzip.NewReader(byteCountingReader); err == nil {
+		return daisy.Errf("the input file is a gzip file, which is not supported by " +
+			"image import. To import a file that was exported from Google Compute " +
+			"Engine, please use image create. To import a file that was exported " +
+			"from a different system, decompress it and run image import on the " +
+			"disk image file directly")
+	}
+
+	// By calling gzip.NewReader above, a few bytes were read from the Reader in
+	// an attempt to decode the compression header. If the Reader represents
+	// an empty file, then BytesRead will be zero.
+	if byteCountingReader.BytesRead <= 0 {
+		return daisy.Errf("cannot import an image from an empty file")
+	}
+
+	return nil
+}
+
+// An importable source backed by a GCE disk image.
+type imageSource struct {
+	uri string
+}
+
+// Creates an imageSource from a reference to a GCE disk image. The syntax of the
+// reference is validated, but no I/O is performed to determine whether the image
+// exists or whether the calling user has access to it.
+func newImageSource(imagePath string) (resource, error) {
+	source := imageSource{
+		uri: param.GetGlobalResourcePath("images", imagePath),
+	}
+	return source, source.validate()
+}
+
+var imageNamePattern = regexp.MustCompile("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+
+// Performs basic validation, focusing on error cases that
+// we've seen in the past.
+//
+// Two key offenders:
+//   1. Using a file path instead of an image name.
+//     Examples:
+//        - file://home/user/image.vmdk
+//        - gs://bucket/image.vmdk
+//        - gs://global/images/image
+//        - https://storage.googleapis.com/bucket/image
+//   2. Using a relative file path instead of an image name.
+//     Examples:
+//        - image.vmdk
+//        - path/to/image.vmdk
+//
+// This method does not validate whether the image exist, or whether
+// the calling user has access to it.
+func (s imageSource) validate() error {
+	parsed, err := url.Parse(s.uri)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "" {
+		return daisy.Errf(
+			"invalid image reference %q.", s.uri)
+	}
+
+	var imageName string
+	if slash := strings.LastIndex(s.uri, "/"); slash > -1 {
+		imageName = s.uri[slash+1:]
+	} else {
+		imageName = s.uri
+	}
+	if imageName == "" || len(imageName) > 63 {
+		return daisy.Errf(
+			"invalid image name %q. Image name must be 1-63 characters long, inclusive", imageName)
+	}
+	if !imageNamePattern.MatchString(imageName) {
+		return daisy.Errf(
+			"invalid image name %q. The first character must be a lowercase letter, and all "+
+				"following characters must be a dash, lowercase letter, or digit, except the last "+
+				"character, which cannot be a dash.", imageName)
+	}
+	return nil
+}
+
+// The path to an imageSource is a fully-qualified global GCP resource path.
+func (s imageSource) path() string {
+	return s.uri
+}

--- a/cli_tools/gce_vm_image_import/importer/source.go
+++ b/cli_tools/gce_vm_image_import/importer/source.go
@@ -45,7 +45,8 @@ func initAndValidateSource(sourceFile, sourceImage string,
 	if sourceFile == "" && sourceImage == "" {
 		return nil, daisy.Errf(
 			"either -source_file or -source_image has to be specified")
-	} else if sourceFile != "" && sourceImage != "" {
+	}
+	if sourceFile != "" && sourceImage != "" {
 		return nil, daisy.Errf(
 			"either -source_file or -source_image has to be specified, but not both %v %v",
 			sourceFile, sourceImage)
@@ -147,22 +148,15 @@ func newImageSource(imagePath string) (resource, error) {
 var imageNamePattern = regexp.MustCompile("^[a-z]([-a-z0-9]*[a-z0-9])?$")
 
 // Performs basic validation, focusing on error cases that
-// we've seen in the past.
+// we've seen in the past. Specifically:
+//  1. Using GCS paths, eg `gs://bucket/image.vmdk`
+//  2. Referencing a file, eg `image.vmdk`
 //
-// Two key offenders:
-//   1. Using a file path instead of an image name.
-//     Examples:
-//        - file://home/user/image.vmdk
-//        - gs://bucket/image.vmdk
-//        - gs://global/images/image
-//        - https://storage.googleapis.com/bucket/image
-//   2. Using a relative file path instead of an image name.
-//     Examples:
-//        - image.vmdk
-//        - path/to/image.vmdk
-//
-// This method does not validate whether the image exist, or whether
-// the calling user has access to it.
+// This method does not validate:
+//  1. Whether the image exists.
+//  2. Whether the calling user has access to it.
+//  3. Whether the user's input is a well-formed
+//     [GCP resource URI](https://cloud.google.com/apis/design/resource_names)
 func (s imageSource) validate() error {
 	parsed, err := url.Parse(s.uri)
 	if err != nil {

--- a/cli_tools/gce_vm_image_import/importer/source_test.go
+++ b/cli_tools/gce_vm_image_import/importer/source_test.go
@@ -1,0 +1,133 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/test"
+	"github.com/GoogleCloudPlatform/compute-image-tools/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyFilesAreRejected(t *testing.T) {
+	emptyReader := ioutil.NopCloser(strings.NewReader(""))
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().GetObjectReader("bucket", "empty.vmdk").Return(emptyReader, nil)
+
+	_, err := initAndValidateSource("gs://bucket/empty.vmdk", "", mockStorageClient)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot import an image from an empty file")
+}
+
+func TestGzipCompressedFilesAreRejected(t *testing.T) {
+	fileString := test.CreateCompressedFile()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().GetObjectReader("bucket", "compressed.tar.gz").Return(
+		ioutil.NopCloser(strings.NewReader(fileString)), nil)
+
+	_, err := initAndValidateSource("gs://bucket/compressed.tar.gz", "", mockStorageClient)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "the input file is a gzip file, which is not supported")
+}
+
+func TestUncompressedFilesAreAllowed(t *testing.T) {
+	fileString := "random content"
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().GetObjectReader("bucket", "path/to/file.vmdk").Return(
+		ioutil.NopCloser(strings.NewReader(fileString)), nil)
+
+	source, err := initAndValidateSource("gs://bucket/path/to/file.vmdk", "", mockStorageClient)
+	assert.NoError(t, err)
+	assert.Equal(t, source, fileSource{
+		gcsPath: "gs://bucket/path/to/file.vmdk",
+		bucket:  "bucket",
+		object:  "path/to/file.vmdk",
+	})
+}
+
+func TestGcsFilePathMustBeFullyQualified(t *testing.T) {
+	cases := []string{"file.vmdk", "gs://bucket", "gs://bucket/"}
+
+	for _, invalidPath := range cases {
+		_, err := initAndValidateSource(invalidPath, "", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a valid Cloud Storage object path")
+	}
+}
+
+func TestEnsureEitherFileOrImageIsPresent(t *testing.T) {
+	_, err := initAndValidateSource("", "", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "either -source_file or -source_image has to be specified")
+
+	_, err = initAndValidateSource("gs://bucket/file.vmdk", "global/images/image", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "either -source_file or -source_image has to be specified")
+}
+
+func TestUnqualifiedImagePathsAreGlobalized(t *testing.T) {
+	var cases = []struct {
+		input          string
+		expectedResult string
+	}{
+		{"ubuntu-1604", "global/images/ubuntu-1604"},
+		{"projects/daisy/global/images/ubuntu-1604", "projects/daisy/global/images/ubuntu-1604"},
+	}
+
+	for _, tt := range cases {
+
+		t.Run(tt.input, func(t *testing.T) {
+			source, err := initAndValidateSource("", tt.input, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, source.path())
+		})
+
+	}
+}
+
+func TestImagePathIsValidated(t *testing.T) {
+	var cases = []struct {
+		path       string
+		errMessage string
+	}{
+		{"file.vmdk", "invalid image name"},
+		{"gs://bucket/file.vmdk", "invalid image reference"},
+		{strings.Repeat("a", 80), "Image name must be 1-63 characters long"},
+		{"global/images/ubuntu/", "Image name must be 1-63 characters long"},
+	}
+
+	for _, tt := range cases {
+
+		t.Run(tt.path, func(t *testing.T) {
+			_, err := initAndValidateSource("", tt.path, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMessage)
+		})
+
+	}
+}


### PR DESCRIPTION
This consolidates the validations for sourceImage and sourceFile and provides a consistent API for dealing with them.

Additionally, this performs syntactic validation of sourceImage.