### PR TITLE
Don't fail import when 70-persistent-net.rules is a directory

### DIFF
--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -220,7 +220,7 @@ def CommonRoutines(g):
   # Remove udev file to force it to be re-generated
   logging.info('Removing udev 70-persistent-net.rules.')
   _ClearImmutableAttr(g, '/etc/udev/rules.d/70-persistent-net.rules')
-  g.rm_f('/etc/udev/rules.d/70-persistent-net.rules')
+  g.rm_rf('/etc/udev/rules.d/70-persistent-net.rules')
 
   # Remove SSH host keys.
   logging.info('Removing SSH host keys.')


### PR DESCRIPTION
A derivative of Ubuntu 18.04 failed import with the message: `rm_f: /etc/udev/rules.d/70-persistent-net.rules: Is a directory"`

## Testing:

 - Confirmed that affected image imported
 - Ran the ubuntu tests in `cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go`