### PR TITLE
Ensure that gcloud shows image import translation logs.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/bootable_disk_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/bootable_disk_processor.go
@@ -89,6 +89,10 @@ func newBootableDiskProcessor(args ImportArguments, pd persistentDisk) (processo
 		return nil, err
 	}
 
+	// Temporary fix to ensure gcloud shows daisy's output.
+	// A less fragile approach is tracked in b/161567644.
+	workflow.Name = LogPrefix
+
 	return &bootableDiskProcessor{
 		workflow:        workflow,
 		userLabels:      args.Labels,

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -30,6 +30,11 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
 )
 
+// LogPrefix is a string that conforms to gcloud's output filter.
+// To ensure that a line is shown by gcloud, emit a line to stdout
+// using this string surrounded in brackets.
+const LogPrefix = "import-image"
+
 // Importer runs the end-to-end import workflow, and exposes the results
 // via an error and Loggable.
 type Importer interface {

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -117,6 +117,9 @@ func createDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector
 		addFeatureToDisk(wf, "WINDOWS", inflationDiskIndex)
 	}
 
+	// Temporary fix to ensure gcloud shows daisy's output.
+	// A less fragile approach is tracked in b/161567644.
+	wf.Name = LogPrefix
 	return &daisyInflater{
 		wf:              wf,
 		inflatedDiskURI: fmt.Sprintf("zones/%s/disks/%s", args.Zone, diskName),

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -27,6 +27,15 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
 )
 
