### PR TITLE
Reflect deprecation of SECURE_BOOT

### DIFF
--- a/cli_tools/common/utils/string/string_utils_test.go
+++ b/cli_tools/common/utils/string/string_utils_test.go
@@ -48,14 +48,14 @@ func TestCombineStringSlices(t *testing.T) {
 			want: []string{"WINDOWS"},
 		},
 		{
-			s1:   []string{"SECURE_BOOT"},
+			s1:   []string{"MULTI_IP_SUBNET"},
 			s2:   []string{"WINDOWS"},
-			want: []string{"SECURE_BOOT", "WINDOWS"},
+			want: []string{"MULTI_IP_SUBNET", "WINDOWS"},
 		},
 		{
-			s1:   []string{"SECURE_BOOT", "UEFI_COMPATIBLE"},
+			s1:   []string{"MULTI_IP_SUBNET", "UEFI_COMPATIBLE"},
 			s2:   []string{"WINDOWS", "UEFI_COMPATIBLE"},
-			want: []string{"SECURE_BOOT", "UEFI_COMPATIBLE", "WINDOWS"},
+			want: []string{"MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "WINDOWS"},
 		},
 	}
 

--- a/daisy/common_test.go
+++ b/daisy/common_test.go
@@ -392,14 +392,14 @@ func TestCombineGuestOSFeatures(t *testing.T) {
 			want:               featuresOf("WINDOWS"),
 		},
 		{
-			currentFeatures:    featuresOf("SECURE_BOOT"),
+			currentFeatures:    featuresOf("MULTI_IP_SUBNET"),
 			additionalFeatures: []string{"WINDOWS"},
-			want:               featuresOf("SECURE_BOOT", "WINDOWS"),
+			want:               featuresOf("MULTI_IP_SUBNET", "WINDOWS"),
 		},
 		{
-			currentFeatures:    featuresOf("SECURE_BOOT", "UEFI_COMPATIBLE"),
+			currentFeatures:    featuresOf("MULTI_IP_SUBNET", "UEFI_COMPATIBLE"),
 			additionalFeatures: []string{"WINDOWS", "UEFI_COMPATIBLE"},
-			want:               featuresOf("SECURE_BOOT", "UEFI_COMPATIBLE", "WINDOWS"),
+			want:               featuresOf("MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "WINDOWS"),
 		},
 	}
 


### PR DESCRIPTION
The SECURE_BOOT flag (when creating a new VM instance) has been deprecated and has no effect.

The only usages were in tests for merging slices.