### PR TITLE
OVF import: use OS ID from OVF descriptor in addition to OS Type

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -433,7 +433,7 @@ func (oi *OVFImporter) setUpImportWorkflow() (*daisy.Workflow, error) {
 			return nil, err
 		}
 		oi.Logger.Log(
-			fmt.Sprintf("Found valid osType in OVF descriptor, importing VM with `%v` as OS.",
+			fmt.Sprintf("Found valid OS info in OVF descriptor, importing VM with `%v` as OS.",
 				osIDValue))
 	} else if err = daisyutils.ValidateOS(oi.params.OsID); err != nil {
 		return nil, err

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -377,14 +377,14 @@ func GetOVFDescriptorAndDiskPaths(ovfDescriptorLoader domain.OvfDescriptorLoader
 func GetOSId(ovfDescriptor *ovf.Envelope) (string, error) {
 
 	if ovfDescriptor.VirtualSystem == nil {
-		return "", daisy.Errf("VirtualSystem must be defined to retrieve OS info")
+		return "", daisy.Errf("OVF descriptor error: VirtualSystem must be defined to retrieve OS info. Use --os flag to specify OS")
 	}
 	if ovfDescriptor.VirtualSystem.OperatingSystem == nil ||
 		len(ovfDescriptor.VirtualSystem.OperatingSystem) == 0 {
-		return "", daisy.Errf("OperatingSystemSection must be defined to retrieve OS info")
+		return "", daisy.Errf("OVF descriptor error: OperatingSystemSection must be defined to retrieve OS info. Use --os flag to specify OS")
 	}
 	if ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType == nil && ovfDescriptor.VirtualSystem.OperatingSystem[0].ID == 0 {
-		return "", daisy.Errf("OperatingSystemSection.OSType or OperatingSystemSection.ID in OVF descriptor must be defined to retrieve OS info")
+		return "", daisy.Errf("OVF descriptor error: OperatingSystemSection.OSType or OperatingSystemSection.ID must be defined to retrieve OS info. Use --os flag to specify OS")
 	}
 
 	var osInfoFromOSType, osInfoFromOSID *osInfo

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -35,42 +35,169 @@ const (
 	usbController          uint16 = 23
 )
 
-//Full list: https://vdc-download.vmware.com/vmwb-repository/dcr-public/da47f910-60ac-438b-8b9b-6122f4d14524/16b7274a-bf8b-4b4c-a05e-746f2aa93c8c/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
-
-// Mapping OVF osType attribute to importer OS ID
-var ovfOSTypeToOSID = map[string]string{
-	"debian8Guest":          "debian-8",
-	"debian8_64Guest":       "debian-8",
-	"debian9Guest":          "debian-9",
-	"debian9_64Guest":       "debian-9",
-	"centos6Guest":          "centos-6",
-	"centos6_64Guest":       "centos-6",
-	"centos7Guest":          "centos-7",
-	"centos7_64Guest":       "centos-7",
-	"centos8Guest":          "centos-8",
-	"centos8_64Guest":       "centos-8",
-	"rhel6Guest":            "rhel-6",
-	"rhel6_64Guest":         "rhel-6",
-	"rhel7Guest":            "rhel-7",
-	"rhel7_64Guest":         "rhel-7",
-	"windows7Server64Guest": "windows-2008r2",
+type osInfo struct {
+	description      string
+	importerOSIDs    []string
+	nonDeterministic bool
 }
 
-// Mapping potentially supported OVF osType values to possible importer OS ID values
+func (oi *osInfo) isDeterministic() bool {
+	return len(oi.importerOSIDs) == 1 && !oi.nonDeterministic
+}
+
+func (oi *osInfo) hasImporterOSIDs() bool {
+	return len(oi.importerOSIDs) > 0
+}
+
+//Mapping OVF OS ID to OS info
+//Full list: http://schemas.dmtf.org/wbem/cim-html/2/CIM_OperatingSystem.html
+var ovfOSIDToImporterOSID = map[int16]osInfo{
+	1:   {description: "Other", importerOSIDs: []string{}},
+	2:   {description: "MACOS", importerOSIDs: []string{}},
+	3:   {description: "ATTUNIX", importerOSIDs: []string{}},
+	4:   {description: "DGUX", importerOSIDs: []string{}},
+	5:   {description: "DECNT", importerOSIDs: []string{}},
+	6:   {description: "Tru64 UNIX", importerOSIDs: []string{}},
+	7:   {description: "OpenVMS", importerOSIDs: []string{}},
+	8:   {description: "HPUX", importerOSIDs: []string{}},
+	9:   {description: "AIX", importerOSIDs: []string{}},
+	10:  {description: "MVS", importerOSIDs: []string{}},
+	11:  {description: "OS400", importerOSIDs: []string{}},
+	12:  {description: "OS/2", importerOSIDs: []string{}},
+	13:  {description: "JavaVM", importerOSIDs: []string{}},
+	14:  {description: "MSDOS", importerOSIDs: []string{}},
+	15:  {description: "WIN3x", importerOSIDs: []string{}},
+	16:  {description: "WIN95", importerOSIDs: []string{}},
+	17:  {description: "WIN98", importerOSIDs: []string{}},
+	18:  {description: "WINNT", importerOSIDs: []string{}},
+	19:  {description: "WINCE", importerOSIDs: []string{}},
+	20:  {description: "NCR3000", importerOSIDs: []string{}},
+	21:  {description: "NetWare", importerOSIDs: []string{}},
+	22:  {description: "OSF", importerOSIDs: []string{}},
+	23:  {description: "DC/OS", importerOSIDs: []string{}},
+	24:  {description: "Reliant UNIX", importerOSIDs: []string{}},
+	25:  {description: "SCO UnixWare", importerOSIDs: []string{}},
+	26:  {description: "SCO OpenServer", importerOSIDs: []string{}},
+	27:  {description: "Sequent", importerOSIDs: []string{}},
+	28:  {description: "IRIX", importerOSIDs: []string{}},
+	29:  {description: "Solaris", importerOSIDs: []string{}},
+	30:  {description: "SunOS", importerOSIDs: []string{}},
+	31:  {description: "U6000", importerOSIDs: []string{}},
+	32:  {description: "ASERIES", importerOSIDs: []string{}},
+	33:  {description: "HP NonStop OS", importerOSIDs: []string{}},
+	34:  {description: "HP NonStop OSS", importerOSIDs: []string{}},
+	35:  {description: "BS2000", importerOSIDs: []string{}},
+	36:  {description: "LINUX", importerOSIDs: []string{}},
+	37:  {description: "Lynx", importerOSIDs: []string{}},
+	38:  {description: "XENIX", importerOSIDs: []string{}},
+	39:  {description: "VM", importerOSIDs: []string{}},
+	40:  {description: "Interactive UNIX", importerOSIDs: []string{}},
+	41:  {description: "BSDUNIX", importerOSIDs: []string{}},
+	42:  {description: "FreeBSD", importerOSIDs: []string{}},
+	43:  {description: "NetBSD", importerOSIDs: []string{}},
+	44:  {description: "GNU Hurd", importerOSIDs: []string{}},
+	45:  {description: "OS9", importerOSIDs: []string{}},
+	46:  {description: "MACH Kernel", importerOSIDs: []string{}},
+	47:  {description: "Inferno", importerOSIDs: []string{}},
+	48:  {description: "QNX", importerOSIDs: []string{}},
+	49:  {description: "EPOC", importerOSIDs: []string{}},
+	50:  {description: "IxWorks", importerOSIDs: []string{}},
+	51:  {description: "VxWorks", importerOSIDs: []string{}},
+	52:  {description: "MiNT", importerOSIDs: []string{}},
+	53:  {description: "BeOS", importerOSIDs: []string{}},
+	54:  {description: "HP MPE", importerOSIDs: []string{}},
+	55:  {description: "NextStep", importerOSIDs: []string{}},
+	56:  {description: "PalmPilot", importerOSIDs: []string{}},
+	57:  {description: "Rhapsody", importerOSIDs: []string{}},
+	58:  {description: "Windows 2000", importerOSIDs: []string{}},
+	59:  {description: "Dedicated", importerOSIDs: []string{}},
+	60:  {description: "OS/390", importerOSIDs: []string{}},
+	61:  {description: "VSE", importerOSIDs: []string{}},
+	62:  {description: "TPF", importerOSIDs: []string{}},
+	63:  {description: "Windows (R) Me", importerOSIDs: []string{}},
+	64:  {description: "Caldera Open UNIX", importerOSIDs: []string{}},
+	65:  {description: "OpenBSD", importerOSIDs: []string{}},
+	66:  {description: "Not Applicable", importerOSIDs: []string{}},
+	67:  {description: "Windows XP", importerOSIDs: []string{}},
+	68:  {description: "z/OS", importerOSIDs: []string{}},
+	69:  {description: "Microsoft Windows Server 2003", importerOSIDs: []string{}},
+	70:  {description: "Microsoft Windows Server 2003 64-Bit", importerOSIDs: []string{}},
+	71:  {description: "Windows XP 64-Bit", importerOSIDs: []string{}},
+	72:  {description: "Windows XP Embedded", importerOSIDs: []string{}},
+	73:  {description: "Windows Vista", importerOSIDs: []string{}},
+	74:  {description: "Windows Vista 64-Bit", importerOSIDs: []string{}},
+	75:  {description: "Windows Embedded for Point of Service", importerOSIDs: []string{}},
+	76:  {description: "Microsoft Windows Server 2008", importerOSIDs: []string{}},
+	77:  {description: "Microsoft Windows Server 2008 64-Bit", importerOSIDs: []string{}},
+	78:  {description: "FreeBSD 64-Bit", importerOSIDs: []string{}},
+	79:  {description: "RedHat Enterprise Linux", importerOSIDs: []string{}},
+	80:  {description: "RedHat Enterprise Linux 64-Bit", importerOSIDs: []string{"rhel-6", "rhel-6-byol", "rhel-7", "rhel-7-byol", "rhel-8", "rhel-8-byol"}},
+	81:  {description: "Solaris 64-Bit", importerOSIDs: []string{}},
+	82:  {description: "SUSE", importerOSIDs: []string{}},
+	83:  {description: "SUSE 64-Bit", importerOSIDs: []string{"opensuse-15"}, nonDeterministic: true},
+	84:  {description: "SLES", importerOSIDs: []string{}},
+	85:  {description: "SLES 64-Bit", importerOSIDs: []string{"sles-12-byol", "sles-15-byol"}},
+	86:  {description: "Novell OES", importerOSIDs: []string{}},
+	87:  {description: "Novell Linux Desktop", importerOSIDs: []string{}},
+	88:  {description: "Sun Java Desktop System", importerOSIDs: []string{}},
+	89:  {description: "Mandriva", importerOSIDs: []string{}},
+	90:  {description: "Mandriva 64-Bit", importerOSIDs: []string{}},
+	91:  {description: "TurboLinux", importerOSIDs: []string{}},
+	92:  {description: "TurboLinux 64-Bit", importerOSIDs: []string{}},
+	93:  {description: "Ubuntu", importerOSIDs: []string{}},
+	94:  {description: "Ubuntu 64-Bit", importerOSIDs: []string{"ubuntu-1404", "ubuntu-1604", "ubuntu-1804"}},
+	95:  {description: "Debian", importerOSIDs: []string{}},
+	96:  {description: "Debian 64-Bit", importerOSIDs: []string{"debian-8", "debian-9"}},
+	97:  {description: "Linux 2.4.x", importerOSIDs: []string{}},
+	98:  {description: "Linux 2.4.x 64-Bit", importerOSIDs: []string{}},
+	99:  {description: "Linux 2.6.x", importerOSIDs: []string{}},
+	100: {description: "Linux 2.6.x 64-Bit", importerOSIDs: []string{}},
+	101: {description: "Linux 64-Bit", importerOSIDs: []string{}},
+	102: {description: "Other 64-Bit", importerOSIDs: []string{}},
+	103: {description: "Microsoft Windows Server 2008 R2", importerOSIDs: []string{"windows-2008r2", "windows-2008r2-byol"}},
+	104: {description: "VMware ESXi", importerOSIDs: []string{}},
+	105: {description: "Microsoft Windows 7", importerOSIDs: []string{"windows-7-x64-byol", "windows-7-x86-byol"}},
+	106: {description: "CentOS 32-bit", importerOSIDs: []string{}},
+	107: {description: "CentOS 64-bit", importerOSIDs: []string{"centos-6", "centos-7", "centos-8"}},
+	108: {description: "Oracle Linux 32-bit", importerOSIDs: []string{}},
+	109: {description: "Oracle Linux 64-bit", importerOSIDs: []string{}},
+	110: {description: "eComStation 32-bitx", importerOSIDs: []string{}},
+	111: {description: "Microsoft Windows Server 2011", importerOSIDs: []string{}},
+	113: {description: "Microsoft Windows Server 2012", importerOSIDs: []string{"windows-2012", "windows-2012-byol"}},
+	114: {description: "Microsoft Windows 8", importerOSIDs: []string{"windows-8-x86-byol"}, nonDeterministic: true},
+	115: {description: "Microsoft Windows 8 64-bit", importerOSIDs: []string{"windows-8-x64-byol"}, nonDeterministic: true},
+	116: {description: "Microsoft Windows Server 2012 R2", importerOSIDs: []string{"windows-2012r2", "windows-2012r2-byol"}},
+	117: {description: "Microsoft Windows Server 2016", importerOSIDs: []string{"windows-2016", "windows-2016-byol"}},
+	118: {description: "Microsoft Windows 8.1", importerOSIDs: []string{}},
+	119: {description: "Microsoft Windows 8.1 64-bit", importerOSIDs: []string{}},
+	120: {description: "Microsoft Windows 10", importerOSIDs: []string{"windows-10-x86-byol"}, nonDeterministic: true},
+	121: {description: "Microsoft Windows 10 64-bit", importerOSIDs: []string{"windows-10-x64-byol"}, nonDeterministic: true},
+	//TODO: windows-2019, windows-2019-byol
+}
+
+//Mapping OVF osType attribute to importer OS ID
+//Some might have multiple importer OS ID  values. In that case, user need to provide a value via --os flag.
 // Some might have only one option but we can't select it automatically as we cannot guarantee
-// correctness. All Windows Client imports will be included here, to check that they
-// expect a Bring Your Own License import.
-var noMappingOSTypes = map[string][]string{
-	"ubuntuGuest":           {"ubuntu-1404"},
-	"ubuntu64Guest":         {"ubuntu-1404", "ubuntu-1604", "ubuntu-1804"},
-	"windows7Guest":         {"windows-7-x86-byol"},
-	"windows7_64Guest":      {"windows-7-x64-byol"},
-	"windows8Guest":         {"windows-8-x86-byol"},
-	"windows8_64Guest":      {"windows-8-x64-byol"},
-	"windows9Guest":         {"windows-10-x86-byol"},
-	"windows9_64Guest":      {"windows-10-x64-byol"},
-	"windows8Server64Guest": {"windows-2012", "windows-2012r2"},
-	"windows9Server64Guest": {"windows-2016", "windows-2019"},
+// correctness. All Windows Client imports are in this category due to the fact we can't assume BYOL licensing.
+//Full list: https://vdc-download.vmware.com/vmwb-repository/dcr-public/da47f910-60ac-438b-8b9b-6122f4d14524/16b7274a-bf8b-4b4c-a05e-746f2aa93c8c/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+var ovfOSTypeToOSID = map[string]osInfo{
+	"debian8_64Guest":       osInfo{importerOSIDs: []string{"debian-8"}},
+	"debian9_64Guest":       osInfo{importerOSIDs: []string{"debian-9"}},
+	"centos6_64Guest":       osInfo{importerOSIDs: []string{"centos-6"}},
+	"centos7_64Guest":       osInfo{importerOSIDs: []string{"centos-7"}},
+	"centos8_64Guest":       osInfo{importerOSIDs: []string{"centos-8"}},
+	"rhel6_64Guest":         osInfo{importerOSIDs: []string{"rhel-6"}},
+	"rhel7_64Guest":         osInfo{importerOSIDs: []string{"rhel-7"}},
+	"windows7Server64Guest": osInfo{importerOSIDs: []string{"windows-2008r2"}},
+	"ubuntu64Guest":         {importerOSIDs: []string{"ubuntu-1404", "ubuntu-1604", "ubuntu-1804"}, nonDeterministic: true},
+	"windows7Guest":         {importerOSIDs: []string{"windows-7-x86-byol"}, nonDeterministic: true},
+	"windows7_64Guest":      {importerOSIDs: []string{"windows-7-x64-byol"}, nonDeterministic: true},
+	"windows8Guest":         {importerOSIDs: []string{"windows-8-x86-byol"}, nonDeterministic: true},
+	"windows8_64Guest":      {importerOSIDs: []string{"windows-8-x64-byol"}, nonDeterministic: true},
+	"windows9Guest":         {importerOSIDs: []string{"windows-10-x86-byol"}, nonDeterministic: true},
+	"windows9_64Guest":      {importerOSIDs: []string{"windows-10-x64-byol"}, nonDeterministic: true},
+	"windows8Server64Guest": {importerOSIDs: []string{"windows-2012", "windows-2012r2", "windows-2012-byol", "windows-2012r2-byol"}},
+	"windows9Server64Guest": {importerOSIDs: []string{"windows-2016", "windows-2016-byol", "windows-2019", "windows-2019-byol"}},
 }
 
 // DiskInfo holds information about virtual disks in an OVF package
@@ -256,25 +383,60 @@ func GetOSId(ovfDescriptor *ovf.Envelope) (string, error) {
 		len(ovfDescriptor.VirtualSystem.OperatingSystem) == 0 {
 		return "", daisy.Errf("OperatingSystemSection must be defined to retrieve OS info")
 	}
-	if ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType == nil {
-		return "", daisy.Errf("OperatingSystemSection.OSType must be defined to retrieve OS info")
-	}
-	var osID string
-	var validOSType bool
-	osType := *ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType
-	if osID, validOSType = ovfOSTypeToOSID[osType]; !validOSType {
-		if osIDCandidates, hasOSIDCandidates := noMappingOSTypes[osType]; hasOSIDCandidates {
-			return "",
-				daisy.Errf(
-					"cannot determine OS from osType attribute value `%v` found in OVF descriptor. Use --os flag to specify OS for this VM. Potential valid values for given osType attribute are: %v",
-					osType,
-					strings.Join(osIDCandidates, ", "),
-				)
-		}
-		return "", daisy.Errf("osType attribute value `%v` found in OVF descriptor cannot be mapped to an OS supported by Google Compute Engine. Use --os flag to specify OS for this VM", osType)
+	if ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType == nil && ovfDescriptor.VirtualSystem.OperatingSystem[0].ID == 0 {
+		return "", daisy.Errf("OperatingSystemSection.OSType or OperatingSystemSection.ID in OVF descriptor must be defined to retrieve OS info")
 	}
 
-	return osID, nil
+	var osInfoFromOSType, osInfoFromOSID *osInfo
+	if ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType != nil && *ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType != "" {
+		if osInfoFromOSTypeValue, ok := ovfOSTypeToOSID[*ovfDescriptor.VirtualSystem.OperatingSystem[0].OSType]; ok {
+			osInfoFromOSType = &osInfoFromOSTypeValue
+		}
+	}
+
+	if ovfDescriptor.VirtualSystem.OperatingSystem[0].ID != 0 {
+		if osInfoFromOSIDValue, ok := ovfOSIDToImporterOSID[ovfDescriptor.VirtualSystem.OperatingSystem[0].ID]; ok {
+			osInfoFromOSID = &osInfoFromOSIDValue
+		}
+	}
+
+	if osInfoFromOSType == nil && osInfoFromOSID == nil {
+		return "", daisy.Errf("cannot determine OS from OVF descriptor. Use --os flag to specify OS")
+	}
+
+	osInfo := getMoreSpecificOSInfo(osInfoFromOSType, osInfoFromOSID)
+
+	if !osInfo.hasImporterOSIDs() {
+		return "", daisy.Errf("operating system `%v` detected but is not supported by Google Compute Engine. Use --os flag to specify OS", osInfo.description)
+	}
+	if osInfo.isDeterministic() {
+		return osInfo.importerOSIDs[0], nil
+	}
+
+	return "",
+		daisy.Errf(
+			"cannot determine OS from OVF descriptor. Use --os flag to specify OS. Potential valid values for given osType attribute are: %v",
+			strings.Join(osInfo.importerOSIDs, ", "),
+		)
+}
+
+func getMoreSpecificOSInfo(osInfo1, osInfo2 *osInfo) *osInfo {
+	if osInfo1 == nil || !osInfo1.hasImporterOSIDs() {
+		return osInfo2
+	}
+	if osInfo2 == nil || !osInfo2.hasImporterOSIDs() {
+		return osInfo1
+	}
+	if osInfo1.isDeterministic() {
+		return osInfo1
+	}
+	if osInfo2.isDeterministic() {
+		return osInfo2
+	}
+	if len(osInfo1.importerOSIDs) < len(osInfo2.importerOSIDs) {
+		return osInfo1
+	}
+	return osInfo2
 }
 
 func getDiskControllersPrioritized(virtualHardware *ovf.VirtualHardwareSection) []ovf.ResourceAllocationSettingData {

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -65,7 +65,6 @@ func (oi *osInfo) hasImporterOSIDs() bool {
 //Mapping OVF OS ID to OS info
 //Full list: http://schemas.dmtf.org/wbem/cim-html/2/CIM_OperatingSystem.html
 var ovfOSIDToImporterOSID = map[int16]osInfo{
-	1:   {description: "Other", importerOSIDs: []string{}},
 	2:   {description: "MACOS", importerOSIDs: []string{}},
 	3:   {description: "ATTUNIX", importerOSIDs: []string{}},
 	4:   {description: "DGUX", importerOSIDs: []string{}},
@@ -166,7 +165,6 @@ var ovfOSIDToImporterOSID = map[int16]osInfo{
 	99:  {description: "Linux 2.6.x", importerOSIDs: []string{}},
 	100: {description: "Linux 2.6.x 64-Bit", importerOSIDs: []string{}},
 	101: {description: "Linux 64-Bit", importerOSIDs: []string{}},
-	102: {description: "Other 64-Bit", importerOSIDs: []string{}},
 	103: {description: "Microsoft Windows Server 2008 R2", importerOSIDs: []string{"windows-2008r2", "windows-2008r2-byol"}},
 	104: {description: "VMware ESXi", importerOSIDs: []string{}},
 	105: {description: "Microsoft Windows 7", importerOSIDs: []string{"windows-7-x64-byol", "windows-7-x86-byol"}},

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -36,15 +36,28 @@ const (
 )
 
 type osInfo struct {
-	description      string
-	importerOSIDs    []string
+	// description holds OS description that can be used for messages shown to users
+	description string
+
+	// importerOSIDs holds a list of OS IDs as expected by the importer (--os flag)
+	importerOSIDs []string
+
+	// nonDeterministic when set to true indicates OVF import can't determine
+	// which OS to use for translate because the mapping is not 1:1 or we don't
+	// want to assume the mapping due to potential legal issues. For example,
+	// windows 7/8/10 (client) images can only be imported as BYOL but we don't
+	// know if BYOL agreement is in place for the customer. In that case, customers
+	// have to explicitly provide --os flag.
 	nonDeterministic bool
 }
 
+// isDeterministic returns true if, based on osInfo, importer OS ID can be determined.
+// if false is returned, the customer needs to provide OS value via the --os flag.
 func (oi *osInfo) isDeterministic() bool {
 	return len(oi.importerOSIDs) == 1 && !oi.nonDeterministic
 }
 
+// hasImporterOSIDs returns true if osInfo has any mappings to importer OS IDs.
 func (oi *osInfo) hasImporterOSIDs() bool {
 	return len(oi.importerOSIDs) > 0
 }

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
@@ -626,17 +626,17 @@ func TestGetOSIdInvalidOSType(t *testing.T) {
 	assert.Equal(t, "", osID)
 	assert.NotNil(t, err)
 	assert.Equal(t,
-		"osType attribute value `not-an-OS` found in OVF descriptor cannot be mapped to an OS supported by Google Compute Engine. Use --os flag to specify OS for this VM",
+		"cannot determine OS from OVF descriptor. Use --os flag to specify OS",
 		err.Error())
 
 }
 
 func TestGetOSIdNonDeterministicSingleOption(t *testing.T) {
-	osID, err := GetOSId(createOVFDescriptorWithOSType("ubuntuGuest"))
+	osID, err := GetOSId(createOVFDescriptorWithOS("windows8_64Guest", 115))
 	assert.Equal(t, "", osID)
 	assert.NotNil(t, err)
 	assert.Equal(t,
-		"cannot determine OS from osType attribute value `ubuntuGuest` found in OVF descriptor. Use --os flag to specify OS for this VM. Potential valid values for given osType attribute are: ubuntu-1404",
+		"cannot determine OS from OVF descriptor. Use --os flag to specify OS. Potential valid values for given osType attribute are: windows-8-x64-byol",
 		err.Error())
 }
 
@@ -645,7 +645,7 @@ func TestGetOSIdNonDeterministicMultiOption(t *testing.T) {
 	assert.Equal(t, "", osID)
 	assert.NotNil(t, err)
 	assert.Equal(t,
-		"cannot determine OS from osType attribute value `windows8Server64Guest` found in OVF descriptor. Use --os flag to specify OS for this VM. Potential valid values for given osType attribute are: windows-2012, windows-2012r2",
+		"cannot determine OS from OVF descriptor. Use --os flag to specify OS. Potential valid values for given osType attribute are: windows-2012, windows-2012r2, windows-2012-byol, windows-2012r2-byol",
 		err.Error())
 }
 
@@ -654,7 +654,31 @@ func TestGetOSIdNilOSIdInDescriptor(t *testing.T) {
 	assert.Equal(t, "", osID)
 	assert.NotNil(t, err)
 	assert.Equal(t,
-		"OperatingSystemSection.OSType must be defined to retrieve OS info",
+		"OperatingSystemSection.OSType or OperatingSystemSection.ID in OVF descriptor must be defined to retrieve OS info",
+		err.Error())
+}
+
+func TestGetOSIdDeterministic(t *testing.T) {
+	osID, err := GetOSId(createOVFDescriptorWithOS("centos6_64Guest", 107))
+	assert.Equal(t, "centos-6", osID)
+	assert.Nil(t, err)
+}
+
+func TestGetOSIdPickMoreSpecificNonDeterministic(t *testing.T) {
+	osID, err := GetOSId(createOVFDescriptorWithOS("windows8Server64Guest", 116))
+	assert.Equal(t, "", osID)
+	assert.NotNil(t, err)
+	assert.Equal(t,
+		"cannot determine OS from OVF descriptor. Use --os flag to specify OS. Potential valid values for given osType attribute are: windows-2012r2, windows-2012r2-byol",
+		err.Error())
+}
+
+func TestGetOSIdNotSupported(t *testing.T) {
+	osID, err := GetOSId(createOVFDescriptorWithOS("MSDOS", 14))
+	assert.Equal(t, "", osID)
+	assert.NotNil(t, err)
+	assert.Equal(t,
+		"operating system `MSDOS` detected but is not supported by Google Compute Engine. Use --os flag to specify OS",
 		err.Error())
 }
 
@@ -668,6 +692,19 @@ func createOVFDescriptorWithOSTypeAsReference(osType *string) *ovf.Envelope {
 			OperatingSystem: []ovf.OperatingSystemSection{
 				{
 					OSType: osType,
+				},
+			},
+		},
+	}
+}
+
+func createOVFDescriptorWithOS(osType string, osID int16) *ovf.Envelope {
+	return &ovf.Envelope{
+		VirtualSystem: &ovf.VirtualSystem{
+			OperatingSystem: []ovf.OperatingSystemSection{
+				{
+					OSType: &osType,
+					ID:     osID,
 				},
 			},
 		},

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils_test.go
@@ -654,7 +654,7 @@ func TestGetOSIdNilOSIdInDescriptor(t *testing.T) {
 	assert.Equal(t, "", osID)
 	assert.NotNil(t, err)
 	assert.Equal(t,
-		"OperatingSystemSection.OSType or OperatingSystemSection.ID in OVF descriptor must be defined to retrieve OS info",
+		"OVF descriptor error: OperatingSystemSection.OSType or OperatingSystemSection.ID must be defined to retrieve OS info. Use --os flag to specify OS",
 		err.Error())
 }
 


### PR DESCRIPTION
OVF import: no OS Type specified in OVF descriptoris currently the highest rate error for instance import.

To solve this, use OS ID from OVF descriptor in addition to OS Type to support a wider range of OVFs that might not have OS Type set (or use OS Type from a different name space, like vbox). 