### PR TITLE
If translation fails, alert user of what was detected on disk.

### DIFF
--- a/cli_tools/common/distro/distro.go
+++ b/cli_tools/common/distro/distro.go
@@ -31,7 +31,7 @@ const (
 )
 
 // Release encapsulates product and version information
-// about a Linux or Windows release.
+// about the operating systems we support.
 type Release interface {
 	ImportCompatible(other Release) bool
 	AsGcloudArg() string

--- a/cli_tools/common/distro/distro.go
+++ b/cli_tools/common/distro/distro.go
@@ -1,0 +1,179 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package distro
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Release encapsulates product and version information
+// about a Linux or Windows release.
+type Release interface {
+	ImportCompatible(other Release) bool
+	AsGcloudArg() string
+}
+
+type release struct {
+	distro  string
+	variant string
+	major   string
+	minor   string
+}
+
+// AsGcloudArg returns a string representation using the format
+// that we use with the `--os` flag.
+func (l release) AsGcloudArg() string {
+	switch l.distro {
+	case "ubuntu":
+		return fmt.Sprintf("%s-%s%s", l.distro, l.major, l.minor)
+	case "sles":
+		if l.variant != "" {
+			return fmt.Sprintf("%s-%s-%s", l.distro, l.variant, l.major)
+		} else {
+			return fmt.Sprintf("%s-%s", l.distro, l.major)
+		}
+	default:
+		return fmt.Sprintf("%s-%s", l.distro, l.major)
+	}
+}
+
+// ImportCompatible uses product-specific information
+// to determine whether two versions are compatible for import.
+func (l release) ImportCompatible(other Release) bool {
+	realOther, ok := other.(release)
+	if !ok {
+		return false
+	}
+
+	if l.distro == "ubuntu" {
+		return l.distro == realOther.distro &&
+			l.major == realOther.major &&
+			l.minor == realOther.minor
+	}
+
+	if l.distro == "sles" {
+		return l.distro == realOther.distro &&
+			l.variant == realOther.variant &&
+			l.major == realOther.major
+	}
+
+	return l.distro == realOther.distro &&
+		l.major == realOther.major
+}
+
+// FromLibguestfs initializes a DistroAndVersion from the fields returned by libguestfs's
+// inspection routines.
+//
+// http://libguestfs.org/guestfs.3.html#guestfs_inspect_get_distro
+func FromLibguestfs(distro string, major string, minor string) (r Release, e error) {
+	distro = strings.ToLower(distro)
+	if distro == "windows" {
+		// We don't currently need windows for this parsing, and punting
+		// since it's not immediately clear how to represent their
+		// version strings, as the user-facing value (Windows 2008r2)
+		// does not match what's used internally by our tools (NT 5.2)
+		// https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
+		return r, errors.New("windows not yet implemented")
+	}
+	if distro == "" || major == "" {
+		return nil, errors.New("distro and major are required")
+	}
+	return release{
+		distro: distro,
+		major:  major,
+		minor:  minor,
+	}, nil
+}
+
+// ParseGcloudOsParam parses the value associated with the `--os` parameter
+// from the `gcloud compute image` tools.
+//
+// https://cloud.google.com/sdk/gcloud/reference/compute/images/import#--os
+func ParseGcloudOsParam(os string) (r Release, e error) {
+	os = strings.ToLower(os)
+	if strings.HasSuffix(os, "-byol") {
+		os = strings.TrimSuffix(os, "-byol")
+	}
+	if strings.HasPrefix(os, "windows") {
+		// We don't currently need windows for this parsing, and punting
+		// since it's not immediately clear how to represent their
+		// version strings, as the user-facing value (Windows 2008r2)
+		// does not match what's used internally by our tools (NT 5.2)
+		// https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
+		return r, errors.New("windows not yet implemented")
+	}
+	parts := strings.Split(os, "-")
+	distro := parts[0]
+
+	// 1. Format is `(debian|centos|rhel|opensuse)-major`.
+	//   Canonical example: debian-8
+	if distro == "debian" ||
+		distro == "centos" ||
+		distro == "rhel" ||
+		distro == "opensuse" {
+		if len(parts) != 2 {
+			return r, fmt.Errorf("expected pattern of `distro-version`. Actual: %q", os)
+		}
+
+		return release{
+			distro: distro,
+			major:  parts[1],
+		}, nil
+	}
+
+	// 2. Format is `sles(-variant)?-major`.
+	//   Canonical examples: sles-sap-12, sles-12
+	if distro == "sles" {
+		switch len(parts) {
+		case 2:
+			return release{
+				distro: distro,
+				major:  parts[1],
+			}, nil
+		case 3:
+			return release{
+				distro:  distro,
+				variant: parts[1],
+				major:   parts[2],
+			}, nil
+		default:
+			return r, fmt.Errorf("unrecognized SLES identifier: %q", os)
+		}
+	}
+
+	// 3. Format is `ubuntu-(major)(minor)`.
+	//   Canonical example: ubuntu-1804
+	if distro == "ubuntu" {
+		if len(parts) != 2 {
+			return r, fmt.Errorf("expected pattern of `distro-version`. Actual: %q", os)
+		}
+
+		version := parts[1]
+		// We support importing LTS versions, which end in 04.
+		if len(version) != 4 {
+			return r, fmt.Errorf("expected version with length four. Actual: %q", version)
+		}
+
+		return release{
+			distro: distro,
+			major:  version[:2],
+			minor:  version[2:],
+		}, nil
+	}
+
+	return r, fmt.Errorf("unrecognized identifier: %q", os)
+}

--- a/cli_tools/common/distro/distro_test.go
+++ b/cli_tools/common/distro/distro_test.go
@@ -24,14 +24,14 @@ func TestParseGcloudOsParam_WindowsIsNotImplemented(t *testing.T) {
 	d, err := ParseGcloudOsParam("windows-2008")
 	assert.Nil(t, d)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "windows not yet implemented")
+	assert.Contains(t, err.Error(), "Windows not yet implemented")
 }
 
 func TestFromLibguestfs_WindowsIsNotImplemented(t *testing.T) {
 	d, err := FromLibguestfs("windows", "6", "1")
 	assert.Nil(t, d)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "windows not yet implemented")
