### PR TITLE
Ensure gce_vm_image_import.Dockerfile has CA certs.

### DIFF
--- a/gce_vm_image_import.Dockerfile
+++ b/gce_vm_image_import.Dockerfile
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 FROM debian:stretch
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg ca-certificates
 RUN echo "deb http://packages.cloud.google.com/apt gcsfuse-stretch main" > /etc/apt/sources.list.d/gcsfuse.list
 # gcsfuse, installed using instructions from:
 #  https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/installing.md

--- a/gce_vm_image_import.Dockerfile
+++ b/gce_vm_image_import.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch
+FROM marketplace.gcr.io/google/debian9
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg ca-certificates
 RUN echo "deb http://packages.cloud.google.com/apt gcsfuse-stretch main" > /etc/apt/sources.list.d/gcsfuse.list
 # gcsfuse, installed using instructions from:


### PR DESCRIPTION
Prior to this change, executing `gce_vm_image_import` would yield errors such as:

```
[import-image]: 2020-07-20T21:41:30.558Z failed to read GCS file when validating resource file: unable to open file from bucket "edens-images", file "win2008r2-all-updates-disk1.vmdk": Get "https://storage.googleapis.com/edens-images/win2008r2-all-updates-disk1.vmdk": x509: certificate signed by unknown authority
```

## Testing:

1. Built gce_vm_image_import.Dockerfile: `docker build -f gce_vm_image_import.Dockerfile . -t gcr.io/edens-test/dir`
2. Pushed image: `gcr.io/edens-test/dir`
3. Ran a cloud build invocation using:

```
timeout: 7200s
tags: gce-daisy
steps:
  - name: gcr.io/edens-test/dir:latest
    args:
      - -project=edens-test
      - -client_id=api
      - -image_name=certs
      - -source_image=projects/compute-image-tools-test/global/images/ubuntu-1404-img-import
      - --data_disk
    env:
      - BUILD_ID=$BUILD_ID
```
