### PR TITLE
Update multi-regional mapping in import/export wrappers

### DIFF
--- a/cli_tools/common/utils/storage/resource_location_retriever.go
+++ b/cli_tools/common/utils/storage/resource_location_retriever.go
@@ -35,9 +35,9 @@ var (
 	// GCE cost per region: https://cloud.google.com/compute/vm-instance-pricing
 	// GCS multi-regions: https://cloud.google.com/storage/docs/locations#location-mr
 	multiRegions = map[string]multiRegion{
-		"US":   {[]string{"us-central1", "us-east1", "us-east4", "us-west1", "us-west2"}, true},
-		"EU":   {[]string{"europe-north1", "europe-west1", "europe-west2", "europe-west3", "europe-west4", "europe-west6"}, true},
-		"ASIA": {[]string{"asia-east1", "asia-east2", "asia-northeast1", "asia-northeast2", "asia-south1", "asia-southeast1"}, true},
+		"US":   {[]string{"us-central1", "us-east1", "us-west1", "us-east4", "us-west4", "us-west2", "us-west3"}, true},
+		"EU":   {[]string{"europe-west1", "europe-west4", "europe-north1", "europe-west2", "europe-west3", "europe-west6"}, true},
+		"ASIA": {[]string{"asia-east1", "asia-south1", "asia-southeast1", "asia-northeast1", "asia-northeast2", "asia-northeast3", "asia-southeast2", "asia-east2"}, true},
 
 		"EUR4": {[]string{"europe-north1", "europe-west4"}, false},
 		"NAM4": {[]string{"us-central1", "us-east1"}, false},


### PR DESCRIPTION
Update multi-regional mapping in import/export wrappers when determining the best zone to run import in when multi-regional storage is used: add new regions and sort based on VM cost.