### PR TITLE
Daisy: Consolidate reading of serial port output.

### DIFF
--- a/daisy/serial_output_watcher.go
+++ b/daisy/serial_output_watcher.go
@@ -1,0 +1,165 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisy
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// SerialOutputWatcher provides a pubsub mechanism for serial port output. Subscribers
+// call Watch with a channel and requested duration. Logs are relayed to
+// the channel c as they are received from the instance.
+//
+// The SerialOutputWatcher signal will not block sending to c: the caller must ensure
+// that c has sufficient buffer space to keep up with the expected
+// signal rate. For a channel that is immediately consumed, a buffer of size 1 is
+// sufficient.
+//
+// Watch needs to be called prior to the instance's CreateInstance step being run.
+// Invocations after that point will be ignored.
+//
+// Polling occurs using the shortest interval of all subscribers,
+// and continues until the instance is deleted. It is guaranteed
+// to continue through a reboot. For a reference of instance lifecycles, see:
+//
+// https://cloud.google.com/compute/docs/instances/instance-life-cycle
+type SerialOutputWatcher interface {
+	Watch(instanceName string, port int64, c chan<- string, interval time.Duration)
+	start(instanceName string)
+}
+
+// NewSerialOutputWatcher constructs a new instance of SerialOutputWatcher using the GCP
+// compute API to make periodic polling requests to check for new serial output.
+func NewSerialOutputWatcher(client serialOutputClient, project, zone string) SerialOutputWatcher {
+	return &serialOutputWatcher{
+		subscriptions: map[instanceAndPort][]watch{},
+		client:        client,
+		project:       project,
+		zone:          zone,
+	}
+}
+
+type serialOutputWatcher struct {
+	subscriptions map[instanceAndPort][]watch
+	client        serialOutputClient
+	project, zone string
+}
+
+// serialOutputWatcher assumes that 404s are returned when an instance doesn't
+// exist. The value `deletionNum404s` determines how many subsequent HTTP 404 responses to
+// see prior to deciding the instance has been deleted (assuming the
+// instance was seen earlier).
+//
+// Although a value of 1 is theoretically sufficient, a higher value allows withstanding
+// unexpected intermittent failures.
+//
+// At the time of writing, the following HTTP error codes were seen:
+//  - Prior to creating instance: 404
+//  - Once deletion finished: 404
+//  - Instance stopped, but not deleted: 400
+//  - Serial output successfully returned: 200
+const deletionNum404s = 3
+
+type instanceAndPort struct {
+	instance   string
+	portNumber int64
+}
+
+type watch struct {
+	channel         chan<- string
+	pollingInterval time.Duration
+}
+
+func (s *serialOutputWatcher) Watch(
+	instanceName string, port int64, c chan<- string, interval time.Duration) {
+	sp := instanceAndPort{instanceName, port}
+	s.subscriptions[sp] = append(s.subscriptions[sp], watch{c, interval})
+}
+
+func (s *serialOutputWatcher) start(instanceName string) {
+	for serialPort := range s.subscriptions {
+		if serialPort.instance != instanceName {
+			continue
+		}
+		callbacks := s.subscriptions[serialPort]
+		if len(callbacks) == 0 {
+			panic(fmt.Sprintf("Start called without subscribers for %v", serialPort))
+		}
+		var subscribers []chan<- string
+		pollingFrequency := callbacks[0].pollingInterval
+		for _, cb := range callbacks {
+			subscribers = append(subscribers, cb.channel)
+			if cb.pollingInterval < pollingFrequency {
+				cb.pollingInterval = pollingFrequency
+			}
+		}
+		watchOnePort(s.client, pollingFrequency, s.project, s.zone, serialPort.instance, serialPort.portNumber, subscribers)
+	}
+}
+
+// run starts a goroutine that polls for an instance's serial output. Output is written to the
+// subscribing channels. Channels are closed when the instance is deleted.
+func watchOnePort(client serialOutputClient, pollingFrequency time.Duration,
+	project, zone, instanceName string, port int64, subscribers []chan<- string) {
+	go func() {
+		seenInstance := false
+		consecutive404s := 0
+		offset := int64(0)
+		ticker := time.NewTicker(pollingFrequency)
+		for {
+			resp, err := client.GetSerialPortOutput(project, zone, instanceName, port, offset)
+			var httpCode int
+			if err != nil {
+				realErr := err.(*googleapi.Error)
+				httpCode = realErr.Code
+			} else {
+				offset = resp.Next
+				httpCode = resp.HTTPStatusCode
+				seenInstance = true
+				if len(resp.Contents) > 0 {
+					for _, c := range subscribers {
+						select {
+						case c <- resp.Contents:
+						default:
+						}
+					}
+				}
+			}
+			if seenInstance && httpCode == http.StatusNotFound {
+				consecutive404s++
+				if consecutive404s >= deletionNum404s {
+					for _, c := range subscribers {
+						close(c)
+					}
+					return
+				}
+			} else {
+				consecutive404s = 0
+			}
+			// Sleep at the end to ensure the first read occurs immediately.
+			<-ticker.C
+		}
+	}()
+}
+
+// serialOutputClient is the subset of the compute API used by the reader's daemon.
+type serialOutputClient interface {
+	GetSerialPortOutput(project, zone, instanceName string, port, start int64) (*compute.SerialPortOutput, error)
+}

