### PR TITLE
Remove epel from EL7 builds. It is no longer needed for the base image

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el7-post.cfg
@@ -2,9 +2,6 @@
 %post --log=/dev/ttyS0
 set -x
 
-# Install EPEL.
-yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
 # Delete the dummy user account.
 userdel -r gce
 


### PR DESCRIPTION
case.