### PR TITLE
Import module: Allow network to be empty

### DIFF
--- a/cli_tools/gce_vm_image_import/importer/request.go
+++ b/cli_tools/gce_vm_image_import/importer/request.go
@@ -83,7 +83,7 @@ type ImageImportRequest struct {
 	ImageName             string `name:"image_name" validate:"required,gce_disk_image_name"`
 	Inspect               bool
 	Labels                map[string]string
-	Network               string `name:"network" validate:"required"`
+	Network               string
 	NoExternalIP          bool
 	NoGuestEnvironment    bool
 	Oauth                 string

--- a/cli_tools/gce_vm_image_import/importer/request_test.go
+++ b/cli_tools/gce_vm_image_import/importer/request_test.go
@@ -63,10 +63,16 @@ func Test_validate_RequiresWorkflowDir(t *testing.T) {
 	assertMissingField(t, request, "workflow_dir")
 }
 
-func Test_validate_RequiresNetwork(t *testing.T) {
+func Test_validate_NetworkIsOptional(t *testing.T) {
 	request := makeValidRequest()
 	request.Network = ""
-	assertMissingField(t, request, "network")
+	assert.NoError(t, request.validate())
+}
+
+func Test_validate_SubnetIsOptional(t *testing.T) {
+	request := makeValidRequest()
+	request.Subnet = ""
+	assert.NoError(t, request.validate())
 }
 
 func Test_validate_RequiresProject(t *testing.T) {


### PR DESCRIPTION
Tests where subnet is specified, but network is omitted, are [failing now.]( https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1348836025501224960) This is a result of #1481, that assumed an empty network is populated by `gce_vm_image_import`. That's true, *except* when subnet is specified; in this case, the GCE backend infers the network.

 

`if the network is not specified but the subnetwork is specified, the network is inferred.` - [instances.insert](https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert)