+// gcloud expects log lines to start with the substring "[import". Daisy
+// constructs the log prefix using the workflow's name.
+func TestCreateDaisyInflater_SetsWorkflowNameToGcloudPrefix(t *testing.T) {
+	inflater := createDaisyInflaterForImageSafe(t, ImportArguments{
+		Source: imageSource{uri: "projects/test/uri/image"},
+	})
+	assert.Equal(t, inflater.wf.Name, "import-image")
+}
+
 func TestCreateDaisyInflater_Image_HappyCase(t *testing.T) {
 	inflater := createDaisyInflaterForImageSafe(t, ImportArguments{
 		Source:      imageSource{uri: "projects/test/uri/image"},

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -88,7 +88,8 @@ func main() {
 type logWriter struct{}
 
 func (l *logWriter) Write(bytes []byte) (int, error) {
-	return fmt.Printf("[import-image]: %v %v", time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), string(bytes))
+	return fmt.Printf("[%s]: %v %v", importer.LogPrefix,
+		time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), string(bytes))
 }
 
 // terminate is used when there is a failure prior to running import. It sends


### PR DESCRIPTION
Since #1227, we've been using modularized daisy workflows in image import. A side effect is that gcloud isn't showing all of the log lines to users. This was caused by:

1. gcloud is configured to show lines that start with `[image` (or one of  a few other prefixes)
2. daisy emits log lines using the workflow's name as a prefix
3. Some of the modularized workflow names don't start with `image`.

This PR is a quick fix that dynamically renames the workflows to have a name that matches the prefix. I have b/161567644 to track a longer-term fix where gcloud output isn't coupled to workflow names.

# Example invocation

```
./main -image_name img -os debian-8 -client_id  edens-test -source_image projects/compute-image-tools-test/global/images/debian-8-translate -project=edens-test
```
## Current output:

```
[import-from-image]: 2020-07-17T15:41:03-07:00 Validating workflow
[import-from-image]: 2020-07-17T15:41:03-07:00 Validating step "create-disk"
[import-from-image]: 2020-07-17T15:41:04-07:00 Validation Complete
[import-from-image]: 2020-07-17T15:41:04-07:00 Workflow Project: edens-test
[import-from-image]: 2020-07-17T15:41:04-07:00 Workflow Zone: us-central1-c
[import-from-image]: 2020-07-17T15:41:04-07:00 Workflow GCSPath: gs://edens-test-daisy-bkt-us/
[import-from-image]: 2020-07-17T15:41:04-07:00 Daisy scratch path: https://console.cloud.google.com/storage/browser/edens-test-daisy-bkt-us/daisy-import-from-image-20200717-22:41:03-mj2w0
[import-from-image]: 2020-07-17T15:41:04-07:00 Uploading sources
[import-from-image]: 2020-07-17T15:41:04-07:00 Running workflow
[import-from-image]: 2020-07-17T15:41:04-07:00 Running step "create-disk" (CreateDisks)
[import-from-image.create-disk]: 2020-07-17T15:41:04-07:00 CreateDisks: Creating disk "disk-t1v4x".
[import-from-image]: 2020-07-17T15:41:36-07:00 Step "create-disk" (CreateDisks) successfully finished.
[import-from-image]: 2020-07-17T15:41:36-07:00 Workflow "import-from-image" cleaning up (this may take up to 2 minutes).
[import-from-image]: 2020-07-17T15:41:37-07:00 Workflow "import-from-image" finished cleanup.
[import-image]: 2020-07-17T22:41:37.216Z Running experimental disk inspections on zones/us-central1-c/disks/disk-t1v4x.
[translate-debian-8]: 2020-07-17T15:42:17-07:00 Validating workflow
[translate-debian-8]: 2020-07-17T15:42:17-07:00 Validating step "translate-disk"
[translate-debian-8.translate-disk]: 2020-07-17T15:42:17-07:00 Validating step "setup-disk"
[translate-debian-8.translate-disk]: 2020-07-17T15:42:18-07:00 Validating step "translate-disk-inst"
[translate-debian-8.translate-disk]: 2020-07-17T15:42:18-07:00 Validating step "wait-for-translator"
[translate-debian-8.translate-disk]: 2020-07-17T15:42:18-07:00 Validating step "delete-instance"
[translate-debian-8]: 2020-07-17T15:42:18-07:00 Validating step "create-image"
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Validation Complete
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Cloud Build ID: 
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Workflow Project: edens-test
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Workflow Zone: us-central1-c
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Workflow GCSPath: gs://edens-test-daisy-bkt-us/
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Daisy scratch path: https://console.cloud.google.com/storage/browser/edens-test-daisy-bkt-us/daisy-translate-debian-8-20200717-22:42:17-69sh9
[translate-debian-8]: 2020-07-17T15:42:19-07:00 Uploading sources
[translate-debian-8]: 2020-07-17T15:42:20-07:00 Running workflow
```

## After PR:

```
./main -image_name img -os debian-8 -client_id  edens-test -source_image projects/compute-image-tools-test/global/images/debian-8-translate -project=edens-test[import-image]: 2020-07-21T18:54:02-07:00 Validating workflow
[import-image]: 2020-07-21T18:54:02-07:00 Validating step "create-disk"
[import-image]: 2020-07-21T18:54:03-07:00 Validation Complete
[import-image]: 2020-07-21T18:54:03-07:00 Workflow Project: edens-test
[import-image]: 2020-07-21T18:54:03-07:00 Workflow Zone: us-central1-c
[import-image]: 2020-07-21T18:54:03-07:00 Workflow GCSPath: gs://edens-test-daisy-bkt-us/
[import-image]: 2020-07-21T18:54:03-07:00 Daisy scratch path: https://console.cloud.google.com/storage/browser/edens-test-daisy-bkt-us/daisy-import-image-20200722-01:54:02-sd6yh
[import-image]: 2020-07-21T18:54:03-07:00 Uploading sources
[import-image]: 2020-07-21T18:54:03-07:00 Running workflow
[import-image]: 2020-07-21T18:54:03-07:00 Running step "create-disk" (CreateDisks)
[import-image.create-disk]: 2020-07-21T18:54:03-07:00 CreateDisks: Creating disk "disk-ld7l2".
[import-image]: 2020-07-21T18:54:05-07:00 Step "create-disk" (CreateDisks) successfully finished.
[import-image]: 2020-07-21T18:54:05-07:00 Workflow "import-image" cleaning up (this may take up to 2 minutes).
[import-image]: 2020-07-21T18:54:05-07:00 Workflow "import-image" finished cleanup.
[import-image]: 2020-07-21T18:54:06-07:00 Validating workflow
[import-image]: 2020-07-21T18:54:06-07:00 Validating step "translate-disk"
[import-image.translate-disk]: 2020-07-21T18:54:06-07:00 Validating step "setup-disk"
[import-image.translate-disk]: 2020-07-21T18:54:07-07:00 Validating step "translate-disk-inst"
[import-image.translate-disk]: 2020-07-21T18:54:07-07:00 Validating step "wait-for-translator"
[import-image.translate-disk]: 2020-07-21T18:54:07-07:00 Validating step "delete-instance"
[import-image]: 2020-07-21T18:54:07-07:00 Validating step "create-image"
[import-image]: 2020-07-21T18:54:08-07:00 Validation Complete
[import-image]: 2020-07-21T18:54:08-07:00 Cloud Build ID: 
[import-image]: 2020-07-21T18:54:08-07:00 Workflow Project: edens-test
[import-image]: 2020-07-21T18:54:08-07:00 Workflow Zone: us-central1-c
[import-image]: 2020-07-21T18:54:08-07:00 Workflow GCSPath: gs://edens-test-daisy-bkt-us/
[import-image]: 2020-07-21T18:54:08-07:00 Daisy scratch path: https://console.cloud.google.com/storage/browser/edens-test-daisy-bkt-us/daisy-import-image-20200722-01:54:06-0g8d4
[import-image]: 2020-07-21T18:54:08-07:00 Uploading sources
[import-image]: 2020-07-21T18:54:09-07:00 Running workflow
[import-image]: 2020-07-21T18:54:09-07:00 Running step "translate-disk" (IncludeWorkflow)
[import-image.translate-disk]: 2020-07-21T18:54:09-07:00 Running step "setup-disk" (CreateDisks)
[import-image.translate-disk.setup-disk]: 2020-07-21T18:54:09-07:00 CreateDisks: Creating disk "disk-translator-import-image-translate-disk-0g8d4".
[import-image.translate-disk]: 2020-07-21T18:54:11-07:00 Step "setup-disk" (CreateDisks) successfully finished.
[import-image.translate-disk]: 2020-07-21T18:54:11-07:00 Running step "translate-disk-inst" (CreateInstances)
[import-image.translate-disk.translate-disk-inst]: 2020-07-21T18:54:11-07:00 CreateInstances: Creating instance "inst-translator-import-image-translate-disk-0g8d4".
[import-image.translate-disk]: 2020-07-21T18:54:18-07:00 Step "translate-disk-inst" (CreateInstances) successfully finished.
[import-image.translate-disk.translate-disk-inst]: 2020-07-21T18:54:18-07:00 CreateInstances: Streaming instance "inst-translator-import-image-translate-disk-0g8d4" serial port 1 output to https://storage.cloud.google.com/edens-test-daisy-bkt-us/daisy-import-image-20200722-01:54:06-0g8d4/logs/inst-translator-import-image-translate-disk-0g8d4-serial-port1.log
[import-image.translate-disk]: 2020-07-21T18:54:18-07:00 Running step "wait-for-translator" (WaitForInstancesSignal)
[import-image.translate-disk.wait-for-translator]: 2020-07-21T18:54:18-07:00 WaitForInstancesSignal: Instance "inst-translator-import-image-translate-disk-0g8d4": watching serial port 1, SuccessMatch: "TranslateSuccess:", FailureMatch: ["TranslateFailed:"] (this is not an error), StatusMatch: "TranslateStatus:".
```