### PR TITLE
[daisy] snapshots: add tests; adjust populate logic

### DIFF
--- a/daisy/disk_test.go
+++ b/daisy/disk_test.go
@@ -32,6 +32,12 @@ func TestDiskPopulate(t *testing.T) {
 			false,
 		},
 		{
+			"input size",
+			&Disk{Disk: compute.Disk{Name: name}, SizeGb: "10"},
+			&Disk{Disk: compute.Disk{Name: genName, Type: defType, SizeGb: 10, Zone: w.Zone}, SizeGb: "10"},
+			false,
+		},
+		{
 			"extend Type URL case",
 			&Disk{Disk: compute.Disk{Name: name, Type: "pd-ssd"}, SizeGb: "10"},
 			&Disk{Disk: compute.Disk{Name: genName, Type: ssdType, SizeGb: 10, Zone: w.Zone}, SizeGb: "10"},
@@ -408,6 +414,11 @@ func TestDiskValidate(t *testing.T) {
 			"source snapshot dne case",
 			&Disk{Disk: compute.Disk{Name: "d10", SourceSnapshot: "dne", Type: ty}},
 			true,
+		},
+		{
+			"source snapshot with size",
+			&Disk{Disk: compute.Disk{Name: "d11", SourceSnapshot: "ss1", Type: ty}, SizeGb: "50"},
+			false,
 		},
 	}
 

