### PR TITLE
[scratch bucket not in project] collect metrics

### DIFF
--- a/cli_tools/common/utils/errors/errors.go
+++ b/cli_tools/common/utils/errors/errors.go
@@ -1,0 +1,20 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package errors
+
+// Error types thrown from cli_tools
+const (
+	ScratchBucketNotInProjectError = "ScratchBucketNotInProjectError"
+)

--- a/cli_tools/common/utils/logging/service/daisy_loggable.go
+++ b/cli_tools/common/utils/logging/service/daisy_loggable.go
@@ -22,7 +22,7 @@ import (
 )
 
 // NewLoggableFromWorkflow provides a Loggable from a daisy workflow.
-func NewLoggableFromWorkflow(wf *daisy.Workflow) Loggable {
+func NewLoggableFromWorkflow(wf *daisy.Workflow, err error) Loggable {
 	if wf == nil {
 		return nil
 	}

--- a/cli_tools/common/utils/logging/service/daisy_loggable_test.go
+++ b/cli_tools/common/utils/logging/service/daisy_loggable_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 func TestNewLoggableFromWorkflow_ReturnsNilWhenWorkflowNil(t *testing.T) {
-	assert.Nil(t, NewLoggableFromWorkflow(nil))
+	assert.Nil(t, NewLoggableFromWorkflow(nil, nil))
 }
 
 func TestWorkflowToLoggable_GetValueAsInt64Slice(t *testing.T) {
 	wf := daisy.Workflow{}
 	wf.AddSerialConsoleOutputValue("gb", "1,2,3")
-	loggable := NewLoggableFromWorkflow(&wf)
+	loggable := NewLoggableFromWorkflow(&wf, nil)
 
 	assert.Equal(t, []int64{1, 2, 3}, loggable.GetValueAsInt64Slice("gb"))
 	assert.Empty(t, loggable.GetValueAsInt64Slice("not-there"))
@@ -38,7 +38,7 @@ func TestWorkflowToLoggable_GetValueAsInt64Slice(t *testing.T) {
 func TestWorkflowToLoggable_GetValue(t *testing.T) {
 	wf := daisy.Workflow{}
 	wf.AddSerialConsoleOutputValue("hello", "world")
-	loggable := NewLoggableFromWorkflow(&wf)
+	loggable := NewLoggableFromWorkflow(&wf, nil)
 
 	assert.Equal(t, "world", loggable.GetValue("hello"))
 	assert.Empty(t, loggable.GetValue("not-there"))
@@ -50,14 +50,14 @@ func TestWorkflowToLoggable_ReadSerialPortLogs(t *testing.T) {
 			"log-a", "log-b",
 		}},
 	}
-	loggable := NewLoggableFromWorkflow(&wf)
+	loggable := NewLoggableFromWorkflow(&wf, nil)
 
 	assert.Equal(t, []string{"log-a", "log-b"}, loggable.ReadSerialPortLogs())
 }
 
 func TestWorkflowToLoggable_ReadSerialPortLogs_SupportsMissingDaisyLogger(t *testing.T) {
 	wf := daisy.Workflow{}
-	loggable := NewLoggableFromWorkflow(&wf)
+	loggable := NewLoggableFromWorkflow(&wf, nil)
 
 	assert.Empty(t, loggable.ReadSerialPortLogs())
 }

--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -254,6 +254,8 @@ type OutputInfo struct {
 	IsUEFICompatibleImage bool `json:"is_uefi_compatible_image,omitempty"`
 	// Indicates whether the image is auto-detected to be UEFI compatible
 	IsUEFIDetected bool `json:"is_uefi_detected,omitempty"`
+	// Scratch bucket not in project
+	ScratchBucketNotInProject bool `json:"scratch_bucket_not_in_project,omitempty"`
 }
 
 func (l *Logger) updateParams(projectPointer *string) {

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/errors"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/google/uuid"
 	"github.com/minio/highwayhash"
@@ -161,6 +162,13 @@ func (l *Logger) createComputeImageToolsLogExtension(status string, outputInfo *
 	}
 }
 
+func isScratchBucketNotInProjectError(err error) bool {
+	if dErr, ok := err.(daisy.DError); ok {
+		return dErr.CausedByErrType(errors.ScratchBucketNotInProjectError)
+	}
+	return false
+}
+
 func getFailureReason(err error) string {
 	return daisyutils.RemovePrivacyLogTag(err.Error())
 }
@@ -198,6 +206,7 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 		if loggable != nil {
 			o.SerialOutputs = loggable.ReadSerialPortLogs()
 		}
+		o.ScratchBucketNotInProject = isScratchBucketNotInProjectError(err)
 	}
 
 	return &o

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/errors"
 	"google.golang.org/api/option"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
@@ -90,7 +91,7 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 				}
 			}
 
