### PR TITLE
EL import: Always run depmod if modules.dep missing.

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -165,8 +165,7 @@ def DistroSpecific(g):
 
   logging.info('Updating initramfs')
   for kver in g.ls('/lib/modules'):
-    if el_release == '8' and not g.exists(
-        os.path.join('/lib/modules', kver, 'modules.dep')):
+    if not g.exists(os.path.join('/lib/modules', kver, 'modules.dep')):
       g.command(['depmod', kver])
     if el_release == '6':
       # Version 6 doesn't have option --kver


### PR DESCRIPTION
Fixes #1144 and b/150026001

Testing:
* Ran:
   * centos-6-qcow2-translate-test
   * centos-7-qcow2-translate-test