### PR TITLE
Increase verbosity of disk resizing.

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -76,11 +76,14 @@ function resizeDisk() {
     fi
     exit
   fi
+  echo "Resizing result: $out"
 
   echo "Import: Checking for ${deviceId} ${requiredSizeInGb}G"
   for t in {1..60}; do
     if [[ -e ${deviceId} ]]; then
-      local actualSizeBytes=$(lsblk "${deviceId}" --output=size -b | sed -n 2p)
+      lsblk_out=$(lsblk "${deviceId}" --output=size -b)
+      printf "lsblk output:\n%s" "$lsblk_out"
+      local actualSizeBytes=$(echo "$lsblk_out" | sed -n 2p)
       local actualSizeGb=$(awk "BEGIN {print int(${actualSizeBytes}/${BYTES_1GB})}")
       if [[ "${actualSizeGb}" == "${requiredSizeInGb}" ]]; then
         echo "Import: ${deviceId} is attached and ready."


### PR DESCRIPTION
Testing:
- Ran `import_image.wf.json` with a disk that would need to be resized, confirmed that it was successful.
- Logs:

```
Sep  2 00:47:25 localhost GCEMetadataScripts[809]: 2020/09/02 00:47:25 GCEMetadataScripts: startup-script: Resizing result: Updated [https://www.googleapis.com/compute/v1/projects/compute-image-test-pool-001/zones/us-central1-c/disks/disk-import-disk-scratch-xqs4y]. --- creationTimestamp: '2020-09-01T17:46:56.560-07:00' description: Disk created by Daisy in workflow "import-disk" on behalf of ericedens. id: '2828647025030157679' kind: compute#disk labelFingerprint: 42WmSpB8rSM= lastAttachTimestamp: '2020-09-01T17:46:59.443-07:00' name: disk-import-disk-scratch-xqs4y physicalBlockSizeBytes: '4096' selfLink: https://www.googleapis.com/compute/v1/projects/compute-image-test-pool-001/zones/us-central1-c/disks/disk-import-disk-scratch-xqs4y sizeGb: '13' status: READY type: https://www.googleapis.com/compute/v1/projects/compute-image-test-pool-001/zones/us-central1-c/diskTypes/pd-ssd users: - https://www.googleapis.com/compute/v1/projects/compute-image-test-pool-001/zones/us-central1-c/instances/inst-importer-import-image-import-disk-xqs4y zone: https://www.googleapis.com/compute/v1/projects/compute-image-test-pool-001/zones/us-central1-c
Sep  2 00:47:25 localhost GCEMetadataScripts[809]: 2020/09/02 00:47:25 GCEMetadataScripts: startup-script: Import: Checking for /dev/sdb 13G
Sep  2 00:47:25 localhost GCEMetadataScripts[809]: 2020/09/02 00:47:25 GCEMetadataScripts: startup-script: lsblk output:
Sep  2 00:47:25 localhost GCEMetadataScripts[809]: 2020/09/02 00:47:25 GCEMetadataScripts: startup-script:        SIZE
Sep  2 00:47:25 localhost GCEMetadataScripts[809]: 2020/09/02 00:47:25 GCEMetadataScripts: startup-script: 13958643712
Sep  2 00:47:25 localhost GCEMetadataScripts[809]: 2020/09/02 00:47:25 GCEMetadataScripts: startup-script: Import: /dev/sdb is attached and ready.
```