### PR TITLE
OpenSUSE 15 translate: Use Debian 10 worker

### DIFF
--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -45,7 +45,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1438 I accidentally switched the translator for OpenSUSE 15 to run in Debian 9. Translation of OpenSUSE 15 needs the newest version of libguestfs, and has been using it since it was originally implemented. 

Using Debian 9 causes the failure  "No SUSE operating systems found", and occurs since the version of libguestfs on Debian9 does not support detection of OpenSUSE 15.

1. https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-daisy-e2e/1329200730476646400

## Testing:
 - Ran `daisy_workflows/image_import/suse/translate_opensuse_15.wf.json`