### PR TITLE
Add e2e test to validate rollout of ubuntu-2004 to gcloud.

### DIFF
--- a/cli_tools_e2e_test/common/utils/utils.go
+++ b/cli_tools_e2e_test/common/utils/utils.go
@@ -242,6 +242,7 @@ func RunTestForTestType(cmd string, args []string, testType CLITestType, logger 
 			return false
 		}
 	case GcloudBetaLatestWrapperLatest:
+		fallthrough
 	case GcloudGaLatestWrapperRelease:
 		if !GcloudUpdate(logger, testCase, true) {
 			return false

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/cli_tests.go
@@ -78,7 +78,7 @@ func CLITestSuite(
 		testsMap[testType][imageImportWithRichParamsTestCase] = runImageImportWithRichParamsTest
 		testsMap[testType][imageImportWithDifferentNetworkParamStylesTestCase] = runImageImportWithDifferentNetworkParamStyles
 		testsMap[testType][imageImportWithSubnetWithoutNetworkSpecifiedTestCase] = runImageImportWithSubnetWithoutNetworkSpecified
-		testsMap[testType][newOSUbuntu2004] = runImportForImage("projects/compute-image-tools-test/global/images/ubuntu-2004", "ubuntu-2004")
+		testsMap[testType][newOSUbuntu2004] = verifyNewOSIsAvailableInGcloud("projects/compute-image-tools-test/global/images/ubuntu-2004", "ubuntu-2004")
 	}
 	utils.CLITestSuite(ctx, tswg, testSuites, logger, testSuiteRegex, testCaseRegex,
 		testProjectConfig, testSuiteName, testsMap)
@@ -148,7 +148,7 @@ func runImageImportOSTest(ctx context.Context, testCase *junitxml.TestCase, logg
 	runImportTest(ctx, argsMap[testType], testType, testProjectConfig, imageName, logger, testCase)
 }
 
-func runImportForImage(sourceImageURI, osID string) func(
+func verifyNewOSIsAvailableInGcloud(sourceImageURI, osID string) func(
 	context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, utils.CLITestType) {
 
 	return func(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
@@ -164,21 +164,24 @@ func runImportForImage(sourceImageURI, osID string) func(
 				"-source_image", sourceImageURI,
 				"-zone", testProjectConfig.TestZone,
 			},
-			utils.GcloudProdWrapperLatest: {"beta", "compute", "images", "import", imageName, "--quiet",
-				"--docker-image-tag=latest", "--os", osID, "--project", testProjectConfig.TestProjectID,
+			utils.GcloudBetaProdWrapperLatest: {"beta", "compute", "images", "import", imageName, "--quiet",
+				"--os", osID, "--project", testProjectConfig.TestProjectID,
 				"--source-image", sourceImageURI,
 				"--zone", testProjectConfig.TestZone,
 			},
-			utils.GcloudLatestWrapperLatest: {"beta", "compute", "images", "import", imageName, "--quiet",
-				"--docker-image-tag=latest", "--os", osID, "--project", testProjectConfig.TestProjectID,
+			utils.GcloudBetaLatestWrapperLatest: {"beta", "compute", "images", "import", imageName, "--quiet",
+				"--os", osID, "--project", testProjectConfig.TestProjectID,
+				"--source-image", sourceImageURI,
+				"--zone", testProjectConfig.TestZone,
+			},
+			utils.GcloudGaLatestWrapperRelease: {"compute", "images", "import", imageName, "--quiet",
+				"--os", osID, "--project", testProjectConfig.TestProjectID,
 				"--source-image", sourceImageURI,
 				"--zone", testProjectConfig.TestZone,
 			},
 		}
-
 		runImportTest(ctx, argsMap[testType], testType, testProjectConfig, imageName, logger, testCase)
 	}
-
 }
 
 func runImageImportOSFromImageTest(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,


### PR DESCRIPTION
We're preparing to add `ubuntu-2004` as an option for `--os` in gcloud. This PR creates an e2e test that imports an `ubuntu-2004`, which we will use to track the deployment of the new flag value.

## Testing
- Ran the  "ubuntu-2004 should be an option for --os" suite, and confirmed that the `gce_vm_image_import` case passes, while the gcloud cases fail. Prior to failing, they emit: "argument --os: Invalid choice: 'ubuntu-2004'. Did you mean 'ubuntu-1804'?"