### PR TITLE
Show a more user friendly error when external IP addresses are prohibited

### DIFF
--- a/cli_tools/gce_vm_image_import/cli/cli.go
+++ b/cli_tools/gce_vm_image_import/cli/cli.go
@@ -94,6 +94,9 @@ func Main(args []string, toolLogger logging.ToolLogger, workflowDir string) erro
 }
 
 func userFriendlyError(err error, importArgs importer.ImportArguments) error {
+	if err == nil {
+		return err
+	}
 	if strings.Contains(err.Error(), "constraints/compute.vmExternalIpAccess") {
 		return fmt.Errorf("constraint constraints/compute.vmExternalIpAccess "+
 			"violated for project %v. For more information about importing disks using "+

--- a/cli_tools/gce_vm_image_import/cli/cli.go
+++ b/cli_tools/gce_vm_image_import/cli/cli.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"google.golang.org/api/option"
 
@@ -81,7 +82,7 @@ func Main(args []string, toolLogger logging.ToolLogger, workflowDir string) erro
 
 	importClosure := func() (service.Loggable, error) {
 		err := importRunner.Run(ctx)
-		return service.NewOutputInfoLoggable(toolLogger.ReadOutputInfo()), err
+		return service.NewOutputInfoLoggable(toolLogger.ReadOutputInfo()), userFriendlyError(err, importArgs)
 	}
 
 	project := importArgs.Project
@@ -90,6 +91,17 @@ func Main(args []string, toolLogger logging.ToolLogger, workflowDir string) erro
 		return err
 	}
 	return nil
+}
+
+func userFriendlyError(err error, importArgs importer.ImportArguments) error {
+	if strings.Contains(err.Error(), "constraints/compute.vmExternalIpAccess") {
+		return fmt.Errorf("constraint constraints/compute.vmExternalIpAccess "+
+			"violated for project %v. For more information about importing disks using "+
+			"networks that don't allow external IP addresses, see "+
+			"https://cloud.google.com/compute/docs/import/importing-virtual-disks#no-external-ip",
+			importArgs.Project)
+	}
+	return err
 }
 
 // logFailure sends a message to the logging framework, and is expected to be

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -17,8 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
-	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
@@ -28,7 +26,8 @@ import (
 func main() {
 	// Directory where workflows are located; in this case, the value indicates that
 	// that the `daisy_workflows` directory is located in the same directory as the current binary.
-	workflowDir := path.Join(filepath.Dir(os.Args[0]), "daisy_workflows")
+	//workflowDir := path.Join(filepath.Dir(os.Args[0]), "daisy_workflows")
+	workflowDir := "/usr/local/google/home/zoranl/go/src/github.com/GoogleCloudPlatform/compute-image-tools/daisy_workflows"
 	toolLogger := logging.NewToolLogger(fmt.Sprintf("[%s]", importer.LogPrefix))
 	if err := cli.Main(os.Args[1:], toolLogger, workflowDir); err != nil {
 		// Main is responsible for logging the failure.

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import/cli"
@@ -26,8 +28,7 @@ import (
 func main() {
 	// Directory where workflows are located; in this case, the value indicates that
 	// that the `daisy_workflows` directory is located in the same directory as the current binary.
-	//workflowDir := path.Join(filepath.Dir(os.Args[0]), "daisy_workflows")
-	workflowDir := "/usr/local/google/home/zoranl/go/src/github.com/GoogleCloudPlatform/compute-image-tools/daisy_workflows"
+	workflowDir := path.Join(filepath.Dir(os.Args[0]), "daisy_workflows")
 	toolLogger := logging.NewToolLogger(fmt.Sprintf("[%s]", importer.LogPrefix))
 	if err := cli.Main(os.Args[1:], toolLogger, workflowDir); err != nil {
 		// Main is responsible for logging the failure.


### PR DESCRIPTION
Show a more user friendly error when external IP addresses are prohibitedited by org policy with a link to image import docs.

Currently, the error shown to users is:

`googleapi: Error 412: Constraint constraints/compute.vmExternalIpAccess violated for project 111111111111. Add instance projects/a-project/zones/europe-west3-c/instances/inst-importer-import-image-87wd3 to the constraint to use external IP with it., conditionNotMet`

This is not useful as the recommendation to add importer VM to an exclusion list won't work because importer VM names change for each import.

After this change, error will be:

`constraint constraints/compute.vmExternalIpAccess violated for project a-project. For more information about importing disks using networks that don't allow external IP addresses, see https://cloud.google.com/compute/docs/import/importing-virtual-disks#no-external-ip`