### PR TITLE
Load disk inspection workflow relative to daisy_workflows directory.

### DIFF
--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -16,13 +16,14 @@ package disk
 
 import (
 	"context"
+	"path"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
 const (
-	workflowFile = "daisy_workflows/image_import/inspection/inspect-disk.wf.json"
+	workflowFile = "image_import/inspection/inspect-disk.wf.json"
 )
 
 // Inspector finds partition and boot-related properties for a disk.
@@ -38,7 +39,7 @@ type InspectionResult struct {
 
 // NewInspector creates an Inspector that can inspect GCP disks.
 func NewInspector(wfAttributes daisycommon.WorkflowAttributes) (Inspector, error) {
-	wf, err := daisy.NewFromFile(workflowFile)
+	wf, err := daisy.NewFromFile(path.Join(wfAttributes.WorkflowDirectory, workflowFile))
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/daisycommon/daisy_utils.go
+++ b/cli_tools/daisycommon/daisy_utils.go
@@ -52,8 +52,8 @@ Loop:
 
 // WorkflowAttributes holds common attributes that are required to instantiate a daisy workflow.
 type WorkflowAttributes struct {
-	Project, Zone, GCSPath, OAuth, Timeout, ComputeEndpoint           string
-	DisableGCSLogs, DisableCloudLogs, DisableStdoutLogs, NoExternalIP bool
+	Project, Zone, GCSPath, OAuth, Timeout, ComputeEndpoint, WorkflowDirectory string
+	DisableGCSLogs, DisableCloudLogs, DisableStdoutLogs, NoExternalIP          bool
 }
 
 // SetWorkflowAttributes sets workflow running attributes.

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -36,7 +36,7 @@ const (
 	dataDiskFlag       = "data_disk"
 	osFlag             = "os"
 	customWorkflowFlag = "custom_translate_workflow"
-	workflowDir        = "daisy_workflows/image_import/"
+	workflowDir        = "daisy_workflows"
 )
 
 // ImportArguments holds the structured results of parsing CLI arguments,
@@ -281,5 +281,6 @@ func (args ImportArguments) DaisyAttrs() daisycommon.WorkflowAttributes {
 		DisableCloudLogs:  args.CloudLogsDisabled,
 		DisableStdoutLogs: args.StdoutLogsDisabled,
 		NoExternalIP:      args.NoExternalIP,
+		WorkflowDirectory: args.WorkflowDir,
 	}
 }

--- a/cli_tools/gce_vm_image_import/importer/args_test.go
+++ b/cli_tools/gce_vm_image_import/importer/args_test.go
@@ -68,7 +68,7 @@ func TestTrimAndLowerStorageLocation(t *testing.T) {
 }
 
 func TestPopulateWorkflowDir(t *testing.T) {
-	assert.Regexp(t, ".*/daisy_workflows/image_import", expectSuccessfulParse(t).WorkflowDir)
+	assert.Regexp(t, ".*/daisy_workflows", expectSuccessfulParse(t).WorkflowDir)
 }
 
 func TestFailWhenClientIdMissing(t *testing.T) {

--- a/cli_tools/gce_vm_image_import/importer/bootable_disk_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/bootable_disk_processor.go
@@ -67,7 +67,7 @@ func newBootableDiskProcessor(args ImportArguments, pd persistentDisk) (processo
 		translateWorkflowPath = args.CustomWorkflow
 	} else {
 		relPath := daisy_utils.GetTranslateWorkflowPath(args.OS)
-		translateWorkflowPath = path.Join(args.WorkflowDir, relPath)
+		translateWorkflowPath = path.Join(args.WorkflowDir, "image_import", relPath)
 	}
 
 	vars := map[string]string{

--- a/cli_tools/gce_vm_image_import/importer/bootable_disk_processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/bootable_disk_processor_test.go
@@ -155,7 +155,7 @@ func TestImage_StorageLocation_NotSet(t *testing.T) {
 func TestSerials_ReadsFromDaisyLogger(t *testing.T) {
 	expected := []string{"serials"}
 	args := defaultImportArgs()
-	args.WorkflowDir = "testdata/image_import"
+	args.WorkflowDir = "testdata"
 	translator, e := newBootableDiskProcessor(args, persistentDisk{})
 	realTranslator := translator.(*bootableDiskProcessor)
 	realTranslator.workflow.Logger = daisyLogger{
@@ -167,7 +167,7 @@ func TestSerials_ReadsFromDaisyLogger(t *testing.T) {
 
 func TestBootableDiskProcessorCancel(t *testing.T) {
 	args := defaultImportArgs()
-	args.WorkflowDir = "testdata/image_import"
+	args.WorkflowDir = "testdata"
 	processor, e := newBootableDiskProcessor(args, persistentDisk{})
 	assert.NoError(t, e)
 
@@ -178,7 +178,7 @@ func TestBootableDiskProcessorCancel(t *testing.T) {
 }
 
 func createAndRunPrePostFunctions(t *testing.T, pd persistentDisk, args ImportArguments) *bootableDiskProcessor {
-	args.WorkflowDir = "testdata/image_import"
+	args.WorkflowDir = "testdata"
 	translator, e := newBootableDiskProcessor(args, pd)
 	assert.NoError(t, e)
 	realTranslator := translator.(*bootableDiskProcessor)

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	inflateFilePath  = "inflate_file.wf.json"
-	inflateImagePath = "inflate_image.wf.json"
+	inflateFilePath  = "image_import/inflate_file.wf.json"
+	inflateImagePath = "image_import/inflate_image.wf.json"
 
 	// When exceeded, we use default values for PDs, rather than more accurate
 	// values used by inspection. When using default values, the worker may

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -205,7 +205,7 @@ func TestCreateDaisyInflater_File_NotWindows(t *testing.T) {
 
 func createDaisyInflaterSafe(t *testing.T, args ImportArguments,
 	inspector imagefile.Inspector) *daisyInflater {
-	args.WorkflowDir = "testdata/image_import"
+	args.WorkflowDir = "testdata"
 	inflater, err := createDaisyInflater(args, inspector)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)


### PR DESCRIPTION
The `gcr.io/compute-image-tools/gce_vm_image_import:latest` docker image was at runtime with an error of:

```
[import-image]: 2020-07-20T19:15:30.92Z open daisy_workflows/image_import/inspection/inspect-disk.wf.json: no such file or directory
```

This occurred since loading of `daisy_workflows/image_import/inspection/inspect-disk.wf.json` assumed that the directory `daisy_workflows` was available in the process's working directory. This isn't true for the  `gcr.io/compute-image-tools/gce_vm_image_import:latest`  image. It has a directory layout of:

```
/gce_vm_image_import
/daisy_workflows
/workspace
...
```

When Cloud Build invokes `gce_vm_image_import`, it sets the working directory to  `/workspace`, and the daisy_workflows directory is not a child of the current working directory. [1]

1. https://cloud.google.com/cloud-build/docs/build-config