### PR TITLE
Use absolute paths when looking up workflow directory.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -34,41 +35,42 @@ const (
 	dataDiskFlag       = "data_disk"
 	osFlag             = "os"
 	customWorkflowFlag = "custom_translate_workflow"
+	workflowDir        = "daisy_workflows/image_import/"
 )
 
 // ImportArguments holds the structured results of parsing CLI arguments,
 // and optionally allows for validating and populating the arguments.
 type ImportArguments struct {
-	ExecutionID           string
-	ClientID              string
-	CloudLogsDisabled     bool
-	ComputeEndpoint       string
-	CurrentExecutablePath string
-	CustomWorkflow        string
-	DataDisk              bool
-	Description           string
-	Family                string
-	GcsLogsDisabled       bool
-	ImageName             string
-	Labels                map[string]string
-	Network               string
-	NoExternalIP          bool
-	NoGuestEnvironment    bool
-	Oauth                 string
-	OS                    string
-	Project               string
-	Region                string
-	ScratchBucketGcsPath  string
-	Source                Source
-	SourceFile            string
-	SourceImage           string
-	StdoutLogsDisabled    bool
-	StorageLocation       string
-	Subnet                string
-	SysprepWindows        bool
-	Timeout               time.Duration
-	UefiCompatible        bool
-	Zone                  string
+	ExecutionID          string
+	ClientID             string
+	CloudLogsDisabled    bool
+	ComputeEndpoint      string
+	WorkflowDir          string
+	CustomWorkflow       string
+	DataDisk             bool
+	Description          string
+	Family               string
+	GcsLogsDisabled      bool
+	ImageName            string
+	Labels               map[string]string
+	Network              string
+	NoExternalIP         bool
+	NoGuestEnvironment   bool
+	Oauth                string
+	OS                   string
+	Project              string
+	Region               string
+	ScratchBucketGcsPath string
+	Source               Source
+	SourceFile           string
+	SourceImage          string
+	StdoutLogsDisabled   bool
+	StorageLocation      string
+	Subnet               string
+	SysprepWindows       bool
+	Timeout              time.Duration
+	UefiCompatible       bool
+	Zone                 string
 }
 
 // NewImportArguments parses args to create an ImportArguments instance.
