### PR TITLE
[windows upgrade] firelog: adjust field sequence

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -194,11 +194,11 @@ type CommonParams struct {
 type WindowsUpgradeParams struct {
 	*CommonParams
 
+	SourceOS               string `json:"source_os,omitempty"`
+	TargetOS               string `json:"target_os,omitempty"`
 	Instance               string `json:"instance,omitempty"`
 	CreateMachineBackup    bool   `json:"create_machine_backup"`
 	AutoRollback           bool   `json:"auto_rollback"`
-	SourceOS               string `json:"source_os,omitempty"`
-	TargetOS               string `json:"target_os,omitempty"`
 	UseStagingInstallMedia bool   `json:"use_staging_install_media"`
 }
 
@@ -245,9 +245,5 @@ func (l *Logger) updateParams(projectPointer *string) {
 	if l.Params.MachineImageImportParams != nil {
 		l.Params.MachineImageImportParams.CommonParams.Project = project
 		l.Params.MachineImageImportParams.CommonParams.ObfuscatedProject = obfuscatedProject
-	}
-	if l.Params.WindowsUpgradeParams != nil {
-		l.Params.WindowsUpgradeParams.CommonParams.Project = project
-		l.Params.WindowsUpgradeParams.CommonParams.ObfuscatedProject = obfuscatedProject
 	}
 }

--- a/cli_tools/gce_windows_upgrade/main.go
+++ b/cli_tools/gce_windows_upgrade/main.go
@@ -75,8 +75,6 @@ func main() {
 			CommonParams: &service.CommonParams{
 				ClientID:                *clientID,
 				Timeout:                 *timeout,
-				Project:                 *project,
-				ObfuscatedProject:       service.Hash(*project),
 				Zone:                    *zone,
 				ScratchBucketGcsPath:    *scratchBucketGcsPath,
 				Oauth:                   *oauth,
@@ -85,11 +83,11 @@ func main() {
 				DisableCloudLogging:     *cloudLogsDisabled,
 				DisableStdoutLogging:    *stdoutLogsDisabled,
 			},
+			SourceOS:               *sourceOS,
+			TargetOS:               *targetOS,
 			Instance:               *instance,
 			CreateMachineBackup:    *createMachineBackup,
 			AutoRollback:           *autoRollback,
-			SourceOS:               *sourceOS,
-			TargetOS:               *targetOS,
 			UseStagingInstallMedia: *useStagingInstallMedia,
 		},
 	}


### PR DESCRIPTION
1. adjust field sequence
2. remov "project" and "obfuscatedProject"
to be align with compute_image_tools_log.proto.

If not align, the log will be thrown.