--- a/daisy/snapshot.go
+++ b/daisy/snapshot.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 var (
@@ -57,14 +59,13 @@ func (ss *Snapshot) populate(ctx context.Context, s *Step) DError {
 
 	ss.Description = strOr(ss.Description, fmt.Sprintf("Snapshot created by Daisy in workflow %q on behalf of %s.", s.w.Name, s.w.username))
 
+	// If it's a URI, try to extend it because it may missed "project" part.
+	// Otherwise, it can be a daisy-created resource. Leave it as-is.
+	// If it matches neither daisy-created disk nor existing resource URI, "validate"
+	// will fail.
 	if diskURLRgx.MatchString(ss.SourceDisk) {
 		ss.SourceDisk = extendPartialURL(ss.SourceDisk, ss.Project)
 	}
-
-	m := NamedSubexp(diskURLRgx, ss.SourceDisk)
-	ss.sourceDiskProject = m["project"]
-	ss.sourceDiskZone = m["zone"]
-	ss.sourceDiskName = m["disk"]
 
 	ss.link = fmt.Sprintf("projects/%s/global/snapshots/%s", ss.Project, ss.Name)
 	return errs
@@ -77,9 +78,19 @@ func (ss *Snapshot) validate(ctx context.Context, s *Step) DError {
 	// Source disk checking.
 	if ss.SourceDisk == "" {
 		errs = addErrs(errs, Errf("%s: must provide SourceDisk", pre))
-	}
-	if _, err := s.w.disks.regUse(ss.SourceDisk, s); err != nil {
+	} else if _, err := s.w.disks.regUse(ss.SourceDisk, s); err != nil {
 		errs = addErrs(errs, newErr("failed to get source disk", err))
+	} else {
+		var sourceDiskURI string
+		if diskURLRgx.MatchString(ss.SourceDisk) {
+			sourceDiskURI = ss.SourceDisk
+		} else {
+			sourceDiskURI = s.w.disks.m[ss.SourceDisk].link
+		}
+		m := NamedSubexp(diskURLRgx, sourceDiskURI)
+		ss.sourceDiskProject = m["project"]
+		ss.sourceDiskZone = m["zone"]
+		ss.sourceDiskName = m["disk"]
 	}
 
 	// Register creation.
@@ -96,4 +107,13 @@ func newSnapshotRegistry(w *Workflow) *snapshotRegistry {
 	sr.baseResourceRegistry.deleteFn = sr.deleteFn
 	sr.init()
 	return sr
+}
+
+func (sr *snapshotRegistry) deleteFn(res *Resource) DError {
+	m := NamedSubexp(snapshotURLRgx, res.link)
+	err := sr.w.ComputeClient.DeleteSnapshot(m["project"], m["snapshot"])
+	if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusNotFound {
+		return typedErr(resourceDNEError, "failed to delete snapshot", err)
+	}
+	return newErr("failed to delete snapshot", err)
 }

--- a/daisy/snapshot_test.go
+++ b/daisy/snapshot_test.go
@@ -95,10 +95,10 @@ func TestSnapshotValidate(t *testing.T) {
 	}{
 		{"no source disk case failure", &Snapshot{Snapshot: compute.Snapshot{Name: "ss1"}}, true},
 		{"source disk created by daisy", &Snapshot{Snapshot: compute.Snapshot{Name: "ss2", SourceDisk: "sd"}}, false},
-		{"source disk with disk size", &Snapshot{Snapshot: compute.Snapshot{Name: "ss2", SourceDisk: "sd", DiskSizeGb: 100}}, false},
-		{"source disk URI: only name", &Snapshot{Snapshot: compute.Snapshot{Name: "ss3", SourceDisk: fmt.Sprintf("aaa")}}, true},
-		{"source disk URI: with zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss4", SourceDisk: fmt.Sprintf("zones/%v/disks/%v", testZone, testDisk)}}, false},
-		{"source disk URI: with projects and zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss5", SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, testZone, testDisk)}}, false},
+		{"source disk with disk size", &Snapshot{Snapshot: compute.Snapshot{Name: "ss3", SourceDisk: "sd", DiskSizeGb: 100}}, false},
+		{"source disk URI: only name", &Snapshot{Snapshot: compute.Snapshot{Name: "ss4", SourceDisk: fmt.Sprintf("aaa")}}, true},
+		{"source disk URI: with zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss5", SourceDisk: fmt.Sprintf("zones/%v/disks/%v", testZone, testDisk)}}, false},
+		{"source disk URI: with projects and zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss6", SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, testZone, testDisk)}}, false},
 	}
 
 	for _, tt := range tests {

--- a/daisy/snapshot_test.go
+++ b/daisy/snapshot_test.go
@@ -39,15 +39,18 @@ func TestSnapshotPopulate(t *testing.T) {
 	}{
 		{"source disk URI: only name", &Snapshot{
 			Resource: Resource{ExactName: true},
-			Snapshot: compute.Snapshot{Name: testSnapshot, SourceDisk: fmt.Sprintf("aaa")}}, false, "aaa", fmt.Sprintf("projects/%s/global/snapshots/%s", testProject, testSnapshot),
+			Snapshot: compute.Snapshot{Name: testSnapshot, SourceDisk: fmt.Sprintf("aaa")}}, false,
+			"aaa", fmt.Sprintf("projects/%s/global/snapshots/%s", testProject, testSnapshot),
 		},
 		{"source disk URI: with zones", &Snapshot{
 			Resource: Resource{ExactName: true},
-			Snapshot: compute.Snapshot{Name: testSnapshot, SourceDisk: fmt.Sprintf("zones/%v/disks/%v", currentTestZone, currentTestDisk)}}, false, fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, currentTestZone, currentTestDisk), fmt.Sprintf("projects/%s/global/snapshots/%s", testProject, testSnapshot),
+			Snapshot: compute.Snapshot{Name: testSnapshot, SourceDisk: fmt.Sprintf("zones/%v/disks/%v", currentTestZone, currentTestDisk)}}, false,
+			fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, currentTestZone, currentTestDisk), fmt.Sprintf("projects/%s/global/snapshots/%s", testProject, testSnapshot),
 		},
 		{"source disk URI: with projects and zones", &Snapshot{
 			Resource: Resource{ExactName: true},
-			Snapshot: compute.Snapshot{Name: testSnapshot, SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", currentTestProject, currentTestZone, currentTestDisk)}}, false, fmt.Sprintf("projects/%v/zones/%v/disks/%v", currentTestProject, currentTestZone, currentTestDisk), fmt.Sprintf("projects/%s/global/snapshots/%s", testProject, testSnapshot),
+			Snapshot: compute.Snapshot{Name: testSnapshot, SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", currentTestProject, currentTestZone, currentTestDisk)}}, false,
+			fmt.Sprintf("projects/%v/zones/%v/disks/%v", currentTestProject, currentTestZone, currentTestDisk), fmt.Sprintf("projects/%s/global/snapshots/%s", testProject, testSnapshot),
 		},
 	}
 
@@ -92,6 +95,7 @@ func TestSnapshotValidate(t *testing.T) {
 	}{
 		{"no source disk case failure", &Snapshot{Snapshot: compute.Snapshot{Name: "ss1"}}, true},
 		{"source disk created by daisy", &Snapshot{Snapshot: compute.Snapshot{Name: "ss2", SourceDisk: "sd"}}, false},
+		{"source disk with disk size", &Snapshot{Snapshot: compute.Snapshot{Name: "ss2", SourceDisk: "sd", DiskSizeGb: 100}}, false},
 		{"source disk URI: only name", &Snapshot{Snapshot: compute.Snapshot{Name: "ss3", SourceDisk: fmt.Sprintf("aaa")}}, true},
 		{"source disk URI: with zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss4", SourceDisk: fmt.Sprintf("zones/%v/disks/%v", testZone, testDisk)}}, false},
 		{"source disk URI: with projects and zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss5", SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, testZone, testDisk)}}, false},

