### PR TITLE
[export] adjust 'echo' sequence

### DIFF
--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -92,7 +92,6 @@ if [[ $? -ne 0 ]] ; then
   echo "ExportFailed: Failed to copy output image to GCS [Privacy-> ${GS_PATH}, error: $(<gsutil_err.txt) <-Privacy]"
   exit
 fi
-cat gsutil_err.txt
-
 echo "export success"
+cat gsutil_err.txt
 sync


### PR DESCRIPTION
The ImageExport for large image is still blocked. Even we 'cat' the output with some special chars, it still stuck.
Move the 'cat' to be after the 'export success' so the "waitForInstanceSignal" can recognize the export has finished.
Manually test 3 time and they passed.