### PR TITLE
EL import: Update ca-certificates when translation starts

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -282,6 +282,14 @@ var basicCases = []*testCase{
 		os:       "centos-8",
 		inspect:  true,
 	},
+	{
+		// If an admin adds epel to an older version of EL 6 without updating ca-certificates,
+		// then yum operations will fail. For more info: https://stackoverflow.com/questions/26734777
+		caseName: "don't fail when stale CA certificates and epel repo is present",
+		source:   "projects/compute-image-tools-test/global/images/centos-6-epel",
+		os:       "centos-6",
+		inspect:  true,
+	},
 
 	// Windows
 	{

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -246,6 +246,7 @@ def RunTranslate(translate_func: typing.Callable,
       translate_func()
     logging.success('Translation finished.')
   except Exception as e:
+    logging.debug(traceback.format_exc())
     logging.error('error: %s', str(e))
 
 


### PR DESCRIPTION
Import fails when `ca-certificates`  is stale such that a yum repo cannot by verified. A concrete example occurs when `epel` is added to an older version of EL 6, as described in https://stackoverflow.com/questions/26734777 .

After this PR, all EL imports will have `ca-certificates` upgraded, _if_ `ca-certificates` is installed.  

## Testing

* Create a CentOS 6 image that reproduces the issue.
* Ran all EL tests in `import_tests.go`