### PR TITLE
Add SerialPortToLog parameter to InstanceBase

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -232,6 +232,10 @@ func shouldRetryWithWait(tripper http.RoundTripper, err error, multiplier int) b
 	case apiErr.Code >= 429:
 		// Too many API requests.
 		retry = true
+	case apiErr.Code == 403 && strings.Contains(err.Error(), "rateLimitExceeded"):
+		// Quota errors are reported as 403.
+		// Generally we don't want to retry on quota errors, but if it's quota on rate (GetSerialPortOutput) - we should.
+		retry = true
 	case !tkValid:
 		// This was probably a failure to get new token from metadata server.
 		retry = true

--- a/daisy/instance_test.go
+++ b/daisy/instance_test.go
@@ -75,6 +75,14 @@ func TestInstancePopulate(t *testing.T) {
 	}
 }
 
+func TestInstancePopulateSerialPortsToLog(t *testing.T) {
+	ib := InstanceBase{}
+	ib.populateSerialPortsToLog()
+	if !reflect.DeepEqual(ib.SerialPortsToLog, []int64{1}) {
+		t.Errorf("SerialPortsToLog should default to 1")
+	}
+}
+
 func TestInstancePopulateDisks(t *testing.T) {
 	w := testWorkflow()
 
@@ -478,6 +486,41 @@ func TestInstancesValidate(t *testing.T) {
 			t.Errorf("%s: should have returned an error", tt.desc)
 		} else if !tt.shouldErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", tt.desc, err)
+		}
+	}
+}
+
+func TestInstanceValidateSerialPortsToLog(t *testing.T) {
+	// Test:
+	// - 0 good case
+	// - 1 good case
+	// - 4 good case
+	// - -1 bad case
+	// - 5 bad case
+
+	tests := []struct {
+		desc          string
+		ports         []int64
+		expectedPorts []int64
+		shouldErr     bool
+	}{
+		{"success 1", []int64{1}, []int64{1}, false},
+		{"success 1 1 4 4", []int64{1, 1, 4, 4}, []int64{1, 4}, false},
+		{"success 4", []int64{4}, []int64{4}, false},
+		{"error -1", []int64{-1}, nil, true},
+		{"error 1 5", []int64{1, 5}, nil, true},
+	}
+
+	for _, tt := range tests {
+		ib := &InstanceBase{SerialPortsToLog: tt.ports}
+		ib.populateSerialPortsToLog()
+		if err := ib.validateSerialPortsToLog(); tt.shouldErr && err == nil {
+			t.Errorf("%s: should have returned an error", tt.desc)
+		} else if !tt.shouldErr && err != nil {
+			t.Errorf("%s: unexpected error: %v", tt.desc, err)
+		}
+		if !tt.shouldErr && !reflect.DeepEqual(ib.SerialPortsToLog, tt.expectedPorts) {
+			t.Errorf("%s: unexpected ports. got: %v, expected: %v", tt.desc, ib.SerialPortsToLog, tt.expectedPorts)
 		}
 	}
 }

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -197,7 +197,9 @@ func (ci *CreateInstances) run(ctx context.Context, s *Step) DError {
 		}
 
 		ib.createdInWorkflow = true
-		go logSerialOutput(ctx, s, ii, ib, 1, 3*time.Second)
+		for _, port := range ib.SerialPortsToLog {
+			go logSerialOutput(ctx, s, ii, ib, port, 3*time.Second)
+		}
 	}
 
 	if ci.instanceUsesBetaFeatures() {


### PR DESCRIPTION
When using the WaitForInstancesSignal with a port other than 1:

  "WaitForInstancesSignal": [{
    "Name": "builder",
    "SerialOutput": {
      "Port": 3,
      "SuccessMatch": "BuilderSuccess:",
      "FailureMatch": "BuilderFailure:",
      "StatusMatch": "BuilderStatus:"
    }
  }]

It is not possible to see the entire serial port logs in GCS due to the
fact that the logging is actually an attribute of the CreateInstances
and the port number there is hardcoded to 1.

Introduce SerialPortToLog parameter for instance base to configure which
serial port is being logged for the given instance.