### PR TITLE
Don't install Cloud SDK when importing Debian 8.

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -135,7 +135,7 @@ function check_google_cloud_sdk {
     fi
   fi
 
-    # Skip for Debian 8: b/161567418
+    # Skip for Debian 8, (Cloud SDK requires Python 3.5+)
   if [ -f /etc/os-release ]; then
     grep -qi "jessie" /etc/os-release
     if [ $? -eq 0 ]; then

--- a/daisy_integration_tests/scripts/post_translate_test.sh
+++ b/daisy_integration_tests/scripts/post_translate_test.sh
@@ -135,6 +135,14 @@ function check_google_cloud_sdk {
     fi
   fi
 
+    # Skip for Debian 8: b/161567418
+  if [ -f /etc/os-release ]; then
+    grep -qi "jessie" /etc/os-release
+    if [ $? -eq 0 ]; then
+      return
+    fi
+  fi
+
   # Skip for SUSE (gcloud and gsutil aren't in all of their repos)
   if [ -f /etc/os-release ]; then
     grep -qi "suse" /etc/os-release

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -70,7 +70,7 @@ def DistroSpecific(g):
     pkgs = ['google-cloud-packages-archive-keyring', 'google-compute-engine']
     # Debian 8 differences:
     #   1. No NGE
-    #   2. No Cloud SDK b/161567418
+    #   2. No Cloud SDK, since it requires Python 3.5+
     if deb_release == 'jessie':
       pkgs += ['python-google-compute-engine',
                'python3-google-compute-engine']

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -67,13 +67,15 @@ def DistroSpecific(g):
       logging.warn('Could not uninstall Azure agent. Continuing anyway.')
 
     utils.update_apt(g)
-    pkgs = ['google-cloud-packages-archive-keyring', 'google-cloud-sdk',
-            'google-compute-engine']
-    # Debian 8 doesn't support the new guest agent, so we need to install
-    # the legacy Python version.
+    pkgs = ['google-cloud-packages-archive-keyring', 'google-compute-engine']
+    # Debian 8 differences:
+    #   1. No NGE
+    #   2. No Cloud SDK b/161567418
     if deb_release == 'jessie':
       pkgs += ['python-google-compute-engine',
                'python3-google-compute-engine']
+    else:
+      pkgs += ['google-cloud-sdk']
     utils.install_apt_packages(g, *pkgs)
 
   # Update grub config to log to console.


### PR DESCRIPTION
The Cloud SDK is currently broken for Debian 8 imports; the SDK dropped support for Python 3.4, which is Debian 8's version.

This change skips installing the Cloud SDK for Debian 8, and skips testing for it.

## Testing

Ran the following:
1. daisy -project edens-test -zone=us-central1-b daisy_integration_tests/debian_8_translate.wf.json
2. daisy -project edens-test -zone=us-central1-b daisy_integration_tests/debian_9_translate.wf.json