+	assert.Contains(t, err.Error(), "Windows not yet implemented")
 }
 
 func TestParseGcloudOsParam_HappyCasesLinux(t *testing.T) {
@@ -75,7 +75,7 @@ func TestHumanReadable(t *testing.T) {
 		{release{distro: "debian", major: "8"}, "debian-8"},
 		{release{distro: "opensuse", major: "15"}, "opensuse-15"},
 		{release{distro: "sles", variant: "sap", major: "12"}, "sles-sap-12"},
-		{release{distro: "sles", major: "15", minor: "1"}, "sles-15"},
+		{release{distro: "sles", major: "15", minor: "2"}, "sles-15"},
 		{release{distro: "ubuntu", major: "14", minor: "04"}, "ubuntu-1404"},
 	}
 	for _, tt := range cases {

--- a/cli_tools/common/distro/distro_test.go
+++ b/cli_tools/common/distro/distro_test.go
@@ -1,0 +1,176 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package distro
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGcloudOsParam_WindowsIsNotImplemented(t *testing.T) {
+	d, err := ParseGcloudOsParam("windows-2008")
+	assert.Nil(t, d)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "windows not yet implemented")
+}
+
+func TestFromLibguestfs_WindowsIsNotImplemented(t *testing.T) {
+	d, err := FromLibguestfs("windows", "6", "1")
+	assert.Nil(t, d)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "windows not yet implemented")
+}
+
+func TestParseGcloudOsParam_HappyCasesLinux(t *testing.T) {
+	var cases = []struct {
+		in       string
+		expected release
+	}{
+		{"debian-8", release{distro: "debian", major: "8"}},
+		{"debian-9", release{distro: "debian", major: "9"}},
+		{"centos-6", release{distro: "centos", major: "6"}},
+		{"centos-7", release{distro: "centos", major: "7"}},
+		{"centos-8", release{distro: "centos", major: "8"}},
+		{"opensuse-15", release{distro: "opensuse", major: "15"}},
+		{"sles-sap-12-byol", release{distro: "sles", variant: "sap", major: "12"}},
+		{"sles-12-byol", release{distro: "sles", major: "12"}},
+		{"sles-15-byol", release{distro: "sles", major: "15"}},
+		{"rhel-6", release{distro: "rhel", major: "6"}},
+		{"rhel-7", release{distro: "rhel", major: "7"}},
+		{"rhel-8", release{distro: "rhel", major: "8"}},
+		{"rhel-6-byol", release{distro: "rhel", major: "6"}},
+		{"rhel-7-byol", release{distro: "rhel", major: "7"}},
+		{"rhel-8-byol", release{distro: "rhel", major: "8"}},
+		{"ubuntu-1404", release{distro: "ubuntu", major: "14", minor: "04"}},
+		{"ubuntu-1604", release{distro: "ubuntu", major: "16", minor: "04"}},
+		{"ubuntu-1804", release{distro: "ubuntu", major: "18", minor: "04"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.in, func(t *testing.T) {
+			d, e := ParseGcloudOsParam(tt.in)
+			assert.NoError(t, e)
+			assert.Equal(t, tt.expected, d)
+		})
+	}
+}
+
+func TestHumanReadable(t *testing.T) {
+	var cases = []struct {
+		in       release
+		expected string
+	}{
+		{release{distro: "debian", major: "8"}, "debian-8"},
+		{release{distro: "opensuse", major: "15"}, "opensuse-15"},
+		{release{distro: "sles", variant: "sap", major: "12"}, "sles-sap-12"},
+		{release{distro: "sles", major: "15", minor: "1"}, "sles-15"},
+		{release{distro: "ubuntu", major: "14", minor: "04"}, "ubuntu-1404"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.in.AsGcloudArg())
+		})
+	}
+}
+
+func TestParseGcloudOsParam_ErrorsLinux(t *testing.T) {
+	var cases = []struct {
+		in  string
+		err string
+	}{
+		{"sles", "unrecognized SLES identifier: \"sles\""},
+		{"kali-12", "unrecognized identifier: \"kali-12\""},
+		{"ubuntu", "expected pattern of `distro-version`"},
+		{"ubuntu-12", "expected version with length four"},
+		{"opensuse-15-leap", "expected pattern of `distro-version`"},
+		{"debian", "expected pattern of `distro-version`"},
+		{"centos7", "unrecognized identifier: \"centos7\""},
+		{"rhel", "expected pattern of `distro-version`"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.in, func(t *testing.T) {
+			d, e := ParseGcloudOsParam(tt.in)
+			assert.Nil(t, d)
+			assert.Error(t, e)
+			assert.Contains(t, e.Error(), tt.err)
+		})
+	}
+}
+
+func TestImportCompatible_Libguestfs(t *testing.T) {
+	assert.True(t,
+		safeParse(t, "centos-7").ImportCompatible(
+			safeFromLibguestfs(t, "centos", "7", "")))
+
+	assert.True(t,
+		safeParse(t, "centos-7").ImportCompatible(
+			safeFromLibguestfs(t, "centos", "7", "1")))
+
+	assert.True(t,
+		safeParse(t, "ubuntu-1404").ImportCompatible(
+			safeFromLibguestfs(t, "ubuntu", "14", "04")))
+
+	assert.False(t,
+		safeParse(t, "ubuntu-1404").ImportCompatible(
+			safeFromLibguestfs(t, "ubuntu", "14", "10")))
+}
+
+func TestImportCompatible_CommonLinux(t *testing.T) {
+	cent7 := safeParse(t, "centos-7")
+	cent8 := safeParse(t, "centos-8")
+	rhel7 := safeParse(t, "rhel-7")
+	deb7 := safeParse(t, "debian-7")
+
+	assert.True(t, cent7.ImportCompatible(cent7))
+	assert.False(t, cent7.ImportCompatible(cent8))
+	assert.False(t, cent7.ImportCompatible(rhel7))
+	assert.False(t, cent7.ImportCompatible(deb7))
+}
+
+func TestImportCompatible_Ubuntu(t *testing.T) {
+	ubuntu1404 := release{distro: "ubuntu", major: "14", minor: "04"}
+	ubuntu1410 := release{distro: "ubuntu", major: "14", minor: "10"}
+
+	assert.True(t, ubuntu1404.ImportCompatible(ubuntu1404))
+	assert.True(t, ubuntu1410.ImportCompatible(ubuntu1410))
+
+	assert.False(t, ubuntu1404.ImportCompatible(ubuntu1410))
+}
+
+func TestImportCompatible_SLES(t *testing.T) {
+	opensuse := release{distro: "opensuse", major: "15"}
+	sles := release{distro: "sles", major: "15"}
+	slesSap := release{distro: "sles", variant: "sap", major: "15"}
+
+	assert.True(t, opensuse.ImportCompatible(opensuse))
+	assert.True(t, sles.ImportCompatible(sles))
+	assert.True(t, slesSap.ImportCompatible(slesSap))
+
+	assert.False(t, sles.ImportCompatible(opensuse))
+	assert.False(t, sles.ImportCompatible(slesSap))
+	assert.False(t, slesSap.ImportCompatible(opensuse))
+}
+
+func safeParse(t *testing.T, s string) Release {
+	r, e := ParseGcloudOsParam(s)
+	assert.NoError(t, e)
+	return r
+}
+
+func safeFromLibguestfs(t *testing.T, distro, major, minor string) Release {
+	r, e := FromLibguestfs(distro, major, minor)
+	assert.NoError(t, e)
+	return r
+}

