### PR TITLE
Add tests for EL 7.8 and EL 8.2

### DIFF
--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
@@ -96,14 +96,36 @@ var cases = []testCase{
 		source:        "projects/compute-image-tools-test/global/images/debian-9-translate",
 		os:            "opensuse-15",
 		expectedError: "\"debian-9\" was detected on your disk, but \"opensuse-15\" was specified",
+	},
+	// EL
+	{
+		caseName: "el-centos-7-8",
+		source:   "projects/compute-image-tools-test/global/images/centos-7-8",
+		os:       "centos-7",
 	}, {
-		caseName:  "rhel-7-uefi",
+		caseName: "el-centos-8-0",
+		source:   "projects/compute-image-tools-test/global/images/centos-8-import",
+		os:       "centos-8",
+	}, {
+		caseName: "el-centos-8-2",
+		source:   "projects/compute-image-tools-test/global/images/centos-8-2",
+		os:       "centos-8",
+	}, {
+		caseName:  "el-rhel-7-uefi",
 		source:    "projects/compute-image-tools-test/global/images/linux-uefi-no-guestosfeature-rhel7",
 		os:        "rhel-7",
 		extraArgs: []string{"-uefi_compatible=true"},
 	}, {
-		caseName: "rhel-8",
-		source:   "projects/compute-image-tools-test/global/images/rhel-8-import",
+		caseName: "el-rhel-7-8",
+		source:   "projects/compute-image-tools-test/global/images/rhel-7-8",
+		os:       "rhel-7",
+	}, {
+		caseName: "el-rhel-8-0",
+		source:   "projects/compute-image-tools-test/global/images/rhel-8-0",
+		os:       "rhel-8",
+	}, {
+		caseName: "el-rhel-8-2",
+		source:   "projects/compute-image-tools-test/global/images/rhel-8-2",
 		os:       "rhel-8",
 	}, {
 		caseName:  "windows-2019-uefi",


### PR DESCRIPTION
This includes images for EL 7.8 and EL 8.2 to ensure that the centos-7, centos-8, rhel-7, and rhel-8 `--os` flags work with the new minor versions.

Ran all of the EL tests, and they pass.