### PR TITLE
Use a non-GUI image to avoid flaky RHEL8 test.

### DIFF
--- a/daisy_integration_tests/rhel_8_translate.wf.json
+++ b/daisy_integration_tests/rhel_8_translate.wf.json
@@ -8,7 +8,7 @@
       "Value": "rhel-8-licensed-translate-test-${ID}"
     },
     "source_image": {
-      "Value": "projects/compute-image-tools-test/global/images/rhel-8-import"
+      "Value": "projects/compute-image-tools-test/global/images/rhel-8-0"
     },
     "test-id": {
       "Value": "",


### PR DESCRIPTION
The rhel-8-import image was created with a GUI, and the GUI's initialization is causing the tests to occasionally timeout. This replaces the image with a minimal server, which better matches what we're expecting to be imported.