### PR TITLE
Fixed an edge case in image importer run step that can cause a deadlock on timeout

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/importer.go
+++ b/cli_tools/gce_vm_image_import/importer/importer.go
@@ -137,7 +137,6 @@ func (i *importer) runProcess(ctx context.Context) error {
 func (i *importer) runStep(ctx context.Context, step func() error, cancel func(string) bool, getTraceLogs func() []string) (err error) {
 	e := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
 	go func() {
 		//this select checks if context expired prior to runStep being called
 		//if not, step is run
@@ -145,6 +144,7 @@ func (i *importer) runStep(ctx context.Context, step func() error, cancel func(s
 		case <-ctx.Done():
 			e <- i.getCtxError(ctx)
 		default:
+			wg.Add(1)
 			stepErr := step()
 			wg.Done()
 			e <- stepErr

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -487,12 +488,11 @@ func (m *mockInflater) Inflate() (persistentDisk, shadowTestFields, error) {
 	if m.inflationTime > 0 {
 		select {
 		case <-m.cancelChan:
-			break
+			return m.pd, m.ii, fmt.Errorf("cancelled inflater")
 		case <-time.After(m.inflationTime):
 			break
 		}
 	}
-
 	return m.pd, m.ii, m.err
 }
 

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -374,9 +374,11 @@ func TestRunStep_VeryShortTimeout(t *testing.T) {
 		defer cancel()
 
 		cancelChan := make(chan bool)
+		didStepRun := false
 		importer.runStep(ctx,
 			func() error {
 				// step
+				didStepRun = true
 				select {
 				case <-cancelChan:
 					break
@@ -399,6 +401,7 @@ func TestRunStep_VeryShortTimeout(t *testing.T) {
 				//getTraceLogs
 				return []string{}
 			})
+		assert.False(t, didStepRun)
 	})
 }
 


### PR DESCRIPTION
Fixed an edge case in image importer run step that can cause deadlock to occur on timeout due to WaitGroup being added to before checking for context expiration/timeout. This can cause wg.Wait() in the cancellation handler below to wait forever.