### PR TITLE
Add link to Cloud Console for the output log.

### DIFF
--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -57,7 +57,7 @@ func logSerialOutput(ctx context.Context, s *Step, ii InstanceInterface, ib *Ins
 	defer w.stepWait.Done()
 
 	logsObj := path.Join(w.logsPath, fmt.Sprintf("%s-serial-port%d.log", ii.getName(), port))
-	w.LogStepInfo(s.name, "CreateInstances", "Streaming instance %q serial port %d output to https://storage.cloud.google.com/%s/%s", ii.getName(), port, w.bucket, logsObj)
+	w.LogStepInfo(s.name, "CreateInstances", "Streaming instance %q serial port %d output to https://storage.cloud.google.com/%s/%s (https://console.cloud.google.com/storage/browser/_details/%s/%s)", ii.getName(), port, w.bucket, logsObj, w.bucket, logsObj)
 	var start int64
 	var buf bytes.Buffer
 	var gcsErr bool

--- a/daisy/step_create_instances_test.go
+++ b/daisy/step_create_instances_test.go
@@ -57,28 +57,28 @@ func TestLogSerialOutput(t *testing.T) {
 	}{
 		{
 			"Error but instance stopped",
-			"Streaming instance \"i1\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i1-serial-port0.log",
+			"Streaming instance \"i1\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i1-serial-port0.log (https://console.cloud.google.com/storage/browser/_details/test-bucket/i1-serial-port0.log)",
 			"",
 			&Instance{Instance: compute.Instance{Name: "i1"}},
 			&InstanceBeta{Instance: computeBeta.Instance{Name: "i1"}},
 		},
 		{
 			"Error but instance running",
-			"Streaming instance \"i2\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i2-serial-port0.log",
+			"Streaming instance \"i2\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i2-serial-port0.log (https://console.cloud.google.com/storage/browser/_details/test-bucket/i2-serial-port0.log)",
 			"Instance \"i2\": error getting serial port: fail",
 			&Instance{Instance: compute.Instance{Name: "i2"}},
 			&InstanceBeta{Instance: computeBeta.Instance{Name: "i2"}},
 		},
 		{
 			"Normal flow",
-			"Streaming instance \"i3\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i3-serial-port0.log",
+			"Streaming instance \"i3\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i3-serial-port0.log (https://console.cloud.google.com/storage/browser/_details/test-bucket/i3-serial-port0.log)",
 			"",
 			&Instance{Instance: compute.Instance{Name: "i3"}},
 			&InstanceBeta{Instance: computeBeta.Instance{Name: "i3"}},
 		},
 		{
 			"Error but instance deleted",
-			"Streaming instance \"i4\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i4-serial-port0.log",
+			"Streaming instance \"i4\" serial port 0 output to https://storage.cloud.google.com/test-bucket/i4-serial-port0.log (https://console.cloud.google.com/storage/browser/_details/test-bucket/i4-serial-port0.log)",
 			"",
 			&Instance{Instance: compute.Instance{Name: "i4"}},
 			&InstanceBeta{Instance: computeBeta.Instance{Name: "i4"}},


### PR DESCRIPTION
If [GCS Uniform Bucket ACLs](https://cloud.google.com/storage/docs/uniform-bucket-level-access) are configured then the streaming log is not easily accessible via the link provided.
This change provides an alternate link that allows you to easily get an Authenticated URL to the GCS object.