### PR TITLE
Support ShieldedInstanceInitialState in the publish workflow

### DIFF
--- a/cli_tools/gce_image_publish/publish/publish.go
+++ b/cli_tools/gce_image_publish/publish/publish.go
@@ -95,6 +95,8 @@ type Image struct {
 	IgnoreLicenseValidationIfForbidden bool `json:",omitempty"`
 	// Optional DeprecationStatus.Obsolete entry for the image (RFC 3339).
 	ObsoleteDate *time.Time `json:",omitempty"`
+	// Optional ShieldedInstanceInitialState entry for secure-boot feature.
+	ShieldedInstanceInitialState *compute.InitialStateConfig `json:",omitempty"`
 }
 
 var (
@@ -259,11 +261,12 @@ func publishImage(p *Publish, img *Image, pubImgs []*compute.Image, skipDuplicat
 
 	ci := daisy.Image{
 		Image: compute.Image{
-			Name:        publishName,
-			Description: img.Description,
-			Licenses:    img.Licenses,
-			Family:      img.Family,
-			Deprecated:  ds,
+			Name:                         publishName,
+			Description:                  img.Description,
+			Licenses:                     img.Licenses,
+			Family:                       img.Family,
+			Deprecated:                   ds,
+			ShieldedInstanceInitialState: img.ShieldedInstanceInitialState,
 		},
 		ImageBase: daisy.ImageBase{
 			Resource: daisy.Resource{

--- a/cli_tools/gce_image_publish/publish/publish_test.go
+++ b/cli_tools/gce_image_publish/publish/publish_test.go
@@ -27,6 +27,21 @@ import (
 
 func TestPublishImage(t *testing.T) {
 	now := time.Now()
+	fakeInitialState := &compute.InitialStateConfig{
+		Dbs: []*compute.FileContentBuffer{
+			{
+				Content:  "abc",
+				FileType: "BIN",
+			},
+		},
+		Dbxs: []*compute.FileContentBuffer{
+			{
+				Content:  "abc",
+				FileType: "X509",
+			},
+		},
+		NullFields: []string{"Keks", "Pk"},
+	}
 
 	tests := []struct {
 		desc    string
@@ -211,6 +226,19 @@ func TestPublishImage(t *testing.T) {
 			&daisy.CreateImages{Images: []*daisy.Image{{ImageBase: daisy.ImageBase{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-3"}, IgnoreLicenseValidationIfForbidden: false}, Image: compute.Image{
 				Name: "foo-3", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-3"}, GuestOsFeatures: []string{"foo-feature"}},
 			}},
+			nil,
+			false,
+		},
+		{
+			"new image from src, with ShieldedInstanceInitialState",
+			&Publish{SourceProject: "bar-project", PublishProject: "foo-project"},
+			&Image{Prefix: "foo-x", Family: "foo-family", ShieldedInstanceInitialState: fakeInitialState},
+			[]*compute.Image{},
+			false,
+			false,
+			&daisy.CreateImages{Images: []*daisy.Image{{ImageBase: daisy.ImageBase{Resource: daisy.Resource{Project: "foo-project", NoCleanup: true, RealName: "foo-x"}}, Image: compute.Image{
+				Name: "foo-x", Family: "foo-family", SourceImage: "projects/bar-project/global/images/foo-x", ShieldedInstanceInitialState: fakeInitialState},
+			}}},
 			nil,
 			false,
 		},


### PR DESCRIPTION
long overdue, since we do not save the initial config into the image tarball, aka, if you export an image and re-publish that, the VM won't be able to boot up properly.

(bug 143374751 if you want more context)

/assign @rkolchmeyer @hopkiw @adjackura 
fixes https://github.com/GoogleCloudPlatform/compute-image-tools/issues/1148