### PR TITLE
Disk inspection: Don't panic when disk has unsupported distro

### DIFF
--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -178,6 +178,10 @@ func (i *bootInspector) validate(results *pb.InspectionResults) error {
 		return nil
 	}
 
+	if results.OsRelease == nil {
+		return errors.New("Worker should return OsRelease when OsCount == 1")
+	}
+
 	if results.OsRelease.CliFormatted != "" {
 		return errors.New("Worker should not return CliFormatted")
 	}

--- a/cli_tools/common/disk/inspect_test.go
+++ b/cli_tools/common/disk/inspect_test.go
@@ -121,6 +121,14 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 			expectErrorToContain: "Worker should not return OsRelease when NumOsFound != 1",
 		},
 		{
+			caseName: "Fail when OsCount is one and OsRelease is nil",
+			responseFromInspection: &pb.InspectionResults{
+				OsCount: 1,
+			},
+			expectResults:        InspectionResult{},
+			expectErrorToContain: "Worker should return OsRelease when OsCount == 1",
+		},
+		{
 			caseName: "Fail when OsCount > 1 and OsRelease non-nil",
 			responseFromInspection: &pb.InspectionResults{
 				OsCount:   2,

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/inspection.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/inspection.py
@@ -128,7 +128,7 @@ def inspect_device(g) -> inspect_pb2.InspectionResults:
 
   return inspect_pb2.InspectionResults(
       os_release=operating_system,
-      os_count=1,
+      os_count=1 if operating_system else 0,
   )
 
 


### PR DESCRIPTION
Prior to this, a panic occurred at [1] when there was a bootable partition, but we didn't recognize the distro in it. Two changes:
1. Fixed the root cause in inspection.py
2. Added a nil check so  that an error is returned rather than a panic

The issue was identified in the testcase "el-yum-not-found" [2], which uses a disk image with manjaro in it. 


Testing:
- Added test that reproduced the issue and confirms the fix
- Ran `daisy/cli_tools_tests/e2e/gce_image_import_export/test_suites/import`
1. https://github.com/GoogleCloudPlatform/compute-image-tools/blob/93b6de86409bc966e4cabdff93c2e852c469ab4a/cli_tools/common/disk/inspect.go#L181-L180
2. https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1327973760887689216