-			return "", daisy.Errf(strings.Join(errorParts, ". "))
+			return "", daisy.TypedErrf(errors.ScratchBucketNotInProjectError, strings.Join(errorParts, ". "))
 		}
 
 		scratchBucketAttrs, err := storageClient.GetBucketAttrs(scratchBucketName)

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -280,7 +280,7 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 			caseName:       "In scratch - Successful deletion",
 			deleteResult:   nil,
 			deleteExpected: true,
-			expectedError: "Scratch bucket \"scratchbucket\" is not in project \"a_project\". " +
+			expectedError: "ScratchBucketNotInProjectError: Scratch bucket \"scratchbucket\" is not in project \"a_project\". " +
 				"Deleted \"gs://scratchbucket/sourcefile\"",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "gs://scratchbucket/sourcefile",
@@ -289,7 +289,7 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 			caseName:       "In scratch - Failed deletion",
 			deleteResult:   errors.New("Failed to delete path"),
 			deleteExpected: true,
-			expectedError: "Scratch bucket \"scratchbucket\" is not in project \"a_project\". " +
+			expectedError: "ScratchBucketNotInProjectError: Scratch bucket \"scratchbucket\" is not in project \"a_project\". " +
 				"Failed to delete \"gs://scratchbucket/sourcefile\". Check with the owner of " +
 				"gs://\"scratchbucket\" for more information",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
@@ -297,13 +297,13 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 		},
 		{
 			caseName:             "Not in scratch - Don't delete",
-			expectedError:        "Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
+			expectedError:        "ScratchBucketNotInProjectError: Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "gs://source-images/sourcefile",
 		},
 		{
 			caseName:             "GCS Image - Don't delete",
-			expectedError:        "Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
+			expectedError:        "ScratchBucketNotInProjectError: Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "",
 		},

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -113,7 +113,7 @@ func runImport() (service.Loggable, error) {
 	}
 
 	wf, err := ovfImporter.Import()
