### PR TITLE
Image import: Take logging.Logger as a dependency

### DIFF
--- a/cli_tools/common/assert/assert.go
+++ b/cli_tools/common/assert/assert.go
@@ -14,7 +14,11 @@
 
 package assert
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/files"
+)
 
 // GreaterThanOrEqualTo asserts that value is greater than or equal to limit.
 func GreaterThanOrEqualTo(value int, limit int) {
@@ -31,4 +35,11 @@ func Contains(element string, arr []string) {
 		}
 	}
 	panic(fmt.Sprintf("%s is not a member of %v", element, arr))
+}
+
+// DirectoryExists asserts that a directory is on the current filesystem.
+func DirectoryExists(dir string) {
+	if !files.DirectoryExists(dir) {
+		panic(fmt.Sprintf("%s: Directory not found", dir))
+	}
 }

--- a/cli_tools/common/assert/assert_test.go
+++ b/cli_tools/common/assert/assert_test.go
@@ -16,6 +16,8 @@ package assert
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,6 +97,45 @@ func TestContains(t *testing.T) {
 				})
 			} else {
 				Contains(tt.element, tt.arr)
+			}
+		})
+	}
+}
+
+func TestDirectoryExists(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	tmpFileObj, err := ioutil.TempFile("", "*.txt")
+	assert.NoError(t, err)
+	tmpFile := tmpFileObj.Name()
+	tests := []struct {
+		name        string
+		dir         string
+		expectPanic string
+	}{
+		{
+			name: "Don't panic when directory exists",
+			dir:  tmpDir,
+		},
+		{
+			name:        "Panic when dir doesn't exist",
+			dir:         path.Join(tmpDir, "dir-doesn't-exist"),
+			expectPanic: fmt.Sprintf("%s/dir-doesn't-exist: Directory not found", tmpDir),
+		},
+		{
+			name:        "Panic when dir is a file",
+			dir:         tmpFile,
+			expectPanic: fmt.Sprintf("%v: Directory not found", tmpFile),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectPanic != "" {
+				assert.PanicsWithValue(t, tt.expectPanic, func() {
+					DirectoryExists(tt.dir)
+				})
+			} else {
+				DirectoryExists(tt.dir)
 			}
 		})
 	}

--- a/cli_tools/common/utils/files/files.go
+++ b/cli_tools/common/utils/files/files.go
@@ -15,11 +15,33 @@
 package files
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
-// Exists returns where filename references an existing file.
-func Exists(filename string) bool {
-	_, err := os.Stat(filename)
+// DirectoryExists returns whether dir references an existing directory.
+func DirectoryExists(dir string) bool {
+	stat, err := os.Stat(dir)
+	return !os.IsNotExist(err) && stat.IsDir()
+}
+
+// Exists returns whether path references an existing file or directory.
+func Exists(path string) bool {
+	_, err := os.Stat(path)
 	return !os.IsNotExist(err)
+}
+
+// MakeAbsolute converts path to absolute, relative to the process's current working directory.
+// Panics if path isn't found.
+func MakeAbsolute(path string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	abs := filepath.Join(wd, path)
+	if !Exists(abs) {
+		panic(fmt.Sprintf("%s: File not found", path))
+	}
+	return abs
 }

--- a/cli_tools/common/utils/logging/logger.go
+++ b/cli_tools/common/utils/logging/logger.go
@@ -21,8 +21,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 	"github.com/golang/protobuf/proto"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 )
 
 // Logger is a logger for CLI tools. It supports
