### PR TITLE
Revert "[daisy] populate daisy input vars early to support non-string types"

### DIFF
--- a/daisy/cli/main.go
+++ b/daisy/cli/main.go
@@ -76,14 +76,15 @@ func populateVars(input string) map[string]string {
 }
 
 func parseWorkflow(ctx context.Context, path string, varMap map[string]string, project, zone, gcsPath, oauth, dTimeout, cEndpoint string, disableGCSLogs, diableCloudLogs, disableStdoutLogs bool) (*daisy.Workflow, error) {
-	w, err := daisy.NewFromFile(path, varMap)
+	w, err := daisy.NewFromFile(path)
 	if err != nil {
 		return nil, err
 	}
 Loop:
-	for k := range varMap {
+	for k, v := range varMap {
 		for wv := range w.Vars {
 			if k == wv {
+				w.AddVar(k, v)
 				continue Loop
 			}
 		}

--- a/daisy/daisy_test_runner/main.go
+++ b/daisy/daisy_test_runner/main.go
@@ -157,9 +157,12 @@ func (l *logger) ReadSerialPortLogs() []string {
 func (l *logger) Flush() { return }
 
 func createTestCase(ctx context.Context, testLogger *logger, path, project, zone, oauthPath, ce string, varMap map[string]string) (*daisy.Workflow, error) {
-	w, err := daisy.NewFromFile(path, varMap)
+	w, err := daisy.NewFromFile(path)
 	if err != nil {
 		return nil, err
+	}
+	for k, v := range varMap {
+		w.AddVar(k, v)
 	}
 
 	if oauthPath != "" {

--- a/daisy/step_includeworkflow.go
+++ b/daisy/step_includeworkflow.go
@@ -35,7 +35,7 @@ type IncludeWorkflow struct {
 func (i *IncludeWorkflow) populate(ctx context.Context, s *Step) DError {
 	if i.Path != "" {
 		var err error
-		if i.Workflow, err = s.w.NewIncludedWorkflowFromFile(i.Path, i.Vars); err != nil {
+		if i.Workflow, err = s.w.NewIncludedWorkflowFromFile(i.Path); err != nil {
 			return newErr("failed to parse duration for step includeworkflow", err)
 		}
 	} else {

--- a/daisy/step_sub_workflow.go
+++ b/daisy/step_sub_workflow.go
@@ -29,7 +29,7 @@ type SubWorkflow struct {
 func (s *SubWorkflow) populate(ctx context.Context, st *Step) DError {
 	if s.Path != "" {
 		var err error
-		if s.Workflow, err = st.w.NewSubWorkflowFromFile(s.Path, s.Vars); err != nil {
+		if s.Workflow, err = st.w.NewSubWorkflowFromFile(s.Path); err != nil {
 			return ToDError(err)
 		}
 	}

--- a/daisy/test_data/test.wf.json
+++ b/daisy/test_data/test.wf.json
@@ -9,8 +9,7 @@
     "bootstrap_instance_name": {"Value": "bootstrap-${NAME}", "Required": true},
     "machine_type": "n1-standard-1",
     "key1": "var1",
-    "key2": "var2",
-    "required_key1": {"Value": "", "Required": true}
+    "key2": "var2"
   },
   "steps": {
     "create-disks": {

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -191,7 +191,7 @@ func TestNewFromFileError(t *testing.T) {
 			t.Fatalf("error creating json file: %v", err)
 		}
 
-		if _, err := NewFromFile(tf, nil); err == nil {
+		if _, err := NewFromFile(tf); err == nil {
 			t.Errorf("expected error, got nil for test %d", i+1)
 		} else if err.Error() != tt.error {
 			t.Errorf("did not get expected error from NewFromFile():\ngot: %q\nwant: %q", err.Error(), tt.error)
@@ -200,7 +200,7 @@ func TestNewFromFileError(t *testing.T) {
 }
 
 func TestNewFromFile(t *testing.T) {
-	got, derr := NewFromFile("./test_data/test.wf.json", map[string]string{"required_key1": "v"})
+	got, derr := NewFromFile("./test_data/test.wf.json")
 	if derr != nil {
 		t.Fatal(derr)
 	}
@@ -234,7 +234,6 @@ func TestNewFromFile(t *testing.T) {
 		"machine_type":            {Value: "n1-standard-1"},
 		"key1":                    {Value: "var1"},
 		"key2":                    {Value: "var2"},
-		"required_key1":           {Value: "v"},
 	}
 	want.Steps = map[string]*Step{
 		"create-disks": {
@@ -806,7 +805,7 @@ func TestPrint(t *testing.T) {
 	tf := filepath.Join(td, "test.wf.json")
 	ioutil.WriteFile(tf, data, 0600)
 
-	got, err := NewFromFile(tf, nil)
+	got, err := NewFromFile(tf)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/compute-image-tools#1177

It's not the best solution for windows-upgrade "rollback" workflow. Revert it to avoid publishing unnecessary functionalities.