### PR TITLE
Add disk space warning for Windows imports

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -306,7 +306,20 @@ function Enable-WinRM {
   }
 }
 
+function Add-Warning {
+  param (
+    [parameter(Mandatory=$true)]
+      [string]$message,
+  )
+  if $script:warnings -ne '' {
+    $script:warnings += ' '
+  }
+  $script:warnings += $message
+  "Translate: Warning - $message"
+}
+
 try {
+  $script:warnings = ''
   Write-Output 'Translate: Beginning translate PowerShell script.'
   $script:pn = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name ProductName).ProductName
   Write-Host "Translate: OS is $script:pn, version $([System.Environment]::OSVersion.Version.ToString())"
@@ -381,6 +394,10 @@ try {
 catch {
   Write-Output 'Exception caught in script:'
   Write-Output $_.InvocationInfo.PositionMessage
-  Write-Output "TranslateFailed: $($_.Exception.Message)"
+  $previous_warnings = ''
+  if $script:warnings -ne '' {
+    $previous_warnings = " Previous warning(s): $script:warnings"
+  }
+  Write-Output "TranslateFailed: $($_.Exception.Message).$previous_warnings"
   exit 1
 }

--- a/daisy_workflows/image_import/windows/translate_bootstrap.ps1
+++ b/daisy_workflows/image_import/windows/translate_bootstrap.ps1
@@ -148,6 +148,13 @@ try {
   Write-Output "Detected BCD folder drive letter: ${bcd_drive}"
   Write-Output "Detected Windows folder drive letter: ${script:os_drive}"
 
+  # Output system volume utilization and warn if less than 1GB free disk space.
+  $diskInfo = get-WmiObject win32_logicaldisk -Filter "DeviceID='${script:os_drive}'"
+  Write-Output "${script:os_drive} has $([math]::Round($diskInfo.FreeSpace / 1GB,2))GB free and is $([math]::Round(($diskInfo.FreeSpace / $diskInfo.Size)*100,2))% used."
+  if (($diskInfo.FreeSpace / 1GB) -lt 1) {
+    Write-Output "TranslateBootstrap: Warning imported system volume has less than 1GB free. $([math]::Round($diskInfo.FreeSpace / 1MB,2))MB disk space free. This may cause the import to fail."
+  }
+
   $kernel32_ver = (Get-Command "${script:os_drive}\Windows\System32\kernel32.dll").Version
   $os_version = "$($kernel32_ver.Major).$($kernel32_ver.Minor)"
 


### PR DESCRIPTION
- If imported system volume has less than 1GB disk space free, output warning to TranslateBootstrap.
- Output system volume utilization and amount of free space to detailed log.