### PR TITLE
Remove resources when bucket owned by different project

### DIFF
--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -71,8 +71,18 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 		if err != nil {
 			return "", daisy.Errf("invalid scratch bucket GCS path %v", scratchBucketGcsPath)
 		}
+
 		if !scratchBucketCreator.IsBucketInProject(*project, scratchBucketName) {
-			return "", daisy.Errf("Scratch bucket `%v` is not in project `%v`", scratchBucketName, *project)
+			err := storageClient.DeleteGcsPath(*scratchBucketGcsPath)
+			var deletionResults string
+			if err == nil {
+				deletionResults = fmt.Sprintf("The resources in %q have been deleted.", *scratchBucketGcsPath)
+			} else {
+				deletionResults = fmt.Sprintf("Failed to delete resources in %q. Check with the owner of %q for more information",
+					*scratchBucketGcsPath, scratchBucketName)
+			}
+			return "", daisy.Errf("Scratch bucket %q is not in project %q. %s",
+				scratchBucketName, *project, deletionResults)
 		}
 
 		scratchBucketAttrs, err := storageClient.GetBucketAttrs(scratchBucketName)

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -22,11 +22,12 @@ import (
 
 	"google.golang.org/api/option"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/paramhelper"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
 // GetProjectID gets project id from flag if exists; otherwise, try to retrieve from GCE metadata.
@@ -73,16 +74,23 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 		}
 
 		if !scratchBucketCreator.IsBucketInProject(*project, scratchBucketName) {
-			err := storageClient.DeleteGcsPath(*scratchBucketGcsPath)
-			var deletionResults string
-			if err == nil {
-				deletionResults = fmt.Sprintf("The resources in %q have been deleted.", *scratchBucketGcsPath)
-			} else {
-				deletionResults = fmt.Sprintf("Failed to delete resources in %q. Check with the owner of %q for more information",
-					*scratchBucketGcsPath, scratchBucketName)
+			errorParts := []string{
+				fmt.Sprintf("Scratch bucket %q is not in project %q",
+					scratchBucketName, *project),
 			}
-			return "", daisy.Errf("Scratch bucket %q is not in project %q. %s",
-				scratchBucketName, *project, deletionResults)
+
+			if strings.HasPrefix(file, fmt.Sprintf("gs://%s/", scratchBucketName)) {
+				err := storageClient.DeleteGcsPath(file)
+				if err == nil {
+					errorParts = append(errorParts, fmt.Sprintf("Deleted %q", file))
+				} else {
+					errorParts = append(errorParts, fmt.Sprintf(
+						"Failed to delete %q. Check with the owner of gs://%q for more information",
+						file, scratchBucketName))
+				}
+			}
+
+			return "", daisy.Errf(strings.Join(errorParts, ". "))
 		}
 
 		scratchBucketAttrs, err := storageClient.GetBucketAttrs(scratchBucketName)

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -22,16 +22,21 @@ import (
 	"os"
 	"time"
 
+	"google.golang.org/api/option"
+
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/importer"
-	"google.golang.org/api/option"
 )
 
 func main() {
+	Main(os.Args[1:])
+}
+
+func Main(args []string) {
 	log.SetFlags(0)
 	log.SetOutput(new(logWriter))
 	ctx := context.Background()
@@ -39,7 +44,7 @@ func main() {
 	// 1. Parse the args without validating or populating. Splitting parsing and
 	// validation allows us to log the intermediate, non-validated values, if
 	// there's an error setting up dependencies.
-	importArgs, err := importer.NewImportArguments(os.Args[1:])
+	importArgs, err := importer.NewImportArguments(args)
 	if err != nil {
 		terminate(importArgs, err)
 	}

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -36,6 +36,7 @@ func main() {
 	Main(os.Args[1:])
 }
 
+// Main starts an image import.
 func Main(args []string) {
 	log.SetFlags(0)
 	log.SetOutput(new(logWriter))


### PR DESCRIPTION
If `scratchBucketCreator.IsBucketInProject` returns false, delete `sourceFile` if it's in the scratch bucket.

Use 'hide whitespace' to see the relevant changes to the test.