### PR TITLE
Don't check for OSConfig agent in Ubuntu e2e test.

### DIFF
--- a/daisy_integration_tests/image_import_and_translate_ova_with_spaces_in_vmdk_filename.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_ova_with_spaces_in_vmdk_filename.wf.json
@@ -34,6 +34,9 @@
             }
           ],
           "machineType": "n1-standard-4",
+          "Metadata": {
+            "osconfig_not_supported": "true"
+          },
           "name": "test-the-image-instance",
           "StartupScript": "post_translate_test.sh"
         }


### PR DESCRIPTION
The test `image_import_and_translate_ova_with_spaces_in_vmdk_filename.wf.json` is failing with the message "TestFailed: google-osconfig-agent not running.". This started after #1289 was pushed, and is occurring since the OS config agent is currently not supported on Ubuntu.