### PR TITLE
Adding exit after Restart-Computer, to prevent the script from continuing.

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -320,6 +320,7 @@ try {
     if (-not (Test-Path -Path $env:TEMP\translate_metadata_reboot.txt -PathType Leaf)) {
       New-Item -Path $env:TEMP\translate_metadata_reboot.txt
       Restart-Computer -Force
+      exit 0
     }
     else {
       Throw "Failed to obtain at least one of the required values from metadata and a reboot has already been attempted."
@@ -349,7 +350,7 @@ try {
   }
 
   Enable-RemoteDesktop
-    
+
   if ($script:sysprep.ToLower() -ne 'true') {
     if ($script:is_byol.ToLower() -ne 'true') {
       Write-Output 'Translate: Setting up KMS activation'


### PR DESCRIPTION
This is to correct an issue where the script continued after the restart-computer cmdlet was called. This caused the build to fail prior to the reboot completing so the script didn't get the second attempt which is the intention.