@@ -68,7 +69,7 @@ func (l redirectShim) Write(p []byte) (n int, err error) {
 
 // OutputInfoReader exposes pb.OutputInfo to a consumer.
 type OutputInfoReader interface {
-	read() *pb.OutputInfo
+	ReadOutputInfo() *pb.OutputInfo
 }
 
 // ToolLogger implements Logger and OutputInfoReader. Create an instance at the
@@ -158,7 +159,7 @@ func (l *defaultToolLogger) Metric(metric *pb.OutputInfo) {
 //     member of OutputInfo.SerialLogs; each trace log is a separate member.
 // All buffers are cleared when this is called. In other words, a subsequent call to
 // ReadOutputInfo will return an empty object.
-func (l *defaultToolLogger) read() *pb.OutputInfo {
+func (l *defaultToolLogger) ReadOutputInfo() *pb.OutputInfo {
 	// Locking since ReadOutputInfo has a side effect of clearing the internal state.
 	l.mutationLock.Lock()
 	defer l.mutationLock.Unlock()

--- a/cli_tools/common/utils/logging/service/daisy_loggable_test.go
+++ b/cli_tools/common/utils/logging/service/daisy_loggable_test.go
@@ -18,8 +18,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
 func TestNewLoggableFromWorkflow_ReturnsNilWhenWorkflowNil(t *testing.T) {

--- a/cli_tools/common/utils/logging/service/outputinfo_loggable.go
+++ b/cli_tools/common/utils/logging/service/outputinfo_loggable.go
@@ -1,0 +1,74 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package service
+
+import "github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
+
+// outputInfoLoggable is an implementation of Loggable that exposes fields
+// from an OutputInfo object.
+type outputInfoLoggable struct {
+	outputInfo *pb.OutputInfo
+}
+
+// NewOutputInfoLoggable returns a Loggable that is bacaked by a concrete instance
+// of pb.OutputInfo. It's intended as a temporary shim while we
+// transition tools to use the ToolLogger type.
+func NewOutputInfoLoggable(outputInfo *pb.OutputInfo) Loggable {
+	return &outputInfoLoggable{outputInfo}
+}
+
+func (o *outputInfoLoggable) GetValue(key string) string {
+	switch key {
+	case importFileFormat:
+		return o.outputInfo.GetImportFileFormat()
+	case inflationType:
+		return o.outputInfo.GetInflationType()
+	case shadowDiskMatchResult:
+		return o.outputInfo.GetShadowDiskMatchResult()
+	}
+	return ""
+}
+
+func (o *outputInfoLoggable) GetValueAsBool(key string) bool {
+	switch key {
+	case isUEFICompatibleImage:
+		return o.outputInfo.GetIsUefiCompatibleImage()
+	case isUEFIDetected:
+		return o.outputInfo.GetIsUefiDetected()
+	}
+	return false
+}
+
+func (o *outputInfoLoggable) GetValueAsInt64Slice(key string) []int64 {
+	switch key {
+	case targetSizeGb:
+		return o.outputInfo.GetTargetsSizeGb()
+	case sourceSizeGb:
+		return o.outputInfo.GetSourcesSizeGb()
+	case inflationTime:
+		return o.outputInfo.GetInflationTimeMs()
+	case shadowInflationTime:
+		return o.outputInfo.GetShadowInflationTimeMs()
+	}
+	return nil
+}
+
+func (o *outputInfoLoggable) GetInspectionResults() *pb.InspectionResults {
+	return o.outputInfo.GetInspectionResults()
+}
+
+func (o *outputInfoLoggable) ReadSerialPortLogs() []string {
+	return o.outputInfo.SerialOutputs
+}

--- a/cli_tools/common/utils/logging/service/outputinfo_loggable_test.go
+++ b/cli_tools/common/utils/logging/service/outputinfo_loggable_test.go
@@ -1,0 +1,114 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pbtesting"
+)
+
+func Test_OutputInfoLoggable_GetInspectionResults(t *testing.T) {
+	outputInfo := &pb.OutputInfo{
+		InspectionResults: &pb.InspectionResults{
+			OsRelease: &pb.OsRelease{
+				DistroId: pb.Distro_WINDOWS,
+			},
+			RootFs:  path.RandString(5),
+			OsCount: 1,
+		},
+	}
+	pbtesting.AssertEqual(t, outputInfo.InspectionResults, NewOutputInfoLoggable(outputInfo).GetInspectionResults())
+}
+
+func Test_OutputInfoLoggable_GetValue(t *testing.T) {
+	outputInfo := &pb.OutputInfo{
+		ImportFileFormat:      "vmdk",
+		InflationType:         "api",
+		ShadowDiskMatchResult: "matched",
+	}
+
+	loggable := NewOutputInfoLoggable(outputInfo)
+	assert.Equal(t, "vmdk", loggable.GetValue(importFileFormat))
+	assert.Equal(t, "api", loggable.GetValue(inflationType))
+	assert.Equal(t, "matched", loggable.GetValue(shadowDiskMatchResult))
+	assert.Equal(t, "", loggable.GetValue("not-a-key"))
+}
+
+func Test_OutputInfoLoggable_GetValueAsBool(t *testing.T) {
+	for i, tt := range []struct {
+		input                  *pb.OutputInfo
+		expectedUefiCompatible bool
+		expectedUefiDetected   bool
+	}{
+		{
+			input:                  &pb.OutputInfo{},
+			expectedUefiCompatible: false,
+			expectedUefiDetected:   false,
+		},
+		{
+			input:                  &pb.OutputInfo{IsUefiCompatibleImage: true},
+			expectedUefiCompatible: true,
+			expectedUefiDetected:   false,
+		},
+		{
+			input:                  &pb.OutputInfo{IsUefiDetected: true},
+			expectedUefiCompatible: false,
+			expectedUefiDetected:   true,
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			loggable := NewOutputInfoLoggable(tt.input)
+			assert.Equal(t, tt.expectedUefiCompatible, loggable.GetValueAsBool(isUEFICompatibleImage))
+			assert.Equal(t, tt.expectedUefiDetected, loggable.GetValueAsBool(isUEFIDetected))
+			assert.False(t, loggable.GetValueAsBool("random-key"))
+		})
+	}
+}
+
+func Test_OutputInfoLoggable_GetValueAsInt64Slice(t *testing.T) {
+	outputInfo := &pb.OutputInfo{
+		TargetsSizeGb:         []int64{1, 2},
+		SourcesSizeGb:         []int64{3, 4},
+		InflationTimeMs:       []int64{5, 6},
+		ShadowInflationTimeMs: []int64{7, 8},
+	}
+
+	loggable := NewOutputInfoLoggable(outputInfo)
+	assert.Equal(t, []int64{1, 2}, loggable.GetValueAsInt64Slice(targetSizeGb))
+	assert.Equal(t, []int64{3, 4}, loggable.GetValueAsInt64Slice(sourceSizeGb))
+	assert.Equal(t, []int64{5, 6}, loggable.GetValueAsInt64Slice(inflationTime))
+	assert.Equal(t, []int64{7, 8}, loggable.GetValueAsInt64Slice(shadowInflationTime))
+	assert.Empty(t, loggable.GetValueAsInt64Slice("not-a-key"))
+}
+
+func Test_OutputInfoLoggable_ReadSerialPortLogs(t *testing.T) {
+	outputInfo := &pb.OutputInfo{
+		ImportFileFormat:      "vmdk",
+		InflationType:         "api",
+		ShadowDiskMatchResult: "matched",
+	}
+
+	loggable := NewOutputInfoLoggable(outputInfo)
+	assert.Equal(t, "vmdk", loggable.GetValue(importFileFormat))
+	assert.Equal(t, "api", loggable.GetValue(inflationType))
+	assert.Equal(t, "matched", loggable.GetValue(shadowDiskMatchResult))
+	assert.Equal(t, "", loggable.GetValue("not-a-key"))
+}

--- a/cli_tools/gce_vm_image_import/importer/args.go
+++ b/cli_tools/gce_vm_image_import/importer/args.go
@@ -18,8 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -38,7 +36,6 @@ const (
 	dataDiskFlag       = "data_disk"
 	osFlag             = "os"
 	customWorkflowFlag = "custom_translate_workflow"
-	workflowDir        = "daisy_workflows"
 )
 
 // ImportArguments holds the structured results of parsing CLI arguments,
@@ -83,14 +80,14 @@ type ImportArguments struct {
 
 // NewImportArguments parses args to create an ImportArguments instance.
 // No validation occurs; to validate, use ValidateAndPopulate.
-func NewImportArguments(args []string) (ImportArguments, error) {
+func NewImportArguments(args []string, workflowDir string) (ImportArguments, error) {
 	flagSet := flag.NewFlagSet("image-import", flag.ContinueOnError)
 	// Don't write parse errors to stdout, instead propagate them via an
 	// exception since we use flag.ContinueOnError.
 	flagSet.SetOutput(ioutil.Discard)
 
 	parsed := ImportArguments{
-		WorkflowDir: filepath.Join(filepath.Dir(os.Args[0]), workflowDir),
+		WorkflowDir: workflowDir,
 		Started:     time.Now(),
 	}
 

--- a/cli_tools/gce_vm_image_import/importer/args_test.go
+++ b/cli_tools/gce_vm_image_import/importer/args_test.go
@@ -53,7 +53,7 @@ func TestFailOnLabelSyntaxError(t *testing.T) {
 
 func TestPopulateStorageLocationIfMissing(t *testing.T) {
 	args := []string{"-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:            "us-west2-a",
@@ -66,10 +66,6 @@ func TestPopulateStorageLocationIfMissing(t *testing.T) {
 
 func TestTrimAndLowerStorageLocation(t *testing.T) {
 	assert.Equal(t, "eu", parseAndValidate(t, "-storage_location", "  EU  ").StorageLocation)
-}
-
-func TestPopulateWorkflowDir(t *testing.T) {
-	assert.Regexp(t, ".*/daisy_workflows", parseAndValidate(t).WorkflowDir)
 }
 
 func TestFailWhenClientIdMissing(t *testing.T) {
@@ -90,7 +86,7 @@ func TestTrimProject(t *testing.T) {
 
 func TestPopulateProjectIfMissing(t *testing.T) {
 	args := []string{"-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:    "us-west2-a",
@@ -115,7 +111,7 @@ func TestTrimAndLowerZone(t *testing.T) {
 
 func TestPopulateZoneIfMissing(t *testing.T) {
 	args := []string{"-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:   "us-west2-a",
@@ -127,7 +123,7 @@ func TestPopulateZoneIfMissing(t *testing.T) {
 
 func TestPopulateRegion(t *testing.T) {
 	args := []string{"-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:   "us-west2-a",
@@ -268,7 +264,7 @@ func TestTrimSourceImage(t *testing.T) {
 
 func TestSourceObjectFromSourceImage(t *testing.T) {
 	args := []string{"-source_image", "path/source-image", "-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:          "us-west2-a",
@@ -285,7 +281,7 @@ func TestSourceObjectFromSourceImage(t *testing.T) {
 
 func TestSourceObjectFromSourceFile(t *testing.T) {
 	args := []string{"-source_file", "gs://path/file", "-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:          "us-west2-a",
@@ -302,7 +298,7 @@ func TestSourceObjectFromSourceFile(t *testing.T) {
 
 func TestErrorWhenSourceValidationFails(t *testing.T) {
 	args := []string{"-image_name=i", "-client_id=c", "-data_disk"}
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:          "us-west2-a",
@@ -518,19 +514,19 @@ func parse(t *testing.T, args ...string) ImportArguments {
 		args = append(args, "-image_name=name")
 	}
 
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	return actual
 }
 
 func expectFailedParse(t *testing.T, args ...string) error {
-	_, err := NewImportArguments(args)
+	_, err := NewImportArguments(args, "")
 	assert.Error(t, err)
 	return err
 }
 
 func expectFailedValidation(t *testing.T, args ...string) error {
-	actual, err := NewImportArguments(args)
+	actual, err := NewImportArguments(args, "")
 	assert.NoError(t, err)
 	err = actual.ValidateAndPopulate(mockPopulator{
 		zone:   "us-west2-a",

--- a/cli_tools/gce_vm_image_import/importer/data_disk_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/data_disk_processor.go
@@ -17,9 +17,9 @@ package importer
 import (
 	"log"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
-	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"google.golang.org/api/compute/v1"
+
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
 type dataDiskProcessor struct {
@@ -55,12 +55,7 @@ func newDataDiskProcessor(pd persistentDisk, client daisyCompute.Client, project
 	}
 }
 
-func (d dataDiskProcessor) traceLogs() []string {
-	return []string{}
-}
-
-func (d dataDiskProcessor) process(pd persistentDisk,
-	loggableBuilder *service.SingleImageImportLoggableBuilder) (persistentDisk, error) {
+func (d dataDiskProcessor) process(pd persistentDisk) (persistentDisk, error) {
 
 	log.Printf("Creating image \"%v\"", d.request.Name)
 	return pd, d.computeImageClient.CreateImage(d.project, &d.request)

--- a/cli_tools/gce_vm_image_import/importer/data_disk_processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/data_disk_processor_test.go
@@ -17,10 +17,10 @@ package importer
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
-	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
+
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
 func Test_ImageIncludesTrackingLabelAndLicense(t *testing.T) {
@@ -40,7 +40,7 @@ func Test_ImageIncludesTrackingLabelAndLicense(t *testing.T) {
 		"family-name",
 		"image-name")
 
-	_, err := processor.process(persistentDisk{}, service.NewSingleImageImportLoggableBuilder())
+	_, err := processor.process(persistentDisk{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, mockClient.invocations)
 	assert.Equal(t, compute.Image{

--- a/cli_tools/gce_vm_image_import/importer/importer_test.go
+++ b/cli_tools/gce_vm_image_import/importer/importer_test.go
@@ -25,48 +25,51 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 )
 
-func TestRun_HappyCase_CollectAllLogs(t *testing.T) {
-	inflaterLogs := []string{"log-a", "log-b"}
-	processorLogs := []string{"log-c", "log-d"}
-	expectedLogs := []string{"log-a", "log-b", "log-c", "log-d"}
+func TestRun_HappyCase_CollectDiskMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Metric(&pb.OutputInfo{
+		SourcesSizeGb:    []int64{10},
+		TargetsSizeGb:    []int64{100},
+		ImportFileFormat: "vmdk",
+	})
+
 	pd := persistentDisk{
 		sizeGb:     100,
 		sourceGb:   10,
 		sourceType: "vmdk",
 	}
-	mockProcessor := mockProcessor{
-		serialLogs: processorLogs,
-	}
+	mockProcessor := mockProcessor{}
 	importer := importer{
 		preValidator: mockValidator{},
 		inflater: &mockInflater{
-			serialLogs: inflaterLogs,
-			pd:         pd,
+			pd: pd,
 		},
 		processorProvider: &mockProcessorProvider{
 			processors: []processor{&mockProcessor},
 		},
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		logger: mockLogger,
 	}
-	loggable, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	assert.Nil(t, actualError)
-	assert.NotNil(t, loggable)
-	assert.Equal(t, expectedLogs, loggable.ReadSerialPortLogs())
-	assert.Equal(t, "vmdk", loggable.GetValue("import-file-format"))
-	assert.Equal(t, []int64{10}, loggable.GetValueAsInt64Slice("source-size-gb"))
-	assert.Equal(t, []int64{100}, loggable.GetValueAsInt64Slice("target-size-gb"))
-	assert.Equal(t, true, loggable.GetValueAsBool("is-uefi-compatible-image"))
-	assert.Equal(t, true, loggable.GetValueAsBool("is-uefi-detected"))
 	assert.Equal(t, 1, mockProcessor.interactions)
 }
 
-func TestRun_DeleteDisk(t *testing.T) {
+func TestRun_DeletesDisk_AfterImportingImage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	project := "project"
 	zone := "zone"
 	diskURI := "uri"
@@ -88,9 +91,9 @@ func TestRun_DeleteDisk(t *testing.T) {
 		processorProvider: &mockProcessorProvider{
 			processors: []processor{&mockProcessor{}},
 		},
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		logger: mockLogger,
 	}
-	_, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	assert.NoError(t, actualError)
 	assert.Equal(t, 1, mockDiskClient.interactions)
 	assert.Equal(t, project, mockDiskClient.project)
@@ -99,6 +102,10 @@ func TestRun_DeleteDisk(t *testing.T) {
 }
 
 func TestRun_NoErrorLoggedWhenDeletingDiskThatWasNotCreated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	defer func() {
@@ -126,9 +133,9 @@ func TestRun_NoErrorLoggedWhenDeletingDiskThatWasNotCreated(t *testing.T) {
 		processorProvider: &mockProcessorProvider{
 			processors: []processor{&mockProcessor{}},
 		},
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		logger: mockLogger,
 	}
-	_, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	assert.NoError(t, actualError)
 	assert.Equal(t, 1, mockDiskClient.interactions)
 	assert.Equal(t, project, mockDiskClient.project)
@@ -137,6 +144,10 @@ func TestRun_NoErrorLoggedWhenDeletingDiskThatWasNotCreated(t *testing.T) {
 }
 
 func TestRun_ErrorLoggedWhenErrorDeletingDisk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	defer func() {
@@ -164,9 +175,9 @@ func TestRun_ErrorLoggedWhenErrorDeletingDisk(t *testing.T) {
 		processorProvider: &mockProcessorProvider{
 			processors: []processor{&mockProcessor{}},
 		},
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		logger: mockLogger,
 	}
-	_, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	assert.NoError(t, actualError)
 	assert.Equal(t, 1, mockDiskClient.interactions)
 	assert.Equal(t, project, mockDiskClient.project)
@@ -175,20 +186,27 @@ func TestRun_ErrorLoggedWhenErrorDeletingDisk(t *testing.T) {
 }
 
 func TestRun_DontRunInflate_IfPreValidationFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	expectedError := errors.New("failed validation")
 	inflater := mockInflater{}
 	importer := importer{
-		preValidator:    mockValidator{err: errors.New("failed validation")},
-		inflater:        &inflater,
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		preValidator: mockValidator{err: errors.New("failed validation")},
+		inflater:     &inflater,
+		logger:       mockLogger,
 	}
-	loggable, actualError := importer.Run(context.Background())
-	assert.NotNil(t, loggable)
+	actualError := importer.Run(context.Background())
 	assert.Equal(t, expectedError, actualError)
 	assert.Equal(t, 0, inflater.interactions)
 }
 
 func TestRun_DontRunProcessIfInflateFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	expectedError := errors.New("the errors")
 	mockProcessorProvider := mockProcessorProvider{}
 	importer := importer{
@@ -197,22 +215,29 @@ func TestRun_DontRunProcessIfInflateFails(t *testing.T) {
 			err: expectedError,
 		},
 		processorProvider: &mockProcessorProvider,
-		loggableBuilder:   service.NewSingleImageImportLoggableBuilder(),
+		logger:            mockLogger,
 	}
-	loggable, actualError := importer.Run(context.Background())
-	assert.NotNil(t, loggable)
+	actualError := importer.Run(context.Background())
 	assert.Equal(t, expectedError, actualError)
 	assert.Equal(t, 0, mockProcessorProvider.interactions)
 }
 
 func TestRun_IncludeInflaterLogs_WhenFailureToCreateProcessor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Metric(&pb.OutputInfo{
+		SourcesSizeGb:    []int64{10},
+		TargetsSizeGb:    []int64{100},
+		ImportFileFormat: "vmdk",
+	})
+
 	mockProcessor := mockProcessor{}
 	expectedError := errors.New("the errors")
-	expectedLogs := []string{"log-a", "log-b"}
 	importer := importer{
 		preValidator: mockValidator{},
 		inflater: &mockInflater{
-			serialLogs: expectedLogs,
+			serialLogs: []string{"log-a", "log-b"},
 			pd: persistentDisk{
 				sizeGb:     100,
 				sourceGb:   10,
@@ -223,19 +248,18 @@ func TestRun_IncludeInflaterLogs_WhenFailureToCreateProcessor(t *testing.T) {
 			err:        expectedError,
 			processors: []processor{&mockProcessor},
 		},
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		logger: mockLogger,
 	}
-	loggable, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	assert.Equal(t, expectedError, actualError)
-	assert.NotNil(t, loggable)
-	assert.Equal(t, expectedLogs, loggable.ReadSerialPortLogs())
-	assert.Equal(t, "vmdk", loggable.GetValue("import-file-format"))
-	assert.Equal(t, []int64{10}, loggable.GetValueAsInt64Slice("source-size-gb"))
-	assert.Equal(t, []int64{100}, loggable.GetValueAsInt64Slice("target-size-gb"))
 	assert.Equal(t, 0, mockProcessor.interactions)
 }
 
 func TestRun_DeleteDisk_WhenFailureToCreateProcessor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	project := "project"
 	zone := "zone"
 	diskURI := "uri"
@@ -257,9 +281,9 @@ func TestRun_DeleteDisk_WhenFailureToCreateProcessor(t *testing.T) {
 		processorProvider: &mockProcessorProvider{
 			err: expectedError,
 		},
-		loggableBuilder: service.NewSingleImageImportLoggableBuilder(),
+		logger: mockLogger,
 	}
-	_, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	assert.Equal(t, expectedError, actualError)
 	assert.Equal(t, 1, mockDiskClient.interactions)
 	assert.Equal(t, project, mockDiskClient.project)
@@ -268,6 +292,10 @@ func TestRun_DeleteDisk_WhenFailureToCreateProcessor(t *testing.T) {
 }
 
 func TestRun_DontRunProcessIfTimedOutDuringInflate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	mockProcessor := mockProcessor{
 		processingTime: 10 * time.Second,
 	}
@@ -281,14 +309,13 @@ func TestRun_DontRunProcessIfTimedOutDuringInflate(t *testing.T) {
 		preValidator:      mockValidator{},
 		inflater:          inflater,
 		processorProvider: &mockProcessorProvider,
-		loggableBuilder:   service.NewSingleImageImportLoggableBuilder(),
+		logger:            mockLogger,
 		timeout:           100 * time.Millisecond,
 	}
 	start := time.Now()
-	loggable, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	duration := time.Since(start)
 
-	assert.NotNil(t, loggable)
 	assert.NotNil(t, actualError)
 	assert.Equal(t, 1, inflater.interactions)
 	assert.Equal(t, 0, mockProcessorProvider.interactions)
@@ -299,6 +326,10 @@ func TestRun_DontRunProcessIfTimedOutDuringInflate(t *testing.T) {
 }
 
 func TestRun_ProcessInterruptedTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	mockProcessor := mockProcessor{
 		processingTime: time.Duration(10) * time.Second,
 	}
@@ -310,14 +341,13 @@ func TestRun_ProcessInterruptedTimeout(t *testing.T) {
 		preValidator:      mockValidator{},
 		inflater:          mockInflater,
 		processorProvider: &mockProcessorProvider,
-		loggableBuilder:   service.NewSingleImageImportLoggableBuilder(),
+		logger:            mockLogger,
 		timeout:           time.Duration(100) * time.Millisecond,
 	}
 	start := time.Now()
-	loggable, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	duration := time.Since(start)
 
-	assert.NotNil(t, loggable)
 	assert.NotNil(t, actualError)
 	assert.Equal(t, 1, mockInflater.interactions)
 	assert.Equal(t, 1, mockProcessor.interactions)
@@ -327,6 +357,10 @@ func TestRun_ProcessInterruptedTimeout(t *testing.T) {
 }
 
 func TestRun_ProcessCantTimeoutImportSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	mockProcessor := mockProcessor{
 		processingTime: time.Duration(1) * time.Second,
 		cantCancel:     true,
@@ -339,14 +373,13 @@ func TestRun_ProcessCantTimeoutImportSucceeds(t *testing.T) {
 		preValidator:      mockValidator{},
 		inflater:          mockInflater,
 		processorProvider: &mockProcessorProvider,
-		loggableBuilder:   service.NewSingleImageImportLoggableBuilder(),
+		logger:            mockLogger,
 		timeout:           time.Duration(100) * time.Millisecond,
 	}
 	start := time.Now()
-	loggable, actualError := importer.Run(context.Background())
+	actualError := importer.Run(context.Background())
 	duration := time.Since(start)
 
-	assert.NotNil(t, loggable)
 	assert.Nil(t, actualError)
 	assert.Equal(t, 1, mockInflater.interactions)
 	assert.Equal(t, 1, mockProcessor.interactions)
@@ -357,6 +390,10 @@ func TestRunStep_VeryShortTimeout(t *testing.T) {
 	// This test ensures that inflater.runStep doesn't dead lock when timeout
 	// has already passed before step function is able to run.
 
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockLogger := mocks.NewMockLogger(ctrl)
+
 	doTestWithTimeOut(t, 2*time.Second, func(t *testing.T) {
 		// run this test with a timeout as it might never finish if there is a bug
 
@@ -364,7 +401,7 @@ func TestRunStep_VeryShortTimeout(t *testing.T) {
 			preValidator:      mockValidator{},
 			inflater:          &mockInflater{},
 			processorProvider: &mockProcessorProvider{},
-			loggableBuilder:   service.NewSingleImageImportLoggableBuilder(),
+			logger:            mockLogger,
 			// this simulates a very short timeout, or a situation when a timeout
 			// occurs immediately after one step finishes and the next one is about
 			// to start
@@ -397,10 +434,6 @@ func TestRunStep_VeryShortTimeout(t *testing.T) {
 					break
 				}
 				return true
-			},
-			func() []string {
-				//getTraceLogs
-				return []string{}
 			})
 		assert.False(t, didStepRun)
 	})
@@ -443,7 +476,7 @@ type mockProcessor struct {
 	cancelChan     chan bool
 }
 
-func (m *mockProcessor) process(pd persistentDisk, loggableBuilder *service.SingleImageImportLoggableBuilder) (persistentDisk, error) {
+func (m *mockProcessor) process(pd persistentDisk) (persistentDisk, error) {
 	m.interactions++
 	m.cancelChan = make(chan bool)
 
@@ -456,13 +489,7 @@ func (m *mockProcessor) process(pd persistentDisk, loggableBuilder *service.Sing
 		}
 	}
 
-	loggableBuilder.SetUEFIMetrics(true, true, true, "btrfs")
-
 	return pd, m.err
-}
-
-func (m *mockProcessor) traceLogs() []string {
-	return m.serialLogs
 }
 
 func (m *mockProcessor) cancel(reason string) bool {
@@ -493,10 +520,6 @@ func (m *mockInflater) Inflate() (persistentDisk, shadowTestFields, error) {
 		}
 	}
 	return m.pd, m.ii, m.err
-}
-
-func (m *mockInflater) TraceLogs() []string {
-	return m.serialLogs
 }
 
 func (m *mockInflater) Cancel(reason string) bool {

--- a/cli_tools/gce_vm_image_import/importer/inflater_test.go
+++ b/cli_tools/gce_vm_image_import/importer/inflater_test.go
@@ -20,9 +20,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	logging2 "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
 )
@@ -293,7 +296,7 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 func createDaisyInflaterSafe(t *testing.T, args ImportArguments,
 	inspector imagefile.Inspector) *daisyInflater {
 	args.WorkflowDir = "../../../daisy_workflows"
-	inflater, err := NewDaisyInflater(args, inspector)
+	inflater, err := NewDaisyInflater(args, inspector, logging2.NewToolLogger("TODO"))
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)

--- a/cli_tools/gce_vm_image_import/importer/metadata_processor.go
+++ b/cli_tools/gce_vm_image_import/importer/metadata_processor.go
@@ -19,11 +19,11 @@ import (
 	"log"
 	"strings"
 
+	"google.golang.org/api/compute/v1"
+
 	daisyUtils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
-	"google.golang.org/api/compute/v1"
 )
 
 // metadataProcessor ensures metadata is present on a GCP disk. If
@@ -43,8 +43,7 @@ func newMetadataProcessor(
 	return &metadataProcessor{project: project, zone: zone, computeDiskClient: computeDiskClient}
 }
 
-func (p *metadataProcessor) process(pd persistentDisk,
-	loggableBuilder *service.SingleImageImportLoggableBuilder) (persistentDisk, error) {
+func (p *metadataProcessor) process(pd persistentDisk) (persistentDisk, error) {
 
 	// Fast path 1: No modification requested.
 	if len(p.requiredFeatures) == 0 && len(p.requiredLicenses) == 0 {
@@ -141,8 +140,4 @@ func hasGuestOSFeature(existingDisk *compute.Disk, feature *compute.GuestOsFeatu
 func (p *metadataProcessor) cancel(reason string) bool {
 	// Cancel is not performed since there is only one critical API call - CreateDisk
 	return false
-}
-
-func (p *metadataProcessor) traceLogs() []string {
-	return []string{}
 }

--- a/cli_tools/gce_vm_image_import/importer/metadata_processor_test.go
+++ b/cli_tools/gce_vm_image_import/importer/metadata_processor_test.go
@@ -18,10 +18,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
 )
 
 func Test_MetadataProcessor_RecreateDiskWhenRequestedAttributesNotFound(t *testing.T) {
@@ -114,7 +115,7 @@ func Test_MetadataProcessor_RecreateDiskWhenRequestedAttributesNotFound(t *testi
 			processor := newMetadataProcessor(project, zone, mockComputeClient)
 			processor.requiredLicenses = tt.requiredLicenses
 			processor.requiredFeatures = tt.requiredFeatures
-			returnedPD, err := processor.process(tt.argPD, nil)
+			returnedPD, err := processor.process(tt.argPD)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedReturnPD, returnedPD)
 		})
@@ -126,7 +127,7 @@ func Test_MetadataProcessor_ReturnEarlyWhenNoChangesRequested(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	originalPD := persistentDisk{}
-	returnedPD, err := newMetadataProcessor("project", "zone", mockComputeClient).process(originalPD, nil)
+	returnedPD, err := newMetadataProcessor("project", "zone", mockComputeClient).process(originalPD)
 
 	assert.NoError(t, err)
 	assert.Equal(t, originalPD, returnedPD)
@@ -178,7 +179,7 @@ func Test_MetadataProcessor_DontModifyDisk_IfChangesAlreadyPresent(t *testing.T)
 			processor := newMetadataProcessor(project, zone, mockComputeClient)
 			processor.requiredLicenses = tt.requiredLicenses
 			processor.requiredFeatures = tt.requiredFeatures
-			returnedPD, err := processor.process(tt.argPD, nil)
+			returnedPD, err := processor.process(tt.argPD)
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.argPD, returnedPD)
@@ -194,7 +195,7 @@ func Test_MetadataProcessor_DontModifyOriginalDisk_IfGetFails(t *testing.T) {
 	argPD := persistentDisk{sizeGb: 10}
 	processor := newMetadataProcessor("project", "zone", mockComputeClient)
 	processor.requiredLicenses = []string{"new/license"}
-	returnedPD, err := processor.process(argPD, nil)
+	returnedPD, err := processor.process(argPD)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Failed to get disk")
@@ -210,7 +211,7 @@ func Test_MetadataProcessor_DontDeleteOriginalDisk_IfCreateFails(t *testing.T) {
 	argPD := persistentDisk{sizeGb: 10}
 	processor := newMetadataProcessor("project", "zone", mockComputeClient)
 	processor.requiredLicenses = []string{"new/license"}
-	returnedPD, err := processor.process(argPD, nil)
+	returnedPD, err := processor.process(argPD)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Failed to create UEFI disk")
@@ -228,7 +229,7 @@ func Test_MetadataProcessor_SilentlyPassesIfDeleteFails(t *testing.T) {
 	expectedReturnPD := persistentDisk{uri: "zones/test-zone/disks/disk-name-1"}
 	processor := newMetadataProcessor("project", "test-zone", mockComputeClient)
 	processor.requiredLicenses = []string{"license/uri"}
-	returnedPD, err := processor.process(argPD, nil)
+	returnedPD, err := processor.process(argPD)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedReturnPD, returnedPD)

--- a/cli_tools/gce_vm_image_import/importer/processor.go
+++ b/cli_tools/gce_vm_image_import/importer/processor.go
@@ -15,7 +15,7 @@
 package importer
 
 import (
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging/service"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
@@ -26,8 +26,7 @@ import (
 // Implementers can expose detailed logs using the traceLogs() method.
 type processor interface {
 	// Returns a pd with updated values. It can be a different pd with different URI.
-	process(persistentDisk, *service.SingleImageImportLoggableBuilder) (persistentDisk, error)
-	traceLogs() []string
+	process(persistentDisk) (persistentDisk, error)
 	cancel(reason string) bool
 }
 
@@ -40,6 +39,7 @@ type defaultProcessorProvider struct {
 	ImportArguments
 	computeClient daisyCompute.Client
 	planner       processPlanner
+	logger        logging.Logger
 }
 
 func (d defaultProcessorProvider) provide(pd persistentDisk) ([]processor, error) {
@@ -64,7 +64,7 @@ func (d defaultProcessorProvider) provide(pd persistentDisk) ([]processor, error
 		processors = append(processors, p)
 	}
 
-	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImportArguments, plan.translationWorkflowPath)
+	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImportArguments, plan.translationWorkflowPath, d.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_import/importer/validator.go
+++ b/cli_tools/gce_vm_image_import/importer/validator.go
@@ -14,6 +14,7 @@ package importer
 
 import (
 	"fmt"
+
 	"google.golang.org/api/compute/v1"
 )
 

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -15,13 +15,22 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/importer"
 )
 
 func main() {
-	if err := cli.Main(os.Args[1:]); err != nil {
+	// Directory where workflows are located; in this case, the value indicates that
+	// that the `daisy_workflows` directory is located in the same directory as the current binary.
+	workflowDir := path.Join(filepath.Dir(os.Args[0]), "daisy_workflows")
+	toolLogger := logging.NewToolLogger(fmt.Sprintf("[%s]", importer.LogPrefix))
+	if err := cli.Main(os.Args[1:], toolLogger, workflowDir); err != nil {
 		// Main is responsible for logging the failure.
 		os.Exit(1)
 	}

--- a/cli_tools_tests/module/diskinspect/disk_inspect_test.go
+++ b/cli_tools_tests/module/diskinspect/disk_inspect_test.go
@@ -17,22 +17,22 @@ package diskinspect
 import (
 	"context"
 	"fmt"
-	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/testing/protocmp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
-
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/paramhelper"
-	"github.com/GoogleCloudPlatform/compute-image-tools/common/runtime"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/paramhelper"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
+	"github.com/GoogleCloudPlatform/compute-image-tools/common/runtime"
 	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 )
 
 const (
@@ -328,7 +328,7 @@ func TestInspectDisk(t *testing.T) {
 				Project:           project,
 				Zone:              zone,
 				WorkflowDirectory: workflowDir,
-			}, defaultNetwork, defaultSubnet, "")
+			}, defaultNetwork, defaultSubnet, "", logging.NewToolLogger(t.Name()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -397,7 +397,7 @@ func TestInspectionWorksWithNonDefaultNetwork(t *testing.T) {
 				Project:           "compute-image-test-custom-vpc",
 				Zone:              zone,
 				WorkflowDirectory: workflowDir,
-			}, currentTest.network, currentTest.subnet, "")
+			}, currentTest.network, currentTest.subnet, "", logging.NewToolLogger(t.Name()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -464,7 +464,7 @@ func makeClientAndInspector(t *testing.T, project string) (daisycompute.Client, 
 		Project:           project,
 		Zone:              zone,
 		WorkflowDirectory: workflowDir,
-	}, defaultNetwork, defaultSubnet, "")
+	}, defaultNetwork, defaultSubnet, "", logging.NewToolLogger(t.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli_tools_tests/module/import/inflater_test.go
+++ b/cli_tools_tests/module/import/inflater_test.go
@@ -32,10 +32,6 @@ import (
 	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 )
 
-const (
-	workflowDir = "../../../daisy_workflows"
-)
-
 func TestDaisyInflater_SupportsImages_LargerThanDefaultDiskSize(t *testing.T) {
 	// The default GCE disk is 10 GB. This test ensures the following:
 	//  1. The worker resizes the destination disk to fit the image's virtual size.
@@ -132,7 +128,7 @@ func runDaisyInflate(t *testing.T, fileURI string) string {
 		Timeout:     time.Hour,
 		Zone:        zone,
 	}
-	inflater, err := importer.NewDaisyInflater(args, imagefile.NewGCSInspector())
+	inflater, err := importer.NewDaisyInflater(args, imagefile.NewGCSInspector(), logging.NewToolLogger("TODO"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli_tools_tests/module/import/logs_test.go
+++ b/cli_tools_tests/module/import/logs_test.go
@@ -1,0 +1,173 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package import_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
+	daisycompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
+	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pbtesting"
+)
+
+func Test_IncludeInflationWorkerLogs_WhenInflationFails(t *testing.T) {
+	t.Parallel()
+	logger := newBufferedToolLogger()
+	imageName := "i" + uuid.New().String()
+	err := cli.Main([]string{
+		"-image_name", imageName,
+		"-client_id", "test",
+		"-source_file", "gs://compute-image-tools-test-resources/vmdk-with-missing-footer.vmdk",
+		"-project", project,
+		"-zone", zone,
+	}, logger, "../../../daisy_workflows")
+
+	if err == nil {
+		t.Fatal("Expected import to fail.")
+	}
+	assert.Contains(t, err.Error(), "ImportFailed: The image file is not decodable")
+	// Look for a log line from daisy_workflows/image_import/import_image.sh
+	assertTraceLogsContain(t, logger, "IMAGE_PATH: /daisy-scratch/vmdk-with-missing-footer.vmdk")
+}
+
+func Test_IncludeTranslationLogs_WhenTranslationFails(t *testing.T) {
+	t.Parallel()
+	logger := newBufferedToolLogger()
+	imageName := "i" + uuid.New().String()
+	err := cli.Main([]string{
+		"-image_name", imageName,
+		"-client_id", "test",
+		"-source_image", "projects/compute-image-tools-test/global/images/debian-9-translate",
+		"-os=sles-15",
+		"-project", project,
+		"-zone", zone,
+	}, logger, "../../../daisy_workflows")
+	if err == nil {
+		t.Fatal("Expected import to fail.")
+	}
+	assert.Contains(t, err.Error(), "\"debian-9\" was detected on your disk, but \"sles-15\" was specified. Please verify and re-import")
+	// Look for a log line from daisy_workflows/image_import/import_image.sh
+	assertTraceLogsContain(t, logger, "/files/run-translate.sh")
+	actualResults := logger.ReadOutputInfo().InspectionResults
+	actualResults.ElapsedTimeMs = 0
+	pbtesting.AssertEqual(t, &pb.InspectionResults{
+		OsCount: 1,
+		OsRelease: &pb.OsRelease{
+			CliFormatted: "debian-9",
+			Distro:       "debian",
+			MajorVersion: "9",
+			MinorVersion: "12",
+			Architecture: pb.Architecture_X64,
+			DistroId:     pb.Distro_DEBIAN,
+		},
+	}, actualResults)
+}
+
+func Test_IncludeInspectionResults_WhenImportSucceeds(t *testing.T) {
+	t.Parallel()
+	client, err := daisycompute.NewClient(context.Background())
+	assert.NoError(t, err)
+
+	logger := newBufferedToolLogger()
+	imageName := "i" + uuid.New().String()
+	err = cli.Main([]string{
+		"-image_name", imageName,
+		"-client_id", "test",
+		"-source_image", "projects/compute-image-tools-test/global/images/debian-9-translate",
+		"-project", project,
+		"-zone", zone,
+	}, logger, "../../../daisy_workflows")
+
+	assert.NoError(t, err)
+	actualResults := logger.ReadOutputInfo().InspectionResults
+	actualResults.ElapsedTimeMs = 0
+	pbtesting.AssertEqual(t, &pb.InspectionResults{
+		OsCount: 1,
+		OsRelease: &pb.OsRelease{
+			CliFormatted: "debian-9",
+			Distro:       "debian",
+			MajorVersion: "9",
+			MinorVersion: "12",
+			Architecture: pb.Architecture_X64,
+			DistroId:     pb.Distro_DEBIAN,
+		},
+	}, actualResults)
+	client.DeleteImage(project, imageName)
+}
+
+func assertTraceLogsContain(t *testing.T, logger *bufferedLogger, substring string) {
+	if len(logger.trace) < 1 {
+		t.Errorf("No trace logs recorded. Expected to find %q", substring)
+		return
+	}
+	var found bool
+	for _, msg := range logger.trace {
+		if strings.Contains(msg, substring) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Did not find %q in trace logs.", substring)
+	}
+}
+
+func newBufferedToolLogger() *bufferedLogger {
+	return &bufferedLogger{outputInfo: &pb.OutputInfo{}}
+}
+
+type bufferedLogger struct {
+	user, debug, trace []string
+	outputInfo         *pb.OutputInfo
+	mu                 sync.Mutex
+}
+
+func (b *bufferedLogger) ReadOutputInfo() *pb.OutputInfo {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.outputInfo
+}
+
+func (b *bufferedLogger) User(message string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.user = append(b.user, message)
+}
+
+func (b *bufferedLogger) Debug(message string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.debug = append(b.debug, message)
+}
+
+func (b *bufferedLogger) Trace(message string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.trace = append(b.trace, message)
+}
+
+func (b *bufferedLogger) Metric(metric *pb.OutputInfo) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	proto.Merge(b.outputInfo, metric)
+}

--- a/cli_tools_tests/module/import/pkg_test.go
+++ b/cli_tools_tests/module/import/pkg_test.go
@@ -20,3 +20,7 @@ var (
 	project = runtime.GetConfig("GOOGLE_CLOUD_PROJECT", "project")
 	zone    = runtime.GetConfig("GOOGLE_CLOUD_ZONE", "compute/zone")
 )
+
+const (
+	workflowDir = "../../../daisy_workflows"
+)

--- a/cli_tools_tests/module/import/scratch_ownership_test.go
+++ b/cli_tools_tests/module/import/scratch_ownership_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/googleapi"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
 )
 
@@ -118,7 +119,7 @@ func Test_DeleteSourceFile_WhenScratchOwnedByDifferentProject(t *testing.T) {
 				"-scratch_bucket_gcs_path", tt.scratch.toURI(),
 				"-project", project,
 				"-zone", zone,
-			})
+			}, logging.NewToolLogger(t.Name()), "")
 
 			// The import should always fail if the scratch bucket
 			// is owned by a different project.
@@ -197,7 +198,7 @@ func Test_DontRecursivelyDelete(t *testing.T) {
 				"-scratch_bucket_gcs_path", "gs://" + sharedBucket,
 				"-project", project,
 				"-zone", zone,
-			})
+			}, logging.NewToolLogger(t.Name()), "")
 
 			// The import should always fail if the scratch bucket
 			// is owned by a different project.
@@ -232,7 +233,7 @@ func Test_DeleteSourceFile_WhenAnotherFileHasSamePrefix(t *testing.T) {
 		"-scratch_bucket_gcs_path", scratch.toURI(),
 		"-project", project,
 		"-zone", zone,
-	})
+	}, logging.NewToolLogger(t.Name()), "")
 
 	assert.Error(t, err)
 


### PR DESCRIPTION
Prepares for modularizing image import. OVF import allows multiple disks to be imported, so a single logger needs to be shared across all importers.

Key changes:
* Take `logging.Logger` as a parameter; use the logger throughout with all dependencies.
* Added module test that verifies important logs (serial console, inspection results)
* Steps no longer expose their trace logs with the method `TraceLogs`; instead, steps write their trace logs to the injected logger.

Testing:
* Added module tests to verify logs and metrics
* Verified log creation in backend