### PR TITLE
EL import: Improve error messages for 6.4

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -285,6 +285,13 @@ var basicCases = []*testCase{
 		os:       "centos-8",
 		inspect:  true,
 	}, {
+		// Fail when a packge isn't found, and alert user with useful message.
+		caseName:      "el-package-not-found",
+		source:        "projects/compute-image-tools-test/global/images/centos-6-missing-base-repo",
+		os:            "centos-6",
+		expectedError: "No package centos-release-scl available",
+		inspect:       true,
+	}, {
 		// Fail when yum has an unreachable repo.
 		caseName:      "el-unreachable-repos",
 		source:        "projects/compute-image-tools-test/global/images/centos-8-cdrom-repo",

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -285,7 +285,7 @@ var basicCases = []*testCase{
 		os:       "centos-8",
 		inspect:  true,
 	}, {
-		// Fail when a packge isn't found, and alert user with useful message.
+		// Fail when a package isn't found, and alert user with useful message.
 		caseName:      "el-package-not-found",
 		source:        "projects/compute-image-tools-test/global/images/centos-6-missing-base-repo",
 		os:            "centos-6",


### PR DESCRIPTION
An EL 6.4 import recently failed with: "TranslateFailed: error: Ensure all configured repos are reachable. Failed to install ('centos-release-scl',). Details: sh: Error: Nothing to do."

A couple of issues, fixed in this PR:

1. Only run `yum updateinfo` if the command is available. (It's not in EL 6.4 doesn't have `yum updateinfo` by default, but it is in later versions)
2. Include stderr and stdout if the yum command fails. 
3. Chain exceptions to retain the entire stack trace
4. Tweak log message of updating ca-certificates to clarify when we expect the operation to pass

## Testing

* Ran all EL tests in cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
