### PR TITLE
[Onestep Import] Move sections in prow config to trigger args update

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -184,6 +184,27 @@ periodics:
        - name: compute-image-tools-test-service-account
          secret:
            secretName: compute-image-tools-test-service-account
+ - name: ci-windows-upgrade-e2e-tests
+   interval: 6h
+   agent: kubernetes
+   spec:
+     containers:
+     - image: gcr.io/compute-image-tools-test/gce-windows-upgrade-tests:latest
+       args:
+       - "-out_dir=/artifacts"
+       - "-test_project_id=compute-image-test-pool-001"
+       - "-test_zone=us-central1-c"
+       env:
+       - name: ARTIFACTS
+         value: /artifacts
+       volumeMounts:
+       - name: compute-image-tools-test-service-account
+         mountPath: /etc/compute-image-tools-test-service-account
+         readOnly: true
+     volumes:
+     - name: compute-image-tools-test-service-account
+       secret:
+         secretName: compute-image-tools-test-service-account
  - name: ci-images-import-export-cli-e2e-tests
    interval: 6h
    agent: kubernetes
@@ -210,27 +231,6 @@ periodics:
        - name: compute-image-tools-test-service-account
          secret:
            secretName: compute-image-tools-test-service-account
- - name: ci-windows-upgrade-e2e-tests
-   interval: 6h
-   agent: kubernetes
-   spec:
-     containers:
-     - image: gcr.io/compute-image-tools-test/gce-windows-upgrade-tests:latest
-       args:
-       - "-out_dir=/artifacts"
-       - "-test_project_id=compute-image-test-pool-001"
-       - "-test_zone=us-central1-c"
-       env:
-       - name: ARTIFACTS
-         value: /artifacts
-       volumeMounts:
-       - name: compute-image-tools-test-service-account
-         mountPath: /etc/compute-image-tools-test-service-account
-         readOnly: true
-     volumes:
-     - name: compute-image-tools-test-service-account
-       secret:
-         secretName: compute-image-tools-test-service-account
  - name: osconfig-head-images
    interval: 5h
    agent: kubernetes


### PR DESCRIPTION
Prow jobs did not capture changes in test args in ci-images-import-export-cli-e2e-tests. Thus, we need move the position of the entire section.