### PR TITLE
Import: Ensure that dhclient is installed for SLES and OpenSUSE.

### DIFF
--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -71,7 +71,7 @@ class _SuseRelease:
 
 
 _packages = [
-    _Package('cloud-init', gce=False, required=False),
+    _Package('dhcp-client', gce=False, required=True),
     _Package('google-cloud-sdk', gce=True, required=False),
     _Package('google-compute-engine-init', gce=True, required=True),
     _Package('google-compute-engine-oslogin', gce=True, required=True)


### PR DESCRIPTION
The `daisy_integration_tests/sles_15_1_byol.wf.json` started failing today, with the symptom of the test phase timing out. This occurs since google_network_daemon fails to call dhclient:

```
[   33.308577] google_network_daemon[1798]: timeout: failed to run command â€˜dhclientâ€™: No such file or directory
```

The root cause is the rollout of NGE for SLES 15.1. 

Testing:
- Ran integ tests for: SLES 15.1, SLES 12.5, OpenSUSE 15.1

Also, this removes `cloud-init` which isn't required for SLES/OpenSUSE.