### PR TITLE
[VMDK shadow test] minor: fix error construction logic

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/api_inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater.go
@@ -134,7 +134,10 @@ func (inflater *apiInflater) Inflate() (persistentDisk, shadowTestFields, error)
 	// Calculate checksum by daisy workflow
 	inflater.addTraceLog("Started checksum calculation.")
 	ii.checksum, err = inflater.calculateChecksum(ctx, diskURI)
-	return pd, ii, daisy.Errf("Failed to calculate checksum: %v", err)
+	if err != nil {
+		err = daisy.Errf("Failed to calculate checksum: %v", err)
+	}
+	return pd, ii, err
 }
 
 func (inflater *apiInflater) getShadowDiskName() string {


### PR DESCRIPTION
The previous logic will print an misleading log field to shadow test result:
"Shadow inflater failed while main inflater succeeded: [Failed to calculate checksum: <nil>]"
It's actually a success. It doesn't impact our analysis (just treat it as success when doing statistics) but is misleading to other engineers.