### PR TITLE
Switch OVF import tests to a 12hrs schedule

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -164,7 +164,7 @@ periodics:
       secret:
        secretName: compute-image-tools-test-service-account
  - name: ci-ovf-import-e2e-tests-daily
-   interval: 24h
+   interval: 12h
    agent: kubernetes
    spec:
      containers:


### PR DESCRIPTION
Switch OVF import tests to a 12hrs schedule as the 24hrs schedule is often delaying releases and not providing timely failure notifications. Decided to keep the name as is, even though it's a bit misleading as I don't find it worth the effort of renaming and potentially causing issues.