### PR TITLE
Image import: When scratch is shared, ensure file deletion isn't recursive

### DIFF
--- a/cli_tools/common/domain/interfaces.go
+++ b/cli_tools/common/domain/interfaces.go
@@ -35,6 +35,7 @@ type StorageClientInterface interface {
 	GetGcsFileContent(gcsObject *storage.ObjectHandle) ([]byte, error)
 	WriteToGCS(destinationBucketName string, destinationObjectPath string, reader io.Reader) error
 	DeleteGcsPath(gcsPath string) error
+	DeleteObject(gcsPath string) error
 	Close() error
 }
 

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -85,8 +85,8 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 					errorParts = append(errorParts, fmt.Sprintf("Deleted %q", file))
 				} else {
 					errorParts = append(errorParts, fmt.Sprintf(
-						"Failed to delete %q. Check with the owner of gs://%q for more information: %v",
-						file, scratchBucketName, err))
+						"Failed to delete %q: %v. Check with the owner of gs://%q for more information.",
+						file, err, scratchBucketName))
 				}
 			}
 

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -80,13 +80,13 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 			}
 
 			if strings.HasPrefix(file, fmt.Sprintf("gs://%s/", scratchBucketName)) {
-				err := storageClient.DeleteGcsPath(file)
+				err := storageClient.DeleteObject(file)
 				if err == nil {
 					errorParts = append(errorParts, fmt.Sprintf("Deleted %q", file))
 				} else {
 					errorParts = append(errorParts, fmt.Sprintf(
-						"Failed to delete %q. Check with the owner of gs://%q for more information",
-						file, scratchBucketName))
+						"Failed to delete %q. Check with the owner of gs://%q for more information: %v",
+						file, scratchBucketName, err))
 				}
 			}
 

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -45,9 +45,14 @@ func GetProjectID(mgce domain.MetadataGCEInterface, projectFlag string) (string,
 	return projectFlag, nil
 }
 
+// populateScratchBucketGcsPath validates the scratch bucket, creating a new one if not
+// provided, and returns the region of the scratch bucket. If the scratch bucket is
+// already populated, and the owning project doesn't match `project`, then an error is returned.
+// In that case, if `file` resides in the non-owned scratch bucket and `removeFileWhenScratchNotOwned`
+// is specified, then `file` is deleted from GCS.
 func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgce domain.MetadataGCEInterface,
 	scratchBucketCreator domain.ScratchBucketCreatorInterface, file string, project *string,
-	storageClient domain.StorageClientInterface, cleanupSharedScratch bool) (string, error) {
+	storageClient domain.StorageClientInterface, removeFileWhenScratchNotOwned bool) (string, error) {
 
 	scratchBucketRegion := ""
 	if *scratchBucketGcsPath == "" {
@@ -79,7 +84,7 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 					scratchBucketName, *project),
 			}
 