--- a/daisy/serial_output_watcher_test.go
+++ b/daisy/serial_output_watcher_test.go
@@ -112,7 +112,7 @@ func TestSerialPortWatcher_AllSubscribedPortsPolled_WhenStartCalled(t *testing.T
 }
 
 func TestSerialPortWatcher_StopsWhenInstanceDeleted(t *testing.T) {
-	assert.Equal(t, 3, deletionNum404s, "These tests assume that deletionNum404s is 3.")
+	assert.Equal(t, 3, deletionRetry404s, "These tests assume that deletionRetry404s is 3.")
 	type testCase struct {
 		name           string
 		expectedOutput string
@@ -120,7 +120,7 @@ func TestSerialPortWatcher_StopsWhenInstanceDeleted(t *testing.T) {
 	}
 	for _, tt := range []testCase{
 		{
-			name:           "Tolerate intermittent 404s, but stop when deletionNum404s reached.",
+			name:           "Tolerate intermittent 404s, but stop when deletionRetry404s reached.",
 			expectedOutput: "one two three",
 			responses: []serialPortResponse{
 				{200, "one "},
@@ -244,9 +244,8 @@ func (m *mockSerialPortClient) GetSerialPortOutput(
 				HTTPStatusCode: curr.code,
 			},
 		}, nil
-	} else {
-		return nil, &googleapi.Error{Code: curr.code}
 	}
+	return nil, &googleapi.Error{Code: curr.code}
 }
 
 type mockMultiSerialPortClient struct {

--- a/daisy/serial_output_watcher_test.go
+++ b/daisy/serial_output_watcher_test.go
@@ -1,0 +1,259 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+)
+
+const (
+	port     = int64(2)
+	project  = "test-project"
+	zone     = "test-zone"
+	instance = "test-instance"
+)
+
+func TestSerialPortWatcher_AllowsMultipleSubscribers(t *testing.T) {
+	c1 := make(chan string, 10)
+	c2 := make(chan string, 10)
+
+	client := &mockSerialPortClient{
+		expectedProject:  project,
+		expectedZone:     zone,
+		expectedInstance: instance,
+		expectedPort:     port,
+		t:                t,
+		responses: []serialPortResponse{
+			{200, "one"},
+			{200, "two"},
+			{404, ""},
+			{404, ""},
+			{404, ""},
+		},
+	}
+	watcher := NewSerialOutputWatcher(client, project, zone)
+	watcher.Watch(instance, port, c1, time.Nanosecond)
+	watcher.Watch(instance, port, c2, time.Hour)
+	watcher.start(instance)
+
+	// Regardless of the poll threshold, the first message is read immediately.
+	assert.Equal(t, "one", <-c1)
+	assert.Equal(t, "one", <-c2)
+
+	// Sleeping occurs after the first poll. If we didn't pick the smallest poll threshold,
+	// then this test would require an hour to pass.
+	assert.Equal(t, "two", <-c1)
+	assert.Equal(t, "two", <-c2)
+}
+
+func TestSerialPortWatcher_AllSubscribedPortsPolled_WhenStartCalled(t *testing.T) {
+	c1 := make(chan string, 10)
+	port1 := int64(1)
+	client1 := &mockSerialPortClient{
+		expectedProject:  project,
+		expectedZone:     zone,
+		expectedInstance: instance,
+		expectedPort:     port1,
+		t:                t,
+		responses: []serialPortResponse{
+			{200, "1_one"},
+			{200, "1_two"},
+			{404, ""},
+			{404, ""},
+			{404, ""},
+		},
+	}
+
+	c2 := make(chan string, 10)
+	port2 := int64(2)
+	client2 := &mockSerialPortClient{
+		expectedProject:  project,
+		expectedZone:     zone,
+		expectedInstance: instance,
+		expectedPort:     port2,
+		t:                t,
+		responses: []serialPortResponse{
+			{200, "2_one"},
+			{200, "2_two"},
+			{404, ""},
+			{404, ""},
+			{404, ""},
+		},
+	}
+
+	watcher := NewSerialOutputWatcher(mockMultiSerialPortClient{map[int64]*mockSerialPortClient{
+		port1: client1, port2: client2,
+	}}, project, zone)
+	watcher.Watch(instance, 1, c1, time.Nanosecond)
+	watcher.Watch(instance, 2, c2, time.Nanosecond)
+	watcher.start(instance)
+
+	assert.Equal(t, "1_one", <-c1)
+	assert.Equal(t, "2_one", <-c2)
+	assert.Equal(t, "1_two", <-c1)
+	assert.Equal(t, "2_two", <-c2)
+}
+
+func TestSerialPortWatcher_StopsWhenInstanceDeleted(t *testing.T) {
+	assert.Equal(t, 3, deletionNum404s, "These tests assume that deletionNum404s is 3.")
+	type testCase struct {
+		name           string
+		expectedOutput string
+		responses      []serialPortResponse
+	}
+	for _, tt := range []testCase{
+		{
+			name:           "Tolerate intermittent 404s, but stop when deletionNum404s reached.",
+			expectedOutput: "one two three",
+			responses: []serialPortResponse{
+				{200, "one "},
+				{404, ""},
+				{200, "two "},
+				{404, ""},
+				{404, ""},
+				{200, "three"},
+				{404, ""},
+				{404, ""},
+				{404, ""},
+				{200, "four"},
+			},
+		},
+		{
+			name:           "Allow unlimited 404s prior to reading first log",
+			expectedOutput: "log",
+			responses: []serialPortResponse{
+				{404, ""},
+				{404, ""},
+				{404, ""},
+				{404, ""},
+				{404, ""},
+				{404, ""},
+				{200, "log"},
+				{404, ""},
+				{404, ""},
+				{404, ""},
+			},
+		},
+		{
+			name:           "Ignore non-404s",
+			expectedOutput: "one two",
+			responses: func() []serialPortResponse {
+				// This assembles a slice of serialPortResponses with the following:
+				//  - real content
+				//  - all HTTP codes, other than 200 and 404
+				//  - real content
+				//  - three 404s
+				resp := []serialPortResponse{
+					{200, "one "},
+				}
+				for i := 100; i < 600; i++ {
+					if i == 404 || i == 200 {
+						continue
+					}
+					resp = append(resp, serialPortResponse{i, ""},
+						serialPortResponse{i, ""}, serialPortResponse{i, ""})
+				}
+				// Finally end with a single message, plus sufficient 404s to
+				// signify the instance is deleted.
+				resp = append(resp, serialPortResponse{200, "two"})
+				return append(resp, serialPortResponse{404, ""},
+					serialPortResponse{404, ""}, serialPortResponse{404, ""})
+			}(),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := make(chan string, 100)
+			pollingFrequency := time.Nanosecond
+
+			client := &mockSerialPortClient{
+				expectedProject:  project,
+				expectedZone:     zone,
+				expectedInstance: instance,
+				expectedPort:     port,
+				t:                t,
+				responses:        tt.responses,
+			}
+
+			watcher := NewSerialOutputWatcher(client, project, zone)
+			watcher.Watch(instance, port, c, pollingFrequency)
+			watcher.start(instance)
+
+			actual := ""
+			read := <-c
+			for read != "" {
+				actual += read
+				read = <-c
+			}
+
+			assert.Equal(t, tt.expectedOutput, actual)
+		})
+	}
+}
+
+type serialPortResponse struct {
+	code    int
+	content string
+}
+
+type mockSerialPortClient struct {
+	expectedProject  string
+	expectedZone     string
+	expectedInstance string
+	expectedPort     int64
+	expectedStart    int64
+	t                *testing.T
+	responses        []serialPortResponse
+}
+
+func (m *mockSerialPortClient) GetSerialPortOutput(
+	project, zone, instanceName string, port, start int64) (*compute.SerialPortOutput, error) {
+	assert.Equal(m.t, m.expectedProject, project)
+	assert.Equal(m.t, m.expectedZone, zone)
+	assert.Equal(m.t, m.expectedInstance, instanceName)
+	assert.Equal(m.t, m.expectedPort, port)
+	assert.Equal(m.t, m.expectedStart, start)
+	var curr serialPortResponse
+	curr, m.responses = m.responses[0], m.responses[1:]
+	if curr.code/100 == 2 {
+		thisStart := m.expectedStart
+		m.expectedStart += int64(len(curr.content))
+		return &compute.SerialPortOutput{
+			Contents: curr.content,
+			Next:     m.expectedStart,
+			SelfLink: "",
+			Start:    thisStart,
+			ServerResponse: googleapi.ServerResponse{
+				HTTPStatusCode: curr.code,
+			},
+		}, nil
+	} else {
+		return nil, &googleapi.Error{Code: curr.code}
+	}
+}
+
+type mockMultiSerialPortClient struct {
+	delegates map[int64]*mockSerialPortClient
+}
+
+func (m mockMultiSerialPortClient) GetSerialPortOutput(
+	project, zone, instanceName string, port, start int64) (*compute.SerialPortOutput, error) {
+	return m.delegates[port].GetSerialPortOutput(project, zone, instanceName, port, start)
+}

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	serialPortToArchive     = 1
-	serialPortPollInterval  = 3 * time.Second
+	serialPortToArchive    = 1
+	serialPortPollInterval = 3 * time.Second
 )
 
 // CreateInstances is a Daisy CreateInstances workflow step.

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -16,6 +16,7 @@ package daisy
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -39,7 +40,9 @@ func TestLogSerialOutput(t *testing.T) {
 	s := &Step{name: "i1", w: w}
 	mockWatcher := newMockSerialOutputWatcher(t, []string{"log ","content"})
 	mockWriter := mockStorageClient{}
-	logSerialOutput(s, "instance-name", &mockWatcher, &mockWriter)
+	logSerialOutput(s, "instance-name", &mockWatcher, func() io.WriteCloser {
+		return &mockWriter
+	})
 	assert.Equal(t, "log content", mockWriter.content)
 }
 

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -38,15 +38,13 @@ func TestLogSerialOutput(t *testing.T) {
 	mockLogger := &MockLogger{}
 	w.Logger = mockLogger
 	s := &Step{name: "i1", w: w}
-	mockWatcher := newMockSerialOutputWatcher(t, []string{"log ","content"})
+	mockWatcher := newMockSerialOutputWatcher(t, []string{"log ", "content"})
 	mockWriter := mockStorageClient{}
 	logSerialOutput(s, "instance-name", &mockWatcher, func() io.WriteCloser {
 		return &mockWriter
 	})
 	assert.Equal(t, "log content", mockWriter.content)
 }
