### PR TITLE
SUSE import: Don't install cloud-init; require iputils.

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -176,11 +176,11 @@ function check_package_install {
   if [[ -d /etc/apt ]]; then
     status "Checking if apt can install a package."
     for i in $(seq 1 20) ; do
-      apt-get update && apt-get install --reinstall iputils && return 0
+      apt-get update && apt-get install --reinstall iputils-ping && return 0
       status "Waiting until apt is available."
       sleep $((i**2))
     done
-    fail "apt-get cannot install iputils."
+    fail "apt-get cannot install iputils-ping."
   fi
 
   # Yum

--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -169,39 +169,40 @@ function check_cloud_init {
   fi
 }
 
-# Check package installs.
+# Check package installs. Using iputils to ensure
+# ping is available for the check_metadata_connectivity test.
 function check_package_install {
   # Apt
   if [[ -d /etc/apt ]]; then
     status "Checking if apt can install a package."
     for i in $(seq 1 20) ; do
-      apt-get update && apt-get install --reinstall make && return 0
+      apt-get update && apt-get install --reinstall iputils && return 0
       status "Waiting until apt is available."
       sleep $((i**2))
     done
-    fail "apt-get cannot install make."
+    fail "apt-get cannot install iputils."
   fi
 
   # Yum
   if [[ -d /etc/yum ]]; then
     status "Checking if yum can install a package."
-    if rpm -q make; then
-      yum -y update make
+    if rpm -q iputils; then
+      yum -y update iputils
     else
-      yum -y install make
+      yum -y install iputils
     fi
-    yum -y reinstall make
+    yum -y reinstall iputils
     if [[ $? -ne 0 ]]; then
-      fail "yum cannot install make."
+      fail "yum cannot install iputils."
     fi
   fi
 
   # Zypper
   if [[ -d /etc/zypp ]]; then
     status "Checking if zypper can install a package."
-    zypper install -f -y make
+    zypper install -f -y iputils
     if [[ $? -ne 0 ]]; then
-      fail "zypper cannot install make."
+      fail "zypper cannot install iputils."
     fi
   fi
 }

--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -65,7 +65,6 @@ class _SuseRelease:
 
 
 _packages = [
-    _Package('iputils', gce=False),
     _Package('google-compute-engine-init', gce=True),
     _Package('google-compute-engine-oslogin', gce=True)
 ]


### PR DESCRIPTION
This was motivated by failed SUSE 15.1 integ tests. The root cause was that cloud-init was marked as optional, and when it wasn't installed, the iputils transitive dependency wasn't added. The integration test expected that `ping` was available, so when cloud-init isn't installed, `ping` wasn't available (assuming the original image didn't have it).

Key changes:
* Install all packages in a single zypper operation.
* Increase retry time for `SUSEConnect -p` from 60 seconds to 5 minutes; I've observed that invocations (failing and passing) were exceeding 60 seconds for a single invocation.
* Remove the concept of optional packages, since this causes non-deterministic behavior.
* Remove cloud-init
* Remove google-cloud-sdk -- the package isn't available in SUSE repos.