### PR TITLE
Disable OS config test on windows_7_x64_byol.wf.json

### DIFF
--- a/daisy_integration_tests/windows_7_x64_byol.wf.json
+++ b/daisy_integration_tests/windows_7_x64_byol.wf.json
@@ -40,7 +40,8 @@
           ],
           "machineType": "n1-standard-4",
           "Metadata": {
-              "byol": "true"
+            "byol": "true",
+            "osconfig_not_supported": "true"
           },
           "name": "test",
           "StartupScript": "post_translate_test.ps1"


### PR DESCRIPTION
OS Config agent is only supported for Windows greater than 2008r2. Windows 7 and Windows 2008r2 are both NT 6.1.