-			if cleanupSharedScratch && strings.HasPrefix(file, fmt.Sprintf("gs://%s/", scratchBucketName)) {
+			if removeFileWhenScratchNotOwned && strings.HasPrefix(file, fmt.Sprintf("gs://%s/", scratchBucketName)) {
 				err := storageClient.DeleteObject(file)
 				if err == nil {
 					errorParts = append(errorParts, fmt.Sprintf("Deleted %q", file))

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -47,7 +47,7 @@ func GetProjectID(mgce domain.MetadataGCEInterface, projectFlag string) (string,
 
 func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgce domain.MetadataGCEInterface,
 	scratchBucketCreator domain.ScratchBucketCreatorInterface, file string, project *string,
-	storageClient domain.StorageClientInterface) (string, error) {
+	storageClient domain.StorageClientInterface, cleanupSharedScratch bool) (string, error) {
 
 	scratchBucketRegion := ""
 	if *scratchBucketGcsPath == "" {
@@ -79,13 +79,13 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 					scratchBucketName, *project),
 			}
 
-			if strings.HasPrefix(file, fmt.Sprintf("gs://%s/", scratchBucketName)) {
+			if cleanupSharedScratch && strings.HasPrefix(file, fmt.Sprintf("gs://%s/", scratchBucketName)) {
 				err := storageClient.DeleteObject(file)
 				if err == nil {
 					errorParts = append(errorParts, fmt.Sprintf("Deleted %q", file))
 				} else {
 					errorParts = append(errorParts, fmt.Sprintf(
-						"Failed to delete %q: %v. Check with the owner of gs://%q for more information.",
+						"Failed to delete %q: %v. Check with the owner of gs://%q for more information",
 						file, err, scratchBucketName))
 				}
 			}

--- a/cli_tools/common/utils/param/populator.go
+++ b/cli_tools/common/utils/param/populator.go
@@ -20,7 +20,7 @@ import (
 
 // Populator standardizes user input, and determines omitted values.
 type Populator interface {
-	PopulateMissingParameters(project *string, zone *string, region *string,
+	PopulateMissingParameters(project *string, clientID string, zone *string, region *string,
 		scratchBucketGcsPath *string, file string, storageLocation *string) error
 }
 
@@ -45,15 +45,15 @@ type populator struct {
 	scratchBucketClient domain.ScratchBucketCreatorInterface
 }
 
-func (p populator) PopulateMissingParameters(project *string, zone *string, region *string,
-	scratchBucketGcsPath *string, file string, storageLocation *string) error {
+func (p populator) PopulateMissingParameters(project *string, clientID string, zone *string,
+	region *string, scratchBucketGcsPath *string, file string, storageLocation *string) error {
 
 	if err := PopulateProjectIfMissing(p.metadataClient, project); err != nil {
 		return err
 	}
 
 	scratchBucketRegion, err := populateScratchBucketGcsPath(scratchBucketGcsPath, *zone, p.metadataClient,
-		p.scratchBucketClient, file, project, p.storageClient)
+		p.scratchBucketClient, file, project, p.storageClient, clientID == "gcloud")
 	if err != nil {
 		return err
 	}

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -53,8 +53,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenZoneCantBeRetrieved(
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "zone not found")
 }
@@ -81,8 +80,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenProjectNotProvidedAn
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "project cannot be determined because build is not running on GCE")
 }
@@ -110,8 +108,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenProjectNotProvidedAn
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "project cannot be determined")
 }
@@ -139,8 +136,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenProjectNotProvidedAn
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "project cannot be determined")
 }
@@ -168,8 +164,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenScratchBucketCreatio
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "failed to create scratch bucket")
 }
@@ -195,8 +190,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenScratchBucketInvalid
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "invalid scratch bucket")
 }
@@ -224,8 +218,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenPopulateRegionFails(
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Contains(t, err.Error(), "NOT_ZONE is not a valid zone")
 }
@@ -258,8 +251,7 @@ func TestPopulator_PopulateMissingParametersDoesNotChangeProvidedScratchBucketAn
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "a_project", project)
@@ -271,6 +263,7 @@ func TestPopulator_PopulateMissingParametersDoesNotChangeProvidedScratchBucketAn
 func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.T) {
 	for _, tt := range []struct {
 		caseName             string
+		client               string
 		deleteResult         error
 		deleteExpected       bool
 		expectedError        string
@@ -278,7 +271,8 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 		fileGCSPath          string
 	}{
 		{
-			caseName:       "In scratch - Successful deletion",
+			caseName:       "In scratch - gcloud - Successful deletion",
+			client:         "gcloud",
 			deleteResult:   nil,
 			deleteExpected: true,
 			expectedError: "Scratch bucket \"scratchbucket\" is not in project \"a_project\". " +
@@ -287,23 +281,33 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 			fileGCSPath:          "gs://scratchbucket/sourcefile",
 		},
 		{
-			caseName:       "In scratch - Failed deletion",
+			caseName:       "In scratch - gcloud - Failed deletion",
+			client:         "gcloud",
 			deleteResult:   errors.New("Failed to delete path"),
 			deleteExpected: true,
 			expectedError: "Scratch bucket \"scratchbucket\" is not in project \"a_project\". Failed to delete " +
 				"\"gs://scratchbucket/sourcefile\": Failed to delete path. " +
-				"Check with the owner of gs://\"scratchbucket\" for more information.",
+				"Check with the owner of gs://\"scratchbucket\" for more information",
+			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
+			fileGCSPath:          "gs://scratchbucket/sourcefile",
+		},
+		{
+			caseName:             "In scratch - not gcloud - don't delete",
+			client:               "api",
+			expectedError:        "Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "gs://scratchbucket/sourcefile",
 		},
 		{
 			caseName:             "Not in scratch - Don't delete",
+			client:               "gcloud",
 			expectedError:        "Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "gs://source-images/sourcefile",
 		},
 		{
 			caseName:             "GCS Image - Don't delete",
+			client:               "gcloud",
 			expectedError:        "Scratch bucket \"scratchbucket\" is not in project \"a_project\"",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "",
@@ -334,8 +338,7 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 				mockStorageClient,
 				mockResourceLocationRetriever,
 				mockScratchBucketCreator,
-			).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-				file, &storageLocation)
+			).PopulateMissingParameters(&project, tt.client, &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 			assert.EqualError(t, err, tt.expectedError)
 		})
