### PR TITLE
Revert "Replace 1 minute wait with network connectivity checks and reboot remediation in run_startup_script.cmd. (#1434)

### DIFF
--- a/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM Copyright 2017 Google Inc. All Rights Reserved.
+REM Copyright 2019 Google Inc. All Rights Reserved.
 REM
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ ping 127.0.0.1 -n 60
 
 echo "Translate: Starting image translate..." > COM1:
 
+echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow
 
 REM Enable outbound communication to the metadata server.
 netsh advfirewall firewall add rule name="Allow outgoing to GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=out action=allow
 
+echo "Translate: Network configuration for Windows 2008 R2/Windows 7" > COM1:
 REM This is needed for 2008R2 networking to work, this will fail on post 2008R2 but that's fine.
 for /f "tokens=2 delims=:" %%a in (
   'ipconfig ^| find "Gateway"'
@@ -33,10 +35,11 @@ for /f "tokens=2 delims=:" %%a in (
   netsh interface ipv4 set dnsservers "Local Area Connection 3" static address=%%a primary
 )
 
-tzutil /s 'UTC'
+echo "Translate: Setting timezone" > COM1:
+tzutil /s Greenwich Standard Time
 w32tm /resync
 
-C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet > COM1:
-REM Install google-compute-engine-metadata-scripts and then run the task.
-REM This needs to be on one line as this file will get overwritten.
-start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm verify -reinstall google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"
+echo "Translate: Installing GooGet." > COM1:
+C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\googet-x86.x86_32.2.16.3@1.goo
+echo "Translate: Installing metadata scripts runner." > COM1:
+start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: && C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm verify -reinstall C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: && schtasks /run /tn GCEStartup > COM1:"

--- a/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
@@ -52,7 +52,7 @@
     "translate.ps1": "./translate.ps1",
     "translate_bootstrap.ps1": "./translate_bootstrap.ps1",
     "drivers": "${drivers}",
-    "components/run_startup_scripts.cmd": "./run_startup_scripts.cmd",
+    "components/run_startup_scripts.cmd": "./run_startup_scripts_x86.cmd",
     "components/GCEStartup.reg": "${task_reg}",
     "components/GCEStartup": "${task_xml}",
     "components/googet.exe": "gs://win-32bit-files/googet/googet.exe",


### PR DESCRIPTION
Reverting Revert "Replace 1 minute wait with network connectivity checks and reboot remediation in run_startup_script.cmd. (#1434) so we can release while investigate flakiness with Win7 tests after this change.