### PR TITLE
Image import: Inspect OS and log results

### DIFF
--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -38,25 +39,9 @@ const (
 type Inspector interface {
 	// Inspect finds partition and boot-related properties for a disk and
 	// returns an InspectionResult. The reference is implementation specific.
-	Inspect(reference string, inspectOS bool) (InspectionResult, error)
+	Inspect(reference string, inspectOS bool) (*pb.InspectionResults, error)
 	Cancel(reason string) bool
 	TraceLogs() []string
-}
-
-// InspectionResult contains the partition and boot-related properties of a disk.
-type InspectionResult struct {
-	// UEFIBootable indicates whether the disk is bootable with UEFI.
-	UEFIBootable bool
-
-	// BIOSBootableWithHybridMBROrProtectiveMBR indicates whether the disk is BIOS-bootable
-	// or "hybrid MBR" mode or "protective MBR" mode.
-	BIOSBootableWithHybridMBROrProtectiveMBR bool
-
-	// RootFS indicates the file system type of the partition containing
-	// the root directory ("/").
-	RootFS string
-
-	Architecture, Distro, Major, Minor string
 }
 
 // NewInspector creates an Inspector that can inspect GCP disks.
@@ -96,7 +81,8 @@ func (i *bootInspector) TraceLogs() []string {
 // returns an InspectionResult. `reference` is a fully-qualified PD URI, such as
 // "projects/project-name/zones/us-central1-a/disks/disk-name". `inspectOS` is a flag
 // to determine whether to inspect OS on the disk.
-func (i *bootInspector) Inspect(reference string, inspectOS bool) (InspectionResult, error) {
+func (i *bootInspector) Inspect(reference string, inspectOS bool) (*pb.InspectionResults, error) {
+	started := time.Now()
 	results := &pb.InspectionResults{}
 
 	// Run the inspection worker.
@@ -106,7 +92,7 @@ func (i *bootInspector) Inspect(reference string, inspectOS bool) (InspectionRes
 	}
 	encodedProto, err := i.worker.RunAndReadSerialValue("inspect_pb", vars)
 	if err != nil {
-		return i.assembleErrors(reference, results, pb.InspectionResults_RUNNING_WORKER, err)
+		return i.assembleErrors(reference, results, pb.InspectionResults_RUNNING_WORKER, err, started)
 	}
 
 	// Decode the base64-encoded proto.
@@ -115,20 +101,21 @@ func (i *bootInspector) Inspect(reference string, inspectOS bool) (InspectionRes
 		err = proto.Unmarshal(bytes, results)
 	}
 	if err != nil {
-		return i.assembleErrors(reference, results, pb.InspectionResults_DECODING_WORKER_RESPONSE, err)
+		return i.assembleErrors(reference, results, pb.InspectionResults_DECODING_WORKER_RESPONSE, err, started)
 	}
 	i.tracef("Detection results: %s", results.String())
 
 	// Validate the results.
 	if err = i.validate(results); err != nil {
-		return i.assembleErrors(reference, results, pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS, err)
+		return i.assembleErrors(reference, results, pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS, err, started)
 	}
 
 	if err = i.populate(results); err != nil {
-		return i.assembleErrors(reference, results, pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS, err)
+		return i.assembleErrors(reference, results, pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS, err, started)
 	}
 
-	return createLegacyResults(results), nil
+	results.ElapsedTimeMs = time.Now().Sub(started).Milliseconds()
+	return results, nil
 }
 
 // tracef formats according to a format specifier and appends the results to the trace logs.
@@ -138,32 +125,15 @@ func (i *bootInspector) tracef(format string, a ...interface{}) {
 
 // assembleErrors sets the errorWhen field, and generates an error object.
 func (i *bootInspector) assembleErrors(reference string, results *pb.InspectionResults,
-	errorWhen pb.InspectionResults_ErrorWhen, err error) (InspectionResult, error) {
+	errorWhen pb.InspectionResults_ErrorWhen, err error, started time.Time) (*pb.InspectionResults, error) {
 	results.ErrorWhen = errorWhen
 	if err != nil {
 		err = fmt.Errorf("failed to inspect %v: %w", reference, err)
 	} else {
 		err = fmt.Errorf("failed to inspect %v", reference)
 	}
-	return createLegacyResults(results), err
-}
-
-// createLegacyResults converts pb.InspectionResults to InspectionResult.
-func createLegacyResults(pbResults *pb.InspectionResults) (results InspectionResult) {
-	if pbResults.OsCount == 1 && pbResults.OsRelease != nil {
-		results = InspectionResult{
-			Distro: pbResults.OsRelease.GetDistro(),
-			Major:  pbResults.OsRelease.GetMajorVersion(),
-			Minor:  pbResults.OsRelease.GetMinorVersion(),
-		}
-		if pbResults.OsRelease.Architecture != pb.Architecture_ARCHITECTURE_UNKNOWN {
-			results.Architecture = strings.ToLower(pbResults.OsRelease.Architecture.String())
-		}
-	}
-	results.UEFIBootable = pbResults.GetUefiBootable()
-	results.BIOSBootableWithHybridMBROrProtectiveMBR = pbResults.GetBiosBootable()
-	results.RootFS = pbResults.RootFs
-	return results
+	results.ElapsedTimeMs = time.Now().Sub(started).Milliseconds()
+	return results, err
 }
 
 // validate checks the fields from a pb.InspectionResults object for consistency, returning

--- a/cli_tools/common/disk/mocks/mock.go
+++ b/cli_tools/common/disk/mocks/mock.go
@@ -5,7 +5,7 @@
 package mock_disk
 
 import (
-	disk "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
+	pb "github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -34,10 +34,10 @@ func (m *MockInspector) EXPECT() *MockInspectorMockRecorder {
 }
 
 // Inspect mocks base method
-func (m *MockInspector) Inspect(reference string, inspectOS bool) (disk.InspectionResult, error) {
+func (m *MockInspector) Inspect(reference string, inspectOS bool) (*pb.InspectionResults, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Inspect", reference, inspectOS)
-	ret0, _ := ret[0].(disk.InspectionResult)
+	ret0, _ := ret[0].(*pb.InspectionResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -74,70 +74,4 @@ func (m *MockInspector) TraceLogs() []string {
 func (mr *MockInspectorMockRecorder) TraceLogs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceLogs", reflect.TypeOf((*MockInspector)(nil).TraceLogs))
-}
-
-// MockdaisyWorker is a mock of daisyWorker interface
-type MockdaisyWorker struct {
-	ctrl     *gomock.Controller
-	recorder *MockdaisyWorkerMockRecorder
-}
-
-// MockdaisyWorkerMockRecorder is the mock recorder for MockdaisyWorker
-type MockdaisyWorkerMockRecorder struct {
-	mock *MockdaisyWorker
-}
-
-// NewMockdaisyWorker creates a new mock instance
-func NewMockdaisyWorker(ctrl *gomock.Controller) *MockdaisyWorker {
-	mock := &MockdaisyWorker{ctrl: ctrl}
-	mock.recorder = &MockdaisyWorkerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdaisyWorker) EXPECT() *MockdaisyWorkerMockRecorder {
-	return m.recorder
-}
-
-// runAndReadSerialValue mocks base method
-func (m *MockdaisyWorker) runAndReadSerialValue(key string, vars map[string]string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "runAndReadSerialValue", key, vars)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// runAndReadSerialValue indicates an expected call of runAndReadSerialValue
-func (mr *MockdaisyWorkerMockRecorder) runAndReadSerialValue(key, vars interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runAndReadSerialValue", reflect.TypeOf((*MockdaisyWorker)(nil).runAndReadSerialValue), key, vars)
-}
-
-// cancel mocks base method
-func (m *MockdaisyWorker) cancel(reason string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "cancel", reason)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// cancel indicates an expected call of cancel
-func (mr *MockdaisyWorkerMockRecorder) cancel(reason interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "cancel", reflect.TypeOf((*MockdaisyWorker)(nil).cancel), reason)
-}
-
-// traceLogs mocks base method
-func (m *MockdaisyWorker) traceLogs() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "traceLogs")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// traceLogs indicates an expected call of traceLogs
-func (mr *MockdaisyWorkerMockRecorder) traceLogs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "traceLogs", reflect.TypeOf((*MockdaisyWorker)(nil).traceLogs))
 }

--- a/cli_tools/common/utils/logging/service/daisy_loggable.go
+++ b/cli_tools/common/utils/logging/service/daisy_loggable.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 )
 
 // NewLoggableFromWorkflow provides a Loggable from a daisy workflow.
@@ -31,6 +32,10 @@ func NewLoggableFromWorkflow(wf *daisy.Workflow) Loggable {
 
 type workflowLoggable struct {
 	wf *daisy.Workflow
+}
+
+func (w workflowLoggable) GetInspectionResults() *pb.InspectionResults {
+	return nil
 }
 
 func (w workflowLoggable) GetValue(key string) string {

--- a/cli_tools/common/utils/logging/service/literal_loggable.go
+++ b/cli_tools/common/utils/logging/service/literal_loggable.go
@@ -14,11 +14,18 @@
 
 package service
 
+import "github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
+
 type literalLoggable struct {
-	strings   map[string]string
-	int64s    map[string][]int64
-	bools     map[string]bool
-	traceLogs []string
+	strings           map[string]string
+	int64s            map[string][]int64
+	bools             map[string]bool
+	traceLogs         []string
+	inspectionResults *pb.InspectionResults
+}
+
+func (w literalLoggable) GetInspectionResults() *pb.InspectionResults {
+	return w.inspectionResults
 }
 
 func (w literalLoggable) GetValue(key string) string { return w.strings[key] }
@@ -42,6 +49,12 @@ func NewSingleImageImportLoggableBuilder() *SingleImageImportLoggableBuilder {
 		int64s:  map[string][]int64{},
 		bools:   map[string]bool{},
 	}}
+}
+
+// SetInspectionResults sets inspection results.
+func (b *SingleImageImportLoggableBuilder) SetInspectionResults(inspectionResults *pb.InspectionResults) *SingleImageImportLoggableBuilder {
+	b.inspectionResults = inspectionResults
+	return b
 }
 
 // SetUEFIMetrics sets UEFI related metrics.

--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -14,6 +14,8 @@
 
 package service
 
+import "github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
+
 // logRequest is a server-side pre-defined data structure
 type logRequest struct {
 	ClientInfo    clientInfo `json:"client_info"`
@@ -92,21 +94,21 @@ type InputParams struct {
 type ImageImportParams struct {
 	*CommonParams
 
-	ImageName          string            `json:"image_name,omitempty"`
-	DataDisk           bool              `json:"data_disk"`
-	OS                 string            `json:"os,omitempty"`
-	SourceFile         string            `json:"source_file,omitempty"`
-	SourceImage        string            `json:"source_image,omitempty"`
-	NoGuestEnvironment bool              `json:"no_guest_environment"`
-	Family             string            `json:"family,omitempty"`
-	Description        string            `json:"description,omitempty"`
-	NoExternalIP       bool              `json:"no_external_ip"`
-	HasKmsKey          bool              `json:"has_kms_key"`
-	HasKmsKeyring      bool              `json:"has_kms_keyring"`
-	HasKmsLocation     bool              `json:"has_kms_location"`
-	HasKmsProject      bool              `json:"has_kms_project"`
-	StorageLocation    string            `json:"storage_location,omitempty"`
-	InspectionResults  InspectionResults `json:"inspection_results,omitempty"`
+	ImageName          string                `json:"image_name,omitempty"`
+	DataDisk           bool                  `json:"data_disk"`
+	OS                 string                `json:"os,omitempty"`
+	SourceFile         string                `json:"source_file,omitempty"`
+	SourceImage        string                `json:"source_image,omitempty"`
+	NoGuestEnvironment bool                  `json:"no_guest_environment"`
+	Family             string                `json:"family,omitempty"`
+	Description        string                `json:"description,omitempty"`
+	NoExternalIP       bool                  `json:"no_external_ip"`
+	HasKmsKey          bool                  `json:"has_kms_key"`
+	HasKmsKeyring      bool                  `json:"has_kms_keyring"`
+	HasKmsLocation     bool                  `json:"has_kms_location"`
+	HasKmsProject      bool                  `json:"has_kms_project"`
+	StorageLocation    string                `json:"storage_location,omitempty"`
+	InspectionResults  *pb.InspectionResults `json:"inspection_results,omitempty"`
 }
 
 // ImageExportParams contains all input params for image export

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -29,6 +29,7 @@ import (
 
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 	"github.com/google/uuid"
 	"github.com/minio/highwayhash"
 )
@@ -196,11 +197,7 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 
 		// TODO: ideally we suppose to set o.InspectionResults. Will modify after proto is adjusted.
 		if l.Params.ImageImportParams != nil {
-			l.Params.ImageImportParams.InspectionResults = InspectionResults{
-				UEFIBootable: loggable.GetValueAsBool(uefiBootable),
-				BIOSBootable: loggable.GetValueAsBool(biosBootable),
-				RootFS:       loggable.GetValue(rootFS),
-			}
+			l.Params.ImageImportParams.InspectionResults = loggable.GetInspectionResults()
 		}
 	}
 
@@ -394,5 +391,6 @@ type Loggable interface {
 	GetValue(key string) string
 	GetValueAsBool(key string) bool
 	GetValueAsInt64Slice(key string) []int64
+	GetInspectionResults() *pb.InspectionResults
 	ReadSerialPortLogs() []string
 }

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -235,7 +235,7 @@ func (args *ImportArguments) registerFlags(flagSet *flag.FlagSet) {
 	flagSet.BoolVar(&args.NoExternalIP, "no_external_ip", false,
 		"VPC doesn't allow external IPs.")
 
-	flagSet.BoolVar(&args.Inspect, "inspect", false, "Run disk inspections.")
+	flagSet.BoolVar(&args.Inspect, "inspect", true, "Run disk inspections.")
 
 	flagSet.Var((*flags.TrimmedString)(&args.ExecutionID), "execution_id",
 		"The execution ID to differentiate GCE resources of each imports.")

--- a/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/disk_inspection_processor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 )
 
 // diskInspectionProcessor executes inspection towards the disk, including OS info,
@@ -43,17 +44,17 @@ func (p *diskInspectionProcessor) process(pd persistentDisk,
 		return pd, nil
 	}
 
-	isDualBoot := ir.UEFIBootable && ir.BIOSBootableWithHybridMBROrProtectiveMBR
+	isDualBoot := ir.GetUefiBootable() && ir.GetBiosBootable()
 	if !p.args.UefiCompatible && isDualBoot {
 		log.Printf("This disk can boot with either BIOS or a UEFI bootloader. The default setting for booting is BIOS. " +
 			"If you want to boot using UEFI, please see https://cloud.google.com/compute/docs/import/importing-virtual-disks#importing_a_virtual_disk_with_uefi_bootloader'.")
 	}
-	pd.isUEFICompatible = p.args.UefiCompatible || (ir.UEFIBootable && !isDualBoot)
-	loggableBuilder.SetUEFIMetrics(pd.isUEFICompatible, ir.UEFIBootable, ir.BIOSBootableWithHybridMBROrProtectiveMBR, ir.RootFS)
+	pd.isUEFICompatible = p.args.UefiCompatible || (ir.UefiBootable && !isDualBoot)
+	loggableBuilder.SetInspectionResults(ir)
 	return pd, nil
 }
 
-func (p *diskInspectionProcessor) inspectDisk(uri string) (disk.InspectionResult, error) {
+func (p *diskInspectionProcessor) inspectDisk(uri string) (*pb.InspectionResults, error) {
 	log.Printf("Running disk inspections on %v.", uri)
 	ir, err := p.diskInspector.Inspect(uri, p.args.Inspect)
 	if err != nil {

--- a/cli_tools/gce_vm_image_import/importer/disk_inspection_processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/disk_inspection_processor_test.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,9 +54,8 @@ type mockDiskInspector struct {
 	wf           *daisy.Workflow
 }
 
-func (m mockDiskInspector) Inspect(reference string, inspectOS bool) (ir disk.InspectionResult, err error) {
-	ir.UEFIBootable = m.uefiBootable
-	return
+func (m mockDiskInspector) Inspect(reference string, inspectOS bool) (*pb.InspectionResults, error) {
+	return &pb.InspectionResults{UefiBootable: m.uefiBootable}, nil
 }
 
 func (m mockDiskInspector) Cancel(reason string) bool {


### PR DESCRIPTION
Following this PR:
 - All image imports will have OS inspection run.
 - The OS inspection results will be logged

Testing:

- Ran `cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go` and verified that logs were created (start and finish logs)