### PR TITLE
export-metadata v2 design

### DIFF
--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -27,7 +27,8 @@ import urllib.request
 from google.cloud import exceptions
 from google.cloud import storage
 
-METADATA_ENDPOINT = 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true'
+METADATA_ENDPOINT = 'http://metadata.google.internal/computeMetadata/v1' \
+                    '/instance/attributes/?recursive=true '
 
 
 def GetMetadataAttribute():
@@ -66,13 +67,13 @@ def UploadFile(source_file, gcs_dest_file):
                         .format(prefix=prefix, bucket=bucket, obj=obj))
   match = gs_regex.match(gcs_dest_file)
   if not match:
-    raise ValueError('Destination path %s is invalid.'% gcs_dest_file)
+    raise ValueError('Destination path %s is invalid.' % gcs_dest_file)
   client = storage.Client()
   bucket = client.get_bucket(match.group('bucket'))
   blob = bucket.blob(match.group('obj'))
   try:
     blob.upload_from_filename(source_file)
-  except exceptions.from_http_status as e:
+  except exceptions.from_http_status:
     raise ValueError('Upload to bucket %s failed.' % gcs_dest_file)
 
 

--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+"""Export the image metadata on a GCE VM.
+
+Parameters retrieved from instance metadata:
+
+google_cloud_repo: The repo to use to build image. Must be one of
+  ['stable' (default), 'unstable', 'staging'].
+image_tar_location: The Cloud Storage destination for the resultant image.
+metadata_dest: The Cloud Storage destination for the resultant image metadata.
+image_family: The family that image belongs.
+distribution: Use image distribution. Must be one of [enterprise_linux,
+  debian, centos].
+uefi: boolean Whether using UEFI to boot OS.
+"""
+
+import datetime
+import json
+import logging
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+
+from google.cloud import exceptions
+from google.cloud import storage
+
+METADATA_ENDPOINT = 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true'
+
+
+def GetMetadataAttribute():
+  """Get attribute from metadata server.
+
+  Returns:
+    dictionary, the instance attribute metadata.
+  """
+  try:
+    request = urllib.request.Request(METADATA_ENDPOINT)
+    headers = {'Metadata-Flavor': 'Google'}
+    for key, value in headers.items():
+      request.add_unredirected_header(key, value)
+    return json.loads(urllib.request.urlopen(request).read().decode())
+  except urllib.error.HTTPError:
+    raise ValueError('Metadata key not found')
+
+
+def UploadFile(source_file, gcs_dest_file):
+  """Uploads a file to GCS.
+
+  Expects a local source file and a destination bucket and GCS path.
+
+  Args:
+    source_file: string, the path of a source file to upload.
+    gcs_dest_file: string, the path to the resulting file in GCS.
+
+  Raises:
+    ValueError: The error occurred when gcs_dest_file is invalid bucket.
+  """
+
+  bucket = r'(?P<bucket>[a-z0-9][-_.a-z0-9]*[a-z0-9])'
+  obj = r'(?P<obj>[^\*\?]+)'
+  prefix = r'gs://'
+  gs_regex = re.compile(r'{prefix}{bucket}/{obj}'
+                        .format(prefix=prefix, bucket=bucket, obj=obj))
+  match = gs_regex.match(gcs_dest_file)
+  if not match:
+    raise ValueError('Destination path %s is invalid.'% gcs_dest_file)
+  client = storage.Client()
+  bucket = client.get_bucket(match.group('bucket'))
+  blob = bucket.blob(match.group('obj'))
+  try:
+    blob.upload_from_filename(source_file)
+  except exceptions.from_http_status as e:
+    raise ValueError('Upload to bucket %s failed.' % gcs_dest_file)
+
+
+def main():
+  # Get parameters from instance metadata.
+  metadata = GetMetadataAttribute()
+  metadata_dest = metadata.get('metadata_dest')
+  image_id = metadata.get('image_id')
+  image_name = metadata.get('image_name')
+  image_family = metadata.get('image_family')
+  distribution = metadata.get('distribution')
+  uefi = metadata.get('uefi', '').lower() == 'true'
+
+  logging.info('Creating upload metadata of the image and packages.')
+
+  utc_time = datetime.datetime.now(datetime.timezone.utc)
+  image_version = utc_time.strftime('%Y%m%d')
+  build_date = utc_time.astimezone().isoformat(),
+  image = {
+      'id': image_id,
+      'name': image_name,
+      'family': image_family,
+      'version': image_version,
+      'build_date,': build_date,
+      'packages': [],
+  }
+  # All the guest environment packages maintained by guest-os team.
+  guest_packages = [
+      'google-cloud-packages-archive-keyring',
+      'google-compute-engine',
+      'google-compute-engine-oslogin',
+      'google-guest-agent',
+      'google-osconfig-agent',
+      'gce-disk-expand',
+  ]
+
+  # This assumes that:
+  # 1. /dev/sdb1 is the EFI system partition.
+  # 2. /dev/sdb2 is the root mount for the installed system.
+  if uefi:
+    mount_disk = '/dev/sdb2'
+  else:
+    mount_disk = '/dev/sdb1'
+  subprocess.run(['mount', mount_disk, '/mnt'], check=False)
+  logging.info('Mount %s device to /mnt', mount_disk)
+
+  if distribution == 'enterprise_linux':
+    # chroot prevents access to /dev/random and /dev/urandom (as designed).
+    # The rpm required those random bits to initialize GnuTLS otherwise
+    # error: Failed to initialize NSS library.
+    subprocess.run(['mount', '-o', 'bind', '/dev', '/mnt/dev'], check=False)
+
+  has_commit_hash = True
+  if distribution == 'debian':
+    cmd_prefix = ['chroot', '/mnt', 'dpkg-query', '-W', '--showformat',
+                  '${Package}\n${Version}\n${Git}']
+  elif distribution == 'enterprise_linux':
+    if 'centos-6' in image_family or 'rhel-6' in image_family:
+      # centos-6 and rhel-6 doesn't support vcs tag
+      cmd_prefix = ['chroot', '/mnt', 'rpm', '-q', '--queryformat',
+                    '%{NAME}\n%{VERSION}-%{RELEASE}']
+      has_commit_hash = False
+    else:
+      cmd_prefix = ['chroot', '/mnt', 'rpm', '-q', '--queryformat',
+                    '%{NAME}\n%{VERSION}-%{RELEASE}\n%{VCS}']
+  else:
+    logging.error('Unknown Linux distribution.')
+    return Exception
+
+  version, commit_hash = '', ''
+  for package in guest_packages:
+    cmd = cmd_prefix + [package]
+    try:
+      stdout = subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout
+      stdout = stdout.decode()
+      logging.info('Package metadata is %s', stdout)
+    except subprocess.CalledProcessError as e:
+      logging.exception('Fail to execute cmd. %s', e)
+      continue
+    if has_commit_hash:
+      package, version, commit_hash = stdout.split('\n', 2)
+    else:
+      package, version = stdout.split('\n', 1)
+    package_metadata = {
+        'name': package,
+        'version': version,
+        'commit_hash': commit_hash,
+    }
+    image['packages'].append(package_metadata)
+
+  # Write image metadata to a file.
+  with tempfile.NamedTemporaryFile(mode='w', dir='/tmp', delete=False) as f:
+    f.write(json.dumps(image))
+
+  logging.info('Uploading image metadata.')
+  try:
+    UploadFile(f.name, metadata_dest)
+  except ValueError as e:
+    logging.exception('ExportFailed: Failed uploading metadata file %s', e)
+    sys.exit(1)
+
+  logging.info('ExportSuccess: Export metadata was successful!')
+
+
+if __name__ == '__main__':
+  main()

