### PR TITLE
An image import suite focused on translation logic.

### DIFF
--- a/cli_tools_e2e_test/common/logging/logging.go
+++ b/cli_tools_e2e_test/common/logging/logging.go
@@ -1,0 +1,69 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package logging
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+// AsDaisyLogger returns a daisy.Logger that writes to a log.Logger.
+func AsDaisyLogger(logger *log.Logger) daisy.Logger {
+	return goLogToDaisyLog{logger: logger}
+}
+
+// AsWriter returns an io.Writer that writes to a log.Logger.
+func AsWriter(logger *log.Logger) io.Writer {
+	return goLogToIoWriter{logger: logger}
+}
+
+// goLogToDaisyLog is an implementation of daisy.Logger that writes to a log.Logger backend.
+type goLogToDaisyLog struct {
+	logger *log.Logger
+}
+
+func (l goLogToDaisyLog) WriteLogEntry(e *daisy.LogEntry) {
+	l.logger.Printf(e.Message)
+}
+
+func (l goLogToDaisyLog) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {
+	// no-op
+}
+
+func (l goLogToDaisyLog) ReadSerialPortLogs() []string {
+	// no-op
+	return nil
+}
+
+func (l goLogToDaisyLog) Flush() {
+	// no-op
+}
+
+// goLogToDaisyLog is an implementation of io.Writer that writes to a log.Logger backend.
+type goLogToIoWriter struct {
+	logger *log.Logger
+}
+
+func (l goLogToIoWriter) Write(p []byte) (n int, err error) {
+	scanner := bufio.NewScanner(bytes.NewReader(p))
+	for scanner.Scan() {
+		l.logger.Println(scanner.Text())
+	}
+	return len(p), nil
+}

--- a/cli_tools_e2e_test/common/logging/logging.go
+++ b/cli_tools_e2e_test/common/logging/logging.go
@@ -55,7 +55,7 @@ func (l goLogToDaisyLog) Flush() {
 	// no-op
 }
 
-// goLogToDaisyLog is an implementation of io.Writer that writes to a log.Logger backend.
+// goLogToIoWriter is an implementation of io.Writer that writes to a log.Logger backend.
 type goLogToIoWriter struct {
 	logger *log.Logger
 }

--- a/cli_tools_e2e_test/gce_image_import_export/main.go
+++ b/cli_tools_e2e_test/gce_image_import_export/main.go
@@ -32,10 +32,13 @@ func main() {
 	exportTestSuccess := e2etestutils.RunTestsAndOutput([]func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
 		*regexp.Regexp, *regexp.Regexp, *testconfig.Project){exporttestsuites.TestSuite},
 		"[ImageExportTests]")
-	importTestSuccess := e2etestutils.RunTestsAndOutput([]func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
-		*regexp.Regexp, *regexp.Regexp, *testconfig.Project){importtestsuites.TestSuite},
+	importCLIRegressionSuccess := e2etestutils.RunTestsAndOutput([]func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
+		*regexp.Regexp, *regexp.Regexp, *testconfig.Project){importtestsuites.CLITestSuite},
+		"[CLIRegressionImageImportTests]")
+	imageImportSuccess := e2etestutils.RunTestsAndOutput([]func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger,
+		*regexp.Regexp, *regexp.Regexp, *testconfig.Project){importtestsuites.ImageImportSuite},
 		"[ImageImportTests]")
-	if !exportTestSuccess || !importTestSuccess {
+	if !exportTestSuccess || !importCLIRegressionSuccess || !imageImportSuccess {
 		os.Exit(1)
 	}
 }

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/cli_tests.go
@@ -32,11 +32,11 @@ import (
 )
 
 const (
-	testSuiteName = "ImageImportTests"
+	testSuiteName = "CLI"
 )
 
-// TestSuite is image import test suite.
-func TestSuite(
+// CLITestSuite ensures that gcloud and the wrapper have consistent behavior for image imports.
+func CLITestSuite(
 	ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junitxml.TestSuite,
 	logger *log.Logger, testSuiteRegex, testCaseRegex *regexp.Regexp,
 	testProjectConfig *testconfig.Project) {
@@ -52,17 +52,17 @@ func TestSuite(
 
 	for _, testType := range testTypes {
 		imageImportDataDiskTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageImport] %v", testType, "Import data disk"))
+			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import data disk"))
 		imageImportOSTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageImport] %v", testType, "Import OS"))
+			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import OS"))
 		imageImportOSFromImageTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageImport] %v", testType, "Import OS from image"))
+			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import OS from image"))
 		imageImportWithRichParamsTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageImport] %v", testType, "Import with rich params"))
+			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with rich params"))
 		imageImportWithDifferentNetworkParamStylesTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageImport] %v", testType, "Import with different network param styles"))
