### PR TITLE
Ensure destination image doesn't exist prior to running import.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/data_disk_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/data_disk_processor.go
@@ -21,12 +21,12 @@ import (
 )
 
 type dataDiskProcessor struct {
-	client  imageClient
+	client  createImageClient
 	project string
 	request compute.Image
 }
 
-func newDataDiskProcessor(pd persistentDisk, client imageClient, project string,
+func newDataDiskProcessor(pd persistentDisk, client createImageClient, project string,
 	userLabels map[string]string, userStorageLocation string,
 	description string, family string, imageName string) processor {
 	labels := map[string]string{"gce-image-import": "true"}
@@ -61,7 +61,7 @@ func (d dataDiskProcessor) process(ctx context.Context) (err error) {
 	return d.client.CreateImage(d.project, &d.request)
 }
 
-// imageClient is the subset of the GCP compute API that is used by dataDiskProcessor.
-type imageClient interface {
+// createImageClient is the subset of the GCP compute API that is used by dataDiskProcessor.
+type createImageClient interface {
 	CreateImage(project string, i *compute.Image) error
 }

--- a/cli_tools/gce_vm_image_import/importer/processor.go
+++ b/cli_tools/gce_vm_image_import/importer/processor.go
@@ -35,7 +35,7 @@ type processorProvider interface {
 
 type defaultProcessorProvider struct {
 	ImportArguments
-	imageClient imageClient
+	imageClient createImageClient
 }
 
 func (d defaultProcessorProvider) provide(pd persistentDisk) (processor, error) {

--- a/cli_tools/gce_vm_image_import/importer/validator.go
+++ b/cli_tools/gce_vm_image_import/importer/validator.go
@@ -45,8 +45,8 @@ func (v validateImageNameAvailable) validate() error {
 	// then the image name may be available.
 	image, _ := v.client.GetImage(v.project, v.name)
 	if image != nil {
-		return fmt.Errorf("the image %q already exists. Please remove it, "+
-			"or pick a name that isn't already used", v.name)
+		return fmt.Errorf("The resource '%s' already exists. "+
+			"Please pick an image name that isn't already used.", v.name)
 	}
 	return nil
 }

--- a/cli_tools/gce_vm_image_import/importer/validator.go
+++ b/cli_tools/gce_vm_image_import/importer/validator.go
@@ -1,0 +1,57 @@
+//  Copyright 2020  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"fmt"
+	"google.golang.org/api/compute/v1"
+)
+
+// validator is the interface for performing validations.
+//
+// validate returns nil when passing, and non-nil when failing.
+type validator interface {
+	validate() error
+}
+
+func newPreValidator(args ImportArguments, client getImageClient) validator {
+	return validateImageNameAvailable{
+		project: args.Project,
+		name:    args.ImageName,
+		client:  client,
+	}
+}
+
+// validateImageNameAvailable is an importer.validator that
+// ensures the user's destination image name hasn't already
+// been used.
+type validateImageNameAvailable struct {
+	project, name string
+	client        getImageClient
+}
+
+func (v validateImageNameAvailable) validate() error {
+	// We ignore the error, with the assumption that if there's an error,
+	// then the image name may be available.
+	image, _ := v.client.GetImage(v.project, v.name)
+	if image != nil {
+		return fmt.Errorf("the image %q already exists. Please remove it, "+
+			"or pick a name that isn't already used", v.name)
+	}
+	return nil
+}
+
+// diskClient is the subset of the GCP API that is used by validateImageNameAvailable.
+type getImageClient interface {
+	GetImage(project, name string) (*compute.Image, error)
+}

--- a/cli_tools/gce_vm_image_import/importer/validator_test.go
+++ b/cli_tools/gce_vm_image_import/importer/validator_test.go
@@ -36,7 +36,7 @@ func TestPreValidator(t *testing.T) {
 		{
 			testName:        "fail when image already exists",
 			imageFromClient: &compute.Image{},
-			expectedError:   "the image \"image-name\" already exists. Please remove it, or pick a name that isn't already used",
+			expectedError:   "The resource 'image-name' already exists. Please pick an image name that isn't already used.",
 		},
 	}
 

--- a/cli_tools/gce_vm_image_import/importer/validator_test.go
+++ b/cli_tools/gce_vm_image_import/importer/validator_test.go
@@ -1,0 +1,81 @@
+//  Copyright 2020  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+	"testing"
+)
+
+func TestPreValidator(t *testing.T) {
+	var cases = []struct {
+		testName        string
+		imageFromClient *compute.Image
+		errorFromClient error
+		expectedError   string
+	}{
+		{
+			testName: "pass when image not found",
+		},
+		{
+			testName:        "pass when image not found, even if error returned",
+			errorFromClient: errors.New("image not found"),
+		},
+		{
+			testName:        "fail when image already exists",
+			imageFromClient: &compute.Image{},
+			expectedError:   "the image \"image-name\" already exists. Please remove it, or pick a name that isn't already used",
+		},
+	}
+
+	project := "project-name"
+	imageName := "image-name"
+	for _, tt := range cases {
+		t.Run(tt.testName, func(t *testing.T) {
+			client := mockGetImageClient{
+				t:                 t,
+				expectedProject:   project,
+				expectedImageName: imageName,
+				img:               tt.imageFromClient,
+				err:               tt.errorFromClient,
+			}
+
+			validator := newPreValidator(ImportArguments{
+				Project:   project,
+				ImageName: imageName,
+			}, client)
+
+			actualError := validator.validate()
+			if tt.expectedError == "" {
+				assert.NoError(t, actualError)
+			} else {
+				assert.EqualError(t, actualError, tt.expectedError)
+			}
+		})
+	}
+}
+
+type mockGetImageClient struct {
+	t                                  *testing.T
+	expectedProject, expectedImageName string
+	img                                *compute.Image
+	err                                error
+}
+
+func (m mockGetImageClient) GetImage(project, name string) (*compute.Image, error) {
+	assert.Equal(m.t, m.expectedImageName, name)
+	assert.Equal(m.t, m.expectedProject, project)
+	return m.img, m.err
+}


### PR DESCRIPTION
Prior to the #1227, import failed early when an image name was already used. Following #1227, the failure occurred after inflation, which introduces a significant delay.

Example invocation:

```
➜   ./main -image_name ubuntu  \
               -data_disk -client_id  edens-test \
               -source_image projects/compute-image-tools-test/global/images/debian-8-translate \
               -project=edens-test
[import-image] 2020/06/16 12:07:40 the image "ubuntu" already exists. Please remove it, or pick a name that isn't already used
```

The failure message appears instantly (at least to my eyes!).