### PR TITLE
Enable-RemoteDesktop move up further

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -351,8 +351,6 @@ try {
   Enable-RemoteDesktop
     
   if ($script:sysprep.ToLower() -ne 'true') {
-
-
     if ($script:is_byol.ToLower() -ne 'true') {
       Write-Output 'Translate: Setting up KMS activation'
       . 'C:\Program Files\Google\Compute Engine\sysprep\activate_instance.ps1' | Out-Null

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -348,8 +348,10 @@ try {
     & netsh interface ipv4 set dnsservers "$($_.NetConnectionID)" dhcp | Out-Null
   }
 
+  Enable-RemoteDesktop
+    
   if ($script:sysprep.ToLower() -ne 'true') {
-    Enable-RemoteDesktop
+
 
     if ($script:is_byol.ToLower() -ne 'true') {
       Write-Output 'Translate: Setting up KMS activation'


### PR DESCRIPTION
When --syspre-windows flag is used, Enable-RemoteDesktop is not called so that an instance from the imported image can't be accessed unless RDP was enabled before importing.