### PR TITLE
EL6 import: Ensure pip is updated.

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -118,6 +118,8 @@ def DistroSpecific(g):
       logging.info('Installing python27 from SCL.')
       yum_install(g, 'python27')
       g.command(['scl', 'enable', 'python27',
+                 'pip2.7 install --upgrade pip'])
+      g.command(['scl', 'enable', 'python27',
                  'pip2.7 install --upgrade google_compute_engine'])
 
       logging.info('Installing Google Cloud SDK from tar.')


### PR DESCRIPTION
As a result of [setuptools sunsetting Python 2.7](https://github.com/pypa/setuptools/issues/1458), we need to ensure that pip is at least version 9. When python27 is installed in CentOS 6.10, pip is at 8.1.2.