### PR TITLE
Install OS config agent during import.

### DIFF
--- a/daisy_integration_tests/2008r2_vmware_translate.wf.json
+++ b/daisy_integration_tests/2008r2_vmware_translate.wf.json
@@ -39,6 +39,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.ps1"
         }

--- a/daisy_integration_tests/debian_8_translate.wf.json
+++ b/daisy_integration_tests/debian_8_translate.wf.json
@@ -37,6 +37,9 @@
               "source": "disk-import-test"
             }
           ],
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "machineType": "n1-standard-4",
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.sh"

--- a/daisy_integration_tests/opensuse_15_1.wf.json
+++ b/daisy_integration_tests/opensuse_15_1.wf.json
@@ -35,6 +35,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/scripts/post_translate_test.ps1
+++ b/daisy_integration_tests/scripts/post_translate_test.ps1
@@ -56,6 +56,16 @@ function Get-MetadataValue {
   }
 }
 
+function Check-OSConfigAgent {
+  # To disable checking for the OS config agent, add an instance metadata
+  # value of osconfig_not_supported: true.
+  $osconfig_not_supported = Get-MetadataValue -key 'osconfig_not_supported' -default 'false'
+  if ($osconfig_not_supported.ToLower() -ne 'true') {
+    Write-Output 'Test: OS Config agent'
+    Get-Service google_osconfig_agent
+  }
+}
+
 function Check-Activation {
   # Force activation as this is on a timer.
   & cscript c:\windows\system32\slmgr.vbs /ato

--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -50,7 +50,8 @@ function wait_for_connectivity {
   exit 1
 }
 
-# Assert that a service is running; supports upstart and systemd.
+# Assert that a service is running; first trying `initctl`,
+# then trying `service`.
 function assert_running {
   local service="${1}"
   status "Checking $service"
@@ -209,10 +210,10 @@ function check_package_install {
 wait_for_connectivity
 
 # Run tests.
-check_package_install
 check_google_services
 check_google_cloud_sdk
 check_cloud_init
+check_package_install
 check_metadata_connectivity
 check_internet_connectivity
 

--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -15,6 +15,19 @@
 
 # Basic image tests to validate if Linux image translation was successful.
 
+
+# To disable checking for the OS config agent, add an instance metadata
+# value of osconfig_not_supported: true.
+url=http://metadata.google.internal/computeMetadata/v1/instance/attributes/osconfig_not_supported
+if command -v curl; then
+  OSCONFIG_NOT_SUPPORTED="$(curl --header "Metadata-Flavor: Google" $url)"
+elif command -v wget; then
+  OSCONFIG_NOT_SUPPORTED="$(wget --header "Metadata-Flavor: Google" -O - $url)"
+else
+  echo "TestFailed: Either curl or wget is required to run test suite."
+  exit 1
+fi
+
 FAIL=0
 FAILURES=""
 
@@ -35,6 +48,21 @@ function wait_for_connectivity {
 
   echo "FAILED: Unable to initialize network connection."
   exit 1
+}
+
+# Assert that a service is running; supports upstart and systemd.
+function assert_running {
+  local service="${1}"
+  status "Checking $service"
+  if command -v initctl; then
+    if ! initctl status "$service"; then
+      fail "$service not running."
+    fi
+  else
+    if ! service "$service" status; then
+      fail "$service not running."
+    fi
+  fi
 }
 
 function status {
@@ -71,58 +99,20 @@ function check_internet_connectivity {
 # Check Google services.
 function check_google_services {
   if [[ -f /usr/bin/google_guest_agent ]]; then
-    status "Checking google-guest-agent"
+    # Services expected when using the new guest environment (NGE).
+    assert_running google-guest-agent
+  else
+     # Services expected when using the legacy guest environment.
+    assert_running google-accounts-daemon
+    assert_running google-network-daemon
+    assert_running google-clock-skew-daemon
+  fi
 
-    # Upstart
-    if [[ -d /etc/init ]]; then
-      if initctl status google-guest-agent | grep -qv 'running'; then
-        fail "Google guest agent not running."
-      fi
-    else
-      service google-guest-agent status
-      if [[ $? -ne 0 ]]; then
-        fail "Google guest agent not running."
-      fi
-    fi
-
+  if [[ $OSCONFIG_NOT_SUPPORTED =~ "true" ]]; then
+    status "Skipping check for google-osconfig-agent, since it's not supported for this distro."
     return 0
   fi
-
-  # Upstart
-  if [[ -d /etc/init ]]; then
-    status "Checking google-accounts-daemon."
-    if initctl status google-accounts-daemon | grep -qv 'running'; then
-      fail "Google accounts daemon not running."
-    fi
-
-    status "Checking google-network-daemon."
-    if initctl status google-network-daemon | grep -qv 'running'; then
-      fail "Google Network daemon not running."
-    fi
-
-    status "Checking google-clock-skew-daemon."
-    if initctl status google-clock-skew-daemon | grep -qv 'running'; then
-      fail "Google Clock Skew daemon not running."
-    fi
-  else
-    status "Checking google-accounts-daemon."
-    service google-accounts-daemon status
-    if [[ $? -ne 0 ]]; then
-      fail "Google accounts daemon not running."
-    fi
-
-    status "Checking google-network-daemon."
-    service google-network-daemon status
-    if [[ $? -ne 0 ]]; then
-      fail "Google Network daemon not running."
-    fi
-
-    status "Checking google-clock-skew-daemon."
-    service google-clock-skew-daemon status
-    if [[ $? -ne 0 ]]; then
-      fail "Google Clock Skew daemon not running."
-    fi
-  fi
+  assert_running google-osconfig-agent
 }
 
 # Check Google Cloud SDK.
@@ -219,10 +209,10 @@ function check_package_install {
 wait_for_connectivity
 
 # Run tests.
+check_package_install
 check_google_services
 check_google_cloud_sdk
 check_cloud_init
-check_package_install
 check_metadata_connectivity
 check_internet_connectivity
 

--- a/daisy_integration_tests/sles_12_4_byol.wf.json
+++ b/daisy_integration_tests/sles_12_4_byol.wf.json
@@ -38,6 +38,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/sles_12_5_byol.wf.json
+++ b/daisy_integration_tests/sles_12_5_byol.wf.json
@@ -35,6 +35,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/sles_15_1_byol.wf.json
+++ b/daisy_integration_tests/sles_15_1_byol.wf.json
@@ -35,6 +35,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/sles_sap_12_4_byol.wf.json
+++ b/daisy_integration_tests/sles_sap_12_4_byol.wf.json
@@ -38,6 +38,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1404_img_translate.wf.json
+++ b/daisy_integration_tests/ubuntu_1404_img_translate.wf.json
@@ -38,6 +38,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1604_vmware_translate.wf.json
+++ b/daisy_integration_tests/ubuntu_1604_vmware_translate.wf.json
@@ -38,6 +38,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1804_aws.wf.json
+++ b/daisy_integration_tests/ubuntu_1804_aws.wf.json
@@ -34,6 +34,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1804_azure.wf.json
+++ b/daisy_integration_tests/ubuntu_1804_azure.wf.json
@@ -34,6 +34,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image-instance",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1804_vmware.wf.json
+++ b/daisy_integration_tests/ubuntu_1804_vmware.wf.json
@@ -34,6 +34,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image-instance",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/windows_10_x86_byol.wf.json
+++ b/daisy_integration_tests/windows_10_x86_byol.wf.json
@@ -40,7 +40,8 @@
           ],
           "machineType": "n1-standard-4",
           "Metadata": {
-              "byol": "true"
+            "byol": "true",
+            "osconfig_not_supported": "true"
           },
           "name": "test",
           "StartupScript": "post_translate_test.ps1"

--- a/daisy_integration_tests/windows_7_x86_byol.wf.json
+++ b/daisy_integration_tests/windows_7_x86_byol.wf.json
@@ -40,7 +40,8 @@
           ],
           "machineType": "n1-standard-4",
           "Metadata": {
-              "byol": "true"
+            "byol": "true",
+            "osconfig_not_supported": "true"
           },
           "name": "test",
           "StartupScript": "post_translate_test.ps1"

--- a/daisy_integration_tests/windows_8_x86_byol.wf.json
+++ b/daisy_integration_tests/windows_8_x86_byol.wf.json
@@ -40,7 +40,8 @@
           ],
           "machineType": "n1-standard-4",
           "Metadata": {
-              "byol": "true"
+            "byol": "true",
+            "osconfig_not_supported": "true"
           },
           "name": "test",
           "StartupScript": "post_translate_test.ps1"

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -70,12 +70,15 @@ def DistroSpecific(g):
     pkgs = ['google-cloud-packages-archive-keyring', 'google-compute-engine']
     # Debian 8 differences:
     #   1. No NGE
-    #   2. No Cloud SDK, since it requires Python 3.5+
+    #   2. No Cloud SDK, since it requires Python 3.5+.
+    #   3. No OS config agent.
     if deb_release == 'jessie':
+      # Debian 8 doesn't support the new guest agent, so we need to install
+      # the legacy Python version.
       pkgs += ['python-google-compute-engine',
                'python3-google-compute-engine']
     else:
-      pkgs += ['google-cloud-sdk']
+      pkgs += ['google-cloud-sdk', 'google-osconfig-agent']
     utils.install_apt_packages(g, *pkgs)
 
   # Update grub config to log to console.

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -77,6 +77,8 @@ def DistroSpecific(g):
       # the legacy Python version.
       pkgs += ['python-google-compute-engine',
                'python3-google-compute-engine']
+      logging.info('Skipping installation of OS Config agent. '
+                   'Requires Debian 9 or newer.')
     else:
       pkgs += ['google-cloud-sdk', 'google-osconfig-agent']
     utils.install_apt_packages(g, *pkgs)

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -152,7 +152,7 @@ def DistroSpecific(g):
       g.write_append(
           '/etc/yum.repos.d/google-cloud.repo', repo_sdk % el_release)
       yum_install(g, 'google-cloud-sdk')
-    yum_install(g, 'google-compute-engine')
+    yum_install(g, 'google-compute-engine', 'google-osconfig-agent')
 
   logging.info('Updating initramfs')
   for kver in g.ls('/lib/modules'):
@@ -193,7 +193,7 @@ def yum_install(g, *packages):
 
   Args:
     g (guestfs.GuestFS): A mounted GuestFS instance.
-    *packages (list of str): The YUM packages to be installed.
+    *packages: The YUM packages to be installed.
 
   Raises:
       RuntimeError: If there is a failure during installation.

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -193,7 +193,7 @@ def yum_install(g, *packages):
 
   Args:
     g (guestfs.GuestFS): A mounted GuestFS instance.
-    *packages: The YUM packages to be installed.
+    *packages (list of str): The YUM packages to be installed.
 
   Raises:
       RuntimeError: If there is a failure during installation.

--- a/daisy_workflows/image_import/suse/translate.py
+++ b/daisy_workflows/image_import/suse/translate.py
@@ -23,7 +23,6 @@ Parameters (retrieved from instance metadata):
 import json
 import logging
 import re
-from textwrap import dedent
 
 import utils
 import utils.diskutils as diskutils
@@ -67,8 +66,7 @@ class _SuseRelease:
 
 _packages = [
     _Package('google-compute-engine-init', gce=True),
-    _Package('google-compute-engine-oslogin', gce=True),
-    _Package('google-osconfig-agent', gce=True)
+    _Package('google-compute-engine-oslogin', gce=True)
 ]
 
 _distros = [
@@ -173,31 +171,6 @@ def _disambiguate_suseconnect_product_error(g, product, error) -> Exception:
     'Unable to find an active SLES subscription. SCC returned: %s' % statuses)
 
 
-def _install_gce_repos(distro, g, include_gce_packages):
-  """Add Zypper repositories that are required for installing GCE packages."""
-  if not include_gce_packages:
-    return
-  # Installing OS Config agent via instructions:
-  #    https://cloud.google.com/compute/docs/manage-os
-  repo = """
-    # Enabled for GCE OS config agent
-    [google-compute-engine]
-    name=Google Compute Engine
-    baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-sles{major}-stable
-    enabled=1
-    gpgcheck=1
-    repo_gpgcheck=1
-    gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-           https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-    """.format(major=distro.major)
-  g.write('/etc/zypp/repos.d/google-compute-engine.repo', dedent(repo))
-  g.command([
-    "rpm",
-    "--import", "https://packages.cloud.google.com/yum/doc/yum-key.gpg",
-    "--import", "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
-  ])
-
-
 @utils.RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def _install_product(distro, g):
   """Executes SuseConnect -p for each product on `distro`.
@@ -244,7 +217,7 @@ def install_packages(g, *pkgs):
 @utils.RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def refresh_zypper(g):
   try:
-    g.command(['zypper', '--non-interactive', 'refresh'])
+    g.command(['zypper', 'refresh'])
   except Exception as e:
     raise ValueError('Failed to call zypper refresh', e)
 
@@ -285,7 +258,6 @@ def translate():
   distro = _get_distro(g)
 
   _install_product(distro, g)
-  _install_gce_repos(distro, g, include_gce_packages)
   _install_packages(g, include_gce_packages)
   _install_virtio_drivers(g)
   if include_gce_packages:

--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -154,7 +154,7 @@ def DistroSpecific(g):
         'and ensure that the following command executes successfully: '
         'apt-get install -y --no-install-recommends cloud-init '
         '&& cloud-init -d init')
-    install_gce_packages(g, ubuntu_release)
+    install_gce_packages(g)
 
   # Update grub config to log to console.
   g.command(
@@ -169,36 +169,13 @@ def add_gce_repositories(g, ubuntu_release):
   g.write(
     '/etc/apt/sources.list.d/partner.list',
     partner_repo.format(ubuntu_release=ubuntu_release))
-  if ubuntu_release in ['xenial', 'bionic']:
-    # The OS config agent is currently supported for Ubuntu 16.04 and 18.04.
-    # For adding 20.04, see b/161470431.
-    utils.update_apt(g)
-    utils.install_apt_packages(g, 'gnupg', 'wget')
-    g.command(
-      ['wget', 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
-       '-O', '/tmp/gce_key'])
-    g.command(['apt-key', 'add', '/tmp/gce_key'])
-    g.rm('/tmp/gce_key')
-    # OS Config agent is only supported for xenial and bionic.
-    # Installing via instructions:
-    #    https://cloud.google.com/compute/docs/manage-os
-    g.write('/etc/apt/sources.list.d/google-compute-engine.list',
-            os_config_repo.format(ubuntu_release=ubuntu_release))
 
 
-def install_gce_packages(g, ubuntu_release):
+def install_gce_packages(g):
   logging.info('Installing GCE packages.')
   utils.update_apt(g)
-  pkgs = ['gce-compute-image-packages', 'google-cloud-sdk']
-  if ubuntu_release in ['xenial', 'bionic']:
-    # OS Config agent is only supported for xenial and bionic.
-    # Installing via instructions:
-    #    https://cloud.google.com/compute/docs/manage-os
-    pkgs.append('google-osconfig-agent')
-  else:
-    logging.info('Skipping installation of OS Config agent. '
-                 'Requires Ubuntu 16.04 or newer.')
-  utils.install_apt_packages(g, *pkgs)
+  utils.install_apt_packages(g, 'gce-compute-image-packages',
+                             'google-cloud-sdk')
 
 
 def remove_azure_agents(g):

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -240,6 +240,11 @@ function Install-Packages {
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-balloon -ErrorAction SilentlyContinue
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-pvpanic -ErrorAction SilentlyContinue
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-vss -ErrorAction SilentlyContinue
+    if (([System.Environment]::OSVersion.Version) -ge 6.2) {
+      Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-osconfig-agent
+    } else {
+      Write-Output 'Skipping installation of OS Config agent. Requires 2012 or newer.'
+    }
   }
 }
 

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -243,7 +243,7 @@ function Install-Packages {
     if (([System.Environment]::OSVersion.Version) -ge 6.2) {
       Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-osconfig-agent
     } else {
-      Write-Output 'Skipping installation of OS Config agent. Requires 2012 or newer.'
+      Write-Output 'Skipping installation of OS Config agent. Requires Windows 2012 or newer.'
     }
   }
 }


### PR DESCRIPTION
This PR includes the [OS Config agent](https://cloud.google.com/compute/docs/manage-os) for imported images, instances, and machine images. To disable installation of the agent, users can specify the existing  `no-guest-environment` flag.


## What distros and versions are supported? 
All distro versions [supported by the OS Config agent](https://cloud.google.com/compute/docs/manage-os) will now include the OS config agent, if the agent is vended in GCE's official images. Specifically:
* Windows:
   * ISA: 64-bit only
   * Versions: All versions *after* Windows 2008r2
* Debian:
  * 9 (10 is not currently supported by image import)
* EL:
  * All importable versions

Ubuntu, SLES, and OpenSUSE will be added once the OS config agent is adopted by their upstream maintainers.

## Tests

The e2e tests are updated to verify the agent using the [suggested steps on their docs page](https://cloud.google.com/compute/docs/manage-os#check-install). For distro versions unsupported by the OS config agent (eg: Ubuntu 14.04), the e2e tests include an opt-out mechanism. Using an opt-out mechanism ensures that the test runs against newly-added distro versions in the future.

## FAQ

### How to disable installation of the OS config agent?

Specify the `no-guest-environment` flag during import. Depending on the import tool, the syntax of the flag may differ slightly.

### How do I use the OS config feature?

OS config requires that projects / instances are opted-in. If opt-in hasn't occurred, the agent runs idly, which is the same behavior as the [public images](https://cloud.google.com/compute/docs/images#os-compute-support) provided by Google. For more information, see https://cloud.google.com/compute/docs/manage-os .