--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -98,7 +98,7 @@ def main():
       stdout = stdout.decode()
       logging.info('Package metadata is %s', stdout)
     except subprocess.CalledProcessError as e:
-      logging.exception('Fail to execute cmd. %s', e)
+      logging.warning('Fail to execute cmd. %s', e)
       continue
     if has_commit_hash:
       package, version, commit_hash = stdout.split('\n', 2)

--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -27,12 +27,9 @@ def main():
   # Get parameters from instance metadata.
   metadata_dest = utils.GetMetadataAttribute('metadata_dest',
                                              raise_on_not_found=True)
-  image_id = utils.GetMetadataAttribute('image_id',
-                                        raise_on_not_found=True)
-  image_name = utils.GetMetadataAttribute('image_name',
-                                          raise_on_not_found=True)
-  image_family = utils.GetMetadataAttribute('image_family',
-                                            raise_on_not_found=True)
+  image_id = utils.GetMetadataAttribute('image_id')
+  image_name = utils.GetMetadataAttribute('image_name')
+  image_family = utils.GetMetadataAttribute('image_family')
   distribution = utils.GetMetadataAttribute('distribution',
                                             raise_on_not_found=True)
   uefi = utils.GetMetadataAttribute('uefi', 'false').lower() == 'true'

--- a/daisy_workflows/export_metadata/export_metadata.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata.wf.json
@@ -1,8 +1,5 @@
 {
   "Name": "export-metadata",
-  "Project": "gce-image-builder",
-  "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "metadata_dest": {
       "Required": true,
@@ -36,8 +33,8 @@
   "Sources": {
     "export_metadata/utils/common.py": "../linux_common/utils/common.py",
     "export_metadata/utils/__init__.py": "../linux_common/utils/__init__.py",
-    "export_metadata/export-metadata.py": "export-metadata.py",
-    "export_startup_script": "../linux_common/bootstrap.sh"
+    "export_metadata/export-metadata.py": "./export-metadata.py",
+    "startup_script": "../linux_common/bootstrap.sh"
   },
   "Steps": {
     "setup-disks": {
@@ -48,7 +45,7 @@
           "Type": "pd-ssd"
         },
         {
-          "Name": "source_disk",
+          "Name": "source-disk",
           "SourceImage": "${source_image}",
           "Type": "pd-ssd"
         }
@@ -58,7 +55,7 @@
       "CreateInstances": [
         {
           "Name": "inst-exporter",
-          "Disks": [{"Source": "disk-exporterprep"},{"Source": "source_disk"}],
+          "Disks": [{"Source": "disk-exporterprep"},{"Source": "source-disk"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/export_metadata",
@@ -74,7 +71,7 @@
           "Scopes": [
             "https://www.googleapis.com/auth/devstorage.read_write"
           ],
-          "StartupScript": "export_startup_script"
+          "StartupScript": "startup_script"
         }
       ]
     },
@@ -93,7 +90,8 @@
     },
     "delete-inst": {
       "DeleteResources": {
-        "Instances": ["inst-exporter"]
+        "Instances": ["inst-exporter"],
+        "Disks":["disk-exporterprep", "source-disk"]
       }
     }
   },

--- a/daisy_workflows/export_metadata/export_metadata.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata.wf.json
@@ -9,15 +9,15 @@
       "Description": "The GCS path for the destination image metadata json"
     },
     "image_id": {
-      "Required": true,
+      "Required": false,
       "Description": "The image id used in project"
     },
     "image_name": {
-      "Required": true,
+      "Required": false,
       "Description": "The image name used in project"
     },
     "image_family": {
-      "Required": true,
+      "Required": false,
       "Description": "Image Family"
     },
     "source_image": {

--- a/daisy_workflows/export_metadata/export_metadata.workflow.json
+++ b/daisy_workflows/export_metadata/export_metadata.workflow.json
@@ -1,0 +1,103 @@
+{
+  "Name": "export-metadata",
+  "Project": "gce-image-builder",
+  "Zone": "us-central1-b",
+  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "Vars": {
+    "metadata_dest": {
+      "Required": true,
+      "Description": "The GCS path for the destination image metadata json"
+    },
+    "image_id": {
+      "Required": true,
+      "Description": "The image id used in project"
+    },
+    "image_name": {
+      "Required": true,
+      "Description": "The image name used in project"
+    },
+    "image_family": {
+      "Required": true,
+      "Description": "Image Family"
+    },
+    "source_image": {
+      "Required": true,
+      "Description": "The image that need to export metadata"
+    },
+    "distribution": {
+      "Required":true,
+      "Description": "Use image distribution, enterprise_linux, debian, centos"
+    },
+    "uefi": {
+      "Required":false,
+      "Description": "Whether RHEL is an UEFI image."
+    }
+  },
+  "Sources": {
+    "export_metadata/export-metadata.py": "./export-metadata.py",
+    "export_startup_script": "../linux_common/bootstrap.sh"
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-exporterprep",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "Type": "pd-ssd"
+        },
+        {
+          "Name": "source_disk",
+          "SourceImage": "${source_image}",
+          "Type": "pd-ssd"
+        }
+      ]
+    },
+    "run": {
+      "CreateInstances": [
+        {
+          "Name": "inst-exporter",
+          "Disks": [{"Source": "disk-exporterprep"},{"Source": "source_disk"}],
+          "MachineType": "n1-highcpu-4",
+          "Metadata": {
+            "files_gcs_dir": "${SOURCESPATH}/export_metadata",
+            "script": "export-metadata.py",
+            "metadata_dest": "gs://gce-image-metadata/${image_family}/${image_name}/metadata-${image_id}.json",
+            "image_id": "${image_id}",
+            "image_name": "${image_name}",
+            "image_family": "${image_family}",
+            "prefix": "Export",
+            "distribution": "${distribution}",
+            "uefi": "${uefi}"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write"
+          ],
+          "StartupScript": "export_startup_script"
+        }
+      ]
+    },
+    "wait": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-exporter",
+          "SerialOutput": {
+            "Port": 1,
+            "FailureMatch": "ExportFailed:",
+            "SuccessMatch": "ExportSuccess:",
+            "StatusMatch": "ExportStatus:"
+          }
+        }
+      ]
+    },
+    "delete-inst": {
+      "DeleteResources": {
+        "Instances": ["inst-exporter"]
+      }
+    }
+  },
+  "Dependencies": {
+    "run": ["setup-disks"],
+    "wait": ["run"],
+    "delete-inst": ["wait"]
+  }
+}

