### PR TITLE
[windows upgrade] be compatible with powershell <=2

### DIFF
--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -18,7 +18,7 @@ try {
   Write-Host 'GCEMetadataScripts: Beginning upgrade startup script.'
 
   # Cleanup garbage files left by the previous failed upgrade to unblock a new upgrade.
-  Remove-Item 'C:\$WINDOWS.~BT' -Recurse -ErrorAction Ignore
+  Remove-Item 'C:\$WINDOWS.~BT' -Recurse -ErrorAction SilentlyContinue
 
   $ver=[System.Environment]::OSVersion.Version
   if ("$($ver.Major).$($ver.Minor)" -ne "6.1") {


### PR DESCRIPTION
A internal user failed to upgrade because the instance have a super old powershell version (<=2), which doesn't allow "-ErrorAction IgnoreError". Changed to "-ErrorAction SilientlyContinue" which has the same effect for our usage.

Verified from local manually.