### PR TITLE
EL import: Tune upgrading of ca-certificates

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -34,6 +34,7 @@
     "import_files/translate.py": "./translate.py",
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
+    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
     "startup_script": "../../linux_common/bootstrap.sh"
   },


### PR DESCRIPTION
In #1417 we updated EL import to update ca-certificates. This PR makes two improvements, both found by reading testgrid translation logs:

* Avoid unnecessary latency by updating ca-certificates only when translating EL6 guests that use the epel repo. In the EL6 test [1], the previous PR added about 80 seconds. In the RHEL7 [2] test, it added about 15 minutes. In the current version, the time penalty only occurs when:
   * The guest is EL6
   * It uses the epel repo
   * It uses an old version of ca-certificates 
* Improve debugability of the feature by using the library added in #1418.


1. https://github.com/GoogleCloudPlatform/compute-image-tools/blob/5a2d47d1138373d1ee2a2152eb3a96dffee7ccfd/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go#L288
2. https://github.com/GoogleCloudPlatform/compute-image-tools/blob/5a2d47d1138373d1ee2a2152eb3a96dffee7ccfd/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go#L317