### PR TITLE
OVF import: Specify default timeout

### DIFF
--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -58,7 +58,7 @@ var (
 	bootDiskKmsKeyring          = flag.String("boot-disk-kms-keyring", "", "The KMS keyring of the key.")
 	bootDiskKmsLocation         = flag.String("boot-disk-kms-location", "", "The Cloud location for the key.")
 	bootDiskKmsProject          = flag.String("boot-disk-kms-project", "", "The Cloud project for the key.")
-	timeout                     = flag.String("timeout", "", "Maximum time a build can last before it is failed as TIMEOUT. For example, specifying 2h will fail the process after 2 hours. See `gcloud topic datetimes` for information on duration formats")
+	timeout                     = flag.String("timeout", "2h", "Maximum time a build can last before it is failed as TIMEOUT. For example, specifying 2h will fail the process after 2 hours. See `gcloud topic datetimes` for information on duration formats")
 	project                     = flag.String("project", "", "project to run in, overrides what is set in workflow")
 	scratchBucketGcsPath        = flag.String("scratch-bucket-gcs-path", "", "GCS scratch bucket to use, overrides what is set in workflow")
 	oauth                       = flag.String("oauth", "", "path to oauth json file, overrides what is set in workflow")


### PR DESCRIPTION
The README for OVF import says that the default timeout is 2 hours, but the parser wasn't configured with that value.

This was surfaced after  #1497 where the e2e tests started failing with "Error parsing timeout ``". Prior to that PR, the tests succeeded since the timeout was parsed in a goroutine, rather than the main thread. An invalid timeout would kill that goroutine, but allow the main thread to continue.

https://github.com/GoogleCloudPlatform/compute-image-tools/blob/df208b7437289a35aff067d9f8539c670d4af9e2/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go#L414

https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-ovf-import-e2e-tests-daily/1355045772277583872