### PR TITLE
fix export

### DIFF
--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -92,6 +92,7 @@ if [[ $? -ne 0 ]] ; then
   echo "ExportFailed: Failed to copy output image to GCS [Privacy-> ${GS_PATH}, error: $(<gsutil_err.txt) <-Privacy]"
   exit
 fi
+cat gsutil_err.txt
 
 echo "export success"
 sync

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -87,11 +87,11 @@ echo "GCEExport: $(serialOutputKeyValuePair "target-size-gb" "${TARGET_SIZE_GB}"
 set -x
 
 echo "GCEExport: Copying output image to target GCS path..."
-if ! out=$(gsutil -o GSUtil:parallel_composite_upload_threshold=150M cp "/gs/${IMAGE_OUTPUT_PATH}" "${GS_PATH}" 2>&1); then
-  echo "ExportFailed: Failed to copy output image to GCS [Privacy-> ${GS_PATH}, error: ${out} <-Privacy]"
+gsutil -o GSUtil:parallel_composite_upload_threshold=150M cp "/gs/${IMAGE_OUTPUT_PATH}" "${GS_PATH}" 2>gsutil_err.txt
+if [[ $? -ne 0 ]] ; then
+  echo "ExportFailed: Failed to copy output image to GCS [Privacy-> ${GS_PATH}, error: $(<gsutil_err.txt) <-Privacy]"
   exit
 fi
-echo ${out}
 
 echo "export success"
 sync


### PR DESCRIPTION
out=$(blabla) works in most of the cases, and it also worked for gsutil before. However, starting from 1 week ago, it's not working anymore. The reason is that "2>&1" caused gsutil blocked. Maybe the new version of gsutil have something to do with the stderr/stdout pipe.

So we use a gsutil_err.txt to hold the stderr output instead.