### PR TITLE
Use kaniko-project/executor:debug-edge for builds

### DIFF
--- a/prowjobs_cloudbuild.yaml
+++ b/prowjobs_cloudbuild.yaml
@@ -12,7 +12,7 @@ options:
 
 steps:
 - id: cleanerupper
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/cleanerupper:latest
   - --destination=gcr.io/$PROJECT_ID/cleanerupper:$COMMIT_SHA
@@ -20,7 +20,7 @@ steps:
   - --cache=true
   - --cache-ttl=24h
 - id: wrapper
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/wrapper:latest
   - --destination=gcr.io/$PROJECT_ID/wrapper:$COMMIT_SHA
@@ -28,7 +28,7 @@ steps:
   - --cache=true
   - --cache-ttl=24h
 - id: wrapper-with-gcloud
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/wrapper-with-gcloud:latest
   - --destination=gcr.io/$PROJECT_ID/wrapper-with-gcloud:$COMMIT_SHA
@@ -38,7 +38,7 @@ steps:
   - --cache=true
   - --cache-ttl=24h
 - id: test-runner
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/test-runner:latest
   - --destination=gcr.io/$PROJECT_ID/test-runner:$COMMIT_SHA
@@ -46,7 +46,7 @@ steps:
   - --dockerfile=daisy_test_runner.Dockerfile
   - --build-arg=PROJECT_ID=$PROJECT_ID
 - id: gce-image-import-export-tests
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce-image-import-export-tests:latest
   - --destination=gcr.io/$PROJECT_ID/gce-image-import-export-tests:$COMMIT_SHA
@@ -54,7 +54,7 @@ steps:
   - --dockerfile=gce_image_import_export_tests.Dockerfile
   - --build-arg=PROJECT_ID=$PROJECT_ID
 - id: gce-ovf-import-tests
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce-ovf-import-tests:latest
   - --destination=gcr.io/$PROJECT_ID/gce-ovf-import-tests:$COMMIT_SHA
@@ -62,7 +62,7 @@ steps:
   - --dockerfile=gce_ovf_import_tests.Dockerfile
   - --build-arg=PROJECT_ID=$PROJECT_ID
 - id: gocheck
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gocheck:latest
   - --destination=gcr.io/$PROJECT_ID/gocheck:$COMMIT_SHA
@@ -70,7 +70,7 @@ steps:
   - --build-arg=PROJECT_ID=$PROJECT_ID
   waitFor: ['wrapper']
 - id: gobuild
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gobuild:latest
   - --destination=gcr.io/$PROJECT_ID/gobuild:$COMMIT_SHA
@@ -78,7 +78,7 @@ steps:
   - --build-arg=PROJECT_ID=$PROJECT_ID
   waitFor: ['wrapper']
 - id: flake8
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/flake8:latest
   - --destination=gcr.io/$PROJECT_ID/flake8:$COMMIT_SHA
@@ -86,7 +86,7 @@ steps:
   - --build-arg=PROJECT_ID=$PROJECT_ID
   waitFor: ['wrapper']
 - id: unittests
-  name: 'gcr.io/kaniko-project/executor'
+  name: 'gcr.io/kaniko-project/executor:debug-edge'
   args: 
   - --destination=gcr.io/$PROJECT_ID/unittests:latest
   - --destination=gcr.io/$PROJECT_ID/unittests:$COMMIT_SHA


### PR DESCRIPTION
The latest release of kaniko-project/executor broke our builds due to permission check issues. Using debug/fix release to verify this is the actual cause. Only for compute-image-tools-test for now