### PR TITLE
Only create workflowLoggable if workflow is non-nil.

### DIFF
--- a/cli_tools/common/utils/logging/service/daisy_loggable.go
+++ b/cli_tools/common/utils/logging/service/daisy_loggable.go
@@ -15,13 +15,17 @@
 package service
 
 import (
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"strconv"
 	"strings"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
-// WorkflowToLoggable provides a Loggable from a daisy workflow.
-func WorkflowToLoggable(wf *daisy.Workflow) Loggable {
+// NewLoggableFromWorkflow provides a Loggable from a daisy workflow.
+func NewLoggableFromWorkflow(wf *daisy.Workflow) Loggable {
+	if wf == nil {
+		return nil
+	}
 	return workflowLoggable{wf: wf}
 }
 

--- a/cli_tools/common/utils/logging/service/daisy_loggable_test.go
+++ b/cli_tools/common/utils/logging/service/daisy_loggable_test.go
@@ -16,15 +16,20 @@ package service
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
+
+func TestNewLoggableFromWorkflow_ReturnsNilWhenWorkflowNil(t *testing.T) {
+	assert.Nil(t, NewLoggableFromWorkflow(nil))
+}
 
 func TestWorkflowToLoggable_GetValueAsInt64Slice(t *testing.T) {
 	wf := daisy.Workflow{}
 	wf.AddSerialConsoleOutputValue("gb", "1,2,3")
-	loggable := WorkflowToLoggable(&wf)
+	loggable := NewLoggableFromWorkflow(&wf)
 
 	assert.Equal(t, []int64{1, 2, 3}, loggable.GetValueAsInt64Slice("gb"))
 	assert.Empty(t, loggable.GetValueAsInt64Slice("not-there"))
@@ -33,7 +38,7 @@ func TestWorkflowToLoggable_GetValueAsInt64Slice(t *testing.T) {
 func TestWorkflowToLoggable_GetValue(t *testing.T) {
 	wf := daisy.Workflow{}
 	wf.AddSerialConsoleOutputValue("hello", "world")
-	loggable := WorkflowToLoggable(&wf)
+	loggable := NewLoggableFromWorkflow(&wf)
 
 	assert.Equal(t, "world", loggable.GetValue("hello"))
 	assert.Empty(t, loggable.GetValue("not-there"))
@@ -45,14 +50,14 @@ func TestWorkflowToLoggable_ReadSerialPortLogs(t *testing.T) {
 			"log-a", "log-b",
 		}},
 	}
-	loggable := WorkflowToLoggable(&wf)
+	loggable := NewLoggableFromWorkflow(&wf)
 
 	assert.Equal(t, []string{"log-a", "log-b"}, loggable.ReadSerialPortLogs())
 }
 
 func TestWorkflowToLoggable_ReadSerialPortLogs_SupportsMissingDaisyLogger(t *testing.T) {
 	wf := daisy.Workflow{}
-	loggable := WorkflowToLoggable(&wf)
+	loggable := NewLoggableFromWorkflow(&wf)
 
 	assert.Empty(t, loggable.ReadSerialPortLogs())
 }

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -112,7 +112,7 @@ func runImport() (service.Loggable, error) {
 	}
 
 	wf, err := ovfImporter.Import()
-	return service.WorkflowToLoggable(wf), err
+	return service.NewLoggableFromWorkflow(wf), err
 }
 
 func main() {

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -47,7 +47,7 @@ func exportEntry() (service.Loggable, error) {
 	wf, err := exporter.Run(*clientID, *destinationURI, *sourceImage, *format, project,
 		*network, *subnet, *zone, *timeout, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled,
 		*cloudLogsDisabled, *stdoutLogsDisabled, *labels, currentExecutablePath)
-	return service.WorkflowToLoggable(wf), err
+	return service.NewLoggableFromWorkflow(wf), err
 }
 
 func main() {

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -63,7 +63,7 @@ func importEntry() (service.Loggable, error) {
 		project, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
 		*stdoutLogsDisabled, *noExternalIP, *labels, currentExecutablePath, *storageLocation,
 		*uefiCompatible, *sysprepWindows)
-	return service.WorkflowToLoggable(wf), err
+	return service.NewLoggableFromWorkflow(wf), err
 }
 
 func main() {


### PR DESCRIPTION
This was prompted by a failed OVF integration test. The import failed while copying a VMDK to GCS. A workflow was never created, and a subsequent call to workflowLoggable.wf caused a seg fault.