### PR TITLE
add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,15 @@
+# This file enables automatic assignment of PR reviewers.
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - adjackura
+  - zoran15
+  - hopkiw
+  - EricEdens
+  - dntczdx
+reviewers:
+  - adjackura
+  - zoran15
+  - hopkiw
+  - EricEdens
+  - dntczdx

--- a/OWNERS
+++ b/OWNERS
@@ -7,9 +7,11 @@ approvers:
   - hopkiw
   - EricEdens
   - dntczdx
+  - zmarano
 reviewers:
   - adjackura
   - zoran15
   - hopkiw
   - EricEdens
   - dntczdx
+  - zmarano


### PR DESCRIPTION
Seeded initial OWNERS file with everyone with a stake in this repo. This is our only remaining "mega repo" with multiple projects, we can use granular OWNERS files if that seems warranted. Starting with this for now to enable prow based review assignments and approvals.