### PR TITLE
OVF e2e: Whitelist platforms not supporting osconfig agent

### DIFF
--- a/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -48,7 +48,7 @@ var (
 	}
 	// Apply this as instance metadata if the OS config agent is not
 	// supported for the platform or version being imported.
-	skipOSConfig = map[string]string{"osconfig_not_supported": "true"}
+	skipOSConfigMetadata = map[string]string{"osconfig_not_supported": "true"}
 )
 
 type ovfInstanceImportTestProperties struct {
@@ -204,7 +204,7 @@ func runOVFInstanceImportWindows2008R2FourNICs(ctx context.Context, testCase *ju
 		expectedStartupOutput: "All Tests Passed",
 		sourceURI:             fmt.Sprintf("gs://%v/ova/win2008r2-all-updates-four-nic.ova", ovaBucket),
 		os:                    "windows-2008r2",
-		instanceMetadata:      skipOSConfig,
+		instanceMetadata:      skipOSConfigMetadata,
 		isWindows:             true,
 	}
 
@@ -240,7 +240,7 @@ func runOVFInstanceImportUbuntu16FromVirtualBox(ctx context.Context, testCase *j
 		expectedStartupOutput: "All tests passed!",
 		sourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
 		os:                    "ubuntu-1604",
-		instanceMetadata:      skipOSConfig,
+		instanceMetadata:      skipOSConfigMetadata,
 		machineType:           "n1-standard-4",
 	}
 

--- a/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -46,6 +46,9 @@ var (
 		utils.GcloudProdWrapperLatest:   "gcloud",
 		utils.GcloudLatestWrapperLatest: "gcloud",
 	}
+	// Apply this as instance metadata if the OS config agent is not
+	// supported for the platform or version being imported.
+	skipOSConfig = map[string]string{"osconfig_not_supported": "true"}
 )
 
 type ovfInstanceImportTestProperties struct {
@@ -59,6 +62,7 @@ type ovfInstanceImportTestProperties struct {
 	machineType               string
 	network                   string
 	subnet                    string
+	instanceMetadata          map[string]string
 }
 
 // TestSuite is image import test suite.
@@ -200,6 +204,7 @@ func runOVFInstanceImportWindows2008R2FourNICs(ctx context.Context, testCase *ju
 		expectedStartupOutput: "All Tests Passed",
 		sourceURI:             fmt.Sprintf("gs://%v/ova/win2008r2-all-updates-four-nic.ova", ovaBucket),
 		os:                    "windows-2008r2",
+		instanceMetadata:      skipOSConfig,
 		isWindows:             true,
 	}
 
@@ -235,6 +240,7 @@ func runOVFInstanceImportUbuntu16FromVirtualBox(ctx context.Context, testCase *j
 		expectedStartupOutput: "All tests passed!",
 		sourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
 		os:                    "ubuntu-1604",
+		instanceMetadata:      skipOSConfig,
 		machineType:           "n1-standard-4",
 	}
 
@@ -425,7 +431,7 @@ func verifyImportedInstance(
 		return
 	}
 
-	err = instance.StartWithScriptCode(props.verificationStartupScript)
+	err = instance.StartWithScriptCode(props.verificationStartupScript, props.instanceMetadata)
 	if err != nil {
 		testCase.WriteFailure("Error starting instance `%v` with script: %v", props.instanceName, err)
 		return


### PR DESCRIPTION
#1289 added the OS config agent to import. This PR skips OS config checking for tests that:
- Import Ubuntu or Windows 2008r2 and use `post_translate_test.ps1` or `post_translate_test.sh`.

## Testing
- Ran the ovf e2e import suite