### PR TITLE
[Onestep Image Import] Remove adding HTTP client option to gcs client

### DIFF
--- a/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer.go
@@ -41,7 +41,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/dustin/go-humanize"
 	"google.golang.org/api/option"
-	htransport "google.golang.org/api/transport/http"
 )
 
 const (
@@ -132,13 +131,9 @@ func createGCSClient(ctx context.Context, oauth string) (domain.StorageClientInt
 		TLSHandshakeTimeout:   5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	transport, err := htransport.NewTransport(ctx, baseTransport)
-	if err != nil {
-		return nil, daisy.Errf("failed to create Cloud Storage client: %v", err)
-	}
+	http.DefaultTransport = baseTransport
 
-	storage, err := storageutils.NewStorageClient(ctx, logger, option.WithHTTPClient(&http.Client{Transport: transport}),
-		option.WithCredentialsFile(oauth))
+	storage, err := storageutils.NewStorageClient(ctx, logger, option.WithCredentialsFile(oauth))
 	if err != nil {
 		return nil, daisy.Errf("failed to create Cloud Storage client: %v", err)
 	}

--- a/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer_test.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer_test.go
@@ -120,7 +120,7 @@ func TestNewImporterFailWhenBadOauth(t *testing.T) {
 	args := setUpAWSArgs("", true)
 	awsArgs := getAWSImportArgs(args)
 	_, err := newAWSImporter("bad-oauth", nil, awsArgs)
-	assert.Regexp(t, "failed to create compute client: .* open bad-oauth: no such file or directory", err)
+	assert.Regexp(t, "failed to create Cloud Storage client: .* open bad-oauth: no such file or directory", err)
 }
 
 func TestRunImporterFailWhenValidateFail(t *testing.T) {

--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -3,17 +3,17 @@ module github.com/GoogleCloudPlatform/compute-image-tools/cli_tools
 go 1.13
 
 require (
-	cloud.google.com/go v0.61.0
+	cloud.google.com/go v0.63.0
 	cloud.google.com/go/storage v1.10.0
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200721213208-00ba2b996712
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200812174820-48d917200e28
 	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200128181915-c0775e429077 // indirect
 	github.com/GoogleCloudPlatform/compute-image-tools/mocks v0.0.0-20200414213327-359251a2c860
-	github.com/GoogleCloudPlatform/osconfig v0.0.0-20200721210327-c9ab1b6aeb02
-	github.com/aws/aws-sdk-go v1.33.9
+	github.com/GoogleCloudPlatform/osconfig v0.0.0-20200811201211-fa7e4ba5ee85
+	github.com/aws/aws-sdk-go v1.34.3
 	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-ole/go-ole v1.2.4
-	github.com/golang/mock v1.4.3
+	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/google/logger v1.1.0
 	github.com/google/uuid v1.1.1
@@ -26,13 +26,13 @@ require (
 	go.opencensus.io v0.22.4 // indirect
 	golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5 // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirecresource_labeler_testt
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
-	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666
+	golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d
 	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200721223218-6123e77877b2 // indirect
-	google.golang.org/api v0.29.0
+	golang.org/x/tools v0.0.0-20200812183912-8586c7bd521c // indirect
+	google.golang.org/api v0.30.0
 	google.golang.org/appengine v1.6.6 // indirect
-	google.golang.org/genproto v0.0.0-20200721032028-5044d0edf986 // indirect
-	google.golang.org/grpc v1.30.0 // indirect
+	google.golang.org/genproto v0.0.0-20200812160120-2e714abc8b50 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )


### PR DESCRIPTION
Since we want to upload to GCS with optimal performance, we need to make some changes to the HTTP transport fields. Previously, we were using the `withHTTPClient` option to pass in a HTTP client with custom transport setting. However, as discussed in https://github.com/googleapis/google-api-go-client/issues/404, the `withHTTPClient` option is incompatible with `withCredentialsFile` option.  So instead, will add the `withCredentialsFile` option when new transport is called. We also need to add the default scope for Cloud Storage client, since this step is skipped when we create Cloud Storage client with custom HTTP client.