### PR TITLE
During inflate, allocate external IP unless NoExternalIP is set.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"google.golang.org/api/compute/v1"
 
+	daisy_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	string_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/string"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
 )
@@ -104,6 +105,7 @@ func createDaisyInflater(args ImportArguments) (inflater, error) {
 		return nil, err
 	}
 
+	daisy_utils.UpdateAllInstanceNoExternalIP(wf, args.NoExternalIP)
 	for k, v := range vars {
 		wf.AddVar(k, v)
 	}

--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -86,8 +86,7 @@
           "networkInterfaces": [
             {
               "network": "${import_network}",
-              "subnetwork": "${import_subnet}",
-              "accessConfigs": []
+              "subnetwork": "${import_subnet}"
             }
           ],
           "Scopes": [


### PR DESCRIPTION
Following #1262, two tests that used custom subnetworks failed. Since tests didn't enable privateIpGoogleAccess on their subnetwork [1], the inflation instance failed when calling GCP APIs.

This PR ensures that we create external IPs *unless* the user enables NoExternalIP.


1. https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/insert