### PR TITLE
Daisy e2e: Increase wait period prior to checking logs

### DIFF
--- a/daisy_integration_tests/scripts/run_daisy_and_check_logs.sh
+++ b/daisy_integration_tests/scripts/run_daisy_and_check_logs.sh
@@ -50,7 +50,7 @@ run_daisy() {
 
 verify_logs() {
   echo 'BuildStatus: Waiting for logs to propagate to StackDriver.'
-  sleep 30
+  sleep 120
   LOGS=$(gcloud logging read "resource.labels.instance_id=$INSTANCE_ID jsonPayload.workflow=create-disks-test")
   if [ "$SHOULD_HAVE_LOGS" = 'true' ]; then
     if [ -z "$LOGS" ]; then


### PR DESCRIPTION
The test `validate_cloud_logging.wf.json` has recently been failing with "BuildFailed: Expected Cloud Logs.". This increases the wait period prior to checking for logs.

The alternative is to use a retry mechanism. I opted against that since one of the cases *doesn't* want logs, and therefore need to wait until the logs would have propagated and become available.

Testing:
* Ran validate_cloud_logging test and verified that it passed.