### PR TITLE
[Onestep Import] Change image import exec path

### DIFF
--- a/cli_tools/gce_onestep_image_import/onestep_importer/utils.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/utils.go
@@ -20,12 +20,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/dustin/go-humanize"
 )
@@ -97,7 +97,7 @@ func importFromCloudProvider(args *OneStepImportArguments) error {
 
 // runImageImport calls image import
 func runImageImport(args *OneStepImportArguments) error {
-	imageImportPath := "./" + filepath.Join(filepath.Dir(args.ExecutablePath), "gce_vm_image_import")
+	imageImportPath := path.ToWorkingDir("gce_vm_image_import", args.ExecutablePath)
 	err := runCmd(imageImportPath, []string{
 		fmt.Sprintf("-image_name=%v", args.ImageName),
 		fmt.Sprintf("-client_id=%v", args.ClientID),


### PR DESCRIPTION
Originally, the onestep import calls a binary of image import with the relative path of the executable. This approach will fail the E2E test if we don't specify "./" in the path to indicate the binary is in the current directory. However, the gcr.io/compute-image-tools/gce_vm_image_import has a different directory layout as the E2E tests. The image import binary is not under the current working directory. To solve the error, this PR will change the image import executable path to an absolute path.