### PR TITLE
Deploying image import wrappers to Artifact registry fixe

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -89,10 +89,10 @@ steps:
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
-  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$_RELEASE
-  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
-  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$_RELEASE
-  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
 


### PR DESCRIPTION
Deploying image import wrappers to Artifact registry: fixed the path to published Docker images by adding repository name (wrappers)