### PR TITLE
Building OVF import wrapper and windows upgrader into all repos. 

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -85,7 +85,7 @@ steps:
   dir: 'cli_tools/gce_vm_image_import'
   args: ['go', 'build', '-o=/workspace/linux/gce_vm_image_import']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:kavala'
+- name: 'gcr.io/kaniko-project/executor:v1.1.0'
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
@@ -143,7 +143,7 @@ steps:
   dir: 'cli_tools/gce_vm_image_export'
   args: ['go', 'build', '-o=/workspace/linux/gce_vm_image_export']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:kavala'
+- name: 'gcr.io/kaniko-project/executor:v1.1.0'
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_export:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_vm_image_export:$COMMIT_SHA
@@ -201,10 +201,56 @@ steps:
   dir: 'cli_tools/gce_ovf_import'
   args: ['go', 'build', '-o=/workspace/linux/gce_ovf_import']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v1.0.0'
+- name: 'gcr.io/kaniko-project/executor:v1.1.0'
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_ovf_import:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_ovf_import:$COMMIT_SHA
+  - --destination=us-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=us-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=us-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=us-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=us-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=us-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=us-east4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=us-east4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=southamerica-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=southamerica-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-north1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-north1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-west3-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-west3-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-west4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-west4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=europe-west6-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=europe-west6-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-east2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-east2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-northeast2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-northeast2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-south1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-south1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=asia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=asia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
+  - --destination=australia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$_RELEASE
+  - --destination=australia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_ovf_import:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_ovf_import.Dockerfile
 
@@ -213,10 +259,56 @@ steps:
   dir: 'cli_tools/gce_windows_upgrade'
   args: ['go', 'build', '-o=/workspace/linux/gce_windows_upgrade']
   env: ['CGO_ENABLED=0']
-- name: 'gcr.io/kaniko-project/executor:v1.0.0'
+- name: 'gcr.io/kaniko-project/executor:v1.1.0'
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_windows_upgrade:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=us-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=us-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=us-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=us-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=us-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=us-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=us-east4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=us-east4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=southamerica-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=southamerica-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-north1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-north1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-west3-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-west3-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-west4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-west4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=europe-west6-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=europe-west6-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-east2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-east2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-northeast2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-northeast2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-south1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-south1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=asia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=asia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
+  - --destination=australia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$_RELEASE
+  - --destination=australia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_windows_upgrade:$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_windows_upgrade.Dockerfile
 


### PR DESCRIPTION
Building OVF import wrapper and windows upgrader into all repos. Switched to kaniko executor:v1.1.0 which is the official latest version