### PR TITLE
Increasing Cloud Build jobs timeout from 30m to 1hr

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1800s
+timeout: 3600s
 
 options:
   env:

--- a/prowjobs_cloudbuild.yaml
+++ b/prowjobs_cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1800s
+timeout: 3600s
 
 options:
   env:


### PR DESCRIPTION
Increasing Cloud Build jobs timeout from 30m to 1hr due to recent timeouts.