### PR TITLE
Import unit tests: remove testdata symlink

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
 )
 
+const daisyWorkflows = "../../../daisy_workflows"
+
 func TestCreateInflater_File(t *testing.T) {
 	inflater, err := createInflater(ImportArguments{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
@@ -32,7 +34,7 @@ func TestCreateInflater_File(t *testing.T) {
 		Zone:         "us-west1-c",
 		ExecutionID:  "1234",
 		NoExternalIP: false,
-		WorkflowDir:  "testdata",
+		WorkflowDir:  daisyWorkflows,
 	},
 		nil,
 		storage.Client{},
@@ -66,7 +68,7 @@ func TestCreateInflater_Image(t *testing.T) {
 		Source:      imageSource{uri: "projects/test/uri/image"},
 		Zone:        "us-west1-b",
 		ExecutionID: "1234",
-		WorkflowDir: "testdata",
+		WorkflowDir: daisyWorkflows,
 	}, nil, storage.Client{}, nil)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)

--- a/cli_tools/gce_vm_image_import/importer/bootable_disk_processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/bootable_disk_processor_test.go
@@ -232,7 +232,7 @@ func getImage(t *testing.T, workflow *daisy.Workflow) daisy.Image {
 func defaultImportArgs() ImportArguments {
 	imageSpec := ImportArguments{
 		OS:          "sles-12-byol",
-		WorkflowDir: "testdata",
+		WorkflowDir: "../../../daisy_workflows",
 	}
 	return imageSpec
 }

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -276,7 +276,7 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 
 func createDaisyInflaterSafe(t *testing.T, args ImportArguments,
 	inspector imagefile.Inspector) *daisyInflater {
-	args.WorkflowDir = "testdata"
+	args.WorkflowDir = "../../../daisy_workflows"
 	inflater, err := createDaisyInflater(args, inspector)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)

--- a/cli_tools/gce_vm_image_import/importer/testdata/image_import
+++ b/cli_tools/gce_vm_image_import/importer/testdata/image_import
@@ -1,1 +1,0 @@
-../../../../daisy_workflows/image_import


### PR DESCRIPTION
The symlink existed so that import unit tests could reference workflows. This caused IDEs to double index the files in daisy_workflows. This change removes the symlink, replacing its usage with a relative path.