### PR TITLE
leave empty machine-id file for autogen

### DIFF
--- a/daisy_workflows/image_build/debian/fai_config/scripts/10-gce-clean
+++ b/daisy_workflows/image_build/debian/fai_config/scripts/10-gce-clean
@@ -23,6 +23,9 @@ rm -f $target/etc/resolv.conf \
       $target/var/log/dpkg.log \
       $target/var/log/install_packages.list
 
+# Empty file needed for on-boot generation.
+> $target/etc/machine-id
+
 rm -rf $target/var/log/fai
 
 shred --remove $target/etc/ssh/ssh_host_*


### PR DESCRIPTION
debian 10 images don't have /etc/machine-id populated on boot. create an empty file to trigger its population at boot time.

after this change, the following lines are in the serial console:
```
[    5.101277] systemd[1]: Initializing machine ID from KVM UUID.
[    5.103367] systemd[1]: Installed transient /etc/machine-id file.
```