### PR TITLE
Don't allocate an external IP during inflation.

### DIFF
--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -86,7 +86,8 @@
           "networkInterfaces": [
             {
               "network": "${import_network}",
-              "subnetwork": "${import_subnet}"
+              "subnetwork": "${import_subnet}",
+              "accessConfigs": []
             }
           ],
           "Scopes": [


### PR DESCRIPTION
This change allows organizations that [disable external IPs](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#disableexternalip) to run image import.