### PR TITLE
Switch to gcr.io endpoint that doesn't require auth.

### DIFF
--- a/gce_vm_image_import.Dockerfile
+++ b/gce_vm_image_import.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM marketplace.gcr.io/google/debian9
+FROM launcher.gcr.io/google/debian9
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg ca-certificates
 RUN echo "deb http://packages.cloud.google.com/apt gcsfuse-stretch main" > /etc/apt/sources.list.d/gcsfuse.list
 # gcsfuse, installed using instructions from:


### PR DESCRIPTION
Our build is currently failing with 

```ERRO[0000] Error while retrieving image from cache: marketplace.gcr.io/google/debian9 GET https://marketplace.gcr.io/v2/google/debian9/manifests/latest: UNAUTHORIZED: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication ```

Based on https://github.com/GoogleContainerTools/kaniko/issues/659, one solution is to switch to an endpoint that doesn't require authentication. This endpoint that I'm using comes from the docs for managed images: https://github.com/GoogleContainerTools/base-images-docker/tree/master/debian


## Testing:
I reproduced the issue locally by [invoking kaniko directly](https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-docker). After switching to the new endpoint, the image was able to build.