### PR TITLE
fix err typo, otherwise it won't be built in bazel

### DIFF
--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -493,7 +493,7 @@ func (w *Workflow) populate(ctx context.Context) DError {
 		w.GCSPath = "gs://" + dBkt
 	}
 	bkt, p, derr := splitGCSPath(w.GCSPath)
-	if err != nil {
+	if derr != nil {
 		return derr
 	}
 	w.bucket = bkt


### PR DESCRIPTION
when building this with bazel I got

```
compilepkg: nogo: errors found by nogo during build-time code analysis:
/private/var/tmp/_bazel_senlu/1693ea471a90a355976fdb5d7dafa66b/sandbox/darwin-sandbox/1278/execroot/__main__/external/com_github_googlecloudplatform_compute_image_tools_daisy/workflow.go:496:9: impossible condition: nil != nil
```