### PR TITLE
Update Go inspection clients workflow reference

### DIFF
--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	workflowFile = "image_import/inspection/inspect-disk.wf.json"
+	workflowFile = "image_import/inspection/boot-inspect.wf.json"
 )
 
 // Inspector finds partition and boot-related properties for a disk.


### PR DESCRIPTION
The workflow was renamed in #1326; this updates the hardcoded reference to it.

# Testing:
 - Ran the `ubuntu-1804` test that was failing.
 - Ensured this was the only stale reference.