### PR TITLE
[VMDK API Adoption] cleanup shadow disk when error happens

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
@@ -15,13 +15,16 @@
 package importer
 
 import (
+	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	computeBeta "google.golang.org/api/compute/v0.beta"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	computeBeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/googleapi"
 )
 
 const daisyWorkflows = "../../../daisy_workflows"
@@ -42,9 +45,10 @@ func TestCreateInflater_File(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	}, nil)
 	assert.NoError(t, err)
-	mainInflater, ok := inflater.(*daisyInflater)
+	facade, ok := inflater.(*inflaterFacade)
 	assert.True(t, ok)
 
+	mainInflater, ok := facade.mainInflater.(*daisyInflater)
 	assert.True(t, ok)
 	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", mainInflater.inflatedDiskURI)
 	assert.Equal(t, "gs://bucket/vmdk", mainInflater.wf.Vars["source_disk_file"].Value)
@@ -54,6 +58,9 @@ func TestCreateInflater_File(t *testing.T) {
 	network := getWorkerNetwork(t, mainInflater.wf)
 	assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
 
+	realInflater, _ := facade.shadowInflater.(*apiInflater)
+	assert.NotContains(t, realInflater.guestOsFeatures,
+		&computeBeta.GuestOsFeature{Type: "UEFI_COMPATIBLE"})
 }
 
 func TestCreateInflater_Image(t *testing.T) {
@@ -80,4 +87,119 @@ func TestCreateAPIInflater_IncludesUEFIGuestOSFeature(t *testing.T) {
 	realInflater, _ := createAPIInflater(args, nil, storage.Client{}).(*apiInflater)
 	assert.Contains(t, realInflater.guestOsFeatures,
 		&computeBeta.GuestOsFeature{Type: "UEFI_COMPATIBLE"})
+}
+
+func TestAPIInflater_Inflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().CreateDiskBeta(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("failed to create disk"))
+	mockComputeClient.EXPECT().GetDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &googleapi.Error{Code: 404})
+
+	inflater := createAPIInflater(ImportArguments{
+		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:       "projects/subnet/subnet",
+		Network:      "projects/network/network",
+		Zone:         "us-west1-c",
+		ExecutionID:  "1234",
+		NoExternalIP: false,
+		WorkflowDir:  daisyWorkflows,
+	},
+		mockComputeClient,
+		storage.Client{})
+
+	apiInflater, ok := inflater.(*apiInflater)
+	assert.True(t, ok)
+
+	// Send a cancel signal in prior to guarantee cancellation logic can be executed.
+	cancelResult := apiInflater.Cancel("cancel")
+	assert.True(t, cancelResult)
+
+	_, _, err := apiInflater.Inflate(nil)
+	assert.Equal(t, "apiInflater.inflate is canceled: cancel", apiInflater.serialLogs[0])
+	assert.Error(t, err)
+}
+
+func TestAPIInflater_Inflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().CreateDiskBeta(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockComputeClient.EXPECT().DeleteDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockComputeClient.EXPECT().GetDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &googleapi.Error{Code: 404})
+
+	inflater := createAPIInflater(ImportArguments{
+		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:       "projects/subnet/subnet",
+		Network:      "projects/network/network",
+		Zone:         "us-west1-c",
+		ExecutionID:  "1234",
+		NoExternalIP: false,
+		WorkflowDir:  daisyWorkflows,
+	},
+		mockComputeClient,
+		storage.Client{})
+
+	apiInflater, ok := inflater.(*apiInflater)
+	assert.True(t, ok)
+
+	// Send a cancel signal in prior to guarantee cancellation logic can be executed.
+	cancelResult := apiInflater.Cancel("cancel")
+	assert.True(t, cancelResult)
+
+	_, _, err := apiInflater.Inflate(nil)
+	assert.Equal(t, "apiInflater.inflate is canceled: cancel", apiInflater.serialLogs[0])
+	assert.NoError(t, err)
+}
+
+func TestAPIInflater_Inflate_Cancel_CleanupFailedToVerify(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().GetDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unknown"))
+
+	inflater := createAPIInflater(ImportArguments{
+		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:       "projects/subnet/subnet",
+		Network:      "projects/network/network",
+		Zone:         "us-west1-c",
+		ExecutionID:  "1234",
+		NoExternalIP: false,
+		WorkflowDir:  daisyWorkflows,
+	},
+		mockComputeClient,
+		storage.Client{})
+
+	apiInflater, ok := inflater.(*apiInflater)
+	assert.True(t, ok)
+
+	cancelResult := apiInflater.Cancel("cancel")
+	assert.False(t, cancelResult)
+	assert.Equal(t, "apiInflater.inflate is canceled, cleanup failed to verify: cancel", apiInflater.serialLogs[0])
+}
+
+func TestAPIInflater_Inflate_Cancel_CleanupFailed(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().GetDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	inflater := createAPIInflater(ImportArguments{
+		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:       "projects/subnet/subnet",
+		Network:      "projects/network/network",
+		Zone:         "us-west1-c",
+		ExecutionID:  "1234",
+		NoExternalIP: false,
+		WorkflowDir:  daisyWorkflows,
+	},
+		mockComputeClient,
+		storage.Client{})
+
+	apiInflater, ok := inflater.(*apiInflater)
+	assert.True(t, ok)
+
+	cancelResult := apiInflater.Cancel("cancel")
+	assert.False(t, cancelResult)
+	assert.Equal(t, "apiInflater.inflate is canceled, cleanup is failed: cancel", apiInflater.serialLogs[0])
 }