@@ -374,8 +377,7 @@ func TestPopulator_PopulateMissingParametersCreatesScratchBucketIfNotProvided(t 
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "a_project", project)
@@ -417,8 +419,7 @@ func TestPopulator_PopulateMissingParametersCreatesScratchBucketIfNotProvidedOnG
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "a_project", project)
@@ -451,8 +452,7 @@ func TestPopulator_PopulateMissingParametersPopulatesStorageLocationWithScratchB
 		mockStorageClient,
 		mockResourceLocationRetriever,
 		mockScratchBucketCreator,
-	).PopulateMissingParameters(&project, &zone, &region, &scratchBucketGcsPath,
-		file, &storageLocation)
+	).PopulateMissingParameters(&project, "gcloud", &zone, &region, &scratchBucketGcsPath, file, &storageLocation)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "US", storageLocation)

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -325,7 +325,7 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 			mockResourceLocationRetriever := mocks.NewMockResourceLocationRetrieverInterface(mockCtrl)
 			mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 			if tt.deleteExpected {
-				mockStorageClient.EXPECT().DeleteGcsPath(file).Return(tt.deleteResult)
+				mockStorageClient.EXPECT().DeleteObject(file).Return(tt.deleteResult)
 			}
 
 			err := NewPopulator(

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
 )
@@ -289,9 +290,9 @@ func TestPopulator_DeleteResources_WhenScratchBucketInAnotherProject(t *testing.
 			caseName:       "In scratch - Failed deletion",
 			deleteResult:   errors.New("Failed to delete path"),
 			deleteExpected: true,
-			expectedError: "Scratch bucket \"scratchbucket\" is not in project \"a_project\". " +
-				"Failed to delete \"gs://scratchbucket/sourcefile\". Check with the owner of " +
-				"gs://\"scratchbucket\" for more information",
+			expectedError: "Scratch bucket \"scratchbucket\" is not in project \"a_project\". Failed to delete " +
+				"\"gs://scratchbucket/sourcefile\": Failed to delete path. " +
+				"Check with the owner of gs://\"scratchbucket\" for more information.",
 			scratchBucketGCSPath: "gs://scratchbucket/scratchpath",
 			fileGCSPath:          "gs://scratchbucket/sourcefile",
 		},

