### PR TITLE
[uefi support] enable uefi detection

### DIFF
--- a/cli_tools/common/utils/logging/service/literal_loggable.go
+++ b/cli_tools/common/utils/logging/service/literal_loggable.go
@@ -77,9 +77,13 @@ func (b *SingleImageImportLoggableBuilder) SetInflationAttributes(matchResult st
 	return b
 }
 
-// SetTraceLogs sets trace logs during the import.
-func (b *SingleImageImportLoggableBuilder) SetTraceLogs(traceLogs []string) *SingleImageImportLoggableBuilder {
-	b.traceLogs = traceLogs
+// AppendTraceLogs sets trace logs during the import.
+func (b *SingleImageImportLoggableBuilder) AppendTraceLogs(traceLogs []string) *SingleImageImportLoggableBuilder {
+	if b.traceLogs != nil {
+		b.traceLogs = append(b.traceLogs, traceLogs...)
+	} else {
+		b.traceLogs = traceLogs
+	}
 	return b
 }
 

--- a/cli_tools/common/utils/logging/service/literal_loggable_test.go
+++ b/cli_tools/common/utils/logging/service/literal_loggable_test.go
@@ -80,13 +80,14 @@ func TestSingleImageImportLoggableBuilder(t *testing.T) {
 						uefiBootable:          isUEFIDetectedValue,
 						biosBootable:          biosBootableValue,
 					},
-					traceLogs: traceLogs,
+					traceLogs: append(traceLogs, traceLogs...),
 				}
 				assert.Equal(t, expected, NewSingleImageImportLoggableBuilder().
 					SetDiskAttributes(format, sourceGb, targetGb).
 					SetUEFIMetrics(isUEFICompatibleImageValue, isUEFIDetectedValue, biosBootableValue, bootFSValue).
 					SetInflationAttributes(matchResultValue, inflationTypeValue, inflationTimeValue, shadowInflationTimeValue).
-					SetTraceLogs(traceLogs).
+					AppendTraceLogs(traceLogs).
+					AppendTraceLogs(traceLogs).
 					Build())
 			}
 		}

--- a/cli_tools/common/utils/logging/service/literal_loggable_test.go
+++ b/cli_tools/common/utils/logging/service/literal_loggable_test.go
@@ -52,7 +52,8 @@ func TestSingleImageImportLoggableBuilder(t *testing.T) {
 	format := "vmdk"
 	sourceGb := int64(12)
 	targetGb := int64(100)
-	traceLogs := []string{"log-a", "log-b"}
+	traceLogs1 := []string{"log-a", "log-b"}
+	traceLogs2 := []string{"log-c", "log-d"}
 	inflationTypeValue := "qemu"
 	inflationTimeValue := int64(10000)
 	shadowInflationTimeValue := int64(5000)
@@ -80,14 +81,14 @@ func TestSingleImageImportLoggableBuilder(t *testing.T) {
 						uefiBootable:          isUEFIDetectedValue,
 						biosBootable:          biosBootableValue,
 					},
-					traceLogs: append(traceLogs, traceLogs...),
+					traceLogs: append(traceLogs1, traceLogs2...),
 				}
 				assert.Equal(t, expected, NewSingleImageImportLoggableBuilder().
 					SetDiskAttributes(format, sourceGb, targetGb).
 					SetUEFIMetrics(isUEFICompatibleImageValue, isUEFIDetectedValue, biosBootableValue, bootFSValue).
 					SetInflationAttributes(matchResultValue, inflationTypeValue, inflationTimeValue, shadowInflationTimeValue).
-					AppendTraceLogs(traceLogs).
-					AppendTraceLogs(traceLogs).
+					AppendTraceLogs(traceLogs1).
+					AppendTraceLogs(traceLogs2).
 					Build())
 			}
 		}

--- a/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
@@ -39,6 +39,7 @@ func (p *diskInspectionProcessor) process(pd persistentDisk,
 	ir, err := p.inspectDisk(pd.uri)
 	if err != nil {
 		// Don't directly return err to avoid terminating the import.
+		loggableBuilder.AppendTraceLogs([]string{err.Error()})
 		return pd, nil
 	}
 

--- a/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
 // diskInspectionProcessor executes inspection towards the disk, including OS info,
@@ -56,7 +55,6 @@ func (p *diskInspectionProcessor) inspectDisk(uri string) (disk.InspectionResult
 	ir, err := p.diskInspector.Inspect(uri, p.args.Inspect)
 	if err != nil {
 		log.Printf("Disk inspection error=%v", err)
-		return ir, daisy.Errf("Disk inspection error: %v", err)
 	}
 
 	log.Printf("Disk inspection result=%v", ir)

--- a/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
 // diskInspectionProcessor executes inspection towards the disk, including OS info,
@@ -37,7 +38,8 @@ func (p *diskInspectionProcessor) process(pd persistentDisk,
 
 	ir, err := p.inspectDisk(pd.uri)
 	if err != nil {
-		return pd, err
+		// Don't directly return err to avoid terminating the import.
+		return pd, nil
 	}
 
 	isDualBoot := ir.UEFIBootable && ir.BIOSBootableWithHybridMBROrProtectiveMBR
@@ -55,6 +57,7 @@ func (p *diskInspectionProcessor) inspectDisk(uri string) (disk.InspectionResult
 	ir, err := p.diskInspector.Inspect(uri, p.args.Inspect)
 	if err != nil {
 		log.Printf("Disk inspection error=%v", err)
+		return ir, daisy.Errf("Disk inspection error: %v", err)
 	}
 
 	log.Printf("Disk inspection result=%v", ir)

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -195,7 +195,7 @@ func deleteDisk(diskClient diskClient, project string, zone string, pd persisten
 
 func (i *importer) buildLoggable() service.Loggable {
 	return i.loggableBuilder.SetDiskAttributes(i.pd.sourceType, i.pd.sourceGb, i.pd.sizeGb).
-		SetTraceLogs(i.traceLogs).
+		AppendTraceLogs(i.traceLogs).
 		Build()
 }
 

--- a/cli_tools/gce_vm_image_import/importer/processor.go
+++ b/cli_tools/gce_vm_image_import/importer/processor.go
@@ -51,10 +51,8 @@ func (d defaultProcessorProvider) provide(pd persistentDisk) (processors []proce
 		return
 	}
 
-	if d.ImportArguments.Inspect {
-		processors = append(processors, newDiskInspectionProcessor(d.diskInspector, d.ImportArguments))
-		processors = append(processors, newUefiProcessor(d.computeClient, d.ImportArguments))
-	}
+	processors = append(processors, newDiskInspectionProcessor(d.diskInspector, d.ImportArguments))
+	processors = append(processors, newUefiProcessor(d.computeClient, d.ImportArguments))
 
 	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImportArguments)
 	if err != nil {

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -299,21 +299,18 @@ var inspectUEFICases = []*testCase{
 		source:                  "gs://compute-image-tools-test-resources/uefi/linux-uefi-rhel-7.vmdk",
 		os:                      "rhel-7",
 		requiredGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                 true,
 	}, {
 		caseName: "inspect-uefi-linux-uefi-rhel-7-from-image",
 		// image created from projects/gce-uefi-images/global/images/rhel-7-v20200403 and removed UEFI_COMPATIBLE
 		source:                  "projects/compute-image-tools-test/global/images/linux-uefi-no-guestosfeature-rhel7",
 		os:                      "rhel-7",
 		requiredGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                 true,
 	}, {
 		caseName: "inspect-uefi-linux-nonuefi-debian-9",
 		// source created from projects/debian-cloud/global/images/debian-9-stretch-v20200714
 		source:                    "gs://compute-image-tools-test-resources/uefi/linux-nonuefi-debian-9.vmdk",
 		os:                        "debian-9",
 		notAllowedGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                   true,
 	}, {
 		caseName: "inspect-uefi-linux-dual-protective-mbr-ubuntu-1804",
 		// source created from projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317
@@ -321,7 +318,6 @@ var inspectUEFICases = []*testCase{
 		os:                        "ubuntu-1804",
 		osConfigNotSupported:      true,
 		notAllowedGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                   true,
 	}, {
 		caseName: "inspect-uefi-linux-dual-hybrid-mbr-ubuntu-2004",
 		// source created from scratch
@@ -329,7 +325,6 @@ var inspectUEFICases = []*testCase{
 		os:                        "ubuntu-2004",
 		osConfigNotSupported:      true,
 		notAllowedGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                   true,
 	}, {
 		caseName: "inspect-uefi-linux-uefi-mbr-ubuntu-1804",
 		// source created from projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317 and converted from GPT to MBR
@@ -337,21 +332,18 @@ var inspectUEFICases = []*testCase{
 		os:                      "ubuntu-1804",
 		osConfigNotSupported:    true,
 		requiredGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                 true,
 	}, {
 		caseName: "inspect-uefi-windows-uefi",
 		// source created from projects/gce-uefi-images/global/images/windows-server-2019-dc-core-v20200609
 		source:                  "gs://compute-image-tools-test-resources/uefi/windows-uefi-2019.vmdk",
 		os:                      "windows-2019",
 		requiredGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                 true,
 	}, {
 		caseName: "inspect-uefi-windows-nonuefi",
 		// source created from projects/windows-cloud/global/images/windows-server-2019-dc-v20200114
 		source:                    "gs://compute-image-tools-test-resources/uefi/windows-nonuefi-2019.vmdk",
 		os:                        "windows-2019",
 		notAllowedGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
-		inspect:                   true,
 	},
 }
 


### PR DESCRIPTION
Enable UEFI detection.

Notice: it will enable the shared workflow for OS inspection & UEFIinspection, but the actual OS inspection logic (in python) won't be executed.

Tested by UEFI e2e tests.