--- a/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
@@ -43,7 +43,7 @@ func TestCreateInflater_File(t *testing.T) {
 		expectedReference: "gs://bucket/vmdk",
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
-	}, nil)
+	})
 	assert.NoError(t, err)
 	facade, ok := inflater.(*inflaterFacade)
 	assert.True(t, ok)
@@ -69,7 +69,7 @@ func TestCreateInflater_Image(t *testing.T) {
 		Zone:        "us-west1-b",
 		ExecutionID: "1234",
 		WorkflowDir: daisyWorkflows,
-	}, nil, storage.Client{}, nil, nil)
+	}, nil, storage.Client{}, nil)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)
@@ -115,7 +115,7 @@ func TestAPIInflater_Inflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing
 	cancelResult := apiInflater.Cancel("cancel")
 	assert.True(t, cancelResult)
 
-	_, _, err := apiInflater.Inflate(nil)
+	_, _, err := apiInflater.Inflate()
 	assert.Equal(t, "apiInflater.inflate is canceled: cancel", apiInflater.serialLogs[0])
 	assert.Error(t, err)
 }
@@ -147,7 +147,7 @@ func TestAPIInflater_Inflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T
 	cancelResult := apiInflater.Cancel("cancel")
 	assert.True(t, cancelResult)
 
-	_, _, err := apiInflater.Inflate(nil)
+	_, _, err := apiInflater.Inflate()
 	assert.Equal(t, "apiInflater.inflate is canceled: cancel", apiInflater.serialLogs[0])
 	assert.NoError(t, err)
 }

--- a/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
@@ -43,7 +43,7 @@ func TestCreateInflater_File(t *testing.T) {
 		expectedReference: "gs://bucket/vmdk",
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
-	})
+	}, nil)
 	assert.NoError(t, err)
 	facade, ok := inflater.(*inflaterFacade)
 	assert.True(t, ok)
@@ -69,7 +69,7 @@ func TestCreateInflater_Image(t *testing.T) {
 		Zone:        "us-west1-b",
 		ExecutionID: "1234",
 		WorkflowDir: daisyWorkflows,
-	}, nil, storage.Client{}, nil)
+	}, nil, storage.Client{}, nil, nil)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -109,12 +109,12 @@ func (args *ImportArguments) ValidateAndPopulate(populator param.Populator,
 		return err
 	}
 
+	args.populateExecutionID()
+
 	args.populateNamespacedScratchDirectory()
 	if err := args.populateNetwork(); err != nil {
 		return err
 	}
-
-	args.populateExecutionID()
 
 	return args.validate()
 }

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -87,7 +87,6 @@ func NewImportArguments(args []string) (ImportArguments, error) {
 	flagSet.SetOutput(ioutil.Discard)
 
 	parsed := ImportArguments{
-		ExecutionID: path.RandString(5),
 		WorkflowDir: filepath.Join(filepath.Dir(os.Args[0]), workflowDir),
 		Started:     time.Now(),
 	}
@@ -115,7 +114,15 @@ func (args *ImportArguments) ValidateAndPopulate(populator param.Populator,
 		return err
 	}
 
+	args.populateExecutionID()
+
 	return args.validate()
+}
+
+func (args *ImportArguments) populateExecutionID() {
+	if args.ExecutionID == "" {
+		args.ExecutionID = path.RandString(5)
+	}
 }
 
 // populateNamespacedScratchDirectory updates ScratchBucketGcsPath to include a directory
