### PR TITLE
Image import: Include UEFI guest OS feature during inflation, if requested.

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -234,11 +234,14 @@ func createDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector
 		return nil, err
 	}
 
-	daisyUtils.UpdateAllInstanceNoExternalIP(wf, args.NoExternalIP)
 	for k, v := range vars {
 		wf.AddVar(k, v)
 	}
 
+	daisyUtils.UpdateAllInstanceNoExternalIP(wf, args.NoExternalIP)
+	if args.UefiCompatible {
+		addFeatureToDisk(wf, "UEFI_COMPATIBLE", inflationDiskIndex)
+	}
 	if strings.Contains(args.OS, "windows") {
 		addFeatureToDisk(wf, "WINDOWS", inflationDiskIndex)
 	}

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -64,11 +64,35 @@ func TestCreateDaisyInflater_Image_Windows(t *testing.T) {
 func TestCreateDaisyInflater_Image_NotWindows(t *testing.T) {
 	inflater := createDaisyInflaterForImageSafe(t, ImportArguments{
 		Source: imageSource{uri: "image/uri"},
-		OS:     "ubunt-1804",
+		OS:     "ubuntu-1804",
 	})
 
 	assert.NotContains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
 		Type: "WINDOWS",
+	})
+}
+
+func TestCreateDaisyInflater_Image_UEFI(t *testing.T) {
+	inflater := createDaisyInflaterForImageSafe(t, ImportArguments{
+		Source:         imageSource{uri: "image/uri"},
+		OS:             "ubuntu-1804",
+		UefiCompatible: true,
+	})
+
+	assert.Contains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
+		Type: "UEFI_COMPATIBLE",
+	})
+}
+
+func TestCreateDaisyInflater_Image_NotUEFI(t *testing.T) {
+	inflater := createDaisyInflaterForImageSafe(t, ImportArguments{
+		Source:         imageSource{uri: "image/uri"},
+		OS:             "ubuntu-1804",
+		UefiCompatible: false,
+	})
+
+	assert.NotContains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
+		Type: "UEFI_COMPATIBLE",
 	})
 }
 
@@ -209,6 +233,44 @@ func TestCreateDaisyInflater_File_NotWindows(t *testing.T) {
 	inflatedDisk := getDisk(inflater.wf, 1)
 	assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
 		Type: "WINDOWS",
+	})
+}
+
+func TestCreateDaisyInflater_File_UEFI(t *testing.T) {
+	source := fileSource{gcsPath: "gs://bucket/vmdk"}
+	inflater := createDaisyInflaterSafe(t, ImportArguments{
+		Source:         source,
+		OS:             "ubuntu-1804",
+		UefiCompatible: true,
+	}, mockInspector{
+		t:                 t,
+		expectedReference: source.gcsPath,
+		errorToReturn:     nil,
+		metaToReturn:      imagefile.Metadata{},
+	})
+
+	inflatedDisk := getDisk(inflater.wf, 1)
+	assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
+		Type: "UEFI_COMPATIBLE",
+	})
+}
+
+func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
+	source := fileSource{gcsPath: "gs://bucket/vmdk"}
+	inflater := createDaisyInflaterSafe(t, ImportArguments{
+		Source:         source,
+		OS:             "ubuntu-1804",
+		UefiCompatible: false,
+	}, mockInspector{
+		t:                 t,
+		expectedReference: source.gcsPath,
+		errorToReturn:     nil,
+		metaToReturn:      imagefile.Metadata{},
+	})
+
+	inflatedDisk := getDisk(inflater.wf, 1)
+	assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
+		Type: "UEFI_COMPATIBLE",
 	})
 }
 

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
@@ -51,6 +51,9 @@ type testCase struct {
 	// When empty, the test is expected to pass. When non-empty, the
 	// actual error message must contain this for the test to pass.
 	expectedError string
+
+	// Additional args passed to gce_vm_image_import.
+	extraArgs []string
 }
 
 var cases = []testCase{
@@ -63,6 +66,16 @@ var cases = []testCase{
 		source:        "projects/compute-image-tools-test/global/images/debian-9-translate",
 		os:            "opensuse-15",
 		expectedError: "\"debian-9\" was detected on your disk, but \"opensuse-15\" was specified",
+	}, {
+		caseName:  "rhel-7-uefi",
+		source:    "projects/compute-image-tools-test/global/images/linux-uefi-no-guestosfeature-rhel7",
+		os:        "rhel-7",
+		extraArgs: []string{"-uefi_compatible=true"},
+	}, {
+		caseName:  "windows-2019-uefi",
+		source:    "projects/compute-image-tools-test/global/images/windows-2019-uefi-nodrivers",
+		os:        "windows-2019",
+		extraArgs: []string{"-uefi_compatible=true"},
 	},
 }
 
