### PR TITLE
EL import: Ensure /etc/yum.repos.d exists.

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -26,6 +26,7 @@ import logging
 import os
 import time
 
+import guestfs
 import utils
 import utils.diskutils as diskutils
 
@@ -85,7 +86,7 @@ terminal --timeout=0 serial console
 '''
 
 
-def DistroSpecific(g):
+def DistroSpecific(g: guestfs.GuestFS):
   el_release = utils.GetMetadataAttribute('el_release')
   install_gce = utils.GetMetadataAttribute('install_gce_packages')
   rhel_license = utils.GetMetadataAttribute('use_rhel_gce_license')
@@ -97,6 +98,10 @@ def DistroSpecific(g):
   #   rename: /sysroot/etc/resolv.conf to
   #     /sysroot/etc/i9r7obu6: Operation not permitted
   utils.common.ClearEtcResolv(g)
+
+  # Some imported images haven't contained `/etc/yum.repos.d`.
+  if not g.exists('/etc/yum.repos.d'):
+    g.mkdir('/etc/yum.repos.d')
 
   if rhel_license == 'true':
     if 'Red Hat' in g.cat('/etc/redhat-release'):


### PR DESCRIPTION
Recently a CentOS 6 import failed with the message "/etc/yum.repos.d/google-cloud.repo: No such file or directory". The most likely cause is that `/etc/yum.repos.d` didn't exist on the image prior to this invocation:

https://github.com/GoogleCloudPlatform/compute-image-tools/blob/b0739e9975072ae34031121608e6d4f2c3023e3f/daisy_workflows/image_import/enterprise_linux/translate.py#L116

This change creates the directory if it is missing.

I found no other instances where we assume that a drop-in directory exists prior to writing a file to it.

Testing:
- Ran `daisy_integration_tests/centos_6_qcow2_translate.wf.json` to ensure there weren't regressions.