### PR TITLE
Added custom cancel reason to Daisy workflow. 

### DIFF
--- a/daisy/step.go
+++ b/daisy/step.go
@@ -307,8 +307,7 @@ func (s *Step) run(ctx context.Context) DError {
 	select {
 	case <-s.w.Cancel:
 		// return an error to indicate a canceled workflow is not 'success'
-		s.w.LogWorkflowInfo("Step %q (%s) is canceled.", s.name, st)
-		return Errf("Step %q (%s) is canceled.", s.name, st)
+		return s.w.onStepCancel(s, st)
 	default:
 		s.w.LogWorkflowInfo("Step %q (%s) successfully finished.", s.name, st)
 	}

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -179,8 +179,8 @@ type Workflow struct {
 	ForceCleanupOnError bool
 	// forceCleanup is set to true when resources should be forced clean, even when NoCleanup is set to true
 	forceCleanup bool
-	// CancelReason provides custom reason when workflow is canceled. It replaces "is canceled" in the default error message.
-	CancelReason string `json:"-"`
+	// cancelReason provides custom reason when workflow is canceled. f
+	cancelReason string
 }
 
 //DisableCloudLogging disables logging to Cloud Logging for this workflow.
@@ -891,10 +891,16 @@ func (w *Workflow) IterateWorkflowSteps(cb func(step *Step)) {
 	}
 }
 
+// CancelWithReason cancels workflow with a specific reason. The specific reason replaces "is canceled" in the default error message.
+func (w *Workflow) CancelWithReason(reason string) {
+	w.cancelReason = reason
+	close(w.Cancel)
+}
+
 func (w *Workflow) getCancelReason() string {
-	cancelReason := w.CancelReason
+	cancelReason := w.cancelReason
 	for wi := w; cancelReason == "" && wi != nil; wi = wi.parent {
-		cancelReason = wi.CancelReason
+		cancelReason = wi.cancelReason
 	}
 	return cancelReason
 }

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -1002,13 +1002,19 @@ func TestCancelReasonEmptySingleWorkflow(t *testing.T) {
 	assertWorkflowCancelReason(t, w1, "")
 }
 
+func TestCancelReasonProvidedSingleWorkflow(t *testing.T) {
+	w1 := testWorkflow()
+	w1.CancelReason = "w1 cr"
+	assertWorkflowCancelReason(t, w1, "w1 cr")
+}
+
 func TestCancelReasonChild(t *testing.T) {
 	w1 := testWorkflow()
 	w2 := testWorkflow()
 
 	w2.parent = w1
 	w1.CancelReason = "w1 cr"
-	w1.CancelReason = "w2 cr"
+	w2.CancelReason = "w2 cr"
 	assertWorkflowCancelReason(t, w1, "w1 cr")
 	assertWorkflowCancelReason(t, w2, "w2 cr")
 }

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -996,3 +996,84 @@ func tryPopulateClients(t *testing.T, w *Workflow) {
 		t.Errorf("Failed to populate clients for workflow: %v", err)
 	}
 }