@@ -229,6 +236,9 @@ func (args *ImportArguments) registerFlags(flagSet *flag.FlagSet) {
 		"VPC doesn't allow external IPs.")
 
 	flagSet.BoolVar(&args.Inspect, "inspect", false, "Run disk inspections.")
+
+	flagSet.Var((*flags.TrimmedString)(&args.ExecutionID), "execution_id",
+		"The execution ID to differentiate GCE resources of each imports.")
 
 	flagSet.Bool("kms_key", false, "Reserved for future use.")
 	flagSet.Bool("kms_keyring", false, "Reserved for future use.")

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -44,7 +44,7 @@ type Importer interface {
 // NewImporter constructs an Importer instance.
 func NewImporter(args ImportArguments, computeClient compute.Client, storageClient storage.Client) (Importer, error) {
 	loggableBuilder := service.NewSingleImageImportLoggableBuilder()
-	inflater, err := newInflater(args, computeClient, storageClient, imagefile.NewGCSInspector())
+	inflater, err := newInflater(args, computeClient, storageClient, imagefile.NewGCSInspector(), loggableBuilder)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -44,7 +44,7 @@ type Importer interface {
 // NewImporter constructs an Importer instance.
 func NewImporter(args ImportArguments, computeClient compute.Client, storageClient storage.Client) (Importer, error) {
 	loggableBuilder := service.NewSingleImageImportLoggableBuilder()
-	inflater, err := newInflater(args, computeClient, storageClient, imagefile.NewGCSInspector(), loggableBuilder)
+	inflater, err := newInflater(args, computeClient, storageClient, imagefile.NewGCSInspector())
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -212,7 +212,7 @@ type shadowTestFields struct {
 }
 
 func newInflater(args ImportArguments, computeClient daisyCompute.Client, storageClient storage.Client,
-	inspector imagefile.Inspector, loggableBuilder *service.SingleImageImportLoggableBuilder) (Inflater, error) {
+	inspector imagefile.Inspector) (Inflater, error) {
 
 	di, err := NewDaisyInflater(args, inspector)
 	if err != nil {

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -212,7 +212,7 @@ type shadowTestFields struct {
 }
 
 func newInflater(args ImportArguments, computeClient daisyCompute.Client, storageClient storage.Client,
-	inspector imagefile.Inspector) (Inflater, error) {
+	inspector imagefile.Inspector, loggableBuilder *service.SingleImageImportLoggableBuilder) (Inflater, error) {
 
 	di, err := NewDaisyInflater(args, inspector)
 	if err != nil {
@@ -225,8 +225,9 @@ func newInflater(args ImportArguments, computeClient daisyCompute.Client, storag
 
 	ai := createAPIInflater(args, computeClient, storageClient)
 	return &inflaterFacade{
-		mainInflater:   di,
-		shadowInflater: ai,
+		mainInflater:    di,
+		shadowInflater:  ai,
+		loggableBuilder: loggableBuilder,
 	}, nil
 }
 

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
@@ -326,7 +326,7 @@ func runImageImportWithSubnetWithoutNetworkSpecified(ctx context.Context, testCa
 }
 
 func runImageImportShadowDiskCleanedUpWhenMainInflaterFails(ctx context.Context, testCase *junitxml.TestCase,
-		logger *log.Logger, testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
+	logger *log.Logger, testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
 
 	suffix := path.RandString(5)
 	imageName := "e2e-test-image-import-bad-network-" + suffix


### PR DESCRIPTION
Fix b/169073057

Original design:
1. when main inflater finished later than shadow (which is 99% cases), no problem.
2. when main inflater finished earlier than shadow with an error, the main thread got terminated and shadow inflater missed the chance to cleanup shadow PD.

New design:
1. when main inflater finished later than shadow (which is 99% cases), still no problem.
2. when main inflater finished earlier than shadow, the main thread needs to call "shadowInfalter.cancel()" in order to:
   * cancel the shadowInfalter.Infalte(). The inflate() will try to return early, but needs to guarantee the cleanup is done
   * wait for shadowInfalter.Infalte() to finish, in order to guarantee cleanup won't be interrupted before main thread exits.  