-
-
 
 func TestCreateInstancesRun(t *testing.T) {
 	ctx := context.Background()
@@ -113,8 +111,8 @@ func TestCreateInstancesRun(t *testing.T) {
 	}
 }
 
-func newMockSerialOutputWatcher(t *testing.T, responses    []string) SerialOutputWatcher {
-	return &mockSerialOutputWatcher{t: t, responses:responses}
+func newMockSerialOutputWatcher(t *testing.T, responses []string) SerialOutputWatcher {
+	return &mockSerialOutputWatcher{t: t, responses: responses}
 }
 
 type mockSerialOutputWatcher struct {
@@ -140,7 +138,7 @@ func (m *mockSerialOutputWatcher) start(instanceName string) {
 type mockStorageClient struct {
 	numWrite int
 	numClose int
-	content string
+	content  string
 }
 
 func (m *mockStorageClient) Write(p []byte) (n int, err error) {

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -65,10 +65,10 @@ func (fms *FailureMatches) UnmarshalJSON(b []byte) error {
 // This step will not complete until a line in the serial output matches
 // SuccessMatch or FailureMatch. A match with FailureMatch will cause the step to fail.
 type SerialOutput struct {
-	Port         int64          `json:",omitempty"`
-	SuccessMatch string         `json:",omitempty"`
-	FailureMatch FailureMatches `json:"failureMatch,omitempty"`
-	StatusMatch  string         `json:",omitempty"`
+	Port          int64          `json:",omitempty"`
+	SuccessMatch  string         `json:",omitempty"`
+	FailureMatch  FailureMatches `json:"failureMatch,omitempty"`
+	StatusMatch   string         `json:",omitempty"`
 	outputChannel <-chan string
 }
 
@@ -78,8 +78,8 @@ type InstanceSignal struct {
 	Name string
 	// Interval to check for signal (default is 5s).
 	// Must be parsable by https://golang.org/pkg/time/#ParseDuration.
-	Interval      string `json:",omitempty"`
-	interval      time.Duration
+	Interval string `json:",omitempty"`
+	interval time.Duration
 	// Wait for the instance to stop.
 	Stopped bool `json:",omitempty"`
 	// Wait for a string match in the serial output.

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -285,7 +285,7 @@ func validateForWaitForInstancesSignal(w *[]*InstanceSignal, s *Step) DError {
 			}
 			// A buffered channel is required, since SerialOutputWatcher doesn't block when writing to it.
 			c := make(chan string, 1)
-			s.w.registerListener(registeredInstance.RealName, c, i.SerialOutput.Port, i.interval)
+			(*s.w.SerialOutputWatcher()).Watch(registeredInstance.RealName, i.SerialOutput.Port, c, i.interval)
 			i.SerialOutput.outputChannel = c
 		}
 	}

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -214,9 +214,9 @@ func TestWaitForInstanceSignal(t *testing.T) {
 					SuccessMatch:  "success",
 					outputChannel: c,
 				},
-			},{
-				Name: "i2",
-				Stopped: true,
+			}, {
+				Name:     "i2",
+				Stopped:  true,
 				interval: time.Nanosecond,
 			},
 			}).run(ctx, s)

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -923,7 +923,7 @@ func (w *Workflow) onStepCancel(s *Step, stepClass string) DError {
 
 // SerialOutputWatcher returns a SerialOutputWatcher that can be used to subscribe to the
 // serial output of instances managed by Daisy.
-func (w *Workflow) WorkflowSerialOutputWatcher() *SerialOutputWatcher {
+func (w *Workflow) SerialOutputWatcher() *SerialOutputWatcher {
 	// Using late initialization for serialOutputWatcher since there are many
 	// ways to create a Daisy workflow (bare struct, json, and its New() constructor),
 	// and this is the only common point.
@@ -931,18 +931,4 @@ func (w *Workflow) WorkflowSerialOutputWatcher() *SerialOutputWatcher {
 		w.serialOutputWatcher = NewSerialOutputWatcher(w.ComputeClient, w.Project, w.Zone)
 	}
 	return &w.serialOutputWatcher
-}
-
-func (w *Workflow) registerListener(name string, sink chan<- string, port int64, duration time.Duration) {
-	// Using late initialization for serialOutputWatcher since there are many
-	// ways to create a Daisy workflow (bare struct, json, and its New() constructor),
-	// and this is the only common point.
-	if w.serialOutputWatcher == nil {
-		w.serialOutputWatcher = NewSerialOutputWatcher(w.ComputeClient, w.Project, w.Zone)
-	}
-	w.serialOutputWatcher.Watch(name, port, sink, duration)
-}
-
-func (w *Workflow) startSerialOutputWatcher(name string) {
-	w.serialOutputWatcher.start(name)
 }


### PR DESCRIPTION
Daisy reads serial port output (serial output) in two places: once in createInstances for log archival, and once in waitForInstancesSignal for control flow. These readers are independent: they both make GCP API calls, manage their own errors, and perform their own retries. 
Uncoordinated access causes two errors:
1. Failure to archive logs: Since each reader has its own event loop, there’s a race for createInstances to archive logs prior to waitForInstancesSignal killing the instance (1160). 
2. Subtle bugs: Over time, each set of reader code has been improved to handle transient failures and instance reboots. Since the code has evolved separately, we find subtle, difficult-to-debug errors.

This change introduces a pubsub mechanism to allow a single serial port reader to broadcast updates to multiple consumers.

Fixes #1160