### PR TITLE
SLES import: Improve error messaging when SUSE not found on disk

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -86,6 +86,12 @@ var basicCases = []*testCase{
 		expectedError: "\"debian-9\" was detected on your disk, but \"opensuse-15\" was specified",
 		inspect:       true,
 	},
+	{
+		caseName:      "SLES import with no OS on disk",
+		source:        "gs://compute-image-tools-test-resources/empty-10gb.qcow2",
+		os:            "opensuse-15",
+		expectedError: "no operating systems found",
+	},
 
 	// Debian
 	{

--- a/daisy_workflows/image_import/suse/suse_import/setup.py
+++ b/daisy_workflows/image_import/suse/suse_import/setup.py
@@ -28,6 +28,6 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "translate-suse = translate:translate",
+            "translate-suse = translate:main",
         ],
     })

--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -145,6 +145,9 @@ def _get_release(g: guestfs.GuestFS) -> _SuseRelease:
   major = g.gcp_image_major
   minor = g.gcp_image_minor
 
+  if 'unknown' == product:
+    raise ValueError('No SUSE operating systems found.')
+
   matched = None
   for r in _releases:
     if re.match(r.name, product) \
@@ -337,3 +340,7 @@ def translate():
   _update_grub(g)
   utils.CommonRoutines(g)
   diskutils.UnmountDisk(g)
+
+
+def main():
+  utils.RunTranslate(translate, run_with_tracing=False)

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -26,6 +26,7 @@ import sys
 import time
 import trace
 import traceback
+import typing
 import urllib.error
 import urllib.request
 import uuid
@@ -227,11 +228,22 @@ def CommonRoutines(g):
   g.sh("rm -f /etc/ssh/ssh_host_*")
 
 
-def RunTranslate(translate_func):
+def RunTranslate(translate_func: typing.Callable,
+                 run_with_tracing: bool = True):
+  """Run `translate_func`, and communicate success or failure back to Daisy.
+
+  Args:
+    translate_func: Closure to execute
+    run_with_tracing: When enabled, the closure will be executed with
+    trace.Trace, resulting in executed lines being printed to stdout.
+  """
   try:
-    tracer = trace.Trace(
-        ignoredirs=[sys.prefix, sys.exec_prefix], trace=1, count=0)
-    tracer.runfunc(translate_func)
+    if run_with_tracing:
+      tracer = trace.Trace(
+          ignoredirs=[sys.prefix, sys.exec_prefix], trace=1, count=0)
+      tracer.runfunc(translate_func)
+    else:
+      translate_func()
     logging.success('Translation finished.')
   except Exception as e:
     logging.error('error: %s', str(e))


### PR DESCRIPTION
When no operating system is detected during SLES import, the user currently sees: `TranslateFailed: error: exits with return code 1`

The cause was:

```
ValueError: Import of unknown-0.0 is not supported. The following versions are supported: [opensuse-15.1|2, sles-15.1|2, sles-12.4|5]
```

Which appears in the logs, but is not surfaced to the user.

Two items are fixed:

1. Recognize that a distro of 'unknown' means that no operating system was found.
2. Fix surfacing of the actual error message.