### PR TITLE
Image import: Add e2e test case for VHD

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -77,6 +77,14 @@ type testCase struct {
 }
 
 var basicCases = []*testCase{
+	// Disk image formats
+	{
+		caseName:             "vhd-ubuntu-1804",
+		source:               "gs://compute-image-tools-test-resources/ubuntu-1804-azure.vhd",
+		os:                   "ubuntu-1804",
+		osConfigNotSupported: true,
+	},
+
 	// Error messages
 	{
 		caseName:      "incorrect OS specified",


### PR DESCRIPTION
@Quintonamore -- Here's an example of adding a test that will run in prow. 

1. Once pushed, it'll automatically be integrated into the test runner, and you'll see a row on [our testgrid](https://k8s-testgrid.appspot.com/google-gce-compute-image-tools#ci-images-import-export-cli-e2e-tests&grid=old).
2. Testgrid shows `caseName` in each row.
3. `osConfigNotSupported` is required since we don't currently install the OS config agent on Ubuntu. (When I'm adding a test, I search for an existing row that corresponds to the OS on the disk and copy it  ;)  )