### PR TITLE
EL import: Surface yum_install errors

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -226,6 +226,7 @@ def yum_install(g, *packages):
   Raises:
       RuntimeError: If there is a failure during installation.
   """
+  last_exception = None
   for i in range(6):
     try:
       # There's no sleep on the first iteration since `i` is zero.
@@ -239,11 +240,10 @@ def yum_install(g, *packages):
           '"{0}"'.format(p) for p in packages))
       return
     except Exception as e:
+      last_exception = e
       logging.debug('Failed to install {}. Details: {}.'.format(packages, e))
-  raise RuntimeError(
-      'Verify that you have specified the correct operating system '
-      'in the `--os` flag.  If you are bringing your own license (BYOL), '
-      'also verify that your subscription is eligible to be run on GCP.')
+  raise RuntimeError('Failed to install {}. Details: {}.'.format(
+      packages, last_exception))
 
 
 def main():


### PR DESCRIPTION
Audited ten recent failures, and none were related to the incorrect OS  being specified. This makes sense, since the newer change [1] would have overwritten this error message with correct OS if it were indeed mispecified. After this change, the actual error will be more prominent to the user (rather than logged as the second-to-last line).

Failures from audit: 
1. Repositories unreachable (local file, uncreachable URL)
2. Corrupt rpm database
3. Package conflicts

__

1. https://github.com/GoogleCloudPlatform/compute-image-tools/blob/f5a91c65376c26d14c93854a42d408fc2da41a81/cli_tools/gce_vm_image_import/importer/errors.go#L28-L27