+
+func TestCancelReasonEmptySingleWorkflow(t *testing.T) {
+	w1 := testWorkflow()
+	assertWorkflowCancelReason(t, w1, "")
+}
+
+func TestCancelReasonChild(t *testing.T) {
+	w1 := testWorkflow()
+	w2 := testWorkflow()
+
+	w2.parent = w1
+	w1.CancelReason = "w1 cr"
+	w1.CancelReason = "w2 cr"
+	assertWorkflowCancelReason(t, w1, "w1 cr")
+	assertWorkflowCancelReason(t, w2, "w2 cr")
+}
+
+func TestCancelReasonInheritedFromParent(t *testing.T) {
+	w1 := testWorkflow()
+	w2 := testWorkflow()
+
+	w2.parent = w1
+	w1.CancelReason = "w1 cr"
+	assertWorkflowCancelReason(t, w1, "w1 cr")
+	assertWorkflowCancelReason(t, w2, "w1 cr")
+}
+
+func TestCancelReasonInheritedFromGrandParent(t *testing.T) {
+	w1 := testWorkflow()
+	w2 := testWorkflow()
+	w3 := testWorkflow()
+
+	w2.parent = w1
+	w3.parent = w2
+	w1.CancelReason = "w1 cr"
+
+	assertWorkflowCancelReason(t, w1, "w1 cr")
+	assertWorkflowCancelReason(t, w2, "w1 cr")
+	assertWorkflowCancelReason(t, w3, "w1 cr")
+}
+
+func TestCancelReasonInheritedFromParentWhenGrandchild(t *testing.T) {
+	w1 := testWorkflow()
+	w2 := testWorkflow()
+	w3 := testWorkflow()
+
+	w2.parent = w1
+	w3.parent = w2
+	w2.CancelReason = "w2 cr"
+
+	assertWorkflowCancelReason(t, w1, "")
+	assertWorkflowCancelReason(t, w2, "w2 cr")
+	assertWorkflowCancelReason(t, w3, "w2 cr")
+}
+
+func assertWorkflowCancelReason(t *testing.T, w *Workflow, expected string) {
+	if cr := w.getCancelReason(); cr != expected {
+		t.Errorf("Expected cancel reason `%v` but got `%v` ", expected, cr)
+	}
+}
+
+func TestOnStepCancelDefaultCancelReason(t *testing.T) {
+	w := testWorkflow()
+	s := &Step{name: "s", w: w}
+	err := w.onStepCancel(s, "Dummy")
+	expectedErrorMessage := "Step \"s\" (Dummy) is canceled."
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("Expected error message `%v` but got `%v` ", expectedErrorMessage, err.Error())
+	}
+}
+
+func TestOnStepCancelCustomCancelReason(t *testing.T) {
+	w := testWorkflow()
+	w.CancelReason = "failed horribly"
+	s := &Step{name: "s", w: w}
+	err := w.onStepCancel(s, "Dummy")
+	expectedErrorMessage := "Step \"s\" (Dummy) failed horribly."
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("Expected error message `%v` but got `%v` ", expectedErrorMessage, err.Error())
+	}
+}

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -1004,7 +1004,7 @@ func TestCancelReasonEmptySingleWorkflow(t *testing.T) {
 
 func TestCancelReasonProvidedSingleWorkflow(t *testing.T) {
 	w1 := testWorkflow()
-	w1.CancelReason = "w1 cr"
+	w1.cancelReason = "w1 cr"
 	assertWorkflowCancelReason(t, w1, "w1 cr")
 }
 
@@ -1013,8 +1013,8 @@ func TestCancelReasonChild(t *testing.T) {
 	w2 := testWorkflow()
 
 	w2.parent = w1
-	w1.CancelReason = "w1 cr"
-	w2.CancelReason = "w2 cr"
+	w1.cancelReason = "w1 cr"
+	w2.cancelReason = "w2 cr"
 	assertWorkflowCancelReason(t, w1, "w1 cr")
 	assertWorkflowCancelReason(t, w2, "w2 cr")
 }
@@ -1024,7 +1024,7 @@ func TestCancelReasonInheritedFromParent(t *testing.T) {
 	w2 := testWorkflow()
 
 	w2.parent = w1
-	w1.CancelReason = "w1 cr"
+	w1.cancelReason = "w1 cr"
 	assertWorkflowCancelReason(t, w1, "w1 cr")
 	assertWorkflowCancelReason(t, w2, "w1 cr")
 }
@@ -1036,7 +1036,7 @@ func TestCancelReasonInheritedFromGrandParent(t *testing.T) {
 
 	w2.parent = w1
 	w3.parent = w2
-	w1.CancelReason = "w1 cr"
+	w1.cancelReason = "w1 cr"
 
 	assertWorkflowCancelReason(t, w1, "w1 cr")
 	assertWorkflowCancelReason(t, w2, "w1 cr")
@@ -1050,7 +1050,7 @@ func TestCancelReasonInheritedFromParentWhenGrandchild(t *testing.T) {
 
 	w2.parent = w1
 	w3.parent = w2
-	w2.CancelReason = "w2 cr"
+	w2.cancelReason = "w2 cr"
 
 	assertWorkflowCancelReason(t, w1, "")
 	assertWorkflowCancelReason(t, w2, "w2 cr")
@@ -1075,7 +1075,7 @@ func TestOnStepCancelDefaultCancelReason(t *testing.T) {
 
 func TestOnStepCancelCustomCancelReason(t *testing.T) {
 	w := testWorkflow()
-	w.CancelReason = "failed horribly"
+	w.cancelReason = "failed horribly"
 	s := &Step{name: "s", w: w}
 	err := w.onStepCancel(s, "Dummy")
 	expectedErrorMessage := "Step \"s\" (Dummy) failed horribly."


### PR DESCRIPTION
Added custom cancel reason to Daisy workflow. This will allow us to provide different error messages when workflows are canceled for different reasons. For example, timed out vs. canceled by users.