### PR TITLE
When resolving paths, leave absolute paths unchanged.

### DIFF
--- a/cli_tools/common/utils/files/files.go
+++ b/cli_tools/common/utils/files/files.go
@@ -35,13 +35,15 @@ func Exists(path string) bool {
 // MakeAbsolute converts path to absolute, relative to the process's current working directory.
 // Panics if path isn't found.
 func MakeAbsolute(path string) string {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
+	if !filepath.IsAbs(path) {
+		wd, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		path = filepath.Join(wd, path)
 	}
-	abs := filepath.Join(wd, path)
-	if !Exists(abs) {
+	if !Exists(path) {
 		panic(fmt.Sprintf("%s: File not found", path))
 	}
-	return abs
+	return path
 }

--- a/cli_tools/common/utils/files/files_test.go
+++ b/cli_tools/common/utils/files/files_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -79,7 +80,7 @@ func TestDirectoryExists(t *testing.T) {
 	}
 }
 
-func TestAbsolute_HappyCase(t *testing.T) {
+func TestMakeAbsolute_HappyCase(t *testing.T) {
 	// Return to the test directory after running the test.
 	curr, err := os.Getwd()
 	if err != nil {
@@ -103,10 +104,16 @@ func TestAbsolute_HappyCase(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestAbsolute_PanicWhenTargetDoesntExist(t *testing.T) {
+func TestMakeAbsolute_PanicWhenTargetDoesntExist(t *testing.T) {
 	assert.Panics(t, func() {
 		MakeAbsolute(makeNotExistantFile(t))
 	})
+}
+
+func TestMakeAbsolute_WhenParamIsAbsolute_DontModify(t *testing.T) {
+	absoluteDir := makeTempDir(t)
+	assert.True(t, filepath.IsAbs(absoluteDir))
+	assert.Equal(t, absoluteDir, MakeAbsolute(absoluteDir))
 }
 
 // makeNotExistantFile returns a filesystem path that is guaranteed to *not* point to a file.


### PR DESCRIPTION
The `gce_vm_image_import` tests are currently failing with this stack trace:


```
goroutine 1 [running]:
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/files.MakeAbsolute(0xc0003c4b10, 0x10, 0xc0000dcbd0, 0x7fe8b3a64158)
	/workspace/cli_tools/common/utils/files/files.go:44 +0x199
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli.Main(0xc0000300c0, 0xa, 0xa, 0x1c33440, 0xc0000dcbd0, 0xc0003c4b10, 0x10, 0x13, 0x0)
	/workspace/cli_tools/gce_vm_image_import/cli/cli.go:42 +0xe5
main.main()
	/workspace/cli_tools/gce_vm_image_import/main.go:33 +0x2ec
```

This occurred since the daisy workflow directory for `gce_vm_image_import` is configured as an absolute link, and should not be interpreted as relative to the process's current working directory.