--- a/cli_tools/common/distro/distro_test.go
+++ b/cli_tools/common/distro/distro_test.go
@@ -90,13 +90,17 @@ func TestParseGcloudOsParam_ErrorsLinux(t *testing.T) {
 		in  string
 		err string
 	}{
-		{"sles", "unrecognized SLES identifier: \"sles\""},
-		{"kali-12", "unrecognized identifier: \"kali-12\""},
+		{"", "unrecognized identifier: ``"},
+		{"notSupported", "unrecognized identifier: `notsupported`"},
+		{"notSupported-18", "unrecognized identifier: `notsupported-18`"},
+		{"notSupported-1804", "unrecognized identifier: `notsupported-1804`"},
+		{"sles", "unrecognized SLES identifier: `sles`"},
+		{"kali-12", "unrecognized identifier: `kali-12`"},
 		{"ubuntu", "expected pattern of `distro-version`"},
 		{"ubuntu-12", "expected version with length four"},
 		{"opensuse-15-leap", "expected pattern of `distro-version`"},
 		{"debian", "expected pattern of `distro-version`"},
-		{"centos7", "unrecognized identifier: \"centos7\""},
+		{"centos7", "unrecognized identifier: `centos7`"},
 		{"rhel", "expected pattern of `distro-version`"},
 	}
 	for _, tt := range cases {
@@ -121,6 +125,14 @@ func TestImportCompatible_Libguestfs(t *testing.T) {
 	assert.True(t,
 		safeParse(t, "ubuntu-1404").ImportCompatible(
 			safeFromLibguestfs(t, "ubuntu", "14", "04")))
+
+	assert.False(t,
+		safeParse(t, "rhel-7").ImportCompatible(
+			safeFromLibguestfs(t, "centos", "7", "")))
+
+	assert.False(t,
+		safeParse(t, "centos-7").ImportCompatible(
+			safeFromLibguestfs(t, "debian", "7", "")))
 
 	assert.False(t,
 		safeParse(t, "ubuntu-1404").ImportCompatible(

--- a/cli_tools/gce_vm_image_import/importer/errors.go
+++ b/cli_tools/gce_vm_image_import/importer/errors.go
@@ -1,0 +1,37 @@
+//  Copyright 2020  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+func customizeErrorToDetectionResults(osID string, w *daisy.Workflow, err error) (*daisy.Workflow, error) {
+	// When translation fails, report the detection results if they don't
+	// match the user's input.
+	fromUser, _ := distro.ParseGcloudOsParam(osID)
+	detected, _ := distro.FromLibguestfs(
+		w.GetSerialConsoleOutputValue("detected_distro"),
+		w.GetSerialConsoleOutputValue("detected_major_version"),
+		w.GetSerialConsoleOutputValue("detected_minor_version"))
+	if fromUser != nil && detected != nil && !fromUser.ImportCompatible(detected) {
+		// The error is already logged by Daisy, so skipping re-logging it here.
+		return w, fmt.Errorf("%q was detected on your disk, "+
+			"but %q was specified. Please verify and re-import",
+			detected.AsGcloudArg(), fromUser.AsGcloudArg())
+	}
+	return w, err
+}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -16,13 +16,11 @@ package importer
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -248,20 +248,7 @@ func Run(clientID string, imageName string, dataDisk bool, osID string, customTr
 
 		daisyutils.PostProcessDErrorForNetworkFlag("image import", err, network, w)
 
-		// When translation fails, report the detection results if they don't
-		// match the user's input.
-		fromUser, _ := distro.ParseGcloudOsParam(osID)
-		detected, _ := distro.FromLibguestfs(
-			w.GetSerialConsoleOutputValue("detected_distro"),
-			w.GetSerialConsoleOutputValue("detected_major_version"),
-			w.GetSerialConsoleOutputValue("detected_minor_version"))
-		if fromUser != nil && detected != nil && !fromUser.ImportCompatible(detected) {
-			// The error is already logged by Daisy, so skipping re-logging it here.
-			return w, fmt.Errorf("%q was detected on your disk, "+
-				"but %q was specified. Please verify and re-import",
-				detected.AsGcloudArg(), fromUser.AsGcloudArg())
-		}
-		return w, err
+		return customizeErrorToDetectionResults(osID, w, err)
 	}
 	return w, nil
 }

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -74,7 +74,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -72,7 +72,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -85,7 +85,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -85,7 +85,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_12_byol.wf.json
@@ -86,7 +86,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_15_byol.wf.json
@@ -86,7 +86,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/suse/translate_sles_sap_12_byol.wf.json
+++ b/daisy_workflows/image_import/suse/translate_sles_sap_12_byol.wf.json
@@ -86,7 +86,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -81,7 +81,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -74,7 +74,8 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "TranslateSuccess:",
-            "FailureMatch": "TranslateFailed:"
+            "FailureMatch": "TranslateFailed:",
+            "StatusMatch": "TranslateStatus:"
           }
         }
       ],

