### PR TITLE
Revert "Use disk file from daisy's scratch path."

### DIFF
--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -79,6 +79,7 @@
             "block-project-ssh-keys": "true",
             "disk_name": "${disk_name}",
             "scratch_disk_name": "disk-${NAME}-scratch-${ID}",
+            "source_disk_file": "${source_disk_file}",
             "shutdown-script": "echo 'Worker instance terminated'",
             "startup-script": "${SOURCE:import_image.sh}"
           },

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -29,7 +29,7 @@ fi
 BYTES_1GB=1073741824
 URL="http://metadata/computeMetadata/v1/instance"
 DAISY_SOURCE_URL="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/daisy-sources-path)"
-SOURCE_URL="$DAISY_SOURCE_URL/source_disk_file"
+SOURCE_URL="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/source_disk_file)"
 DISKNAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/disk_name)"
 SCRATCH_DISK_NAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/scratch_disk_name)"
 ME="$(curl -f -H Metadata-Flavor:Google ${URL}/name)"


### PR DESCRIPTION
This caused a regression for OVA support in import_image.sh, which
depends on inspecting the original filename's extension.