### PR TITLE
Increase timeout for el_import_dont_use_proxy.wf.json

### DIFF
--- a/daisy_integration_tests/el_import_dont_use_proxy.wf.json
+++ b/daisy_integration_tests/el_import_dont_use_proxy.wf.json
@@ -54,7 +54,7 @@
       }
     },
     "translate-disk": {
-      "Timeout": "30m",
+      "Timeout": "60m",
       "IncludeWorkflow": {
         "Path": "../daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json",
         "Vars": {


### PR DESCRIPTION
This change increases the timeout of el_import_dont_use_proxy.wf.json from 30 minutes to 60 minutes, since we've been seeing intermittent timeouts recently.