### PR TITLE
update cli_e2e_test_tools to use the latest modules

### DIFF
--- a/cli_tools_e2e_test/go.mod
+++ b/cli_tools_e2e_test/go.mod
@@ -5,13 +5,13 @@ go 1.13
 require (
 	cloud.google.com/go v0.57.0 // indirect
 	cloud.google.com/go/storage v1.7.0
-	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools v0.0.0-20200508212245-538732f1c711
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200508212245-538732f1c711
-	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200508212245-538732f1c711
+	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools v0.0.0-20200508225712-3c09ffd2f054
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200508225712-3c09ffd2f054
+	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200508225712-3c09ffd2f054
 	github.com/golang/protobuf v1.4.1 // indirect
 	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f // indirect
 	golang.org/x/sys v0.0.0-20200508214444-3aab700007d7 // indirect
-	golang.org/x/tools v0.0.0-20200508205758-2d0106b2df1a // indirect
+	golang.org/x/tools v0.0.0-20200508232336-ead0a569305d // indirect
 	google.golang.org/api v0.23.0
 	google.golang.org/genproto v0.0.0-20200507105951-43844f6eee31 // indirect
 )

--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -14,9 +14,9 @@
 FROM golang
 
 # Build test runner
-WORKDIR /cli_tools_e2e_test/gce_image_import_export_tests
-COPY cli_tools_e2e_test/gce_image_import_export_tests/ .
-RUN CGO_ENABLED=0 go build -o /gce_image_import_export_test_runner
+WORKDIR /cli_tools_e2e_test
+COPY cli_tools_e2e_test/ .
+RUN cd gce_image_import_export_tests && CGO_ENABLED=0 go build -o /gce_image_import_export_test_runner
 RUN chmod +x /gce_image_import_export_test_runner
 
 # Build binaries to test

--- a/gce_ovf_import_tests.Dockerfile
+++ b/gce_ovf_import_tests.Dockerfile
@@ -16,10 +16,9 @@ FROM golang:alpine
 RUN apk add --no-cache git
 
 # Build test runner
-WORKDIR /cli_tools_e2e_test/gce_ovf_import_tests
-COPY cli_tools_e2e_test/gce_ovf_import_tests/ .
-RUN go get -d ./...
-RUN CGO_ENABLED=0 go build -o /gce_ovf_import_test_runner
+WORKDIR /cli_tools_e2e_test
+COPY cli_tools_e2e_test/ .
+RUN cd gce_ovf_import_tests && CGO_ENABLED=0 go build -o /gce_ovf_import_test_runner
 RUN chmod +x /gce_ovf_import_test_runner
 
 # Build binaries to test


### PR DESCRIPTION
A couple of changes:
1. update cli_e2e_test_tools to use the latest modules.
2. update e2e's docker files to contain the future's common lib.
3. removed redundant "go get" from docker files.

It optimized the build and fixed the latest dependencies