+			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with different network param styles"))
 		imageImportWithSubnetWithoutNetworkSpecifiedTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageImport] %v", testType, "Import with subnet but without network"))
+			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with subnet but without network"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, utils.CLITestType){}

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
@@ -1,0 +1,192 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importtestsuites
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/junitxml"
+	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/test_config"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools_e2e_test/common/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools_e2e_test/common/utils"
+)
+
+const (
+	suite = "ImageImport"
+)
+
+type testCase struct {
+	caseName string
+
+	// Specify either image for file.
+	source string
+
+	// This is passed directly to the `--os` flag of gce_vm_image_import.
+	os string
+
+	// When empty, the test is expected to pass. When non-empty, the
+	// actual error message must contain this for the test to pass.
+	expectedError string
+}
+
+var cases = []testCase{
+	{
+		caseName: "debian-9",
+		source:   "projects/compute-image-tools-test/global/images/debian-9-translate",
+		os:       "debian-9",
+	}, {
+		caseName:      "incorrect OS specified",
+		source:        "projects/compute-image-tools-test/global/images/debian-9-translate",
+		os:            "opensuse-15",
+		expectedError: "\"debian-9\" was detected on your disk, but \"opensuse-15\" was specified",
+	},
+}
+
+func (t testCase) run(ctx context.Context, junit *junitxml.TestCase, logger *log.Logger,
+	testProjectConfig *testconfig.Project, testType utils.CLITestType) {
+	logger = t.createTestScopedLogger(junit, logger)
+	imageName := "e2e-test-image-import" + path.RandString(5)
+	imagePath := fmt.Sprintf("projects/%s/global/images/%s", testProjectConfig.TestProjectID, imageName)
+
+	importLogs, err := t.runImport(junit, logger, testProjectConfig, imageName)
+
+	if t.expectedError != "" {
+		t.verifyExpectedError(junit, err, importLogs)
+	} else if err != nil {
+		t.writeImportFailed(junit, importLogs)
+	} else {
+		err = t.runPostTranslateTest(ctx, imagePath, testProjectConfig, logger)
+		if err != nil {
+			junit.WriteFailure("Failed post translate test: %v", err)
+		}
+	}
+}
+
+// createTestScopedLogger returns a new logger that is prefixed with the name of the test.
+func (t testCase) createTestScopedLogger(junit *junitxml.TestCase, logger *log.Logger) *log.Logger {
+	return log.New(logger.Writer(), junit.Name+" ", logger.Flags())
+}
+
+// runImport runs an image import workflow, and returns its console output and error.
+func (t testCase) runImport(junit *junitxml.TestCase, logger *log.Logger,
+	testProjectConfig *testconfig.Project, imageName string) (*bytes.Buffer, error) {
+	args := []string{
+		"-client_id", "e2e",
+		"-os", t.os,
+		"-project", testProjectConfig.TestProjectID,
+		"-zone", testProjectConfig.TestZone,
+		"-image_name", imageName,
+	}
+	if strings.Contains(t.source, "gs://") {
+		args = append(args, "-source_file", t.source)
+	} else {
+		args = append(args, "-source_image", t.source)
+	}
+	cmd := exec.Command("./gce_vm_image_import", args...)
+	cmdOutput := &bytes.Buffer{}
+	cmd.Stdout = io.MultiWriter(cmdOutput, logging.AsWriter(logger))
+	cmd.Stderr = io.MultiWriter(cmdOutput, logging.AsWriter(logger))
+	err := cmd.Start()
+	if err != nil {
+		return cmdOutput, err
+	}
+	return cmdOutput, cmd.Wait()
+}
+
+func (t testCase) writeImportFailed(junit *junitxml.TestCase, importLog *bytes.Buffer) {
+	// The Logf messages are shown in the test framework UI.
+	junit.Logf(importLog.String())
+	junit.WriteFailure("Import failed: %q", getLastLine(importLog))
+}
+
+func (t testCase) verifyExpectedError(junit *junitxml.TestCase, actualErr error, importLog *bytes.Buffer) {
+	if actualErr == nil {
+		junit.WriteFailure("Expected failed import: %q.", t.expectedError)
+		return
+	}
+
+	lastLine := getLastLine(importLog)
+	if !strings.Contains(lastLine, t.expectedError) {
+		junit.WriteFailure("Message shown to user %q did not contain %q.",
+			lastLine, t.expectedError)
+	}
+}
+
+// runPostTranslateTest boots the instance and executes a startup script containing tests.
+func (t testCase) runPostTranslateTest(ctx context.Context, imagePath string,
+	testProjectConfig *testconfig.Project, logger *log.Logger) error {
+	wf, err := daisy.NewFromFile("post_translate_test.wf.json")
+	if err != nil {
+		return err
+	}
+	wf.Vars = map[string]daisy.Var{
+		"image_under_test": {
+			Value: imagePath,
+		},
+	}
+	wf.Logger = logging.AsDaisyLogger(logger)
+	wf.Project = testProjectConfig.TestProjectID
+	wf.Zone = testProjectConfig.TestZone
+	err = wf.Run(ctx)
+	return err
+}
+
+// ImageImportSuite performs image imports, and verifies that the results are bootable and are
+// are able to perform basic GCP operations. The suite includes support for negative test cases,
+// where error messages are validated against expected error messages.
+func ImageImportSuite(
+	ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junitxml.TestSuite,
+	logger *log.Logger, testSuiteRegex, testCaseRegex *regexp.Regexp,
+	testProjectConfig *testconfig.Project) {
+
+	junits := map[*junitxml.TestCase]func(
+		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, utils.CLITestType){}
+
+	for _, testCase := range cases {
+		junit := junitxml.NewTestCase(
+			suite, fmt.Sprintf("[%v]", testCase.caseName))
+		junits[junit] = testCase.run
+	}
+
+	testsMap := map[utils.CLITestType]map[*junitxml.TestCase]func(
+		context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, utils.CLITestType){
+		utils.Wrapper: junits,
+	}
+
+	utils.CLITestSuite(ctx, tswg, testSuites, logger, testSuiteRegex, testCaseRegex,
+		testProjectConfig, suite, testsMap)
+}
+
+// getLastLine consumes a buffer, and returns its last line.
+func getLastLine(buffer *bytes.Buffer) string {
+	var lastLine string
+	scanner := bufio.NewScanner(buffer)
+	for scanner.Scan() {
+		lastLine = scanner.Text()
+	}
+	return lastLine
+}

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.sh
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.sh
@@ -1,1 +1,0 @@
-../../../../daisy_integration_tests/scripts/post_translate_test.sh

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.sh
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.sh
@@ -1,0 +1,1 @@
+../../../../daisy_integration_tests/scripts/post_translate_test.sh

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.wf.json
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.wf.json
@@ -1,0 +1,64 @@
+{
+  "Name": "post-translate-test",
+  "Sources": {
+    "post_translate_test.sh": "post_translate_test.sh"
+  },
+  "Vars": {
+    "image_under_test": {
+      "Description": "The ID of this test run.",
+      "Required": true
+    }
+  },
+  "Steps": {
+    "create-instance": {
+      "CreateInstances": [
+        {
+          "disks": [
+            {
+              "initializeParams": {
+                "sourceImage": "${image_under_test}"
+              }
+            }
+          ],
+          "machineType": "n1-standard-4",
+          "name": "inst-import-test",
+          "StartupScript": "post_translate_test.sh"
+        }
+      ]
+    },
+    "wait-for-instance": {
+      "Timeout": "30m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-import-test",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "PASSED:",
+            "FailureMatch": "FAILED:",
+            "StatusMatch": "STATUS:"
+          }
+        }
+      ]
+    },
+    "cleanup": {
+      "DeleteResources": {
+        "Images": [
+          "${image_under_test}"
+        ],
+        "DeleteResources": {
+          "Instances": [
+            "inst-import-test"
+          ]
+        }
+      }
+    }
+  },
+  "Dependencies": {
+    "wait-for-instance": [
+      "create-instance"
+    ],
+    "cleanup": [
+      "wait-for-instance"
+    ]
+  }
+}

--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -35,4 +35,6 @@ COPY --from=0 /gce_image_import_export_test_runner gce_image_import_export_test_
 COPY --from=0 /gce_vm_image_import gce_vm_image_import
 COPY --from=0 /gce_vm_image_export gce_vm_image_export
 COPY /daisy_workflows/ /daisy_workflows/
+COPY /daisy_integration_tests/scripts/post_translate_test.sh .
+COPY /cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.wf.json .
 ENTRYPOINT ["./wrapper", "./gce_image_import_export_test_runner"]


### PR DESCRIPTION
Historically, the majority of import tests are run as daisy integration tests, and therefore bypass the wrapper logic. This change adds a suite to the cli_tools_e2e_test framework that focuses on import logic. The existing e2e suite is recharacterized as "CLI tests", since it focuses on the API contracts of the CLI tools.

Key features, compared to existing solutions for image import tests:
1. Support for negative tests, which verify the output of error messages
1. Efficient test representation (compared to an entire JSON document)

To keep the PR simple, I added two tests to illustrate how the system works. I'll do a subsequent PR that migrates the existing integ tests in `daisy_integration_tests` to here.

Lastly, this adds some utilities to convert between daisy logs, standard library logs, and io.Writers.
