### PR TITLE
Revert "Sanitize control characters from image filename. (#1244)"

### DIFF
--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -79,6 +79,7 @@
             "block-project-ssh-keys": "true",
             "disk_name": "${disk_name}",
             "scratch_disk_name": "disk-${NAME}-scratch-${ID}",
+            "source_disk_file": "${source_disk_file}",
             "shutdown-script": "echo 'Worker instance terminated'",
             "startup-script": "${SOURCE:import_image.sh}"
           },


### PR DESCRIPTION
This change breaks multi-disk OVF imports.