### PR TITLE
Pass inflation disk sizes during OVF data disk import.

### DIFF
--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	createInstanceStepName = "create-instance"
-	importerDiskSize       = "10"
+	gceMinimumDiskSizeGB   = "10"
 )
 
 // AddDiskImportSteps adds Daisy steps to OVF import workflow to import disks
@@ -54,7 +54,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 					Type:        "pd-ssd",
 				},
-				SizeGb:               importerDiskSize,
+				SizeGb:               gceMinimumDiskSizeGB,
 				FallbackToPdStandard: true,
 			},
 			{
@@ -62,7 +62,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Name: diskNames[i],
 					Type: "pd-ssd",
 				},
-				SizeGb:               "10",
+				SizeGb:               gceMinimumDiskSizeGB,
 				FallbackToPdStandard: true,
 				Resource: daisy.Resource{
 					ExactName: true,
@@ -74,7 +74,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 					Name: scratchDiskDiskName,
 					Type: "pd-ssd",
 				},
-				SizeGb:               "10",
+				SizeGb:               gceMinimumDiskSizeGB,
 				FallbackToPdStandard: true,
 				Resource: daisy.Resource{
 					ExactName: true,
@@ -87,6 +87,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 		createDiskImporterInstanceStep := daisy.NewStepDefaultTimeout(createDiskImporterInstanceStepName, w)
 
 		sTrue := "true"
+		diskSizeGB := gceMinimumDiskSizeGB
 		dataDiskImporterInstanceName := fmt.Sprintf("data-disk-importer-%v", dataDiskIndex)
 		createDiskImporterInstanceStep.CreateInstances = &daisy.CreateInstances{
 			Instances: []*daisy.Instance{{
@@ -103,6 +104,8 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 							{Key: "disk_name", Value: &diskNames[i]},
 							{Key: "scratch_disk_name", Value: &scratchDiskDiskName},
 							{Key: "source_disk_file", Value: &dataDiskFilePath},
+							{Key: "scratch_disk_size_gb", Value: &diskSizeGB},
+							{Key: "inflated_disk_size_gb", Value: &diskSizeGB},
 						},
 					},
 					NetworkInterfaces: []*compute.NetworkInterface{

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -41,6 +41,11 @@ SOURCE_SIZE_BYTES="$(gsutil du "${SOURCE_URL}" | grep -o '^[0-9]\+')"
 SOURCE_SIZE_GB=$(awk "BEGIN {print int(((${SOURCE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
 IMAGE_PATH="/daisy-scratch/$(basename "${SOURCE_URL}")"
 
+# Validate input
+
+[[ -z "$SCRATCH_DISK_SIZE_GB" ]] && echo "ImportFailed: metadata scratch_disk_size_gb is unset" && exit 1
+[[ -z "$INFLATED_DISK_SIZE_GB" ]] && echo "ImportFailed: metadata inflated_disk_size_gb is unset" && exit 1
+
 # Print info.
 echo "#################" 2> /dev/null
 echo "# Configuration #" 2> /dev/null
@@ -64,6 +69,7 @@ function resizeDisk() {
   echo "Import: Resizing ${diskId} to ${requiredSizeInGb}GB in ${zone}."
   if ! out=$(gcloud -q compute disks resize "${diskId}" --size="${requiredSizeInGb}"GB --zone="${zone}" 2>&1 | tr "\n\r" " "); then
     if echo "$out" | grep -qP "compute\.disks\.resize"; then
+      echo $out
       echo "ImportFailed: Failed to resize disk. The Compute Engine default service account needs the role: roles/compute.storageAdmin"
     else
       echo "ImportFailed: Failed to resize disk. [Privacy-> resize disk ${diskId} to ${requiredSizeInGb}GB in ${zone}, error: ${out} <-Privacy]"

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -43,8 +43,8 @@ IMAGE_PATH="/daisy-scratch/$(basename "${SOURCE_URL}")"
 
 # Validate input
 
-[[ -z "$SCRATCH_DISK_SIZE_GB" ]] && echo "ImportFailed: metadata scratch_disk_size_gb is unset" && exit 1
-[[ -z "$INFLATED_DISK_SIZE_GB" ]] && echo "ImportFailed: metadata inflated_disk_size_gb is unset" && exit 1
+[[ -z "$SCRATCH_DISK_SIZE_GB" ]] && echo "ImportFailed: metadata scratch_disk_size_gb is not set" && exit 1
+[[ -z "$INFLATED_DISK_SIZE_GB" ]] && echo "ImportFailed: metadata inflated_disk_size_gb is not set" && exit 1
 
 # Print info.
 echo "#################" 2> /dev/null


### PR DESCRIPTION
#1283 caused a regression for OVF imports that contain multiple disks. When performing a multi-disk import, a user would see: "ImportFailed: Failed to resize disk. The Compute Engine default service account needs the role: roles/compute.storageAdmin"

This PR fixes the regression by:
1. Update import_image.sh to validate its required parameters.
2. Update OVF import to include the sizes of the disks that its passing to import_image.sh.