--- a/daisy_workflows/linux_common/utils/diskutils.py
+++ b/daisy_workflows/linux_common/utils/diskutils.py
@@ -24,6 +24,18 @@ except ImportError:
   AptGetInstall(['python3-guestfs'])
   import guestfs
 
+_STATUS_PREFIX = 'TranslateStatus: '
+
+
+def log_key_value(key, value):
+  """
+  Prints the key and value using the format defined by
+  Daiys's serial output inspector.
+
+  The format is defined in `daisy/step_wait_for_instances_signal.go`
+  """
+  print(_STATUS_PREFIX + "<serial-output key:'%s' value:'%s'>" % (key, value))
+
 
 def MountDisk(disk) -> guestfs.GuestFS:
   # All new Python code should pass python_return_dict=True
@@ -59,6 +71,10 @@ def MountDisk(disk) -> guestfs.GuestFS:
   g.gcp_image_distro = g.inspect_get_distro(roots[0])
   g.gcp_image_major = str(g.inspect_get_major_version(roots[0]))
   g.gcp_image_minor = str(g.inspect_get_minor_version(roots[0]))
+
+  log_key_value('detected_distro', g.gcp_image_distro)
+  log_key_value('detected_major_version', g.gcp_image_major)
+  log_key_value('detected_minor_version', g.gcp_image_minor)
 
   for device in sorted(list(mps.keys()), key=len):
     try:

