### PR TITLE
Check for OS config agent in Windows e2e

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.ps1
+++ b/daisy_integration_tests/scripts/post_translate_test.ps1
@@ -101,6 +101,8 @@ try {
   Check-VMWareTools
   Write-Output 'Test: Check-MetadataAccessibility'
   Check-MetadataAccessibility
+  Write-Output 'Test: Check-OSConfigAgent'
+  Check-OSConfigAgent
   if ($byol.ToLower() -eq 'true') {
     Write-Output 'Test: Check-SkipActivation'
     Check-SkipActivation


### PR DESCRIPTION
The test was added in #1289, but not enabled.

## Testing:

Ran the following tests:
 - daisy_integration_tests/2019_translate.wf.json
 - daisy_integration_tests/2008r2_vmware_translate.wf.json
