### PR TITLE
Image import: Only run inspection when -inspect flag is specified

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/processor.go
+++ b/cli_tools/gce_vm_image_import/importer/processor.go
@@ -51,8 +51,11 @@ func (d defaultProcessorProvider) provide(pd persistentDisk) (processors []proce
 		return
 	}
 
-	processors = append(processors, newDiskInspectionProcessor(d.diskInspector, d.ImportArguments))
-	processors = append(processors, newUefiProcessor(d.computeClient, d.ImportArguments))
+	if d.ImportArguments.Inspect {
+		processors = append(processors, newDiskInspectionProcessor(d.diskInspector, d.ImportArguments))
+		processors = append(processors, newUefiProcessor(d.computeClient, d.ImportArguments))
+	}
+
 	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImportArguments)
 	if err != nil {
 		return

--- a/cli_tools/gce_vm_image_import/importer/processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/processor_test.go
@@ -60,6 +60,7 @@ func TestDefaultProcessorProvider_InspectUEFI(t *testing.T) {
 		ImportArguments: ImportArguments{
 			WorkflowDir: "../../../daisy_workflows",
 			OS:          "ubuntu-1804",
+			Inspect:     true,
 		},
 	}
 


### PR DESCRIPTION
Starting at #1338, any inspection failure causes import workflows to fail.

- Prior to #1338:
  - https://github.com/GoogleCloudPlatform/compute-image-tools/blob/v20200922/cli_tools/gce_vm_image_import/importer/processor.go#L50
- After #1338:
  - https://github.com/GoogleCloudPlatform/compute-image-tools/blob/master/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go#L53

This PR disables all inspection unless the `-inspect` flag is present.