### PR TITLE
Don't check for OS config in OVF import E2E test verification

### DIFF
--- a/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_e2e_test/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -132,6 +132,7 @@ func runOVFInstanceImportUbuntu3Disks(ctx context.Context, testCase *junitxml.Te
 		expectedStartupOutput: "All tests passed!",
 		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-1604-three-disks", ovaBucket),
+		instanceMetadata:      skipOSConfigMetadata,
 		os:                    "ubuntu-1604",
 		machineType:           "n1-standard-4"}
 


### PR DESCRIPTION
* Don't check for OS config in OVF import E2E test verification as OS config is currently not supported on imported Ubuntu instances/GMIs.
* Removed an unused GMI import E2E test func