--- a/daisy_workflows/linux_common/utils/diskutils.py
+++ b/daisy_workflows/linux_common/utils/diskutils.py
@@ -30,7 +30,7 @@ _STATUS_PREFIX = 'TranslateStatus: '
 def log_key_value(key, value):
   """
   Prints the key and value using the format defined by
-  Daiys's serial output inspector.
+  Daisy's serial output inspector.
 
   The format is defined in `daisy/step_wait_for_instances_signal.go`
   """


### PR DESCRIPTION
This adds a new module, `cli_tools/common/distro`, that is used to determine whether the detection result matches the user's input. This will get used in the upcoming OS detection project.

Notably, the module doesn't (yet) support Windows. That's a tactical choice, since currently we only perform detection on Linux, and unlike Linux, in Windows the user-facing version strings are different than the internal version strings [1]. So, I'm leaving implementation of Windows for when it's needed, as that will help define the interface.

Lastly, if the detection result doesn't match the user's input, then we replace the current error with a new one. I like this approach, since it improves the signal-to-noise ratio, and since the Daisy error is logged a few lines before. 

Here are the last few log lines, as an example:

```
[import-from-image]: 2020-05-08T12:16:31-07:00 Error running workflow: step "translate-disk" run error: step "translate-disk" run error: step "wait-for-translator" run error: WaitForInstancesSignal FailureMatch found for "inst-translator-import-from-image-translate-disk-transla-3mzmg": "TranslateFailed: error: sh: /bin/sh: 1: cannot create /etc/resolvconf/resolv.conf.d/base: Directory nonexistent"
[import-from-image]: 2020-05-08T12:16:31-07:00 Serial-output value -> detected_distro:debian
[import-from-image]: 2020-05-08T12:16:31-07:00 Serial-output value -> detected_major_version:9
[import-from-image]: 2020-05-08T12:16:31-07:00 Serial-output value -> detected_minor_version:12
[import-from-image]: 2020-05-08T12:16:31-07:00 Workflow "import-from-image" cleaning up (this may take up to 2 minutes).
[import-from-image]: 2020-05-08T12:17:35-07:00 Workflow "import-from-image" finished cleanup.
[import-image] 2020/05/08 12:17:35 "debian-9" was detected on your disk, but "ubuntu-1604" was specified. Please verify and re-import
```

It wasn't intentional to include the extra lines such as `Serial-output value -> detected_distro:debian`. Those are a side effect of the key/value serial logging mechanism.

https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions