### PR TITLE
Ensure shell output from guest is retained

### DIFF
--- a/daisy_workflows/linux_common/tests/test_guestfsprocess.py
+++ b/daisy_workflows/linux_common/tests/test_guestfsprocess.py
@@ -1,0 +1,70 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+import subprocess
+import tempfile
+from unittest.mock import MagicMock
+
+from utils.guestfsprocess import CompletedProcess, GuestFSInterface, run
+
+
+def test_capture_stdout():
+  cmd = 'echo abc123'
+  result = run(_make_local_guestfs(), cmd)
+  assert result == CompletedProcess('abc123\n', '', 0, cmd)
+
+
+def test_capture_stderr():
+  cmd = 'echo error msg > /dev/stderr'
+  result = run(_make_local_guestfs(), cmd)
+  assert result == CompletedProcess('', 'error msg\n', 0, cmd)
+
+
+def test_support_positive_code():
+  cmd = 'exit 100'
+  result = run(_make_local_guestfs(), cmd)
+  assert result == CompletedProcess('', '', 100, cmd)
+
+
+def test_support_array_args():
+  result = run(_make_local_guestfs(), ['echo', 'hi'])
+  assert result == CompletedProcess('hi\n', '', 0, 'echo hi')
+
+
+def test_escape_array_members():
+  result = run(_make_local_guestfs(), ['echo', 'hello', '; ls *'])
+  assert result == CompletedProcess('hello ; ls *\n', '', 0,
+                                    "echo hello '; ls *'")
+
+
+def test_capture_runtime_errors():
+  result = run(_make_local_guestfs(), 'not-a-command')
+  assert result.code != 0
+  assert 'not-a-command' in result.stderr
+
+
+def test_capture_output_when_non_zero_return():
+  cmd = 'printf content; printf err > /dev/stderr; exit 1'
+  result = run(_make_local_guestfs(), cmd)
+  assert result == CompletedProcess('content', 'err', 1, cmd)
+
+
+def _make_local_guestfs():
+  tmp_dir = tempfile.mkdtemp()
+  g = GuestFSInterface()
+  g.mkdtemp = MagicMock(return_value=tmp_dir)
+  g.cat = lambda path: pathlib.Path(path).read_text()
+  g.command = lambda args: subprocess.run(args, check=True)
+  g.write = lambda path, txt: pathlib.Path(path).write_text(txt)
+  return g

