### PR TITLE
[log] move the loc of inspection_results due to the inconsistency of proto v.s. design

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -92,20 +92,21 @@ type InputParams struct {
 type ImageImportParams struct {
 	*CommonParams
 
-	ImageName          string `json:"image_name,omitempty"`
-	DataDisk           bool   `json:"data_disk"`
-	OS                 string `json:"os,omitempty"`
-	SourceFile         string `json:"source_file,omitempty"`
-	SourceImage        string `json:"source_image,omitempty"`
-	NoGuestEnvironment bool   `json:"no_guest_environment"`
-	Family             string `json:"family,omitempty"`
-	Description        string `json:"description,omitempty"`
-	NoExternalIP       bool   `json:"no_external_ip"`
-	HasKmsKey          bool   `json:"has_kms_key"`
-	HasKmsKeyring      bool   `json:"has_kms_keyring"`
-	HasKmsLocation     bool   `json:"has_kms_location"`
-	HasKmsProject      bool   `json:"has_kms_project"`
-	StorageLocation    string `json:"storage_location,omitempty"`
+	ImageName          string            `json:"image_name,omitempty"`
+	DataDisk           bool              `json:"data_disk"`
+	OS                 string            `json:"os,omitempty"`
+	SourceFile         string            `json:"source_file,omitempty"`
+	SourceImage        string            `json:"source_image,omitempty"`
+	NoGuestEnvironment bool              `json:"no_guest_environment"`
+	Family             string            `json:"family,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	NoExternalIP       bool              `json:"no_external_ip"`
+	HasKmsKey          bool              `json:"has_kms_key"`
+	HasKmsKeyring      bool              `json:"has_kms_keyring"`
+	HasKmsLocation     bool              `json:"has_kms_location"`
+	HasKmsProject      bool              `json:"has_kms_project"`
+	StorageLocation    string            `json:"storage_location,omitempty"`
+	InspectionResults  InspectionResults `json:"inspection_results,omitempty"`
 }
 
 // ImageExportParams contains all input params for image export
@@ -254,8 +255,6 @@ type OutputInfo struct {
 	IsUEFICompatibleImage bool `json:"is_uefi_compatible_image,omitempty"`
 	// Indicates whether the image is auto-detected to be UEFI compatible
 	IsUEFIDetected bool `json:"is_uefi_detected,omitempty"`
-	// InspectionResults contains metadata determined using automated inspection
-	InspectionResults InspectionResults `json:"inspection_results,omitempty"`
 }
 
 // InspectionResults contains metadata determined using automated inspection

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -193,6 +193,13 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 		o.ShadowDiskMatchResult = loggable.GetValue(shadowDiskMatchResult)
 		o.IsUEFICompatibleImage = loggable.GetValueAsBool(isUEFICompatibleImage)
 		o.IsUEFIDetected = loggable.GetValueAsBool(isUEFIDetected)
+
+		// TODO: ideally we suppose to set o.InspectionResults. Will modify after proto is adjusted.
+		l.Params.ImageImportParams.InspectionResults = InspectionResults{
+			UEFIBootable: loggable.GetValueAsBool(uefiBootable),
+			BIOSBootable: loggable.GetValueAsBool(biosBootable),
+			RootFS:       loggable.GetValue(rootFS),
+		}
 	}
 
 	if err != nil {
@@ -202,14 +209,6 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 			o.SerialOutputs = loggable.ReadSerialPortLogs()
 		}
 	}
-
-	// TODO: ideally we suppose to set o.InspectionResults. Will modify after proto is adjusted.
-	l.Params.ImageImportParams.InspectionResults = InspectionResults{
-		UEFIBootable: loggable.GetValueAsBool(uefiBootable),
-		BIOSBootable: loggable.GetValueAsBool(biosBootable),
-		RootFS:       loggable.GetValue(rootFS),
-	}
-
 
 	return &o
 }

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -195,10 +195,12 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 		o.IsUEFIDetected = loggable.GetValueAsBool(isUEFIDetected)
 
 		// TODO: ideally we suppose to set o.InspectionResults. Will modify after proto is adjusted.
-		l.Params.ImageImportParams.InspectionResults = InspectionResults{
-			UEFIBootable: loggable.GetValueAsBool(uefiBootable),
-			BIOSBootable: loggable.GetValueAsBool(biosBootable),
-			RootFS:       loggable.GetValue(rootFS),
+		if l.Params.ImageImportParams != nil {
+			l.Params.ImageImportParams.InspectionResults = InspectionResults{
+				UEFIBootable: loggable.GetValueAsBool(uefiBootable),
+				BIOSBootable: loggable.GetValueAsBool(biosBootable),
+				RootFS:       loggable.GetValue(rootFS),
+			}
 		}
 	}
 

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -193,12 +193,6 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 		o.ShadowDiskMatchResult = loggable.GetValue(shadowDiskMatchResult)
 		o.IsUEFICompatibleImage = loggable.GetValueAsBool(isUEFICompatibleImage)
 		o.IsUEFIDetected = loggable.GetValueAsBool(isUEFIDetected)
-
-		o.InspectionResults = InspectionResults{
-			UEFIBootable: loggable.GetValueAsBool(uefiBootable),
-			BIOSBootable: loggable.GetValueAsBool(biosBootable),
-			RootFS:       loggable.GetValue(rootFS),
-		}
 	}
 
 	if err != nil {
@@ -208,6 +202,14 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 			o.SerialOutputs = loggable.ReadSerialPortLogs()
 		}
 	}
+
+	// TODO: ideally we suppose to set o.InspectionResults. Will modify after proto is adjusted.
+	l.Params.ImageImportParams.InspectionResults = InspectionResults{
+		UEFIBootable: loggable.GetValueAsBool(uefiBootable),
+		BIOSBootable: loggable.GetValueAsBool(biosBootable),
+		RootFS:       loggable.GetValue(rootFS),
+	}
+
 
 	return &o
 }


### PR DESCRIPTION
Tested from local, verified that db received the log & parsed correctly