@@ -80,8 +82,8 @@ func NewImportArguments(args []string) (ImportArguments, error) {
 	flagSet.SetOutput(ioutil.Discard)
 
 	parsed := ImportArguments{
-		ExecutionID:           path.RandString(5),
-		CurrentExecutablePath: os.Args[0],
+		ExecutionID: path.RandString(5),
+		WorkflowDir: filepath.Join(filepath.Dir(os.Args[0]), workflowDir),
 	}
 
 	parsed.registerFlags(flagSet)

--- a/cli_tools/gce_vm_image_import/importer/args_test.go
+++ b/cli_tools/gce_vm_image_import/importer/args_test.go
@@ -66,8 +66,8 @@ func TestTrimAndLowerStorageLocation(t *testing.T) {
 	assert.Equal(t, "eu", expectSuccessfulParse(t, "-storage_location", "  EU  ").StorageLocation)
 }
 
-func TestPopulateCurrentDirectory(t *testing.T) {
-	assert.NotEmpty(t, expectSuccessfulParse(t).CurrentExecutablePath)
+func TestPopulateWorkflowDir(t *testing.T) {
+	assert.Regexp(t, ".*/daisy_workflows/image_import", expectSuccessfulParse(t).WorkflowDir)
 }
 
 func TestFailWhenClientIdMissing(t *testing.T) {

--- a/cli_tools/gce_vm_image_import/importer/bootable_disk_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/bootable_disk_processor.go
@@ -56,13 +56,13 @@ func (b bootableDiskProcessor) traceLogs() []string {
 	return []string{}
 }
 
-func newBootableDiskProcessor(args ImportArguments, pd persistentDisk, workflowDirectory string) (processor, error) {
+func newBootableDiskProcessor(args ImportArguments, pd persistentDisk) (processor, error) {
 	var translateWorkflowPath string
 	if args.CustomWorkflow != "" {
 		translateWorkflowPath = args.CustomWorkflow
 	} else {
 		relPath := daisy_utils.GetTranslateWorkflowPath(args.OS)
-		translateWorkflowPath = path.Join(workflowDirectory, relPath)
+		translateWorkflowPath = path.Join(args.WorkflowDir, relPath)
 	}
 
 	vars := map[string]string{

--- a/cli_tools/gce_vm_image_import/importer/bootable_disk_processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/bootable_disk_processor_test.go
@@ -154,7 +154,9 @@ func TestImage_StorageLocation_NotSet(t *testing.T) {
 
 func TestSerials_ReadsFromDaisyLogger(t *testing.T) {
 	expected := []string{"serials"}
-	translator, e := newBootableDiskProcessor(defaultImportArgs(), persistentDisk{}, "testdata/image_import")
+	args := defaultImportArgs()
+	args.WorkflowDir = "testdata/image_import"
+	translator, e := newBootableDiskProcessor(args, persistentDisk{})
 	realTranslator := translator.(bootableDiskProcessor)
 	realTranslator.workflow.Logger = daisyLogger{
 		serials: expected,
@@ -164,7 +166,8 @@ func TestSerials_ReadsFromDaisyLogger(t *testing.T) {
 }
 
 func createAndRunPrePostFunctions(t *testing.T, pd persistentDisk, args ImportArguments) *bootableDiskProcessor {
-	translator, e := newBootableDiskProcessor(args, pd, "testdata/image_import")
+	args.WorkflowDir = "testdata/image_import"
+	translator, e := newBootableDiskProcessor(args, pd)
 	assert.NoError(t, e)
 	realTranslator := translator.(bootableDiskProcessor)
 	// A concrete logger is required since the import/export logging framework writes a log entry

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -24,8 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
 )
 
-const workflowDir = "daisy_workflows/image_import/"
-
 // Importer runs the end-to-end import workflow, and exposes the results
 // via an error and Loggable.
 type Importer interface {
@@ -34,7 +32,7 @@ type Importer interface {
 
 // NewImporter constructs an Importer instance.
 func NewImporter(args ImportArguments, client compute.Client) (Importer, error) {
-	inflater, err := createDaisyInflater(args, workflowDir)
+	inflater, err := createDaisyInflater(args)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -74,7 +74,7 @@ type persistentDisk struct {
 	sourceType string
 }
 
-func createDaisyInflater(args ImportArguments, workflowDirectory string) (inflater, error) {
+func createDaisyInflater(args ImportArguments) (inflater, error) {
 	diskName := "disk-" + args.ExecutionID
 	var wfPath string
 	var vars map[string]string
@@ -97,7 +97,7 @@ func createDaisyInflater(args ImportArguments, workflowDirectory string) (inflat
 		inflationDiskIndex = 1 // First disk is for the worker
 	}
 
-	wf, err := daisycommon.ParseWorkflow(path.Join(workflowDirectory, wfPath), vars,
+	wf, err := daisycommon.ParseWorkflow(path.Join(args.WorkflowDir, wfPath), vars,
 		args.Project, args.Zone, args.ScratchBucketGcsPath, args.Oauth, args.Timeout.String(), args.ComputeEndpoint,
 		args.GcsLogsDisabled, args.CloudLogsDisabled, args.StdoutLogsDisabled)
 	if err != nil {

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -96,8 +96,9 @@ func TestCreateDaisyInflater_File_NotWindows(t *testing.T) {
 	})
 }
 
-func createDaisyInflaterSafe(t *testing.T, spec ImportArguments) daisyInflater {
-	inflater, err := createDaisyInflater(spec, "testdata/image_import")
+func createDaisyInflaterSafe(t *testing.T, args ImportArguments) daisyInflater {
+	args.WorkflowDir = "testdata/image_import"
+	inflater, err := createDaisyInflater(args)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(daisyInflater)
 	assert.True(t, ok)

--- a/cli_tools/gce_vm_image_import/importer/processor.go
+++ b/cli_tools/gce_vm_image_import/importer/processor.go
@@ -44,5 +44,5 @@ func (d defaultProcessorProvider) provide(pd persistentDisk) (processor, error) 
 			d.Labels, d.StorageLocation, d.Description,
 			d.Family, d.ImageName), nil
 	}
-	return newBootableDiskProcessor(d.ImportArguments, pd, workflowDir)
+	return newBootableDiskProcessor(d.ImportArguments, pd)
 }


### PR DESCRIPTION
This change was motivated by test failures saying `open daisy_workflows/image_import/inflate_image.wf.json: no such file or directory`. During initial testing of the feature, I built and ran `gce_vm_image_import` locally, ensuring that  `daisy_workflows` was in the same directory.

The *working* directory, however, in cloud build is not necessarily the location of `gce_vm_image_import` within the image. 

The JSON assets are copied to a directory adjacent to `gce_vm_image_import` in the docker image that runs on Cloud Build, ie:

```
\gce_vm_image_import
\daisy_workflows\
```

This change ensures that we look for the workflow files relative to the implicit root shown above, rather than the current working directory.

Testing:
* Built docker image on cloud build; ran a container from the image. This failed prior to the change, and passed after the change.