--- a/daisy/snapshot_test.go
+++ b/daisy/snapshot_test.go
@@ -86,18 +86,15 @@ func TestSnapshotValidate(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc            string
-		ss              *Snapshot
-		shouldErr       bool
-		expectedProject string
-		expectedZone    string
-		expectedDisk    string
+		desc      string
+		ss        *Snapshot
+		shouldErr bool
 	}{
-		{"no source disk case failure", &Snapshot{Snapshot: compute.Snapshot{Name: "ss1"}}, true, "", "", ""},
-		{"source disk created by daisy", &Snapshot{Snapshot: compute.Snapshot{Name: "ss2", SourceDisk: "sd"}}, false, testProject, testZone, "sd"},
-		{"source disk URI: only name", &Snapshot{Snapshot: compute.Snapshot{Name: "ss3", SourceDisk: fmt.Sprintf("aaa")}}, true, "", "", ""},
-		{"source disk URI: with zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss4", SourceDisk: fmt.Sprintf("zones/%v/disks/%v", testZone, testDisk)}}, false, testProject, testZone, testDisk},
-		{"source disk URI: with projects and zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss5", SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, testZone, testDisk)}}, false, testProject, testZone, testDisk},
+		{"no source disk case failure", &Snapshot{Snapshot: compute.Snapshot{Name: "ss1"}}, true},
+		{"source disk created by daisy", &Snapshot{Snapshot: compute.Snapshot{Name: "ss2", SourceDisk: "sd"}}, false},
+		{"source disk URI: only name", &Snapshot{Snapshot: compute.Snapshot{Name: "ss3", SourceDisk: fmt.Sprintf("aaa")}}, true},
+		{"source disk URI: with zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss4", SourceDisk: fmt.Sprintf("zones/%v/disks/%v", testZone, testDisk)}}, false},
+		{"source disk URI: with projects and zones", &Snapshot{Snapshot: compute.Snapshot{Name: "ss5", SourceDisk: fmt.Sprintf("projects/%v/zones/%v/disks/%v", testProject, testZone, testDisk)}}, false},
 	}
 
 	for _, tt := range tests {
@@ -118,18 +115,6 @@ func TestSnapshotValidate(t *testing.T) {
 			t.Errorf("%s: should have returned an error", tt.desc)
 		} else if !tt.shouldErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", tt.desc, err)
-		}
-
-		if !tt.shouldErr && err == nil {
-			if tt.expectedDisk != tt.ss.sourceDiskName {
-				t.Errorf("%s: expected disk: '%v', actual disk: '%v'", tt.desc, tt.expectedDisk, tt.ss.sourceDiskName)
-			}
-			if tt.expectedZone != tt.ss.sourceDiskZone {
-				t.Errorf("%s: expected zone: '%v', actual zone: '%v'", tt.desc, tt.expectedZone, tt.ss.sourceDiskZone)
-			}
-			if tt.expectedProject != tt.ss.sourceDiskProject {
-				t.Errorf("%s: expected project: '%v', actual project: '%v'", tt.desc, tt.expectedProject, tt.ss.sourceDiskProject)
-			}
 		}
 	}
 }

--- a/daisy_integration_tests/step_create_snapshots.wf.json
+++ b/daisy_integration_tests/step_create_snapshots.wf.json
@@ -1,0 +1,44 @@
+{
+  "Name": "create-snapshots-test",
+  "Vars": {
+    "about-this-test": {
+      "Value": "",
+      "Description": "This test creates an snapshot and confirm it's OK by creating disk from it."
+    }
+  },
+  "Steps": {
+    "create-disks": {
+      "CreateDisks": [
+        {
+          "name": "disk-from-image-family-url",
+          "sourceImage": "projects/debian-cloud/global/images/family/debian-9",
+          "type": "pd-ssd"
+        }
+      ]
+    },
+    "disks-to-snapshots": {
+      "CreateSnapshots": [
+        {
+          "name": "disks-to-snapshots",
+          "sourceDisk": "disk-from-image-family-url"
+        }
+      ]
+    },
+    "snapshots-to-disks": {
+      "CreateDisks": [
+        {
+          "name": "snapshots-to-disks",
+          "sourceSnapshot": "disks-to-snapshots"
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "disks-to-snapshots": [
+      "create-disks"
+    ],
+    "snapshots-to-disks": [
+      "disks-to-snapshots"
+    ]
+  }
+}


### PR DESCRIPTION
Added unit tests and integration tests for snaphosts.

Logic change: link needs to be adjusted before creating the snapshot. Otherwise, the link can be wrong because its project must be the same as corresponding disk, no matter whether user customized "Project" property.