### PR TITLE
Daisy integ: Remove missing reference to centos 6 test

### DIFF
--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -38,9 +38,6 @@
     "Sources upload/download": {
       "Path": "./can_retrieve_sources.wf.json"
     },
-    "centos6 qcow2 translate": {
-      "Path": "./centos_6_qcow2_translate.wf.json"
-    },
     "centos7 qcow2 translate": {
       "Path": "./centos_7_qcow2_translate.wf.json"
     },


### PR DESCRIPTION
Currently this is causing a failure in the daisy integration tests:

`test case creation error: open daisy_integration_tests/centos_6_qcow2_translate.wf.json: no such file or directory`

- https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-daisy-e2e/1338944694658273280

This file was removed in #1458, but I missed this reference to it.