### PR TITLE
Windows inspection: Use marketing versions

### DIFF
--- a/cli_tools_tests/module/diskinspect/disk_inspect_test.go
+++ b/cli_tools_tests/module/diskinspect/disk_inspect_test.go
@@ -53,12 +53,13 @@ func TestInspectDisk(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
+		caseName string
 		imageURI string
 		expected disk.InspectionResult
 	}{
 		{
-			"projects/opensuse-cloud/global/images/opensuse-leap-15-2-v20200702",
-			disk.InspectionResult{
+			imageURI: "projects/opensuse-cloud/global/images/opensuse-leap-15-2-v20200702",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "opensuse",
 				Major:                                    "15",
@@ -67,8 +68,8 @@ func TestInspectDisk(t *testing.T) {
 				BIOSBootableWithHybridMBROrProtectiveMBR: true,
 			},
 		}, {
-			"projects/suse-sap-cloud/global/images/sles-15-sp1-sap-v20200803",
-			disk.InspectionResult{
+			imageURI: "projects/suse-sap-cloud/global/images/sles-15-sp1-sap-v20200803",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "sles-sap",
 				Major:                                    "15",
@@ -76,20 +77,13 @@ func TestInspectDisk(t *testing.T) {
 				UEFIBootable:                             true,
 				BIOSBootableWithHybridMBROrProtectiveMBR: true,
 			},
-		}, {
-			"projects/compute-image-tools-test/global/images/windows-7-ent-x86-nodrivers",
-			disk.InspectionResult{
-				Architecture:                             "x86",
-				Distro:                                   "windows",
-				Major:                                    "6",
-				Minor:                                    "1",
-				UEFIBootable:                             false,
-				BIOSBootableWithHybridMBROrProtectiveMBR: false,
-			},
-		}, {
-			// UEFI inspection test for GPT UEFI
-			"projects/gce-uefi-images/global/images/rhel-7-v20200403",
-			disk.InspectionResult{
+		},
+
+		// UEFI
+		{
+			caseName: "UEFI inspection test for GPT UEFI",
+			imageURI: "projects/gce-uefi-images/global/images/rhel-7-v20200403",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "rhel",
 				Major:                                    "7",
@@ -98,9 +92,9 @@ func TestInspectDisk(t *testing.T) {
 				BIOSBootableWithHybridMBROrProtectiveMBR: false,
 			},
 		}, {
-			// UEFI inspection test for MBR-only
-			"projects/debian-cloud/global/images/debian-9-stretch-v20200714",
-			disk.InspectionResult{
+			caseName: "UEFI inspection test for MBR-only",
+			imageURI: "projects/debian-cloud/global/images/debian-9-stretch-v20200714",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "debian",
 				Major:                                    "9",
@@ -109,20 +103,20 @@ func TestInspectDisk(t *testing.T) {
 				BIOSBootableWithHybridMBROrProtectiveMBR: false,
 			},
 		}, {
-			// UEFI inspection test for GPT UEFI - windows
-			"projects/gce-uefi-images/global/images/windows-server-2019-dc-core-v20200609",
-			disk.InspectionResult{
+			caseName: "UEFI inspection test for GPT UEFI - windows",
+			imageURI: "projects/gce-uefi-images/global/images/windows-server-2019-dc-core-v20200609",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "windows",
-				Major:                                    "10",
+				Major:                                    "2019",
 				Minor:                                    "",
 				UEFIBootable:                             true,
 				BIOSBootableWithHybridMBROrProtectiveMBR: false,
 			},
 		}, {
-			// UEFI inspection test for GPT UEFI with BIOS boot
-			"projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317",
-			disk.InspectionResult{
+			caseName: "UEFI inspection test for GPT UEFI with BIOS boot",
+			imageURI: "projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "ubuntu",
 				Major:                                    "18",
@@ -131,9 +125,9 @@ func TestInspectDisk(t *testing.T) {
 				BIOSBootableWithHybridMBROrProtectiveMBR: true,
 			},
 		}, {
-			// UEFI inspection test for GPT UEFI with hybrid MBR
-			"projects/compute-image-tools-test/global/images/image-ubuntu-2004-hybrid-mbr",
-			disk.InspectionResult{
+			caseName: "UEFI inspection test for GPT UEFI with hybrid MBR",
+			imageURI: "projects/compute-image-tools-test/global/images/image-ubuntu-2004-hybrid-mbr",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "ubuntu",
 				Major:                                    "20",
@@ -142,9 +136,9 @@ func TestInspectDisk(t *testing.T) {
 				BIOSBootableWithHybridMBROrProtectiveMBR: true,
 			},
 		}, {
-			// UEFI inspection test for MBR-only UEFI
-			"projects/compute-image-tools-test/global/images/image-uefi-mbr-only",
-			disk.InspectionResult{
+			caseName: "UEFI inspection test for MBR-only UEFI",
+			imageURI: "projects/compute-image-tools-test/global/images/image-uefi-mbr-only",
+			expected: disk.InspectionResult{
 				Architecture:                             "x64",
 				Distro:                                   "ubuntu",
 				Major:                                    "16",
@@ -153,11 +147,101 @@ func TestInspectDisk(t *testing.T) {
 				BIOSBootableWithHybridMBROrProtectiveMBR: false,
 			},
 		},
+
+		// Windows Server
+		{
+			imageURI: "projects/windows-cloud/global/images/windows-server-2008-r2-dc-v20200114",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "2008",
+				Minor:        "r2",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-2012-r2-vmware-import",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "2012",
+				Minor:        "r2",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-2016-import",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "2016",
+				Minor:        "",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-2019",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "2019",
+				Minor:        "",
+			},
+		},
+
+		// Windows Desktop
+		{
+			imageURI: "projects/compute-image-tools-test/global/images/windows-7-ent-x86-nodrivers",
+			expected: disk.InspectionResult{
+				Architecture: "x86",
+				Distro:       "windows",
+				Major:        "7",
+				Minor:        "",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-7-import",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "7",
+				Minor:        "",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-8-1-ent-x86-nodrivers",
+			expected: disk.InspectionResult{
+				Architecture: "x86",
+				Distro:       "windows",
+				Major:        "8",
+				Minor:        "1",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-8-1-x64",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "8",
+				Minor:        "1",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-10-1909-ent-x86-nodrivers",
+			expected: disk.InspectionResult{
+				Architecture: "x86",
+				Distro:       "windows",
+				Major:        "10",
+				Minor:        "",
+			},
+		}, {
+			imageURI: "projects/compute-image-tools-test/global/images/windows-10-1709-import",
+			expected: disk.InspectionResult{
+				Architecture: "x64",
+				Distro:       "windows",
+				Major:        "10",
+				Minor:        "",
+			},
+		},
 	} {
 		// Without this, each parallel test will reference the last tt instance.
 		// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		currentTest := tt
-		t.Run(currentTest.imageURI, func(t *testing.T) {
+		name := currentTest.caseName
+		if name == "" {
+			name = currentTest.imageURI
+		}
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			inspector, err := disk.NewInspector(daisycommon.WorkflowAttributes{
 				Project:           project,

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/model.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/model.py
@@ -36,8 +36,6 @@ class Distro(enum.Enum):
   SLES = 'sles'
   UBUNTU = 'ubuntu'
   WINDOWS = 'windows'
-  WINDOWS_DESKTOP = 'windows-desktop'
-  WINDOWS_SERVER = 'windows-server'
 
 
 def distro_for(name: str):

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/model.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/model.py
@@ -36,6 +36,8 @@ class Distro(enum.Enum):
   SLES = 'sles'
   UBUNTU = 'ubuntu'
   WINDOWS = 'windows'
+  WINDOWS_DESKTOP = 'windows-desktop'
+  WINDOWS_SERVER = 'windows-server'
 
 
 def distro_for(name: str):

--- a/daisy_workflows/image_import/inspection/tests/test_model.py
+++ b/daisy_workflows/image_import/inspection/tests/test_model.py
@@ -69,8 +69,8 @@ class TestJSONEncoder:
     inspection_results = model.InspectionResults(
       device="/dev/sdb",
       os=model.OperatingSystem(
-        distro=model.Distro.WINDOWS_SERVER,
-        version=model.Version(major="6", minor="1"),
+        distro=model.Distro.WINDOWS,
+        version=model.Version(major="8", minor="1"),
       ),
       architecture=model.Architecture.x86,
     )
@@ -78,9 +78,9 @@ class TestJSONEncoder:
     expected = {
       "device": "/dev/sdb",
       "os": {
-        "distro": "windows-server",
+        "distro": "windows",
         "version": {
-          "major": "6",
+          "major": "8",
           "minor": "1",
         }
       },

--- a/daisy_workflows/image_import/inspection/tests/test_model.py
+++ b/daisy_workflows/image_import/inspection/tests/test_model.py
@@ -69,7 +69,7 @@ class TestJSONEncoder:
     inspection_results = model.InspectionResults(
       device="/dev/sdb",
       os=model.OperatingSystem(
-        distro=model.Distro.WINDOWS,
+        distro=model.Distro.WINDOWS_SERVER,
         version=model.Version(major="6", minor="1"),
       ),
       architecture=model.Architecture.x86,
@@ -78,7 +78,7 @@ class TestJSONEncoder:
     expected = {
       "device": "/dev/sdb",
       "os": {
-        "distro": "windows",
+        "distro": "windows-server",
         "version": {
           "major": "6",
           "minor": "1",

--- a/daisy_workflows/image_import/inspection/tests/test_windows.py
+++ b/daisy_workflows/image_import/inspection/tests/test_windows.py
@@ -1,0 +1,90 @@
+import unittest
+
+from boot_inspect import model
+from boot_inspect.inspectors.os.windows import _from_nt_version
+
+
+class TestNTMapping_Desktop(unittest.TestCase):
+
+  def test_vista(self):
+    assert _from_nt_version(
+        variant='Client', major_nt=6, minor_nt=0,
+        product_name='Windows Vista') == windows('Vista')
+
+  def test_7(self):
+    assert _from_nt_version(
+        variant='Client', major_nt=6, minor_nt=1,
+        product_name='Windows 7 Ultimate') == windows('7')
+
+  def test_8(self):
+    assert _from_nt_version(
+        variant='Client', major_nt=6, minor_nt=2,
+        product_name='Windows 8 Pro') == windows('8')
+
+  def test_8_1(self):
+    assert _from_nt_version(
+        variant='Client', major_nt=6, minor_nt=3,
+        product_name='Windows 8.1 Pro') == windows('8', '1')
+
+  def test_10(self):
+    assert _from_nt_version(
+        variant='Client', major_nt=10, minor_nt=0,
+        product_name='Windows 10 Enterprise') == windows('10')
+
+
+class TestNTMapping_Server(unittest.TestCase):
+
+  def test_2008(self):
+    assert _from_nt_version(
+        product_name='Windows Server 2008 Datacenter', variant='Server',
+        major_nt=6, minor_nt=0) == windows('2008')
+
+  def test_2008r2(self):
+    assert _from_nt_version(
+        product_name='Windows Server 2008 R2 Datacenter', variant='Server',
+        major_nt=6, minor_nt=1) == windows('2008', 'r2')
+
+  def test_2012(self):
+    assert _from_nt_version(
+        product_name='Windows Server 2012 Datacenter', variant='Server',
+        major_nt=6, minor_nt=2) == windows('2012')
+
+  def test_2012r2(self):
+    assert _from_nt_version(
+        product_name='Windows Server 2012 R2 Datacenter', variant='Server',
+        major_nt=6, minor_nt=3) == windows('2012', 'r2')
+
+  def test_2016(self):
+    assert _from_nt_version(
+        product_name='Windows Server 2016 Datacenter', variant='Server',
+        major_nt=10, minor_nt=0) == windows('2016')
+
+  def test_2019(self):
+    assert _from_nt_version(
+        product_name='Windows Server 2019 Datacenter', variant='Server',
+        major_nt=10, minor_nt=0) == windows('2019')
+
+
+class TestNTMapping_Unmatched(unittest.TestCase):
+
+  def test_return_None_when_nt10_ambigous(self):
+    # NT 10.0 is shared between server 2016 and 2019. Default to
+    # None if the product name doesn't include the version.
+    assert _from_nt_version(
+        product_name='Windows Server', variant='Server',
+        major_nt=10, minor_nt=0) is None
+
+  def test_return_None_prior_to_nt_6(self):
+    for major in range(1, 6):
+      for minor in range(1, 11):
+        for variant in ['Server', 'Client']:
+          assert _from_nt_version(
+              major_nt=major, minor_nt=minor, variant=variant,
+              product_name='Windows ' + variant) is None
+
+
+def windows(major, minor=''):
+  return model.OperatingSystem(
+      distro=model.Distro.WINDOWS,
+      version=model.Version(major, minor)
+  )


### PR DESCRIPTION
Prior to this, boot-inspect returned NT versions for Windows' major and minor versions. There are a couple of problems with this:
 1. Desktop and server use the same NT versions (server 2012r2 and desktop 8.1 have the same NT version)
 2. NT versions are sometimes reused. Server 2016 and Server 2019 use the same NT version

NT versions 6.0 and newer are included. Version mappings from https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions