### PR TITLE
Inflation: Verify disk size prior to resizing

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
@@ -35,15 +35,12 @@ func TestCreateInflater_File(t *testing.T) {
 		ExecutionID:  "1234",
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
-	},
-		nil,
-		storage.Client{},
-		mockInspector{
-			t:                 t,
-			expectedReference: "gs://bucket/vmdk",
-			errorToReturn:     nil,
-			metaToReturn:      imagefile.Metadata{},
-		})
+	}, nil, storage.Client{}, mockInspector{
+		t:                 t,
+		expectedReference: "gs://bucket/vmdk",
+		errorToReturn:     nil,
+		metaToReturn:      imagefile.Metadata{},
+	}, nil)
 	assert.NoError(t, err)
 	mainInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)
@@ -65,7 +62,7 @@ func TestCreateInflater_Image(t *testing.T) {
 		Zone:        "us-west1-b",
 		ExecutionID: "1234",
 		WorkflowDir: daisyWorkflows,
-	}, nil, storage.Client{}, nil)
+	}, nil, storage.Client{}, nil, nil)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)

--- a/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater_test.go
@@ -27,7 +27,7 @@ import (
 const daisyWorkflows = "../../../daisy_workflows"
 
 func TestCreateInflater_File(t *testing.T) {
-	inflater, err := createInflater(ImportArguments{
+	inflater, err := newInflater(ImportArguments{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
 		Subnet:       "projects/subnet/subnet",
 		Network:      "projects/network/network",
@@ -57,7 +57,7 @@ func TestCreateInflater_File(t *testing.T) {
 }
 
 func TestCreateInflater_Image(t *testing.T) {
-	inflater, err := createInflater(ImportArguments{
+	inflater, err := newInflater(ImportArguments{
 		Source:      imageSource{uri: "projects/test/uri/image"},
 		Zone:        "us-west1-b",
 		ExecutionID: "1234",

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -44,7 +44,7 @@ type Importer interface {
 // NewImporter constructs an Importer instance.
 func NewImporter(args ImportArguments, computeClient compute.Client, storageClient storage.Client) (Importer, error) {
 	loggableBuilder := service.NewSingleImageImportLoggableBuilder()
-	inflater, err := createInflater(args, computeClient, storageClient, imagefile.NewGCSInspector(), loggableBuilder)
+	inflater, err := newInflater(args, computeClient, storageClient, imagefile.NewGCSInspector(), loggableBuilder)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -43,7 +43,8 @@ type Importer interface {
 
 // NewImporter constructs an Importer instance.
 func NewImporter(args ImportArguments, computeClient compute.Client, storageClient storage.Client) (Importer, error) {
-	inflater, err := createInflater(args, computeClient, storageClient, imagefile.NewGCSInspector())
+	loggableBuilder := service.NewSingleImageImportLoggableBuilder()
+	inflater, err := createInflater(args, computeClient, storageClient, imagefile.NewGCSInspector(), loggableBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func NewImporter(args ImportArguments, computeClient compute.Client, storageClie
 		processorProvider: defaultProcessorProvider{args, computeClient, inspector},
 		traceLogs:         []string{},
 		diskClient:        computeClient,
-		loggableBuilder:   service.NewSingleImageImportLoggableBuilder(),
+		loggableBuilder:   loggableBuilder,
 	}, nil
 }
 
@@ -72,7 +73,7 @@ type importer struct {
 	project, zone     string
 	pd                persistentDisk
 	preValidator      validator
-	inflater          inflater
+	inflater          Inflater
 	processorProvider processorProvider
 	traceLogs         []string
 	diskClient        diskClient
@@ -107,9 +108,9 @@ func (i *importer) Run(ctx context.Context) (loggable service.Loggable, err erro
 func (i *importer) runInflate(ctx context.Context) (err error) {
 	return i.runStep(ctx, func() error {
 		var err error
-		i.pd, _, err = i.inflater.inflate(i.loggableBuilder)
+		i.pd, _, err = i.inflater.Inflate()
 		return err
-	}, i.inflater.cancel, i.inflater.traceLogs)
+	}, i.inflater.Cancel, i.inflater.TraceLogs)
 }
 
 func (i *importer) runProcess(ctx context.Context) error {

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -404,14 +404,14 @@ func (m *mockProcessor) cancel(reason string) bool {
 type mockInflater struct {
 	serialLogs    []string
 	pd            persistentDisk
-	ii            inflationInfo
+	ii            shadowTestFields
 	err           error
 	interactions  int
 	inflationTime time.Duration
 	cancelChan    chan bool
 }
 
-func (m *mockInflater) inflate(_ *service.SingleImageImportLoggableBuilder) (persistentDisk, inflationInfo, error) {
+func (m *mockInflater) Inflate() (persistentDisk, shadowTestFields, error) {
 	m.interactions++
 	m.cancelChan = make(chan bool)
 
@@ -427,11 +427,11 @@ func (m *mockInflater) inflate(_ *service.SingleImageImportLoggableBuilder) (per
 	return m.pd, m.ii, m.err
 }
 
-func (m *mockInflater) traceLogs() []string {
+func (m *mockInflater) TraceLogs() []string {
 	return m.serialLogs
 }
 
-func (m *mockInflater) cancel(reason string) bool {
+func (m *mockInflater) Cancel(reason string) bool {
 	m.cancelChan <- true
 	return true
 }

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -202,13 +202,13 @@ type shadowTestFields struct {
 	inflationType string
 }
 
-func createInflater(args ImportArguments, computeClient daisyCompute.Client, storageClient storage.Client,
+func newInflater(args ImportArguments, computeClient daisyCompute.Client, storageClient storage.Client,
 	inspector imagefile.Inspector, loggableBuilder *service.SingleImageImportLoggableBuilder) (Inflater, error) {
-	return CreateDaisyInflater(args, inspector)
+	return NewDaisyInflater(args, inspector)
 }
 
-// CreateDaisyInflater returns an Inflater implementation that uses a Daisy workflow.
-func CreateDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector) (Inflater, error) {
+// NewDaisyInflater returns an Inflater that uses a Daisy workflow.
+func NewDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector) (Inflater, error) {
 	diskName := "disk-" + args.ExecutionID
 	var wfPath string
 	var vars map[string]string

--- a/cli_tools/gce_vm_image_import/importer/inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater.go
@@ -45,8 +45,9 @@ const (
 
 // inflaterFacade implements an inflater using other concrete implementations.
 type inflaterFacade struct {
-	mainInflater   inflater
-	shadowInflater inflater
+	mainInflater    Inflater
+	shadowInflater  Inflater
+	loggableBuilder *service.SingleImageImportLoggableBuilder
 }
 
 // signals to control the verification towards shadow inflater
@@ -57,15 +58,15 @@ const (
 	sigShadowInflaterErr  = "shadow err"
 )
 
-func (facade *inflaterFacade) inflate(loggableBuilder *service.SingleImageImportLoggableBuilder) (persistentDisk, inflationInfo, error) {
+func (facade *inflaterFacade) Inflate() (persistentDisk, shadowTestFields, error) {
 	inflaterChan := make(chan string)
 
 	// Launch main inflater.
 	var pd persistentDisk
-	var ii inflationInfo
+	var ii shadowTestFields
 	var err error
 	go func() {
-		pd, ii, err = facade.mainInflater.inflate(loggableBuilder)
+		pd, ii, err = facade.mainInflater.Inflate()
 		if err != nil {
 			inflaterChan <- sigMainInflaterErr
 		} else {
@@ -75,10 +76,10 @@ func (facade *inflaterFacade) inflate(loggableBuilder *service.SingleImageImport
 
 	// Launch shadow inflater.
 	var shadowPd persistentDisk
-	var shadowIi inflationInfo
+	var shadowIi shadowTestFields
 	var shadowErr error
 	go func() {
-		shadowPd, shadowIi, shadowErr = facade.shadowInflater.inflate(loggableBuilder)
+		shadowPd, shadowIi, shadowErr = facade.shadowInflater.Inflate()
 		if shadowErr != nil {
 			inflaterChan <- sigShadowInflaterErr
 		} else {
@@ -115,21 +116,21 @@ func (facade *inflaterFacade) inflate(loggableBuilder *service.SingleImageImport
 		}
 	}
 
-	loggableBuilder.SetInflationAttributes(matchResult, ii.inflationType, ii.inflationTime.Milliseconds(), shadowIi.inflationTime.Milliseconds())
+	facade.loggableBuilder.SetInflationAttributes(matchResult, ii.inflationType, ii.inflationTime.Milliseconds(), shadowIi.inflationTime.Milliseconds())
 
 	return pd, ii, err
 }
 
-func (facade *inflaterFacade) cancel(reason string) bool {
-	facade.shadowInflater.cancel(reason)
-	return facade.mainInflater.cancel(reason)
+func (facade *inflaterFacade) Cancel(reason string) bool {
+	facade.shadowInflater.Cancel(reason)
+	return facade.mainInflater.Cancel(reason)
 }
 
-func (facade *inflaterFacade) traceLogs() []string {
-	return facade.mainInflater.traceLogs()
+func (facade *inflaterFacade) TraceLogs() []string {
+	return facade.mainInflater.TraceLogs()
 }
 
-func (facade *inflaterFacade) compareWithShadowInflater(mainPd, shadowPd *persistentDisk, mainIi, shadowIi *inflationInfo) string {
+func (facade *inflaterFacade) compareWithShadowInflater(mainPd, shadowPd *persistentDisk, mainIi, shadowIi *shadowTestFields) string {
 	matchFormat := "sizeGb-%v,sourceGb-%v,content-%v"
 	sizeGbMatch := shadowPd.sizeGb == mainPd.sizeGb
 	sourceGbMatch := shadowPd.sourceGb == mainPd.sourceGb
@@ -145,14 +146,14 @@ func (facade *inflaterFacade) compareWithShadowInflater(mainPd, shadowPd *persis
 	return result
 }
 
-// inflater constructs a new persistentDisk, typically starting from a
+// Inflater constructs a new persistentDisk, typically starting from a
 // frozen representation of a disk, such as a VMDK file or a GCP disk image.
 //
 // Implementers can expose detailed logs using the traceLogs() method.
-type inflater interface {
-	inflate(*service.SingleImageImportLoggableBuilder) (persistentDisk, inflationInfo, error)
-	traceLogs() []string
-	cancel(reason string) bool
+type Inflater interface {
+	Inflate() (persistentDisk, shadowTestFields, error)
+	TraceLogs() []string
+	Cancel(reason string) bool
 }
 
 // daisyInflater implements an inflater using daisy workflows, and is capable
@@ -163,7 +164,7 @@ type daisyInflater struct {
 	serialLogs      []string
 }
 
-func (inflater *daisyInflater) inflate(_ *service.SingleImageImportLoggableBuilder) (persistentDisk, inflationInfo, error) {
+func (inflater *daisyInflater) Inflate() (persistentDisk, shadowTestFields, error) {
 	startTime := time.Now()
 	err := inflater.wf.Run(context.Background())
 	if inflater.wf.Logger != nil {
@@ -179,7 +180,7 @@ func (inflater *daisyInflater) inflate(_ *service.SingleImageImportLoggableBuild
 			sizeGb:     string_utils.SafeStringToInt(targetSizeGB),
 			sourceGb:   string_utils.SafeStringToInt(sourceSizeGB),
 			sourceType: importFileFormat,
-		}, inflationInfo{
+		}, shadowTestFields{
 			checksum:      checksum,
 			inflationTime: time.Since(startTime),
 			inflationType: "qemu",
@@ -194,23 +195,20 @@ type persistentDisk struct {
 	isUEFICompatible bool
 }
 
-type inflationInfo struct {
+type shadowTestFields struct {
 	// Below fields are for shadow API inflation metrics
 	checksum      string
 	inflationTime time.Duration
 	inflationType string
 }
 
-func createInflater(args ImportArguments, computeClient daisyCompute.Client, storageClient storage.Client, inspector imagefile.Inspector) (inflater, error) {
-	di, err := createDaisyInflater(args, inspector)
-	if err != nil {
-		return nil, err
-	}
-
-	return di, nil
+func createInflater(args ImportArguments, computeClient daisyCompute.Client, storageClient storage.Client,
+	inspector imagefile.Inspector, loggableBuilder *service.SingleImageImportLoggableBuilder) (Inflater, error) {
+	return CreateDaisyInflater(args, inspector)
 }
 
-func createDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector) (inflater, error) {
+// CreateDaisyInflater returns an Inflater implementation that uses a Daisy workflow.
+func CreateDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector) (Inflater, error) {
 	diskName := "disk-" + args.ExecutionID
 	var wfPath string
 	var vars map[string]string
@@ -256,7 +254,7 @@ func createDaisyInflater(args ImportArguments, fileInspector imagefile.Inspector
 	}, nil
 }
 
-func (inflater *daisyInflater) traceLogs() []string {
+func (inflater *daisyInflater) TraceLogs() []string {
 	return inflater.serialLogs
 }
 
@@ -283,7 +281,7 @@ func getDisk(workflow *daisy.Workflow, diskIndex int) *daisy.Disk {
 	panic("Did not find CreateDisks step.")
 }
 
-func (inflater *daisyInflater) cancel(reason string) bool {
+func (inflater *daisyInflater) Cancel(reason string) bool {
 	inflater.wf.CancelWithReason(reason)
 	return true
 }

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -277,7 +277,7 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 func createDaisyInflaterSafe(t *testing.T, args ImportArguments,
 	inspector imagefile.Inspector) *daisyInflater {
 	args.WorkflowDir = "../../../daisy_workflows"
-	inflater, err := createDaisyInflater(args, inspector)
+	inflater, err := CreateDaisyInflater(args, inspector)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -277,7 +277,7 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 func createDaisyInflaterSafe(t *testing.T, args ImportArguments,
 	inspector imagefile.Inspector) *daisyInflater {
 	args.WorkflowDir = "../../../daisy_workflows"
-	inflater, err := CreateDaisyInflater(args, inspector)
+	inflater, err := NewDaisyInflater(args, inspector)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)

--- a/cli_tools_tests/go.mod
+++ b/cli_tools_tests/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleCloudPlatform/compute-image-tools/cli_tools_tests
 go 1.13
 
 require (
+	cloud.google.com/go/storage v1.11.0
 	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools v0.0.0
 	github.com/GoogleCloudPlatform/compute-image-tools/common v0.0.0
 	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0

--- a/cli_tools_tests/go.sum
+++ b/cli_tools_tests/go.sum
@@ -56,6 +56,7 @@ github.com/aws/aws-sdk-go v1.34.22 h1:7V2sKilVVgHqdjbW+O/xaVWYfnmuLwZdF/+6JuUh6C
 github.com/aws/aws-sdk-go v1.34.22/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.35.0 h1:Pxqn1MWNfBCNcX7jrXCCTfsKpg5ms2IMUMmmcGtYJuo=
 github.com/aws/aws-sdk-go v1.35.0/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -162,6 +163,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/minio/highwayhash v1.0.0 h1:iMSDhgUILCr0TNm8LWlSjF8N0ZIj2qbO8WHp6Q/J2BA=
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/cli_tools_tests/module/import/file_inflation_test.go
+++ b/cli_tools_tests/module/import/file_inflation_test.go
@@ -1,0 +1,129 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package import_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/importer"
+	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+)
+
+const (
+	workflowDir = "../../../daisy_workflows"
+)
+
+func TestDaisyFileInflation(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		fileURI string
+	}{
+		{
+			name:    "no resizing required",
+			fileURI: "gs://compute-image-tools-test-resources/file-inflation-test/virt-8G.vmdk",
+		},
+		{
+			name:    "resize dest",
+			fileURI: "gs://compute-image-tools-test-resources/file-inflation-test/virt-12G.vmdk",
+		},
+		{
+			name:    "resize scratch",
+			fileURI: "gs://compute-image-tools-test-resources/file-inflation-test/raw-10G-virt-10G.img",
+		},
+		{
+			name:    "resize scratch and dest",
+			fileURI: "gs://compute-image-tools-test-resources/file-inflation-test/raw-12G-virt-12G.img",
+		},
+	} {
+		currentTest := tt
+		t.Run(currentTest.name, func(t *testing.T) {
+			t.Parallel()
+			diskID := runDaisyInflate(t, currentTest.fileURI)
+			assertDiskExists(t, diskID)
+			deleteDisk(t, diskID)
+		})
+	}
+
+}
+
+func assertDiskExists(t *testing.T, diskID string) {
+	client, err := daisycompute.NewClient(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	disk, err := client.GetDisk(project, zone, diskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Found disk: %v", disk)
+}
+
+func deleteDisk(t *testing.T, diskID string) {
+	client, err := daisycompute.NewClient(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.DeleteDisk(project, zone, diskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Deleted disk: %v", diskID)
+}
+
+func runDaisyInflate(t *testing.T, fileURI string) string {
+
+	namespace := uuid.New().String()
+	expectedDiskName := "disk-" + namespace
+
+	ctx := context.Background()
+	storageClient, err := storage.NewStorageClient(ctx, logging.NewDefaultLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sourceObj, err := importer.NewSourceFactory(storageClient).Init(fileURI, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := importer.ImportArguments{
+		ExecutionID: namespace,
+		WorkflowDir: workflowDir,
+		Project:     project,
+		Source:      sourceObj,
+		Timeout:     time.Hour,
+		Zone:        zone,
+	}
+	inflater, err := importer.CreateDaisyInflater(args, imagefile.NewGCSInspector())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pd, inflateInfo, err := inflater.Inflate()
+	t.Logf("Finished inflation: pd=%v, inflateInfo=%v, err=%v", pd, inflateInfo, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return expectedDiskName
+}

--- a/cli_tools_tests/module/import/pkg_test.go
+++ b/cli_tools_tests/module/import/pkg_test.go
@@ -1,0 +1,22 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package import_test
+
+import "github.com/GoogleCloudPlatform/compute-image-tools/common/runtime"
+
+var (
+	project = runtime.GetConfig("GOOGLE_CLOUD_PROJECT", "project")
+	zone    = runtime.GetConfig("GOOGLE_CLOUD_ZONE", "compute/zone")
+)

--- a/cli_tools_tests/module/import/scratch_ownership_test.go
+++ b/cli_tools_tests/module/import/scratch_ownership_test.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/api/googleapi"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
-	"github.com/GoogleCloudPlatform/compute-image-tools/common/runtime"
 )
 
 const (
@@ -43,8 +42,6 @@ const (
 )
 
 var (
-	project       = runtime.GetConfig("GOOGLE_CLOUD_PROJECT", "project")
-	zone          = runtime.GetConfig("GOOGLE_CLOUD_ZONE", "compute/zone")
 	privateBucket = setupPrivateBucket(project)
 )
 
@@ -295,10 +292,10 @@ func setupPrivateBucket(project string) string {
 		panic(err)
 	}
 	if err := client.Bucket(bucketName).Create(ctx, project, nil); err != nil {
-		realError := err.(*googleapi.Error)
+		realError, ok := err.(*googleapi.Error)
 		// Code 409 indicates the bucket already exists:
 		// https://cloud.google.com/storage/docs/troubleshooting#bucket-name-conflict
-		if realError.Code != 409 {
+		if !ok || realError.Code != 409 {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
Includes the following changes:
* import_image.sh: Prior to resizing a disk, check its size to determine whether it needs resizing.
* module tests: Added a test for `gce_vm_image_import/importer/inflater.go`
   * This required reverting the `Inflater.inflate(loggableBuilder *service.SingleImageImportLoggableBuilder)` prototype back to `Inflater.inflate()`; the loggable builder is only used in the facade implementation.
* Create a file `cli_tools_tests/module/import/pkg_test.go` to contain `zone` and `project` variables that are shared within the package.