-	return service.NewLoggableFromWorkflow(wf), err
+	return service.NewLoggableFromWorkflow(wf, err), err
 }
 
 func main() {

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -48,7 +48,7 @@ func exportEntry() (service.Loggable, error) {
 	wf, err := exporter.Run(*clientID, *destinationURI, *sourceImage, *format, project,
 		*network, *subnet, *zone, *timeout, *scratchBucketGcsPath, *oauth, *ce, *gcsLogsDisabled,
 		*cloudLogsDisabled, *stdoutLogsDisabled, *labels, currentExecutablePath)
-	return service.NewLoggableFromWorkflow(wf), err
+	return service.NewLoggableFromWorkflow(wf, err), err
 }
 
 func main() {

--- a/cli_tools/gce_windows_upgrade/upgrader/upgrader.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/upgrader.go
@@ -122,7 +122,7 @@ func (u *upgrader) run() (service.Loggable, error) {
 		return nil, err
 	}
 	w, err := u.runUpgradeWorkflow()
-	return service.NewLoggableFromWorkflow(w), err
+	return service.NewLoggableFromWorkflow(w, err), err
 }
 
 func (u *upgrader) init() error {

--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -37,3 +37,5 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )
+
+replace github.com/GoogleCloudPlatform/compute-image-tools/daisy => ../daisy // TODO: remove

--- a/daisy/error.go
+++ b/daisy/error.go
@@ -124,7 +124,8 @@ func typedErr(errType string, safeErrMsg string, e error) DError {
 	return dE
 }
 
-func typedErrf(errType, format string, a ...interface{}) DError {
+// TypedErrf returns a DError with error type.
+func TypedErrf(errType, format string, a ...interface{}) DError {
 	return typedErr(errType, format, fmt.Errorf(format, a...))
 }
 

--- a/daisy/error_test.go
+++ b/daisy/error_test.go
@@ -77,7 +77,7 @@ func TestErrf(t *testing.T) {
 }
 
 func TestTypedErrf(t *testing.T) {
-	got := typedErrf("FOO", "%s %s", "hello", "world")
+	got := TypedErrf("FOO", "%s %s", "hello", "world")
 	want := &dErrImpl{errs: []error{errors.New("hello world")}, errsType: []string{"FOO"}}
 	if diffRes := diff(got, want, 0); diffRes != "" {
 		t.Errorf("Error not created as expected: (-got,+want)\n%s", diffRes)

--- a/daisy/image.go
+++ b/daisy/image.go
@@ -58,7 +58,7 @@ func (w *Workflow) imageExists(project, family, image string) (bool, DError) {
 		}
 		if img.Deprecated != nil {
 			if img.Deprecated.State == "OBSOLETE" || img.Deprecated.State == "DELETED" {
-				return true, typedErrf(imageObsoleteDeletedError, "image %q in state %q", img.Name, img.Deprecated.State)
+				return true, TypedErrf(imageObsoleteDeletedError, "image %q in state %q", img.Name, img.Deprecated.State)
 			}
 		}
 		w.imageFamilyCache.exists[project][img.Name] = img
@@ -80,7 +80,7 @@ func (w *Workflow) imageExists(project, family, image string) (bool, DError) {
 	for _, i := range w.imageCache.exists[project] {
 		if ic, ok := i.(*compute.Image); ok && image == ic.Name {
 			if ic.Deprecated != nil && (ic.Deprecated.State == "OBSOLETE" || ic.Deprecated.State == "DELETED") {
-				return true, typedErrf(imageObsoleteDeletedError, "image %q in state %q", image, ic.Deprecated.State)
+				return true, TypedErrf(imageObsoleteDeletedError, "image %q in state %q", image, ic.Deprecated.State)
 			}
 			return true, nil
 		}

--- a/daisy/resource_registry.go
+++ b/daisy/resource_registry.go
@@ -200,7 +200,7 @@ func (r *baseResourceRegistry) regURL(url string, checkExist bool) (*Resource, D
 			if err != nil {
 				return nil, err
 			}
-			return nil, typedErrf(r.typeName+resourceDNEError, "%s does not exist", url)
+			return nil, TypedErrf(r.typeName+resourceDNEError, "%s does not exist", url)
 		}
 	}
 

--- a/daisy/sources.go
+++ b/daisy/sources.go
@@ -154,7 +154,7 @@ func (w *Workflow) uploadSources(ctx context.Context) DError {
 			dstPath := w.StorageClient.Bucket(w.bucket).Object(path.Join(w.sourcesPath, dst))
 			if _, err := dstPath.CopierFrom(src).Run(ctx); err != nil {
 				if gErr, ok := err.(*googleapi.Error); ok && gErr.Code == http.StatusNotFound {
-					return typedErrf(resourceDNEError, "error copying from file %s: %v", origPath, err)
+					return TypedErrf(resourceDNEError, "error copying from file %s: %v", origPath, err)
 				}
 				return Errf("error copying from file %s: %v", origPath, err)
 			}


### PR DESCRIPTION
This is a part of the scratch alerting system: collect "scratch bucket not in project" data point.

This is a draft in order for design preview. To land it, we need to:
1. add metrcis field to proto and rollout
2. remove the "replace". split the daisy files and cli_tools files into 2 PRs.