--- a/daisy_workflows/linux_common/utils/guestfsprocess.py
+++ b/daisy_workflows/linux_common/utils/guestfsprocess.py
@@ -45,7 +45,7 @@ def run(g: 'GuestFSInterface', command) -> 'CompletedProcess':
     >>> run(g, 'printf hi; exit 1')
     {'stdout': 'hi', 'stderr': '', 'code': 1, 'cmd': 'printf hi; exit 1'}
   """
-  tmp_dir = g.mkdtemp('gprocXXXXXX')
+  tmp_dir = g.mkdtemp('/tmp/gprocXXXXXX')
   program_path = os.path.join(tmp_dir, 'program.sh')
   stdout_path = os.path.join(tmp_dir, 'stdout.txt')
   stderr_path = os.path.join(tmp_dir, 'stderr.txt')

--- a/daisy_workflows/linux_common/utils/guestfsprocess.py
+++ b/daisy_workflows/linux_common/utils/guestfsprocess.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run a process in a guestfs.GuestFS instance.
+
+This library addresses a shortcoming of GuestFS.command and GuestFS.sh
+that cause data loss. When the command is successful, stderr is discarded.
+When the command fails, stdout is discarded.
+
+This library is motivated by subprocess.run, which returns an object
+containing stdout, stderr, and the return code of the process.
+"""
+
+import os
+import shlex
+import textwrap
+import typing
+
+
+def run(g: 'GuestFSInterface', command) -> 'CompletedProcess':
+  """Runs a process in a mounted GuestFS instance, ensuring that
+  standard output and standard error is always retained.
+
+  Args:
+    g: Mounted GuestFS instance.
+    command (str or List[str]): Script content that will be executed
+    by a bash interpeter on the guest.
+
+  Examples:
+    >>> run(g, 'date').stdout
+    Thu 05 Nov 2020 06:53:55 PM PST
+
+    >>> run(g, 'printf hi; exit 1')
+    {'stdout': 'hi', 'stderr': '', 'code': 1, 'cmd': 'printf hi; exit 1'}
+  """
+  tmp_dir = g.mkdtemp('gprocXXXXXX')
+  program_path = os.path.join(tmp_dir, 'program.sh')
+  stdout_path = os.path.join(tmp_dir, 'stdout.txt')
+  stderr_path = os.path.join(tmp_dir, 'stderr.txt')
+  return_code_path = os.path.join(tmp_dir, 'return_code.txt')
+
+  if not isinstance(command, str):
+    command = ' '.join(shlex.quote(s) for s in command)
+
+  program = _make_wrapping_program(command, stdout_path, stderr_path,
+                                   return_code_path)
+  g.write(program_path, program)
+  g.command(['/bin/bash', program_path])
+
+  return CompletedProcess(cmd=command,
+                          stdout=g.cat(stdout_path),
+                          stderr=g.cat(stderr_path),
+                          code=int(g.cat(return_code_path)))
+
+
+def _make_wrapping_program(
+    cmd: str, stdout_path: str, stderr_path: str,
+    return_code_path: str) -> str:
+  """Creates a shell script that captures the stdout, stderr, and return code
+  to files on the filesystem.
+
+  Args:
+    cmd: Command to execute.
+    stdout_path: Path to file for stdout.
+    stderr_path: Path to file for stderr.
+    return_code_path: Path to write return code of executing cmd.
+
+  Returns:
+    String containing the shell script.
+  """
+  return textwrap.dedent("""
+  touch {stdout_path}
+  touch {stderr_path}
+  touch {return_code_path}
+
+  bash -c {cmd} 1> {stdout_path} 2> {stderr_path}
+  echo $? > {return_code_path}
+  exit 0
+  """.format(cmd=shlex.quote(cmd),
+             stdout_path=shlex.quote(stdout_path),
+             stderr_path=shlex.quote(stderr_path),
+             return_code_path=shlex.quote(return_code_path)))
+
+
+class GuestFSInterface:
+  # The subset of guestfs.GuestFS that's used by this module.
+  def cat(self, path: str) -> str:
+    raise NotImplementedError()
+
+  def command(self, arguments: typing.List[str]) -> str:
+    raise NotImplementedError()
+
+  def mkdtemp(self, tmpl: str) -> str:
+    raise NotImplementedError()
+
+  def write(self, path: str, content: str):
+    raise NotImplementedError()
+
+
+class CompletedProcess:
+  def __init__(self, stdout: str, stderr: str, code: int, cmd: str):
+    self.stdout = stdout
+    self.stderr = stderr
+    self.code = code
+    self.cmd = cmd
+
+  def __eq__(self, o: object) -> bool:
+    return (isinstance(o, CompletedProcess)
+            and o.stdout == self.stdout
+            and o.stderr == self.stderr
+            and o.code == self.code
+            and o.cmd == self.cmd)
+
+  def __repr__(self):
+    return str(self.__dict__)


### PR DESCRIPTION
While debugging recent yum-related failures, half had not-helpful failure messages.

Examples:

* `sh:"""`
* `sh: Error: Nothing to do."""`
* `sh: Traceback (most recent call last):"""`

The problem is guestfs.GuestFS's shell methods. They discard either stdout or stderr, depending on whether the command fails or is successful (respectfully). 


This library is motivated by subprocess.run, which returns an object containing stdout, stderr, and the return code of the process.