### PR TITLE
Fix firewall rule for RDP not being added for non-English Windows

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -224,7 +224,7 @@ function Enable-RemoteDesktop {
   Set-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System' -Name 'DisableCAD' -Value 1 -Force
 
   Write-Output 'Enable RDP firewall rules.'
-  Run-Command netsh advfirewall firewall set rule group="@FirewallAPI.dll,-28752" new enable=Yes
+  Run-Command netsh advfirewall firewall set rule group='@FirewallAPI.dll,-28752' new enable=Yes
 }
 
 function Install-Packages {

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -224,7 +224,7 @@ function Enable-RemoteDesktop {
   Set-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System' -Name 'DisableCAD' -Value 1 -Force
 
   Write-Output 'Enable RDP firewall rules.'
-  Run-Command netsh advfirewall firewall set rule group='remote desktop' new enable=Yes
+  Run-Command netsh advfirewall firewall set rule group="@FirewallAPI.dll,-28752" new enable=Yes
 }
 
 function Install-Packages {


### PR DESCRIPTION
Fix firewall rule for RDP not being added for Japanese (and probably any other non-English) variant of Windows.