### PR TITLE
cli-tools: Switch back to Debian 9 worker

### DIFF
--- a/cli_tools/common/utils/daisy/daisy_utils_test.go
+++ b/cli_tools/common/utils/daisy/daisy_utils_test.go
@@ -246,7 +246,7 @@ func createWorkflowWithCreateDiskImageAndIncludeWorkflow() *daisy.Workflow {
 				},
 				{
 					Disk: compute.Disk{
-						SourceImage: "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+						SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 					},
 				},
 			},

--- a/cli_tools/common/utils/daisy/daisy_utils_test.go
+++ b/cli_tools/common/utils/daisy/daisy_utils_test.go
@@ -246,7 +246,7 @@ func createWorkflowWithCreateDiskImageAndIncludeWorkflow() *daisy.Workflow {
 				},
 				{
 					Disk: compute.Disk{
-						SourceImage: "projects/compute-image-tools/global/images/family/debian-10-worker",
+						SourceImage: "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
 					},
 				},
 			},

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -51,7 +51,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 			{
 				Disk: compute.Disk{
 					Name:        diskImporterDiskName,
-					SourceImage: "projects/compute-image-tools/global/images/family/debian-10-worker",
+					SourceImage: "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
 					Type:        "pd-ssd",
 				},
 				SizeGb:               gceMinimumDiskSizeGB,

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -51,7 +51,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 			{
 				Disk: compute.Disk{
 					Name:        diskImporterDiskName,
-					SourceImage: "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+					SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 					Type:        "pd-ssd",
 				},
 				SizeGb:               gceMinimumDiskSizeGB,

--- a/cli_tools/gce_vm_image_import/importer/api_inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater.go
@@ -177,7 +177,7 @@ func (inflater *apiInflater) calculateChecksum(ctx context.Context, diskURI stri
 				{
 					Disk: compute.Disk{
 						Name:        "disk-${NAME}",
-						SourceImage: "projects/compute-image-tools/global/images/family/debian-10-worker",
+						SourceImage: "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
 						Type:        "pd-ssd",
 					},
 					FallbackToPdStandard: true,

--- a/cli_tools/gce_vm_image_import/importer/api_inflater.go
+++ b/cli_tools/gce_vm_image_import/importer/api_inflater.go
@@ -177,7 +177,7 @@ func (inflater *apiInflater) calculateChecksum(ctx context.Context, diskURI stri
 				{
 					Disk: compute.Disk{
 						Name:        "disk-${NAME}",
-						SourceImage: "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+						SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 						Type:        "pd-ssd",
 					},
 					FallbackToPdStandard: true,

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -34,7 +34,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -34,7 +34,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -39,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/import_image.wf.json
+++ b/daisy_workflows/image_import/import_image.wf.json
@@ -15,7 +15,7 @@
       "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
     },
     "import_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+      "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "image to use for the importer instance"
     },
     "family": {

--- a/daisy_workflows/image_import/import_image.wf.json
+++ b/daisy_workflows/image_import/import_image.wf.json
@@ -15,7 +15,7 @@
       "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
     },
     "import_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
       "Description": "image to use for the importer instance"
     },
     "family": {

--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -19,7 +19,7 @@
       "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
     },
     "import_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
       "Description": "image to use for the importer instance"
     },
     "disk_name": "imported-disk-${ID}",

--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -19,7 +19,7 @@
       "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
     },
     "import_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+      "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
       "Description": "image to use for the importer instance"
     },
     "disk_name": "imported-disk-${ID}",

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -34,7 +34,7 @@
               "AutoDelete": true,
               "boot": true,
               "initializeParams": {
-                "sourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616"
+                "sourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker"
               }
             },
             {

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -34,7 +34,7 @@
               "AutoDelete": true,
               "boot": true,
               "initializeParams": {
-                "sourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker"
+                "sourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616"
               }
             },
             {

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -45,7 +45,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -45,7 +45,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -49,7 +49,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "Licenses": ["${license}"],
           "SizeGb": "10",
           "Type": "pd-ssd",

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -49,7 +49,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "Licenses": ["${license}"],
           "SizeGb": "10",
           "Type": "pd-ssd",

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -34,7 +34,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -34,7 +34,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/debian-9-worker-v20200616",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true


### PR DESCRIPTION
Rollback of #1431 and #1432, which caused a regression for EL and SLES imports: 
 - https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1328876340400623616
 - https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-daisy-e2e/1328882631923732480