### PR TITLE
[windows upgrade] rename 'OS disk' to 'boot disk' on user interface

### DIFF
--- a/cli_tools/gce_windows_upgrade/upgrader/upgrader.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/upgrader.go
@@ -210,21 +210,21 @@ func (u *upgrader) handleResult(err error) {
 	if u.AutoRollback {
 		if isNewOSDiskAttached {
 			fmt.Printf("\nUpgrade failed to finish. Rolling back to the "+
-				"original state from the original OS disk '%v'...\n\n", u.osDiskURI)
+				"original state from the original boot disk '%v'...\n\n", u.osDiskURI)
 			_, err := u.rollback()
 			if err != nil {
 				fmt.Printf("\nRollback failed. Error: %v\n"+
 					"Please rollback the image manually following the instructions in the guide.\n\n", err)
 			} else {
-				fmt.Printf("\nCompleted rollback to the original OS disk. Please " +
+				fmt.Printf("\nCompleted rollback to the original boot disk. Please " +
 					"verify the rollback. If the rollback does not function as expected, " +
 					"consider restoring the instance from the machine image.\n\n")
 			}
 			return
 		}
-		fmt.Printf("\nNo OS disk attached during the failure. No need to rollback. "+
+		fmt.Printf("\nNo boot disk attached during the failure. No need to rollback. "+
 			"If the instance doesn't work as expected, please verify that the original "+
-			"OS disk (%v) is attached and whether the instance has started. If necessary, "+
+			"boot disk (%v) is attached and whether the instance has started. If necessary, "+
 			"please manually rollback by using the instructions in the guide..\n\n", u.osDiskURI)
 	}
 

--- a/cli_tools/gce_windows_upgrade/upgrader/upgrader_test.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/upgrader_test.go
@@ -211,7 +211,7 @@ func initTestUpgrader(t *testing.T) *TestUpgrader {
 	}
 	tu.prepareFn = func() (workflow *daisy.Workflow, e error) {
 		// Test workaround: let newOSDiskName to be the same as current disk name
-		// in order to pretend the enw OS disk has been attached.
+		// in order to pretend the new OS disk has been attached.
 		tu.newOSDiskName = testDisk
 		return nil, nil
 	}

--- a/cli_tools/gce_windows_upgrade/upgrader/upgrader_test.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/upgrader_test.go
@@ -211,7 +211,7 @@ func initTestUpgrader(t *testing.T) *TestUpgrader {
 	}
 	tu.prepareFn = func() (workflow *daisy.Workflow, e error) {
 		// Test workaround: let newOSDiskName to be the same as current disk name
-		// in order to pretend the new OS disk has been attached.
+		// in order to pretend the enw OS disk has been attached.
 		tu.newOSDiskName = testDisk
 		return nil, nil
 	}

--- a/cli_tools/gce_windows_upgrade/upgrader/utils.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/utils.go
@@ -31,11 +31,11 @@ const (
 		"All resources are in project '{{.project}}', zone '{{.zone}}'.\n" +
 		"1. Instance: {{.instanceName}}\n" +
 		"2. Disk for install media: {{.installMediaDiskName}}\n" +
-		"3. Snapshot for original OS disk: {{.osDiskSnapshotName}}\n" +
-		"4. Original OS disk: {{.osDiskName}}\n" +
+		"3. Snapshot for original boot disk: {{.osDiskSnapshotName}}\n" +
+		"4. Original boot disk: {{.osDiskName}}\n" +
 		"   - Device name of the attachment: {{.osDiskDeviceName}}\n" +
 		"   - AutoDelete setting of the attachment: {{.osDiskAutoDelete}}\n" +
-		"5. Name of the new OS disk: {{.newOSDiskName}}\n" +
+		"5. Name of the new boot disk: {{.newOSDiskName}}\n" +
 		"6. Name of the machine image: {{.machineImageName}}\n" +
 		"7. Original startup script URL: {{.originalStartupScriptURL}}\n" +
 		"\n" +
@@ -47,14 +47,14 @@ const (
 		"If the upgrade fails but you didn't enable automatic rollback, auto-rollback " +
 		"failed, or the upgrade succeeded but you need to rollback for another reason, " +
 		"use the following steps to perform a manual rollback:\n" +
-		"1. Detach the new OS disk from the instance and delete the disk.\n" +
-		"2. Attach the original OS disk as a boot disk.\n" +
+		"1. Detach the new boot disk from the instance and delete the disk.\n" +
+		"2. Attach the original boot disk as a boot disk.\n" +
 		"3. Detach the install media disk from the instance and delete the disk.\n" +
 		"4. Delete 'windows-startup-script-url' from the instance's metadata if there isn't an original value for the script. " +
 		"If there is an original value for the script, restore the value. The original value is backed up as metadata 'windows-startup-script-url-backup'.\n" +
 		"\n"
 	cleanupIntroductionTemplate = "After verifying that the upgrading succeeds and you no longer need to rollback:\n" +
-		"1. Delete the original OS disk: {{.osDiskName}}\n" +
+		"1. Delete the original boot disk: {{.osDiskName}}\n" +
 		"2. Delete the machine image (if you created one): {{.machineImageName}}\n" +
 		"3. Delete the snapshot: {{.osDiskSnapshotName}}\n" +
 		"\n"

--- a/cli_tools/gce_windows_upgrade/upgrader/validators.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/validators.go
@@ -193,7 +193,7 @@ func validateAndDeriveOSDisk(osDisk *compute.AttachedDisk, derivedVars *derivedV
 	osDiskName := daisyutils.GetResourceID(osDisk.Source)
 	d, err := computeClient.GetDisk(derivedVars.instanceProject, derivedVars.instanceZone, osDiskName)
 	if err != nil {
-		return daisy.Errf("Failed to get OS disk info: %v", err)
+		return daisy.Errf("Failed to get boot disk info: %v", err)
 	}
 
 	derivedVars.osDiskURI = param.GetZonalResourcePath(derivedVars.instanceZone, "disks", osDisk.Source)

--- a/cli_tools/gce_windows_upgrade/upgrader/validators_test.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/validators_test.go
@@ -359,7 +359,7 @@ func TestValidateOSDisk(t *testing.T) {
 			"Disk not exist",
 			&compute.AttachedDisk{Source: daisy.GetDiskURI(testProject, testZone, DNE),
 				DeviceName: testDiskDeviceName, AutoDelete: testDiskAutoDelete, Boot: true},
-			"Failed to get OS disk info: googleapi: got HTTP response code 404 with body: ",
+			"Failed to get boot disk info: googleapi: got HTTP response code 404 with body: ",
 		},
 		{
 			"Disk not boot",


### PR DESCRIPTION
This is requested by tech writer. Google standard term is boot disk other than OS disk.