### PR TITLE
Updating hibernation registry check

### DIFF
--- a/daisy_integration_tests/scripts/post_translate_test.ps1
+++ b/daisy_integration_tests/scripts/post_translate_test.ps1
@@ -23,7 +23,7 @@ function Check-VMWareTools {
 }
 
 function Check-Hiberation {
-  $HibernateEnabled = Get-ItemPropertyValue -Path  "HKLM:\SYSTEM\CurrentControlSet\Control\Power" -Name HibernateEnabled  -ErrorAction SilentlyContinue
+  $HibernateEnabled = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Power" -ErrorAction SilentlyContinue).HibernateEnabled
   if ($HibernateEnabled -eq $null -or $HibernateEnabled -ne 0) {
     throw "Hibernation not disabled. HKLM:\SYSTEM\CurrentControlSet\Control\Power\HibernateEnabled = $HibernateEnabled"
   }


### PR DESCRIPTION
Updating to use a cmdlet that is in earlier versions of PowerShell.
- This will fix the failing integration tests for Win7/8/2008/2012 where PowerShell 5 is not installed.