### PR TITLE
EL import: Don't fail when unexpected directory in /lib/modules

### DIFF
--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
@@ -160,7 +160,7 @@ var basicCases = []*testCase{
 	// EL - Error cases
 	{
 		caseName: "el-allow-extra-dirs-in-lib-modules", // b/168774581
-		source:   "projects/compute-image-tools-test/global/images/el-depmod-lib-modules",
+		source:   "projects/compute-image-tools-test/global/images/el-depmod-extra-lib-modules",
 		os:       "centos-8",
 		inspect:  true,
 	},

--- a/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_e2e_test/gce_image_import_export/test_suites/import/import_tests.go
@@ -117,6 +117,7 @@ var basicCases = []*testCase{
 		expectedError: "\"debian-9\" was detected on your disk, but \"opensuse-15\" was specified",
 		inspect:       true,
 	},
+
 	// EL
 	{
 		caseName: "el-centos-7-8",
@@ -154,7 +155,18 @@ var basicCases = []*testCase{
 		source:   "projects/compute-image-tools-test/global/images/rhel-8-2",
 		os:       "rhel-8",
 		inspect:  true,
-	}, {
+	},
+
+	// EL - Error cases
+	{
+		caseName: "el-allow-extra-dirs-in-lib-modules", // b/168774581
+		source:   "projects/compute-image-tools-test/global/images/el-depmod-lib-modules",
+		os:       "centos-8",
+		inspect:  true,
+	},
+
+	// Windows
+	{
 		caseName:  "windows-2019-uefi",
 		source:    "projects/compute-image-tools-test/global/images/windows-2019-uefi-nodrivers",
 		os:        "windows-2019",

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -174,8 +174,9 @@ def DistroSpecific(g: guestfs.GuestFS):
     # 2. https://kernel.googlesource.com/pub/scm/linux/kernel/git/mmarek/kmod
     # /+/tip/tools/depmod.c#2537
     if not re.match(r'^\d+.\d+', kver):
-      logging.debug('Skipping {}'.format(kver))
-      pass
+      logging.debug('/lib/modules/{} doesn\'t look like a kernel directory. '
+                    'Skipping creation of initramfs for it'.format(kver))
+      continue
     if not g.exists(os.path.join('/lib/modules', kver, 'modules.dep')):
       try:
         g.command(['depmod', kver])


### PR DESCRIPTION
Prior to this, if a user had extra directories in /lib/modules, the import would fail. In EL6:  'modules must be specified using absolute paths.'  In EL8: 'depmod: ERROR: Bad version passed'

Root cause: Although each directory in /lib/modules typically corresponds to a kernel version, that may not always be true. kernel-abi-whitelists, for example, creates extra directories in /lib/modules. Prior to this change, each directory was blindly passed to depmod. 

## Testing
- Added a new e2e test that repro'd  the issue, and passes after the fix.