### PR TITLE
Introduced failureMatches for OVF import and Windows upgrade E2E tests

### DIFF
--- a/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -55,6 +55,7 @@ type ovfInstanceImportTestProperties struct {
 	instanceName              string
 	isWindows                 bool
 	expectedStartupOutput     string
+	failureMatches            []string
 	verificationStartupScript string
 	zone                      string
 	sourceURI                 string
@@ -129,6 +130,7 @@ func runOVFInstanceImportUbuntu3Disks(ctx context.Context, testCase *junitxml.Te
 			"scripts/ovf_import_test_ubuntu_3_disks.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-1604-three-disks", ovaBucket),
 		os:                    "ubuntu-1604",
 		machineType:           "n1-standard-4"}
@@ -146,6 +148,7 @@ func runOVFInstanceImportCentos68(ctx context.Context, testCase *junitxml.TestCa
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/", ovaBucket),
 		os:                    "centos-6",
 		machineType:           "n1-standard-4",
@@ -164,6 +167,7 @@ func runOVFInstanceImportWindows2012R2TwoDisks(ctx context.Context, testCase *ju
 			"scripts/ovf_import_test_windows_two_disks.ps1", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All Tests Passed",
+		failureMatches:        []string{"Test Failed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/w2k12-r2", ovaBucket),
 		os:                    "windows-2012r2",
 		machineType:           "n1-standard-8",
@@ -183,6 +187,7 @@ func runOVFInstanceImportWindows2016(ctx context.Context, testCase *junitxml.Tes
 			"daisy_integration_tests/scripts/post_translate_test.ps1", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All Tests Passed",
+		failureMatches:        []string{"Test Failed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/w2k16/w2k16.ovf", ovaBucket),
 		os:                    "windows-2016",
 		machineType:           "n2-standard-2",
@@ -202,6 +207,7 @@ func runOVFInstanceImportWindows2008R2FourNICs(ctx context.Context, testCase *ju
 			"daisy_integration_tests/scripts/post_translate_test.ps1", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All Tests Passed",
+		failureMatches:        []string{"Test Failed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/win2008r2-all-updates-four-nic.ova", ovaBucket),
 		os:                    "windows-2008r2",
 		instanceMetadata:      skipOSConfigMetadata,
@@ -238,6 +244,7 @@ func runOVFInstanceImportUbuntu16FromVirtualBox(ctx context.Context, testCase *j
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
 		os:                    "ubuntu-1604",
 		instanceMetadata:      skipOSConfigMetadata,
@@ -272,6 +279,7 @@ func runOVFInstanceImportNetworkSettingsName(ctx context.Context, testCase *juni
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/", ovaBucket),
 		os:                    "centos-6",
 		machineType:           "n1-standard-4",
@@ -293,6 +301,7 @@ func runOVFInstanceImportNetworkSettingsPath(ctx context.Context, testCase *juni
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/", ovaBucket),
 		os:                    "centos-6",
 		machineType:           "n1-standard-4",
@@ -439,7 +448,7 @@ func verifyImportedInstance(
 	logger.Printf("[%v] Waiting for `%v` in instance serial console.", props.instanceName,
 		props.expectedStartupOutput)
 	if err := instance.WaitForSerialOutput(
-		props.expectedStartupOutput, 1, 5*time.Second, 15*time.Minute); err != nil {
+		props.expectedStartupOutput, props.failureMatches, 1, 5*time.Second, 15*time.Minute); err != nil {
 		testCase.WriteFailure("Error during VM validation: %v", err)
 	}
 }

--- a/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -53,6 +53,7 @@ type ovfMachineImageImportTestProperties struct {
 	machineImageName          string
 	isWindows                 bool
 	expectedStartupOutput     string
+	failureMatches            []string
 	verificationStartupScript string
 	zone                      string
 	sourceURI                 string
@@ -112,6 +113,7 @@ func runOVFMachineImageImportUbuntu3Disks(ctx context.Context, testCase *junitxm
 			"scripts/ovf_import_test_ubuntu_3_disks.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-1604-three-disks", ovaBucket),
 		os:                    "ubuntu-1604",
 		machineType:           "n1-standard-4"}
@@ -129,6 +131,7 @@ func runOVFMachineImageImportCentos68(ctx context.Context, testCase *junitxml.Te
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/", ovaBucket),
 		os:                    "centos-6",
 		machineType:           "n1-standard-4",
@@ -147,6 +150,7 @@ func runOVFMachineImageImportWindows2012R2TwoDisks(ctx context.Context, testCase
 			"scripts/ovf_import_test_windows_two_disks.ps1", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All Tests Passed",
+		failureMatches:        []string{"Test Failed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/w2k12-r2", ovaBucket),
 		os:                    "windows-2012r2",
 		machineType:           "n1-standard-8",
@@ -166,6 +170,7 @@ func runOVFMachineImageImportStorageLocation(ctx context.Context, testCase *juni
 			"daisy_integration_tests/scripts/post_translate_test.ps1", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All Tests Passed",
+		failureMatches:        []string{"Test Failed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/w2k16/w2k16.ovf", ovaBucket),
 		os:                    "windows-2016",
 		machineType:           "n2-standard-2",
@@ -186,6 +191,7 @@ func runOVFMachineImageImportNetworkSettingsName(ctx context.Context, testCase *
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/", ovaBucket),
 		os:                    "centos-6",
 		machineType:           "n1-standard-4",
@@ -207,6 +213,7 @@ func runOVFMachineImageImportNetworkSettingsPath(ctx context.Context, testCase *
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
 		zone:                  testProjectConfig.TestZone,
 		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/", ovaBucket),
 		os:                    "centos-6",
 		machineType:           "n1-standard-4",
@@ -357,7 +364,7 @@ func verifyImportedMachineImage(
 	logger.Printf("[%v] Waiting for `%v` in instance serial console.", testInstanceName,
 		props.expectedStartupOutput)
 	if err := instance.WaitForSerialOutput(
-		props.expectedStartupOutput, 1, 5*time.Second, 15*time.Minute); err != nil {
+		props.expectedStartupOutput, props.failureMatches, 1, 5*time.Second, 15*time.Minute); err != nil {
 		testCase.WriteFailure("Error during VM validation: %v", err)
 	}
 }

--- a/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
+++ b/cli_tools_e2e_test/gce_windows_upgrade/test_suites/windows_upgrade/windows_upgrade_test_suite.go
@@ -376,7 +376,7 @@ func runTest(ctx context.Context, image string, args []string, testType utils.CL
 				logger.Printf("[%v] Waiting for `%v` in instance serial console.", instanceName,
 					expectedOutput)
 				if err := instance.WaitForSerialOutput(
-					expectedOutput, 1, 15*time.Second, 20*time.Minute); err != nil {
+					expectedOutput, nil, 1, 15*time.Second, 20*time.Minute); err != nil {
 					testCase.WriteFailure("Error during waiting for preparation finished: %v", err)
 					return
 				}
@@ -498,7 +498,7 @@ func verifyOSVersion(instance *computeUtils.Instance, testCase *junitxml.TestCas
 	logger.Printf("[%v] Waiting for `%v` in instance serial console.", instanceName,
 		expectedOutput)
 	if err := instance.WaitForSerialOutput(
-		expectedOutput, 1, 15*time.Second, 15*time.Minute); err != nil {
+		expectedOutput, nil, 1, 15*time.Second, 15*time.Minute); err != nil {
 		testCase.WriteFailure("Error during validation: %v", err)
 	}
 	return true


### PR DESCRIPTION
Introduced failureMatches for OVF import and Windows upgrade E2E tests. Windows upgrade still needs to be updated to have failure match strings actually set.