--- a/daisy_workflows/export_metadata/export_metadata.workflow.json
+++ b/daisy_workflows/export_metadata/export_metadata.workflow.json
@@ -34,7 +34,9 @@
     }
   },
   "Sources": {
-    "export_metadata/export-metadata.py": "./export-metadata.py",
+    "export_metadata/utils/common.py": "../linux_common/utils/common.py",
+    "export_metadata/utils/__init__.py": "../linux_common/utils/__init__.py",
+    "export_metadata/export-metadata.py": "export-metadata.py",
     "export_startup_script": "../linux_common/bootstrap.sh"
   },
   "Steps": {
@@ -61,7 +63,7 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/export_metadata",
             "script": "export-metadata.py",
-            "metadata_dest": "gs://gce-image-metadata/${image_family}/${image_name}/metadata-${image_id}.json",
+            "metadata_dest": "${metadata_dest}",
             "image_id": "${image_id}",
             "image_name": "${image_name}",
             "image_family": "${image_family}",


### PR DESCRIPTION
The independent export-metadata workflow which use a gce image as source. the output is a metadata.file in gcs.

Update:

-  Use linux_common to retrieve metadata and upload file.
-  Remove project level variable
-  make some variable as not required. 


Testing:
Debian:

https://pantheon.corp.google.com/storage/browser/_details/hanga-testing-daisy-bkt/daisy/hanga/daisy-export-metadata-20201001-22:34:06-1qb9x/logs/inst-exporter-export-metadata-1qb9x-serial-port1.log?organizationId=433637338589&project=hanga-testing

RHEL:

https://pantheon.corp.google.com/storage/browser/_details/hanga-testing-daisy-bkt/daisy/hanga/daisy-export-metadata-20201001-22:34:06-1qb9x/logs/inst-exporter-export-metadata-1qb9x-serial-port1.log?organizationId=433637338589&project=hanga-testing

Daisy Output.

[export-metadata.wait]: 2020-10-01T22:34:26Z WaitForInstancesSignal: Instance "inst-exporter-export-metadata-1qb9x": StatusMatch found: "ExportStatus: Package metadata is gce-disk-expand"
[export-metadata.wait]: 2020-10-01T22:34:26Z WaitForInstancesSignal: Instance "inst-exporter-export-metadata-1qb9x": StatusMatch found: "ExportStatus: Uploading image metadata."
[export-metadata.wait]: 2020-10-01T22:34:26Z WaitForInstancesSignal: Instance "inst-exporter-export-metadata-1qb9x": StatusMatch found: "ExportStatus: ExportSuccess: Export metadata was successful!"
[export-metadata.wait]: 2020-10-01T22:34:26Z WaitForInstancesSignal: Instance "inst-exporter-export-metadata-1qb9x": SuccessMatch found "ExportSuccess: Export metadata was successful!"
[export-metadata]: 2020-10-01T22:34:26Z Step "wait" (WaitForInstancesSignal) successfully finished.
[export-metadata]: 2020-10-01T22:34:26Z Running step "delete-inst" (DeleteResources)
[export-metadata.delete-inst]: 2020-10-01T22:34:26Z DeleteResources: Deleting instance "inst-exporter".
[export-metadata.delete-inst]: 2020-10-01T22:34:42Z DeleteResources: Deleting disk "source-disk".
[export-metadata.delete-inst]: 2020-10-01T22:34:42Z DeleteResources: Deleting disk "disk-exporterprep".
[export-metadata]: 2020-10-01T22:34:43Z Step "delete-inst" (DeleteResources) successfully finished.
[export-metadata]: 2020-10-01T22:34:43Z Workflow "export-metadata" cleaning up (this may take up to 2 minutes).
[export-metadata]: 2020-10-01T22:34:47Z Workflow "export-metadata" finished cleanup.
[Daisy] Workflow "export-metadata" finished
[Daisy] All workflows completed successfully.