### PR TITLE
Import e2e: Only check licenses when provided expected value

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -397,8 +397,10 @@ func (t *testCase) verifyImage(ctx context.Context, junit *junitxml.TestCase, lo
 	logger.Printf("Image '%v' exists! Import finished.", t.imageName)
 
 	e2e.GuestOSFeatures(t.requiredGuestOsFeatures, t.notAllowedGuestOsFeatures, image.GuestOsFeatures, junit, logger)
-	e2e.ContainsAll(image.Licenses, []string{t.expectLicense}, junit, logger,
-		fmt.Sprintf("Expected license %s. Actual licenses %v", t.expectLicense, image.Licenses))
+	if t.expectLicense != "" {
+		e2e.ContainsAll(image.Licenses, []string{t.expectLicense}, junit, logger,
+			fmt.Sprintf("Expected license %s. Actual licenses %v", t.expectLicense, image.Licenses))
+	}
 }
 
 // createTestScopedLogger returns a new logger that is prefixed with the name of the test.

--- a/cli_tools_tests/module/import/inflater_test.go
+++ b/cli_tools_tests/module/import/inflater_test.go
@@ -114,7 +114,7 @@ func runDaisyInflate(t *testing.T, fileURI string) string {
 	expectedDiskName := "disk-" + namespace
 
 	ctx := context.Background()
-	storageClient, err := storage.NewStorageClient(ctx, logging.NewDefaultLogger())
+	storageClient, err := storage.NewStorageClient(ctx, logging.NewToolLogger("[user]"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#1451 updated the test runner to allow verification of licenses after import, but not all cases had the expected license. This updates the runner to only verify licenses when an expected license is provided.

Example of recent failures: https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1336636901204955136

Additionally, updates `cli_tools_tests/module/import/inflater_test.go` to use the new logger interface that was removed in #1444. It was found here since the corresponding check only runs when a file in cli_tools_tests is run:

https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml#L161