### PR TITLE
Split publishing to different repos in separate steps. Upgrade kaniko executor version.

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -89,8 +89,6 @@ steps:
   args:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
-  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
-  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
 

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -95,6 +95,7 @@ steps:
   - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
+  - --cache=true
 
 # Build gce_vm_image_export.
 - name: 'golang'

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -85,17 +85,12 @@ steps:
   dir: 'cli_tools/gce_vm_image_import'
   args: ['go', 'build', '-o=/workspace/linux/gce_vm_image_import']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor@sha256:d60705cb55460f32cee586570d7b14a0e8a5f23030a0532230aaf707ad05cecd'
-  args: 
-  - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
-  - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
+  args:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
-  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
-  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
-  - --cache=true
 
 # Build gce_vm_image_export.
 - name: 'golang'

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
   dir: 'daisy/cli'
   args: ['go', 'build', '-o=/workspace/darwin/daisy']
   env: ['GOOS=darwin']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args: 
   - --destination=gcr.io/$PROJECT_ID/daisy:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/daisy:$COMMIT_SHA
@@ -47,7 +47,7 @@ steps:
   dir: 'cli_tools/gce_image_publish'
   args: ['go', 'build', '-o=/workspace/darwin/gce_image_publish']
   env: ['GOOS=darwin']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_image_publish:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_image_publish:$COMMIT_SHA
@@ -63,7 +63,7 @@ steps:
   dir: 'cli_tools/gce_export'
   args: ['go', 'build', '-o=/workspace/windows/gce_export']
   env: ['GOOS=windows']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_export:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_export:$COMMIT_SHA
@@ -85,7 +85,7 @@ steps:
   dir: 'cli_tools/gce_vm_image_import'
   args: ['go', 'build', '-o=/workspace/linux/gce_vm_image_import']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
@@ -101,7 +101,7 @@ steps:
   dir: 'cli_tools/gce_vm_image_export'
   args: ['go', 'build', '-o=/workspace/linux/gce_vm_image_export']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_export:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_export:$COMMIT_SHA
@@ -113,7 +113,7 @@ steps:
   dir: 'cli_tools/gce_ovf_import'
   args: ['go', 'build', '-o=/workspace/linux/gce_ovf_import']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_ovf_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_ovf_import:$COMMIT_SHA
@@ -125,7 +125,7 @@ steps:
   dir: 'cli_tools/gce_windows_upgrade'
   args: ['go', 'build', '-o=/workspace/linux/gce_windows_upgrade']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_windows_upgrade:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_windows_upgrade:$COMMIT_SHA

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -87,11 +87,25 @@ steps:
   env: ['CGO_ENABLED=0']
 - name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args:
+  - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
+  - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
+  - --context=/workspace
+  - --dockerfile=gce_vm_image_import.Dockerfile
+
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
+  args:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
 
+- name: 'gcr.io/kaniko-project/executor:v1.0.0'
+  args:
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
+  - --context=/workspace
+  - --dockerfile=gce_vm_image_import.Dockerfile
+  -
 # Build gce_vm_image_export.
 - name: 'golang'
   dir: 'cli_tools/gce_vm_image_export'

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -85,7 +85,7 @@ steps:
   dir: 'cli_tools/gce_vm_image_import'
   args: ['go', 'build', '-o=/workspace/linux/gce_vm_image_import']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v1.0.0'
+- name: 'gcr.io/kaniko-project/executor@sha256:d60705cb55460f32cee586570d7b14a0e8a5f23030a0532230aaf707ad05cecd'
   args: 
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -89,6 +89,8 @@ steps:
   args:
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
   - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
 


### PR DESCRIPTION
Kaniko executor has a bug where publishing to multiple repos in a single step causes auth error for all but the first repo. Splitting into separate steps until this is fixed in kaniko executor. Also upgraded kaniko executor to support Artifact registry authentication.