### PR TITLE
[windows upgrade] post-upgrade step; log privacy

### DIFF
--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -24,9 +24,9 @@ try {
   if ("$($ver.Major).$($ver.Minor)" -ne "6.1") {
     if ("$($ver.Major).$($ver.Minor)" -eq "6.3") {
       Write-Host "GCEMetadataScripts: The instance is already running Windows 2012R2!"
-      Write-Host "GCEMetadataScripts: Rerunning upgrade.ps1 for post-upgrade step..."
+      Write-Host "GCEMetadataScripts: Rerunning upgrade.ps1 as the post-upgrade step."
     } else {
-      throw "The instance is not running Windows 2008R2!"
+      throw "The instance is not running Windows 2008R2 (6.1). It is $($new_ver.Major).$($new_ver.Minor)."
     }
   }
 
@@ -61,7 +61,7 @@ online disk noerr
   $new_ver=[System.Environment]::OSVersion.Version
   if ("$($ver.Major).$($ver.Minor)" -eq "6.3")
   {
-    Write-Host "GCEMetadataScripts: post-upgrade step is done!"
+    Write-Host "GCEMetadataScripts: post-upgrade step is done."
   }
   Write-Host "windows_upgrade_current_version=$($new_ver.Major).$($new_ver.Minor)"
 }

--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -21,13 +21,13 @@ try {
   Remove-Item 'C:\$WINDOWS.~BT' -Recurse -ErrorAction Ignore
 
   $ver=[System.Environment]::OSVersion.Version
-  Write-Host "windows_upgrade_current_version=$($ver.Major).$($ver.Minor)"
   if ("$($ver.Major).$($ver.Minor)" -ne "6.1") {
     if ("$($ver.Major).$($ver.Minor)" -eq "6.3") {
       Write-Host "GCEMetadataScripts: The instance is already running Windows 2012R2!"
-      Return
+      Write-Host "GCEMetadataScripts: Rerunning upgrade.ps1 for post-upgrade step..."
+    } else {
+      throw "The instance is not running Windows 2008R2!"
     }
-    throw "The instance is not running Windows 2008R2!"
   }
 
   # Bring all disks online to ensure install media is accessible.
@@ -58,6 +58,12 @@ online disk noerr
   Set-ExecutionPolicy Unrestricted
   Set-Location "$($script:install_media_drive)/Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English"
   ./upgrade.ps1
+  $new_ver=[System.Environment]::OSVersion.Version
+  if ("$($ver.Major).$($ver.Minor)" -eq "6.3")
+  {
+    Write-Host "GCEMetadataScripts: post-upgrade step is done!"
+  }
+  Write-Host "windows_upgrade_current_version=$($new_ver.Major).$($new_ver.Minor)"
 }
 catch {
   Write-Host "UpgradeFailed: $($_.Exception.Message)"

--- a/cli_tools/gce_windows_upgrade/upgrader/workflows.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/workflows.go
@@ -506,6 +506,7 @@ func (u *upgrader) runWorkflowWithSteps(workflowName string, timeout string, pop
 		return w, err
 	}
 
+	w.SetLogProcessHook(daisyutils.RemovePrivacyLogTag)
 	setWorkflowAttributes(w, u)
 	err = daisyutils.RunWorkflowWithCancelSignal(u.ctx, w)
 	return w, err


### PR DESCRIPTION
fix 2 problems:
1. Adjust the startup script to launch post-upgrade step. "upgrade.ps1" needs to be executed again after setup.exe is done, so we move the output of "windows_upgrade_current_version" to the last line.
2. To ensure log privacy, we need to set log process hook for all the workflows. 