### PR TITLE
Fixed nil pointer dereference breaking OVF import

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -256,6 +256,9 @@ func GetOSId(ovfDescriptor *ovf.Envelope) (string, error) {
 		len(ovfDescriptor.VirtualSystem.OperatingSystem) == 0 {
 		return "", daisy.Errf("OperatingSystemSection must be defined to retrieve OS info")
 	}
+	if ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType == nil {
+		return "", daisy.Errf("OperatingSystemSection.OSType must be defined to retrieve OS info")
+	}
 	var osID string
 	var validOSType bool
 	osType := *ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
@@ -649,12 +649,25 @@ func TestGetOSIdNonDeterministicMultiOption(t *testing.T) {
 		err.Error())
 }
 
+func TestGetOSIdNilOSIdInDescriptor(t *testing.T) {
+	osID, err := GetOSId(createOVFDescriptorWithOSTypeAsReference(nil))
+	assert.Equal(t, "", osID)
+	assert.NotNil(t, err)
+	assert.Equal(t,
+		"OperatingSystemSection.OSType must be defined to retrieve OS info",
+		err.Error())
+}
+
 func createOVFDescriptorWithOSType(osType string) *ovf.Envelope {
+	return createOVFDescriptorWithOSTypeAsReference(&osType)
+}
+
+func createOVFDescriptorWithOSTypeAsReference(osType *string) *ovf.Envelope {
 	return &ovf.Envelope{
 		VirtualSystem: &ovf.VirtualSystem{
 			OperatingSystem: []ovf.OperatingSystemSection{
 				{
-					OSType: &osType,
+					OSType: osType,
 				},
 			},
 		},


### PR DESCRIPTION
Fixed nil pointer dereference breaking OVF import if OperatingSystem.OSType is not defined in OVF descriptor.


Fixes #1235