### PR TITLE
[Onestep Image Import E2E] Skip os-config-agent check for ubuntu

### DIFF
--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
@@ -164,14 +164,16 @@ func (t testCase) runPostTranslateTest(ctx context.Context, imagePath string,
 	if err != nil {
 		return err
 	}
-	wf.Vars = map[string]daisy.Var{
-		"image_under_test": {
-			Value: imagePath,
-		},
-		"path_to_post_translate_test": {
-			Value: t.testScript(),
-		},
+
+	varMap := map[string]string{
+		"image_under_test":            imagePath,
+		"path_to_post_translate_test": t.testScript(),
 	}
+
+	for k, v := range varMap {
+		wf.AddVar(k, v)
+	}
+
 	wf.Logger = logging.AsDaisyLogger(logger)
 	wf.Project = testProjectConfig.TestProjectID
 	wf.Zone = testProjectConfig.TestZone

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/onestep_import/aws_test_utils.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/onestep_import/aws_test_utils.go
@@ -52,6 +52,7 @@ type onestepImportAWSTestProperties struct {
 	os                string
 	timeout           string
 	startupScript     string
+	skipOSConfig      string
 }
 
 // setAWSAuth downloads AWS credentials and sets access keys.

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
@@ -107,6 +107,7 @@ func runOnestepImageImportFromAWSLinuxAMI(ctx context.Context, testCase *junitxm
 		amiID:         ubuntuAMIID,
 		os:            "ubuntu-1804",
 		startupScript: "post_translate_test.sh",
+		skipOSConfig:  "true",
 	}
 
 	runOnestepImportTest(ctx, props, testProjectConfig, testType, logger, testCase)
@@ -121,6 +122,7 @@ func runOnestepImageImportFromAWSLinuxVMDK(ctx context.Context, testCase *junitx
 		sourceAMIFilePath: ubuntuVMDKFilePath,
 		os:                "ubuntu-1804",
 		startupScript:     "post_translate_test.sh",
+		skipOSConfig:      "true",
 	}
 
 	runOnestepImportTest(ctx, props, testProjectConfig, testType, logger, testCase)
@@ -231,8 +233,11 @@ func verifyImportedImageFile(ctx context.Context, testCase *junitxml.TestCase, p
 		"image_under_test": {
 			Value: imagePath,
 		},
-		"post_translate_test": {
+		"path_to_post_translate_test": {
 			Value: props.startupScript,
+		},
+		"osconfig_not_supported": {
+			Value: props.skipOSConfig,
 		},
 	}
 

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/scripts/post_translate_test.wf.json
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/scripts/post_translate_test.wf.json
@@ -11,6 +11,10 @@
     "path_to_post_translate_test": {
       "Description": "Path for script to run after translation.",
       "Required": true
+    },
+    "osconfig_not_supported": {
+      "Description": "Whether to skip OS config check.",
+      "Value": "false"
     }
   },
   "Steps": {
@@ -26,7 +30,10 @@
           ],
           "machineType": "n1-standard-4",
           "name": "inst-import-test",
-          "StartupScript": "${path_to_post_translate_test}"
+          "StartupScript": "${path_to_post_translate_test}",
+          "Metadata": {
+            "osconfig_not_supported": "${osconfig_not_supported}"
+          }
         }
       ]
     },


### PR DESCRIPTION
#1289 added the OS config agent to import. This PR change ensures that we do not check for OS config agent on E2E tests using Ubuntu images, since OS config agent is currently not supported on Ubuntu.