### PR TITLE
Boot inspect: Refactor linux matching to allow SLES for SAP detection

### DIFF
--- a/daisy_workflows/image_import/inspection/src/boot_inspect/inspection.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/inspection.py
@@ -37,43 +37,42 @@ from boot_inspect import model
 from boot_inspect.inspectors.os import architecture, linux, windows
 import boot_inspect.system.filesystems
 
-
 _LINUX = [
-  linux.Fingerprint(model.Distro.AMAZON, aliases=['amzn', 'amazonlinux']),
-  linux.Fingerprint(
-    model.Distro.CENTOS,
-    legacy=linux.LegacyFingerprint(
-      metadata_file='/etc/centos-release',
-      version_pattern=re.compile(r'\d+\.\d+'),
-      derivative_metadata_files=[
-        '/etc/fedora-release',
-        '/etc/oracle-release',
-      ]),
-  ),
-  linux.Fingerprint(
-    model.Distro.DEBIAN,
-    legacy=linux.LegacyFingerprint(
-      metadata_file='/etc/debian_version',
-      version_pattern=re.compile(r'\d+\.\d+'),
+    linux.Fingerprint(model.Distro.AMAZON, aliases=['amzn', 'amazonlinux']),
+    linux.Fingerprint(
+        model.Distro.CENTOS,
+        fs_predicate=linux.SentinelFileMatcher(
+            require={'/etc/centos-release'},
+            disallow={'/etc/fedora-release',
+                      '/etc/oracle-release'}),
+        version_reader=linux.VersionReader(
+            metadata_file='/etc/centos-release',
+            version_pattern=re.compile(r'\d+\.\d+')),
     ),
-  ),
-  linux.Fingerprint(model.Distro.FEDORA),
-  linux.Fingerprint(model.Distro.KALI),
-  linux.Fingerprint(
-    model.Distro.RHEL,
-    legacy=linux.LegacyFingerprint(
-      metadata_file='/etc/redhat-release',
-      version_pattern=re.compile(r'\d+\.\d+'),
-      derivative_metadata_files=[
-        '/etc/centos-release',
-        '/etc/fedora-release',
-        '/etc/oracle-release',
-      ]),
-  ),
-  linux.Fingerprint(model.Distro.SLES, aliases=['sles_sap']),
-  linux.Fingerprint(model.Distro.OPENSUSE, aliases=['opensuse-leap']),
-  linux.Fingerprint(model.Distro.ORACLE, aliases=['ol', 'oraclelinux']),
-  linux.Fingerprint(model.Distro.UBUNTU),
+    linux.Fingerprint(
+        model.Distro.DEBIAN,
+        version_reader=linux.VersionReader(
+            metadata_file='/etc/debian_version',
+            version_pattern=re.compile(r'\d+\.\d+'),
+        ),
+    ),
+    linux.Fingerprint(model.Distro.FEDORA),
+    linux.Fingerprint(model.Distro.KALI),
+    linux.Fingerprint(
+        model.Distro.RHEL,
+        fs_predicate=linux.SentinelFileMatcher(
+            require={'/etc/redhat-release'},
+            disallow={'/etc/fedora-release',
+                      '/etc/oracle-release',
+                      '/etc/centos-release'}),
+        version_reader=linux.VersionReader(
+            metadata_file='/etc/redhat-release',
+            version_pattern=re.compile(r'\d+\.\d+')),
+    ),
+    linux.Fingerprint(model.Distro.SLES, aliases=['sles_sap']),
+    linux.Fingerprint(model.Distro.OPENSUSE, aliases=['opensuse-leap']),
+    linux.Fingerprint(model.Distro.ORACLE, aliases=['ol', 'oraclelinux']),
+    linux.Fingerprint(model.Distro.UBUNTU),
 ]
 
 
@@ -112,9 +111,9 @@ def inspect_device(g, device: str) -> model.InspectionResults:
   g.umount_all()
 
   return model.InspectionResults(
-    device=device,
-    os=operating_system,
-    architecture=arch,
+      device=device,
+      os=operating_system,
+      architecture=arch,
   )
 
 

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/inspection.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/inspection.py
@@ -41,7 +41,7 @@ _LINUX = [
     linux.Fingerprint(model.Distro.AMAZON, aliases=['amzn', 'amazonlinux']),
     linux.Fingerprint(
         model.Distro.CENTOS,
-        fs_predicate=linux.SentinelFileMatcher(
+        fs_predicate=linux.FileExistenceMatcher(
             require={'/etc/centos-release'},
             disallow={'/etc/fedora-release',
                       '/etc/oracle-release'}),
@@ -60,7 +60,7 @@ _LINUX = [
     linux.Fingerprint(model.Distro.KALI),
     linux.Fingerprint(
         model.Distro.RHEL,
-        fs_predicate=linux.SentinelFileMatcher(
+        fs_predicate=linux.FileExistenceMatcher(
             require={'/etc/redhat-release'},
             disallow={'/etc/fedora-release',
                       '/etc/oracle-release',

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/inspectors/os/linux.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/inspectors/os/linux.py
@@ -21,7 +21,7 @@ from boot_inspect import model
 import boot_inspect.system.filesystems
 
 
-class SentinelFileMatcher:
+class FileExistenceMatcher:
   """Supports matching based on whether files exist on the filesystem.
 
   To illustrate this, these are the metadata files included by RHEL and its
@@ -92,7 +92,7 @@ class Fingerprint:
   def __init__(self,
                distro: model.Distro,
                aliases: typing.Iterable[str] = (),
-               fs_predicate: SentinelFileMatcher = None,
+               fs_predicate: FileExistenceMatcher = None,
                version_reader: VersionReader = None):
     """
     Args:


### PR DESCRIPTION
This PR refactors Linux inspection to support differentiation between SLES and SLES for SAP. SLES for SAP is identified by a sentinel file in /etc/products.d [1]. Prior to this PR, sentinel file matching was coupled to version extraction. This coupling blocks matching SLES for SAP, since SLES for SAP uses /etc/os-release for its version (and therefore doesn't have a custom version file).

SLES for SAP detection will come in a follow-up PR.

1. https://www.suse.com/support/kb/doc/?id=000019341