### PR TITLE
Sanitize control characters from image filename.

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -15,8 +15,7 @@
 
 set -o pipefail
 
-# Enable case-insensitive match when checking for
-# the ova filetype.
+# Enable case-insensitive match; used by fileIsOva.
 shopt -s nocasematch
 
 # Verify VM has access to Google APIs
@@ -29,7 +28,7 @@ fi
 BYTES_1GB=1073741824
 URL="http://metadata/computeMetadata/v1/instance"
 DAISY_SOURCE_URL="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/daisy-sources-path)"
-SOURCE_URL="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/source_disk_file)"
+SOURCE_URL="$DAISY_SOURCE_URL/source_disk_file"
 DISKNAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/disk_name)"
 SCRATCH_DISK_NAME="$(curl -f -H Metadata-Flavor:Google ${URL}/attributes/scratch_disk_name)"
 ME="$(curl -f -H Metadata-Flavor:Google ${URL}/name)"
@@ -84,6 +83,21 @@ function resizeDisk() {
   exit
 }
 
+# Determines whether a file is an OVA archive.
+# Arguments:
+#   File to check.
+# Returns:
+#   0 if the file is a tar file, non-zero otherwise.
+function fileIsOva() {
+  if [[ $(file --mime-type "$1") =~ application/x-tar ]]; then
+    contents=$(tar --list -f "$1")
+    if [[ "$contents" =~ ovf && "$contents" =~ vmdk ]]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
 function copyImageToScratchDisk() {
   # We allocate an extra 10% capacity to account for ext4's
   # filesystem overhead. According to https://petermolnar.net/why-use-btrfs-for-media-storage/ ,
@@ -93,8 +107,8 @@ function copyImageToScratchDisk() {
   local scratchDiskSizeGigabytes=$(awk "BEGIN {print int((${SOURCE_SIZE_GB} * 1.1) + 1)}")
   # We allocate double capacity for OVA, which would
   # require making an additional copy of its enclosed VMDK.
-  if [[ "${IMAGE_PATH}" =~ \.ova$ ]]; then
-     scratchDiskSizeGigabytes=$((scratchDiskSizeGigabytes * 2))
+  if fileIsOva "${IMAGE_PATH}"; then
+    scratchDiskSizeGigabytes=$((scratchDiskSizeGigabytes * 2))
   fi
 
   # This disk is initially created with 10GB of space.
@@ -144,7 +158,7 @@ function serialOutputKeyValuePair() {
 copyImageToScratchDisk
 
 # If the image is an OVA, then copy out its VMDK.
-if [[ "${IMAGE_PATH}" =~ \.ova$ ]]; then
+if fileIsOva "${IMAGE_PATH}"; then
   echo "Import: Unpacking VMDK files from ova."
   VMDK="$(tar --list -f "${IMAGE_PATH}" | grep -m1 vmdk)"
   tar -C /daisy-scratch -xf "${IMAGE_PATH}" "${VMDK}"

--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -79,7 +79,6 @@
             "block-project-ssh-keys": "true",
             "disk_name": "${disk_name}",
             "scratch_disk_name": "disk-${NAME}-scratch-${ID}",
-            "source_disk_file": "${source_disk_file}",
             "shutdown-script": "echo 'Worker instance terminated'",
             "startup-script": "${SOURCE:import_image.sh}"
           },


### PR DESCRIPTION
gsutil supports control characters, such as wildcards, that can't be escaped [1]. This change does the following:
1. Ignore the original filename (on the worker's disk, it will appear as `source_disk_file`)
2. Make OVA checking more robust:
  * Use magic numbers to check for a tar archive
  * Check contents for an ovf and vmdk file

Testing:
* Ran one of the OVA tests that was failing prior to the fixes described in (2).


1. https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames