### PR TITLE
Linux translate: Print status once

### DIFF
--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -53,6 +53,7 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "translate.py",
+            "script_prints_status": "yes",
             "prefix": "Translate",
             "debian_release": "${debian_release}",
             "install_gce_packages": "${install_gce_packages}"

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -51,6 +51,7 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "translate.py",
+            "script_prints_status": "yes",
             "prefix": "Translate",
             "el_release": "${el_release}",
             "install_gce_packages": "${install_gce_packages}",

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -64,6 +64,7 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "run-translate.sh",
+            "script_prints_status": "yes",
             "prefix": "Translate",
             "install_gce_packages": "${install_gce_packages}"
           },

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -69,6 +69,7 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "run-translate.sh",
+            "script_prints_status": "yes",
             "prefix": "Translate",
             "subscription_model": "${subscription_model}",
             "install_gce_packages": "${install_gce_packages}",

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -53,6 +53,7 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "translate.py",
+            "script_prints_status": "yes",
             "prefix": "Translate",
             "ubuntu_release": "${ubuntu_release}",
             "install_gce_packages": "${install_gce_packages}"

--- a/daisy_workflows/linux_common/bootstrap.sh
+++ b/daisy_workflows/linux_common/bootstrap.sh
@@ -131,4 +131,11 @@ chmod +x "$path_script"
 CheckPython3Installation
 
 logger -p daemon.info "Status: Running $path_script"
+# Remove the trap when script_prints_status equals "yes".
+# Useful when the script handles its own communication with
+# daisy (typically with prefixes such as "TranslateSuccess"
+# and "TranslateFailure").
+GetMetadataAttribute "script_prints_status"
+[ "$attribute_value" = "yes" ] && trap - EXIT
+
 "$path_script"

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -237,6 +237,7 @@ def RunTranslate(translate_func: typing.Callable,
     run_with_tracing: When enabled, the closure will be executed with
     trace.Trace, resulting in executed lines being printed to stdout.
   """
+  exit_code = 0
   try:
     if run_with_tracing:
       tracer = trace.Trace(
@@ -246,8 +247,11 @@ def RunTranslate(translate_func: typing.Callable,
       translate_func()
     logging.success('Translation finished.')
   except Exception as e:
+    exit_code = 1
     logging.debug(traceback.format_exc())
     logging.error('error: %s', str(e))
+  logging.shutdown()
+  sys.exit(exit_code)
 
 
 def MakeExecutable(file_path):


### PR DESCRIPTION
At the end of Linux translation, statuses are double printed, once by Python and once by Bash. If Python reports a failure, but fails to flush its logs, then the incorrect status can be read by Daisy.

This was observed recently in the "Incorrect OS specified" test: 

```
 startup-script-url: TranslateStatus: <serial-output key:'detected_distro' value:'debian'>
 startup-script-url: TranslateStatus: <serial-output key:'detected_major_version' value:'9'>
 startup-script-url: TranslateStatus: <serial-output key:'detected_minor_version' value:'12'>
 startup-script-url: TranslateDebug: Traceback (most recent call last):
 startup-script-url:   File "/usr/local/lib/python3.7/dist-packages/utils/common.py", line 246, in RunTranslate
 startup-script-url:     translate_func()
 startup-script-url:   File "/usr/local/lib/python3.7/dist-packages/translate.py", line 320, in translate
 startup-script-url:     release = _get_release(g)
 startup-script-url:   File "/usr/local/lib/python3.7/dist-packages/translate.py", line 162, in _get_release
 startup-script-url:     product, major, minor, supported))
 startup-script-url: ValueError: Import of debian-9.12 is not supported. The following versions are supported: [opensuse-15.1|2, sles-15.1|2, sles-12.4|5]
 startup-script-url: 
 startup-script-url: TranslateFailed: error: Import of debian-9.12 is not supported. The following versions are supported: [opensuse-15.1|2, sles-15.1|2, sles-12.4|5]
 startup-script-url: + NotifyExit
 startup-script-url: + [ 0 -eq 0 ]
 startup-script-url: + logger -p daemon.info TranslateSuccess: exits with return code 0
Nov 12 13:30:33 inst-translator-import-image-gzzm6 root: TranslateSuccess: exits with return code 0
 startup-script-url exit status 0
 Finished running startup scripts.
```

This PR disables Bash's final-status printing for Linux translations (except if there's a failure prior to running the Python interpreter).

## Testing

* Ran the tests `cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go`


