### PR TITLE
Add external IP flag to daisy export workflows

### DIFF
--- a/daisy/instance.go
+++ b/daisy/instance.go
@@ -103,6 +103,9 @@ type InstanceBase struct {
 	// RetryWhenExternalIPDenied indicates whether to retry CreateInstances when
 	// it fails due to external IP denied by organization IP.
 	RetryWhenExternalIPDenied bool `json:",omitempty"`
+	// NoExternalIP indicates whether to try CreateInstances with
+	// an external IP in the first place.
+	NoExternalIP string `json:",omitempty"`
 	// Should an existing instance of the same name be deleted, defaults to false
 	// which will fail validation.
 	OverWrite bool `json:",omitempty"`
@@ -116,6 +119,7 @@ type Instance struct {
 
 	// Additional metadata to set for the instance.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
 }
 
 // InstanceBeta is used to create a GCE instance using Beta API.
@@ -500,7 +504,11 @@ func (i *Instance) populateNetworks() DError {
 	}
 	for _, n := range i.NetworkInterfaces {
 		if n.AccessConfigs == nil {
-			n.AccessConfigs = defaultAcs
+			if i.NoExternalIP == "true" {
+				n.AccessConfigs = []*compute.AccessConfig{}
+			} else {
+				n.AccessConfigs = defaultAcs
+			}
 		}
 
 		// Only set deafult if no subnetwork or network set.
@@ -528,7 +536,11 @@ func (i *InstanceBeta) populateNetworks() DError {
 	}
 	for _, n := range i.NetworkInterfaces {
 		if n.AccessConfigs == nil {
-			n.AccessConfigs = defaultAcs
+			if i.NoExternalIP == "true" {
+				n.AccessConfigs = []*computeBeta.AccessConfig{}
+			} else {
+				n.AccessConfigs = defaultAcs
+			}
 		}
 
 		// Only set deafult if no subnetwork or network set.

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -32,6 +32,10 @@
     "export_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the export instance"
+    },
+    "no_external_ip": {
+      "Value": "false",
+      "Description": "Specifies to create the export instance without an external IP address"
     }
   },
   "Sources": {
@@ -68,6 +72,7 @@
             }
           ],
           "RetryWhenExternalIPDenied": true,
+          "NoExternalIP": "${no_external_ip}",
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"]
         }
       ]

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -33,6 +33,10 @@
     "export_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the export instance"
+    },
+    "no_external_ip": {
+      "Value": "false",
+      "Description": "Specifies to create the export instance without an external IP address"
     }
   },
   "Sources": {
@@ -82,6 +86,7 @@
             }
           ],
           "RetryWhenExternalIPDenied": true,
+          "NoExternalIP": "${no_external_ip}",
           "Scopes": ["https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/compute"]
         }
       ]

--- a/daisy_workflows/export/image_export.wf.json
+++ b/daisy_workflows/export/image_export.wf.json
@@ -32,6 +32,10 @@
     "export_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the export instance"
+    },
+    "no_external_ip": {
+      "Value": "false",
+      "Description": "Specifies to create the export instance without an external IP address"
     }
   },
   "Steps": {
@@ -56,7 +60,8 @@
           "export_instance_disk_type": "${export_instance_disk_type}",
           "licenses": "${licenses}",
           "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "export_subnet": "${export_subnet}",
+          "no_external_ip": "${no_external_ip}"
         }
       }
     }

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -33,6 +33,10 @@
     "export_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the export instance"
+    },
+    "no_external_ip": {
+      "Value": "false",
+      "Description": "Specifies to create the export instance without an external IP address"
     }
   },
   "Steps": {
@@ -57,7 +61,8 @@
           "export_instance_disk_size": "${export_instance_disk_size}",
           "export_instance_disk_type": "${export_instance_disk_type}",
           "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "export_subnet": "${export_subnet}",
+          "no_external_ip": "${no_external_ip}"
         }
       }
     },


### PR DESCRIPTION
Citrix Machine Creation Services (MCS) uses Daisy Export workflows during VM image preparation. Customers have complained that the export instance launches with an external IP. This pull request adds new workflow vars allowing client to optionally disable external IP address for initial launch of export VM. New flag defaults to "false" to preserve previous behavior.