### PR TITLE
Deploying image import wrappers to Artifact registry

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -89,6 +89,10 @@ steps:
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$_RELEASE
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
 


### PR DESCRIPTION
Deploying image import wrappers to Artifact registry (two zones to start with for POC purposes, all zones and all wrappers to follow) to allow for regional wrapper deployment for reliability purposes.