### PR TITLE
[windows upgrade] modify powershell grammar that is incompatible on old versions

### DIFF
--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -43,10 +43,10 @@ online disk noerr
   }
 
   # Find the drive which contains install media.
-  $Drive_Letters = Get-WmiObject Win32_LogicalDisk
-  ForEach ($DriveLetter in $Drive_Letters.DeviceID) {
-    if (Test-Path "$($DriveLetter)\Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English") {
-      $script:install_media_drive = "$($DriveLetter)"
+  $Drives = Get-WmiObject Win32_LogicalDisk
+  ForEach ($Drive in $Drives) {
+    if (Test-Path "$($Drive.DeviceID)\Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English") {
+      $script:install_media_drive = "$($Drive.DeviceID)"
     }
   }
   if (!$script:install_media_drive) {


### PR DESCRIPTION
The grammar that won't work as expected with powershell < v2.0. Thus it will fail to find the install media.
Tested with a image provided by internal team, which installs v2 only: projects/emea-gcve-lab/zones/us-east4-a/disks/w2k8-vlst-3-boot-disk-6ixd
Previous test was via a simulated v2 so didn't expose this problem.