### PR TITLE
[windows upgrade e2e] delete instance after test

### DIFF
--- a/cli_tools_e2e_test/common/utils/utils.go
+++ b/cli_tools_e2e_test/common/utils/utils.go
@@ -118,7 +118,8 @@ func runTestCases(ctx context.Context, logger *log.Logger, regex *regexp.Regexp,
 	return tests
 }
 
-func runCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString string, args []string) error {
+// RunCliTool runs a cli tool with given args
+func RunCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString string, args []string) error {
 	prefix := "Test Env"
 	if testCase != nil {
 		prefix = testCase.Name
@@ -132,7 +133,7 @@ func runCliTool(logger *log.Logger, testCase *junitxml.TestCase, cmdString strin
 
 // RunTestCommand runs given test command
 func RunTestCommand(cmd string, args []string, logger *log.Logger, testCase *junitxml.TestCase) bool {
-	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+	if err := RunCliTool(logger, testCase, cmd, args); err != nil {
 		Failure(testCase, logger, fmt.Sprintf("Error running cmd: %v\n", err))
 		return false
 	}
@@ -141,7 +142,7 @@ func RunTestCommand(cmd string, args []string, logger *log.Logger, testCase *jun
 
 // RunTestCommandIgnoringError runs given test command. The test case won't be marked as fail even error happens.
 func RunTestCommandIgnoringError(cmd string, args []string, logger *log.Logger, testCase *junitxml.TestCase) bool {
-	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+	if err := RunCliTool(logger, testCase, cmd, args); err != nil {
 		logger.Printf("[%v] %v", testCase.Name, fmt.Sprintf("Error running cmd: %v\n", err))
 		return false
 	}
@@ -174,7 +175,7 @@ func GcloudAuth(logger *log.Logger, testCase *junitxml.TestCase) bool {
 	credsPath := "/etc/compute-image-tools-test-service-account/creds.json"
 	cmd := "gcloud"
 	args := []string{"auth", "activate-service-account", "--key-file=" + credsPath}
-	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+	if err := RunCliTool(logger, testCase, cmd, args); err != nil {
 		Failure(testCase, logger, fmt.Sprintf("Error running cmd: %v\n", err))
 		return false
 	}
@@ -196,14 +197,14 @@ func GcloudUpdate(logger *log.Logger, testCase *junitxml.TestCase, latest bool) 
 	if latest {
 		args := []string{"components", "repositories", "add",
 			"https://storage.googleapis.com/cloud-sdk-testing/ci/staging/components-2.json", "--quiet"}
-		if err := runCliTool(logger, testCase, cmd, args); err != nil {
+		if err := RunCliTool(logger, testCase, cmd, args); err != nil {
 			logger.Printf("Error running cmd: %v\n", err)
 			testCase.WriteFailure("Error running cmd: %v", err)
 			return false
 		}
 	} else {
 		args := []string{"components", "repositories", "remove", "--all"}
-		if err := runCliTool(logger, testCase, cmd, args); err != nil {
+		if err := RunCliTool(logger, testCase, cmd, args); err != nil {
 			logger.Printf("Error running cmd: %v\n", err)
 			testCase.WriteFailure("Error running cmd: %v", err)
 			return false
@@ -211,7 +212,7 @@ func GcloudUpdate(logger *log.Logger, testCase *junitxml.TestCase, latest bool) 
 	}
 
 	args := []string{"components", "update", "--quiet"}
-	if err := runCliTool(logger, testCase, cmd, args); err != nil {
+	if err := RunCliTool(logger, testCase, cmd, args); err != nil {
 		logger.Printf("Error running cmd: %v\n", err)
 		testCase.WriteFailure("Error running cmd: %v", err)
 		return false

--- a/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
+++ b/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
@@ -542,9 +542,10 @@ func verifyCleanup(instance *computeUtils.Instance, testCase *junitxml.TestCase,
 }
 
 func cleanupTestInstance(project, zone, instanceName string, logger *log.Logger, testCase *junitxml.TestCase) {
-	utils.RunTestCommandIgnoringError("gcloud", []string{
+	// Run gcloud to delete the instance, ignoring error.
+	utils.RunCliTool(logger, testCase, "gcloud", []string{
 		"compute", "instances", "delete", "--quiet",
 		fmt.Sprintf("--zone=%v", zone),
 		fmt.Sprintf("--project=%v", project), instanceName,
-	}, logger, testCase)
+	})
 }

--- a/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
+++ b/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
@@ -322,6 +322,17 @@ func runTest(ctx context.Context, image string, args []string, testType utils.CL
 		return
 	}
 
+	defer func() {
+		// delete the test instance when test is done
+		if !utils.RunTestCommandIgnoringError("gcloud", []string{
+			"compute", "instances", "delete",  "--quiet",
+			fmt.Sprintf("--zone=%v", testProjectConfig.TestZone),
+			fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), instanceName,
+		}, logger, testCase) {
+			return
+		}
+	} ()
+
 	// create and attach data disks
 	for dataDiskIndex := 1; dataDiskIndex <= dataDiskCount; dataDiskIndex++ {
 		diskName := fmt.Sprintf("%v-%v", instanceName, dataDiskIndex)

--- a/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
+++ b/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
@@ -543,7 +543,7 @@ func verifyCleanup(instance *computeUtils.Instance, testCase *junitxml.TestCase,
 
 func cleanupTestInstance(project, zone, instanceName string, logger *log.Logger, testCase *junitxml.TestCase) {
 	utils.RunTestCommandIgnoringError("gcloud", []string{
-		"compute", "instances", "delete",  "--quiet",
+		"compute", "instances", "delete", "--quiet",
 		fmt.Sprintf("--zone=%v", zone),
 		fmt.Sprintf("--project=%v", project), instanceName,
 	}, logger, testCase)


### PR DESCRIPTION
CPU resource will be exhausted if we don't delete the test instance proactively. Even the cleanup tool will do the cleanup, the garbage is still too much and it has caused the quota problem yesterday.