### PR TITLE
Windows import: Don't disable hibernation.

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -231,13 +231,6 @@ function Change-InstanceProperties {
 
   # Change time zone to Coordinated Universal Time.
   Run-Command tzutil /s 'UTC'
-
-  # Not supported on 6.1 client, but is supported on 6.1 server
-  $pn_path = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
-  $pn = (Get-ItemProperty -Path $pn_path -Name ProductName).ProductName
-  if ($pn -notlike '*Windows 7*') {
-    Run-Command powercfg /hibernate off
-  }
 }
 
 function Configure-RDPSecurity {


### PR DESCRIPTION
An import with Windows 2008r2 is failing at the step `Run-Command powercfg /hibernate off`. This PR is landing on a separate branch to unblock the customer.