@@ -106,6 +119,9 @@ func (t testCase) runImport(junit *junitxml.TestCase, logger *log.Logger,
 	} else {
 		args = append(args, "-source_image", t.source)
 	}
+	if t.extraArgs != nil {
+		args = append(args, t.extraArgs...)
+	}
 	cmd := exec.Command("./gce_vm_image_import", args...)
 	cmdOutput := &bytes.Buffer{}
 	cmd.Stdout = io.MultiWriter(cmdOutput, logging.AsWriter(logger))
@@ -147,12 +163,22 @@ func (t testCase) runPostTranslateTest(ctx context.Context, imagePath string,
 		"image_under_test": {
 			Value: imagePath,
 		},
+		"post_translate_test": {
+			Value: t.testScript(),
+		},
 	}
 	wf.Logger = logging.AsDaisyLogger(logger)
 	wf.Project = testProjectConfig.TestProjectID
 	wf.Zone = testProjectConfig.TestZone
 	err = wf.Run(ctx)
 	return err
+}
+
+func (t testCase) testScript() string {
+	if strings.Contains(t.os, "windows") {
+		return "post_translate_test.ps1"
+	}
+	return "post_translate_test.sh"
 }
 
 // ImageImportSuite performs image imports, and verifies that the results are bootable and are

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.wf.json
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.wf.json
@@ -1,11 +1,15 @@
 {
   "Name": "post-translate-test",
   "Sources": {
-    "post_translate_test.sh": "post_translate_test.sh"
+    "${post_translate_test}": "${post_translate_test}"
   },
   "Vars": {
     "image_under_test": {
       "Description": "The ID of this test run.",
+      "Required": true
+    },
+    "post_translate_test": {
+      "Description": "Script to run after translation.",
       "Required": true
     }
   },
@@ -22,7 +26,7 @@
           ],
           "machineType": "n1-standard-4",
           "name": "inst-import-test",
-          "StartupScript": "post_translate_test.sh"
+          "StartupScript": "${post_translate_test}"
         }
       ]
     },

--- a/daisy_integration_tests/scripts/post_translate_test.ps1
+++ b/daisy_integration_tests/scripts/post_translate_test.ps1
@@ -119,7 +119,7 @@ try {
       throw 'Activation failed'
     }
   }
-  Write-Output 'All Tests Passed'
+  Write-Output 'PASSED: All Tests Passed'
 }
 catch {
   Write-Output 'Exception caught in script:'

--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -36,5 +36,6 @@ COPY --from=0 /gce_vm_image_import gce_vm_image_import
 COPY --from=0 /gce_vm_image_export gce_vm_image_export
 COPY /daisy_workflows/ /daisy_workflows/
 COPY /daisy_integration_tests/scripts/post_translate_test.sh .
+COPY /daisy_integration_tests/scripts/post_translate_test.ps1 .
 COPY /cli_tools_e2e_test/gce_image_import_export/test_suites/import/post_translate_test.wf.json .
 ENTRYPOINT ["./wrapper", "./gce_image_import_export_test_runner"]


### PR DESCRIPTION
Since Window's translation requires booting the instance, we need to add the UEFI_COMPATIBLE guest OS feature during inflation. Prior to this change, it was only added to the final GCP image.

## Testing
- Unit tests 
- Two new e2e tests (Windows and RHEL) where the source image requires UEFI for booting.