### PR TITLE
Use Python guest agent for Debian 8.

### DIFF
--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -49,7 +49,7 @@ def DistroSpecific(g):
     logging.info('Installing GCE packages.')
 
     utils.update_apt(g)
-    utils.install_apt_package(g, 'gnupg')
+    utils.install_apt_packages(g, 'gnupg')
 
     g.command(
         ['wget', 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
@@ -67,10 +67,14 @@ def DistroSpecific(g):
       logging.warn('Could not uninstall Azure agent. Continuing anyway.')
 
     utils.update_apt(g)
-    utils.install_apt_package(g, 'google-cloud-packages-archive-keyring')
-    utils.install_apt_package(g, 'google-cloud-sdk')
-    utils.install_apt_package(g, 'google-compute-engine')
-    utils.install_apt_package(g, 'google-guest-agent')
+    pkgs = ['google-cloud-packages-archive-keyring', 'google-cloud-sdk',
+            'google-compute-engine']
+    # Debian 8 doesn't support the new guest agent, so we need to install
+    # the legacy Python version.
+    if deb_release == 'jessie':
+      pkgs += ['python-google-compute-engine',
+               'python3-google-compute-engine']
+    utils.install_apt_packages(g, *pkgs)
 
   # Update grub config to log to console.
   g.command(

--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -113,7 +113,7 @@ def DistroSpecific(g):
   if install_gce == 'true':
     utils.update_apt(g)
     logging.info('Installing cloud-init.')
-    utils.install_apt_package(g, 'cloud-init')
+    utils.install_apt_packages(g, 'cloud-init')
 
     # Try to remove azure or aws configs so cloud-init has a chance.
     g.sh('rm -f /etc/cloud/cloud.cfg.d/*azure*')
@@ -151,8 +151,8 @@ def DistroSpecific(g):
         '&& cloud-init -d init')
     logging.info('Installing GCE packages.')
     utils.update_apt(g)
-    utils.install_apt_package(g, 'gce-compute-image-packages')
-    utils.install_apt_package(g, 'google-cloud-sdk')
+    utils.install_apt_packages(g, 'gce-compute-image-packages',
+                               'google-cloud-sdk')
   # Update grub config to log to console.
   g.command(
       ['sed', '-i',

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -754,9 +754,9 @@ class MetadataManager:
 
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
-def install_apt_package(g, pkg):
+def install_apt_packages(g, *pkgs):
   g.sh('DEBIAN_FRONTEND=noninteractive apt-get '
-       'install -y --no-install-recommends ' + pkg)
+       'install -y --no-install-recommends ' + ' '.join(pkgs))
 
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)


### PR DESCRIPTION
In addition, consolidates series of apt requests into a single batch operation.

Running import integration tests in process:
 * Debian 8, 9
 * Ubuntu 16.04, 18.04