### PR TITLE
bugfix: remove comma

### DIFF
--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -38,7 +38,7 @@ def main():
 
   utc_time = datetime.datetime.now(datetime.timezone.utc)
   image_version = utc_time.strftime('%Y%m%d')
-  build_date = utc_time.astimezone().isoformat(),
+  build_date = utc_time.astimezone().isoformat()
   image = {
       'id': image_id,
       'name': image_name,


### PR DESCRIPTION
failed to get image metadata: failure unmarshal file to json parsing time "["2020-11-06T19:06:05.138104+00:00"]" as ""2006-01-02T15:04:05Z07:00"": cannot parse "["2020-11-06T19:06:05.138104+00:00"]" as """

The comma will make build_date to an array when parsing. 