--- a/cli_tools/gce_onestep_image_import/onestep_importer/aws_args.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/aws_args.go
@@ -30,6 +30,7 @@ type awsImportArguments struct {
 	// Passed in by user
 	accessKeyID        string
 	amiID              string
+	clientID           string
 	executablePath     string
 	exportLocation     string
 	sourceFilePath     string
@@ -71,6 +72,7 @@ func newAWSImportArguments(args *OneStepImportArguments) *awsImportArguments {
 	return &awsImportArguments{
 		accessKeyID:        args.AWSAccessKeyID,
 		amiID:              args.AWSAMIID,
+		clientID:           args.ClientID,
 		executablePath:     args.ExecutablePath,
 		exportLocation:     args.AWSAMIExportLocation,
 		sourceFilePath:     args.AWSSourceAMIFilePath,
@@ -94,8 +96,8 @@ func (args *awsImportArguments) validateAndPopulate(populator param.Populator) e
 		return err
 	}
 
-	err = populator.PopulateMissingParameters(args.gcsProjectPtr, &args.gcsZone, &args.gcsRegion,
-		&args.gcsScratchBucket, "", &args.gcsStorageLocation)
+	err = populator.PopulateMissingParameters(args.gcsProjectPtr, args.clientID, &args.gcsZone,
+		&args.gcsRegion, &args.gcsScratchBucket, "", &args.gcsStorageLocation)
 	if err != nil {
 		return err
 	}

--- a/cli_tools/gce_onestep_image_import/onestep_importer/test_utils_test.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/test_utils_test.go
@@ -41,7 +41,7 @@ type mockPopulator struct {
 	err             error
 }
 
-func (m mockPopulator) PopulateMissingParameters(project *string, zone *string, region *string,
+func (m mockPopulator) PopulateMissingParameters(project *string, clientID string, zone *string, region *string,
 	scratchBucketGcsPath *string, file string, storageLocation *string) error {
 	if m.err != nil {
 		return m.err

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -178,7 +178,7 @@ func Run(clientID string, destinationURI string, sourceImage string, format stri
 
 	region := new(string)
 	paramPopulator := param.NewPopulator(metadataGCE, storageClient, resourceLocationRetriever, scratchBucketCreator)
-	err = paramPopulator.PopulateMissingParameters(project, &zone, region, &scratchBucketGcsPath, destinationURI, nil)
+	err = paramPopulator.PopulateMissingParameters(project, clientID, &zone, region, &scratchBucketGcsPath, destinationURI, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/cli/cli.go
+++ b/cli_tools/gce_vm_image_import/cli/cli.go
@@ -1,0 +1,145 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/api/option"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/importer"
+)
+
+// Main starts an image import.
+func Main(args []string) error {
+	log.SetFlags(0)
+	log.SetOutput(new(logWriter))
+	ctx := context.Background()
+
+	// 1. Parse the args without validating or populating. Splitting parsing and
+	// validation allows us to log the intermediate, non-validated values, if
+	// there's an error setting up dependencies.
+	importArgs, err := importer.NewImportArguments(args)
+	if err != nil {
+		logFailure(importArgs, err)
+		return err
+	}
+
+	// 2. Setup dependencies.
+	storageClient, err := storage.NewStorageClient(
+		ctx, logging.NewDefaultLogger(), option.WithCredentialsFile(importArgs.Oauth))
+	if err != nil {
+		logFailure(importArgs, err)
+		return err
+	}
+	computeClient, err := param.CreateComputeClient(
+		&ctx, importArgs.Oauth, importArgs.ComputeEndpoint)
+	if err != nil {
+		logFailure(importArgs, err)
+		return err
+	}
+	metadataGCE := &compute.MetadataGCE{}
+	paramPopulator := param.NewPopulator(
+		metadataGCE,
+		storageClient,
+		storage.NewResourceLocationRetriever(metadataGCE, computeClient),
+		storage.NewScratchBucketCreator(ctx, storageClient),
+	)
+
+	// 3. Parse, validate, and populate arguments.
+	if err = importArgs.ValidateAndPopulate(
+		paramPopulator, importer.NewSourceFactory(storageClient)); err != nil {
+		logFailure(importArgs, err)
+		return err
+	}
+
+	importRunner, err := importer.NewImporter(importArgs, computeClient, *storageClient)
+	if err != nil {
+		logFailure(importArgs, err)
+		return err
+	}
+
+	importClosure := func() (service.Loggable, error) {
+		return importRunner.Run(ctx)
+	}
+
+	project := importArgs.Project
+	if err := service.RunWithServerLogging(
+		service.ImageImportAction, initLoggingParams(importArgs), &project, importClosure); err != nil {
+		return err
+	}
+	return nil
+}
+
+type logWriter struct{}
+
+func (l *logWriter) Write(bytes []byte) (int, error) {
+	return fmt.Printf("[%s]: %v %v", importer.LogPrefix,
+		time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), string(bytes))
+}
+
+// logFailure sends a message to the logging framework, and is expected to be
+// used when a validation failure causes the import to not run.
+func logFailure(allArgs importer.ImportArguments, cause error) {
+	noOpCallback := func() (service.Loggable, error) {
+		return nil, cause
+	}
+	// Ignoring the returned error since its a copy of
+	// the return value from the callback.
+	_ = service.RunWithServerLogging(
+		service.ImageImportAction, initLoggingParams(allArgs), nil, noOpCallback)
+}
+
+func initLoggingParams(args importer.ImportArguments) service.InputParams {
+	return service.InputParams{
+		ImageImportParams: &service.ImageImportParams{
+			CommonParams: &service.CommonParams{
+				ClientID:                args.ClientID,
+				ClientVersion:           args.ClientVersion,
+				Network:                 args.Network,
+				Subnet:                  args.Subnet,
+				Zone:                    args.Zone,
+				Timeout:                 args.Timeout.String(),
+				Project:                 args.Project,
+				ObfuscatedProject:       service.Hash(args.Project),
+				Labels:                  fmt.Sprintf("%v", args.Labels),
+				ScratchBucketGcsPath:    args.ScratchBucketGcsPath,
+				Oauth:                   args.Oauth,
+				ComputeEndpointOverride: args.ComputeEndpoint,
+				DisableGcsLogging:       args.GcsLogsDisabled,
+				DisableCloudLogging:     args.CloudLogsDisabled,
+				DisableStdoutLogging:    args.StdoutLogsDisabled,
+			},
+			ImageName:          args.ImageName,
+			DataDisk:           args.DataDisk,
+			OS:                 args.OS,
+			SourceFile:         args.SourceFile,
+			SourceImage:        args.SourceImage,
+			NoGuestEnvironment: args.NoGuestEnvironment,
+			Family:             args.Family,
+			Description:        args.Description,
+			NoExternalIP:       args.NoExternalIP,
+			StorageLocation:    args.StorageLocation,
+		},
+	}
+}

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -103,7 +103,7 @@ func (args *ImportArguments) ValidateAndPopulate(populator param.Populator,
 		return err
 	}
 
-	if err := populator.PopulateMissingParameters(&args.Project, &args.Zone, &args.Region,
+	if err := populator.PopulateMissingParameters(&args.Project, args.ClientID, &args.Zone, &args.Region,
 		&args.ScratchBucketGcsPath, args.SourceFile, &args.StorageLocation); err != nil {
 		return err
 	}

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -17,13 +17,12 @@ package importer
 import (
 	"flag"
 	"fmt"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
 
 	daisy_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"

--- a/cli_tools/gce_vm_image_import/importer/args_test.go
+++ b/cli_tools/gce_vm_image_import/importer/args_test.go
@@ -397,8 +397,7 @@ type mockPopulator struct {
 	err             error
 }
 
-func (m mockPopulator) PopulateMissingParameters(project *string, zone *string, region *string,
-	scratchBucketGcsPath *string, file string, storageLocation *string) error {
+func (m mockPopulator) PopulateMissingParameters(project *string, client string, zone *string, region *string, scratchBucketGcsPath *string, file string, storageLocation *string) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -12,135 +12,17 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// GCE VM image import tool
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
 	"os"
-	"time"
 
-	"google.golang.org/api/option"
-
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/compute"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/importer"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
 )
 
 func main() {
-	Main(os.Args[1:])
-}
-
-// Main starts an image import.
-func Main(args []string) {
-	log.SetFlags(0)
-	log.SetOutput(new(logWriter))
-	ctx := context.Background()
-
-	// 1. Parse the args without validating or populating. Splitting parsing and
-	// validation allows us to log the intermediate, non-validated values, if
-	// there's an error setting up dependencies.
-	importArgs, err := importer.NewImportArguments(args)
-	if err != nil {
-		terminate(importArgs, err)
-	}
-
-	// 2. Setup dependencies.
-	storageClient, err := storage.NewStorageClient(
-		ctx, logging.NewDefaultLogger(), option.WithCredentialsFile(importArgs.Oauth))
-	if err != nil {
-		terminate(importArgs, err)
-	}
-	computeClient, err := param.CreateComputeClient(
-		&ctx, importArgs.Oauth, importArgs.ComputeEndpoint)
-	if err != nil {
-		terminate(importArgs, err)
-	}
-	metadataGCE := &compute.MetadataGCE{}
-	paramPopulator := param.NewPopulator(
-		metadataGCE,
-		storageClient,
-		storage.NewResourceLocationRetriever(metadataGCE, computeClient),
-		storage.NewScratchBucketCreator(ctx, storageClient),
-	)
-
-	// 3. Parse, validate, and populate arguments.
-	if err = importArgs.ValidateAndPopulate(
-		paramPopulator, importer.NewSourceFactory(storageClient)); err != nil {
-		terminate(importArgs, err)
-	}
-
-	importRunner, err := importer.NewImporter(importArgs, computeClient, *storageClient)
-	if err != nil {
-		terminate(importArgs, err)
-	}
-
-	importClosure := func() (service.Loggable, error) {
-		return importRunner.Run(ctx)
-	}
-
-	project := importArgs.Project
-	if err := service.RunWithServerLogging(
-		service.ImageImportAction, initLoggingParams(importArgs), &project, importClosure); err != nil {
+	if err := cli.Main(os.Args[1:]); err != nil {
+		// Main is responsible for logging the failure.
 		os.Exit(1)
-	}
-}
-
-type logWriter struct{}
-
-func (l *logWriter) Write(bytes []byte) (int, error) {
-	return fmt.Printf("[%s]: %v %v", importer.LogPrefix,
-		time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), string(bytes))
-}
-
-// terminate is used when there is a failure prior to running import. It sends
-// a message to the logging framework, and then executes os.Exit(1).
-func terminate(allArgs importer.ImportArguments, cause error) {
-	noOpCallback := func() (service.Loggable, error) {
-		return nil, cause
-	}
-	// Ignoring the returned error since its a copy of
-	// the return value from the callback.
-	_ = service.RunWithServerLogging(
-		service.ImageImportAction, initLoggingParams(allArgs), nil, noOpCallback)
-	os.Exit(1)
-}
-
-func initLoggingParams(args importer.ImportArguments) service.InputParams {
-	return service.InputParams{
-		ImageImportParams: &service.ImageImportParams{
-			CommonParams: &service.CommonParams{
-				ClientID:                args.ClientID,
-				ClientVersion:           args.ClientVersion,
-				Network:                 args.Network,
-				Subnet:                  args.Subnet,
-				Zone:                    args.Zone,
-				Timeout:                 args.Timeout.String(),
-				Project:                 args.Project,
-				ObfuscatedProject:       service.Hash(args.Project),
-				Labels:                  fmt.Sprintf("%v", args.Labels),
-				ScratchBucketGcsPath:    args.ScratchBucketGcsPath,
-				Oauth:                   args.Oauth,
-				ComputeEndpointOverride: args.ComputeEndpoint,
-				DisableGcsLogging:       args.GcsLogsDisabled,
-				DisableCloudLogging:     args.CloudLogsDisabled,
-				DisableStdoutLogging:    args.StdoutLogsDisabled,
-			},
-			ImageName:          args.ImageName,
-			DataDisk:           args.DataDisk,
-			OS:                 args.OS,
-			SourceFile:         args.SourceFile,
-			SourceImage:        args.SourceImage,
-			NoGuestEnvironment: args.NoGuestEnvironment,
-			Family:             args.Family,
-			Description:        args.Description,
-			NoExternalIP:       args.NoExternalIP,
-			StorageLocation:    args.StorageLocation,
-		},
 	}
 }

--- a/cli_tools/mocks/mock_storage_client.go
+++ b/cli_tools/mocks/mock_storage_client.go
@@ -105,6 +105,20 @@ func (mr *MockStorageClientInterfaceMockRecorder) DeleteGcsPath(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGcsPath", reflect.TypeOf((*MockStorageClientInterface)(nil).DeleteGcsPath), arg0)
 }
 
+// DeleteObject mocks base method
+func (m *MockStorageClientInterface) DeleteObject(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObject", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteObject indicates an expected call of DeleteObject
+func (mr *MockStorageClientInterfaceMockRecorder) DeleteObject(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockStorageClientInterface)(nil).DeleteObject), arg0)
+}
+
 // FindGcsFile mocks base method
 func (m *MockStorageClientInterface) FindGcsFile(arg0, arg1 string) (*storage.ObjectHandle, error) {
 	m.ctrl.T.Helper()

--- a/cli_tools_tests/module/import/scratch_ownership_test.go
+++ b/cli_tools_tests/module/import/scratch_ownership_test.go
@@ -1,0 +1,287 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package import_test
+
+// During image import, we require that the scratch bucket is owned by
+// the project that's performing the import. When it's owned by a different
+// project, the import should be terminated, and the source file should be
+// removed if it's a single file that's located in the scratch bucket.
+//
+// To run this, ensure your account has 'Storage Object Creator' permissions
+// for the bucket `gs://bucket-owned-by-compute-image-test-resources`, which
+// is in the project `compute-image-test-resources`.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
+	"github.com/GoogleCloudPlatform/compute-image-tools/common/runtime"
+)
+
+const (
+	sharedBucket = "bucket-owned-by-compute-image-test-resources"
+)
+
+var (
+	project       = runtime.GetConfig("GOOGLE_CLOUD_PROJECT", "project")
+	zone          = runtime.GetConfig("GOOGLE_CLOUD_ZONE", "compute/zone")
+	privateBucket = setupPrivateBucket(project)
+)
+
+func init() {
+	if project == "compute-image-test-resources" {
+		panic("Execute test using a project other than compute-image-test-resources.")
+	}
+}
+
+func Test_DeleteSourceFile_WhenScratchOwnedByDifferentProject(t *testing.T) {
+	namespace := uuid.New().String()
+	for _, tt := range []struct {
+		caseName       string
+		deleteExpected bool
+		fileToImport   gcsPath
+		scratch        gcsPath
+		expectedError  *regexp.Regexp
+	}{
+		{
+			caseName:       "In scratch",
+			deleteExpected: true,
+			expectedError:  regexp.MustCompile("Scratch bucket.* is not in project.* Deleted"),
+			fileToImport: gcsPath{
+				bucket: sharedBucket,
+				dir:    namespace + "-in-scratch",
+				file:   "file.vmdk",
+			},
+			scratch: gcsPath{
+				bucket: sharedBucket,
+				dir:    namespace + "-in-scratch",
+			},
+		},
+		{
+			caseName:       "Not in scratch",
+			deleteExpected: false,
+			expectedError:  regexp.MustCompile("Scratch bucket.* is not in project"),
+			fileToImport: gcsPath{
+				bucket: privateBucket,
+				dir:    namespace + "-not-in-scratch",
+				file:   "file.vmdk",
+			},
+			scratch: gcsPath{
+				bucket: sharedBucket,
+				dir:    namespace + "-not-in-scratch",
+			},
+		},
+	} {
+		t.Run(tt.caseName, func(t *testing.T) {
+			imageName := "i" + uuid.New().String()
+			tt.fileToImport.write(t, imageName)
+
+			err := cli.Main([]string{
+				"-image_name", imageName,
+				"-data_disk",
+				"-client_id", "e2e",
+				"-source_file", tt.fileToImport.toURI(),
+				"-scratch_bucket_gcs_path", tt.scratch.toURI(),
+				"-project", project,
+				"-zone", zone,
+			})
+
+			// The import should always fail if the scratch bucket
+			// is owned by a different project.
+			assert.Error(t, err)
+			assert.Regexp(t, tt.expectedError, err.Error())
+
+			// Remove -source_file when it's a single file
+			// residing in the non-owned scratch bucket.
+			fileDeleted := !tt.fileToImport.exists(t)
+			if tt.deleteExpected && !fileDeleted {
+				t.Errorf("Expected %s to be deleted, but it wasn't", tt.fileToImport.toURI())
+			} else if !tt.deleteExpected && fileDeleted {
+				t.Errorf("Unexpected deletion of %s", tt.fileToImport.toURI())
+			}
+		})
+	}
+}
+
+func Test_DontDeleteSourceFile_WhenDirectory(t *testing.T) {
+
+	for _, tt := range []struct {
+		// Whether the directory passed to -source_file includes a trailing slash
+		trailingSlash bool
+
+		// Whether to create an empty file to represent the directory. See:
+		//   https://stackoverflow.com/questions/38416598/
+		makeDirObject bool
+
+		expectedError string
+	}{
+		{
+			trailingSlash: true,
+			makeDirObject: true,
+			expectedError: "cannot import an image from an empty file",
+		},
+		{
+			trailingSlash: true,
+			expectedError: "failed to read GCS file when validating resource file",
+		},
+		{
+			makeDirObject: true,
+			expectedError: "failed to read GCS file when validating resource file",
+		},
+		{
+			expectedError: "failed to read GCS file when validating resource file",
+		},
+	} {
+		caseName := fmt.Sprintf("dirObject=%v, trailingSlash=%v",
+			tt.makeDirObject, tt.trailingSlash)
+		t.Run(caseName, func(t *testing.T) {
+			namespace := uuid.New().String()
+
+			var objectsToCheck []gcsPath
+			for i := 0; i < 2; i++ {
+				fname := fmt.Sprintf("file_%d", i)
+				file := gcsPath{sharedBucket, namespace, fname}
+				file.write(t, fname)
+				objectsToCheck = append(objectsToCheck, file)
+			}
+
+			sourceFileArg := gcsPath{sharedBucket, namespace, ""}.toURI()
+			if tt.trailingSlash {
+				sourceFileArg += "/"
+			}
+			if tt.makeDirObject {
+				directory := gcsPath{sharedBucket, namespace, "/"}
+				directory.write(t, "")
+				objectsToCheck = append(objectsToCheck, directory)
+			}
+
+			err := cli.Main([]string{
+				"-image_name", "i" + uuid.New().String(),
+				"-data_disk",
+				"-client_id", "e2e",
+				"-source_file", sourceFileArg,
+				"-scratch_bucket_gcs_path", "gs://" + sharedBucket,
+				"-project", project,
+				"-zone", zone,
+			})
+
+			// The import should always fail if the scratch bucket
+			// is owned by a different project.
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+
+			for _, child := range objectsToCheck {
+				if !child.exists(t) {
+					t.Errorf("Unexpected deletion of %s", child.toURI())
+				}
+			}
+		})
+	}
+}
+
+func Test_DontDeleteSourceFile_WhenAnotherFileHasSamePrefix(t *testing.T) {
+	namespace := uuid.New().String()
+	scratch := gcsPath{
+		bucket: sharedBucket,
+		dir:    namespace,
+	}
+	file1 := gcsPath{bucket: sharedBucket, dir: scratch.dir, file: "disk1.vmdk"}
+	file1.write(t, "disk1 contents")
+	file2 := gcsPath{bucket: sharedBucket, dir: scratch.dir, file: "disk1.vmdk.sha256"}
+	file2.write(t, "ovf contents")
+
+	err := cli.Main([]string{
+		"-image_name", "i" + uuid.New().String(),
+		"-data_disk",
+		"-client_id", "e2e",
+		"-source_file", file1.toURI(),
+		"-scratch_bucket_gcs_path", scratch.toURI(),
+		"-project", project,
+		"-zone", zone,
+	})
+
+	assert.Error(t, err)
+
+	for _, path := range []gcsPath{file1, file2} {
+		if !path.exists(t) {
+			t.Errorf("Contents of %s should have been retained.", path.toURI())
+		}
+	}
+}
+
+type gcsPath struct {
+	bucket, dir, file string
+}
+
+func (path gcsPath) write(t *testing.T, content string) {
+	ctx := context.Background()
+	writer := path.openHandle(t, ctx).NewWriter(ctx)
+	if _, err := fmt.Fprintf(writer, content); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (path gcsPath) openHandle(t *testing.T, ctx context.Context) *storage.ObjectHandle {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client.Bucket(path.bucket).Object(path.dir + "/" + path.file)
+}
+
+func (path gcsPath) exists(t *testing.T) bool {
+	ctx := context.Background()
+	_, err := path.openHandle(t, ctx).NewReader(ctx)
+	return err == nil
+}
+
+func (path gcsPath) toURI() string {
+	uri := fmt.Sprintf("gs://%s/%s/", path.bucket, path.dir)
+	if path.file != "" {
+		uri += path.file
+	}
+	return uri
+}
+
+// setupPrivateBucket makes a bucket within the current project.
+// Naming is deterministic, and it's fine to re-use between tests.
+func setupPrivateBucket(project string) string {
+	bucketName := "compute-image-tools-e2e-" + project
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := client.Bucket(bucketName).Create(ctx, project, nil); err != nil {
+		realError := err.(*googleapi.Error)
+		// Code 409 indicates the bucket already exists:
+		// https://cloud.google.com/storage/docs/troubleshooting#bucket-name-conflict
+		if realError.Code != 409 {
+			panic(err)
+		}
+	}
+	return bucketName
+}


### PR DESCRIPTION
In #1373 we added deletion of the source file when the source file is contained in a scratch bucket that is contained in a different project.

This PR adds the following:
 - Validate that the source file is a single file. If there are other files that have the same prefix, don't perform deletion.
 - Module tests