### PR TITLE
Adding restart in the startup scripts that is cancelled by translate.ps1

### DIFF
--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -18,12 +18,19 @@ ping 127.0.0.1 -n 60
 
 echo "Translate: Starting image translate..." > COM1:
 
+REM Restart the system in 5 minutes. Translate.ps1 will cancel this restart when it starts.
+REM This is to address initial boot issues, mostly on 2008R2, where the network interface is not yet usable.
+echo "Scheduling restart in 5 minutes. Translate.ps1 will cancel this restart." > COM1:
+shutdown /r /t 300
+
+echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow
 
 REM Enable outbound communication to the metadata server.
 netsh advfirewall firewall add rule name="Allow outgoing to GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=out action=allow
 
+echo "Translate: Network configuration for Windows 2008 R2/Windows 7" > COM1:
 REM This is needed for 2008R2 networking to work, this will fail on post 2008R2 but that's fine.
 for /f "tokens=2 delims=:" %%a in (
   'ipconfig ^| find "Gateway"'
@@ -33,10 +40,13 @@ for /f "tokens=2 delims=:" %%a in (
   netsh interface ipv4 set dnsservers "Local Area Connection 3" static address=%%a primary
 )
 
+echo "Translate: Setting timezone" > COM1:
 tzutil /s 'UTC'
 w32tm /resync
 
+echo "Translate: Installing GooGet." > COM1:
 C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install googet > COM1:
 REM Install google-compute-engine-metadata-scripts and then run the task.
 REM This needs to be on one line as this file will get overwritten.
+echo "Translate: Installing metadata scripts runner." > COM1:
 start cmd /c "C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install google-compute-engine-metadata-scripts > COM1: && C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm verify -reinstall google-compute-engine-metadata-scripts > COM1: && schtasks /run /tn GCEStartup > COM1:"

--- a/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
@@ -18,6 +18,11 @@ ping 127.0.0.1 -n 60
 
 echo "Translate: Starting image translate..." > COM1:
 
+REM Restart the system in 5 minutes. Translate.ps1 will cancel this restart when it starts.
+REM This is to address initial boot issues, mostly on 2008R2, where the network interface is not yet usable.
+echo "Scheduling restart in 5 minutes. Translate.ps1 will cancel this restart." > COM1:
+shutdown /r /t 300
+
 echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -321,6 +321,10 @@ function Add-Warning {
 try {
   $script:warnings = ''
   Write-Output 'Translate: Beginning translate PowerShell script.'
+  # Aborting restart triggered in run_startup_scripts.cmd.
+  Start-Process -FilePath "shutdown.exe" -ArgumentList '/a' -ErrorAction SilentlyContinue
+  Write-Output "Scheduled restart aborted with return code $LASTEXITCODE. 0=Restart aborted 1116=No restart scheduled."
+
   $script:pn = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name ProductName).ProductName
   Write-Host "Translate: OS is $script:pn, version $([System.Environment]::OSVersion.Version.ToString())"
   Remove-VMWareTools


### PR DESCRIPTION
- Added scheduled restart to the run_startup_scripts/run_startup_scripts_x86.cmd that is cancelled by translate.ps1. If translate.ps1 does not start the restart has generally been shown to address the underlying OS networking issue.
- Adding logging to run_startup_scripts.cmd to help identify what operation a system stops at.