### PR TITLE
[vmdk api adoption] Switch from shadow-test mode to fallback mode

### DIFF
--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -171,6 +171,8 @@ func (inflater *apiInflater) getShadowDiskName() string {
 
 func (inflater *apiInflater) Cancel(reason string) bool {
 	if !inflater.isShadowInflater {
+		// We don't have to do any actual cancellation for the single CreateDisk API call.
+		// Only the daisy workflow is worth cancelling.
 		return false
 	}
 

--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -47,22 +47,24 @@ func isCausedByAlphaAPIAccess(err error) bool {
 
 // apiInflater implements `importer.inflater` using the Compute Engine API
 type apiInflater struct {
-	request         ImageImportRequest
-	computeClient   daisyCompute.Client
-	storageClient   domain.StorageClientInterface
-	guestOsFeatures []*compute.GuestOsFeature
-	wg              sync.WaitGroup
-	cancelChan      chan string
-	logger          logging.Logger
+	request          ImageImportRequest
+	computeClient    daisyCompute.Client
+	storageClient    domain.StorageClientInterface
+	guestOsFeatures  []*compute.GuestOsFeature
+	wg               sync.WaitGroup
+	cancelChan       chan string
+	logger           logging.Logger
+	isShadowInflater bool
 }
 
-func createAPIInflater(request ImageImportRequest, computeClient daisyCompute.Client, storageClient domain.StorageClientInterface, logger logging.Logger) Inflater {
+func createAPIInflater(request ImageImportRequest, computeClient daisyCompute.Client, storageClient domain.StorageClientInterface, logger logging.Logger, isShadowInflater bool) *apiInflater {
 	inflater := apiInflater{
-		request:       request,
-		computeClient: computeClient,
-		storageClient: storageClient,
-		cancelChan:    make(chan string, 1),
-		logger:        logger,
+		request:          request,
+		computeClient:    computeClient,
+		storageClient:    storageClient,
+		cancelChan:       make(chan string, 1),
+		logger:           logger,
+		isShadowInflater: isShadowInflater,
 	}
 	if request.UefiCompatible {
 		inflater.guestOsFeatures = []*compute.GuestOsFeature{{Type: "UEFI_COMPATIBLE"}}
@@ -71,6 +73,23 @@ func createAPIInflater(request ImageImportRequest, computeClient daisyCompute.Cl
 }
 
 func (inflater *apiInflater) Inflate() (persistentDisk, shadowTestFields, error) {
+	if inflater.isShadowInflater {
+		return inflater.inflateForShadowTest()
+	}
+
+	ctx := context.Background()
+	startTime := time.Now()
+	diskName := "disk-" + inflater.request.ExecutionID
+
+	cd, err := inflater.createDisk(diskName)
+	if err != nil {
+		return persistentDisk{}, shadowTestFields{}, daisy.Errf("Failed to create disk by api inflater: %v", err)
+	}
+
+	return inflater.getDiskAttributes(ctx, diskName, cd, startTime)
+}
+
+func (inflater *apiInflater) inflateForShadowTest() (persistentDisk, shadowTestFields, error) {
 	inflater.wg.Add(1)
 	defer inflater.wg.Done()
 
@@ -78,14 +97,7 @@ func (inflater *apiInflater) Inflate() (persistentDisk, shadowTestFields, error)
 	startTime := time.Now()
 	diskName := inflater.getShadowDiskName()
 
-	// Create shadow disk
-	cd := compute.Disk{
-		Name:                diskName,
-		SourceStorageObject: inflater.request.Source.Path(),
-		GuestOsFeatures:     inflater.guestOsFeatures,
-	}
-
-	err := inflater.computeClient.CreateDisk(inflater.request.Project, inflater.request.Zone, &cd)
+	cd, err := inflater.createDisk(diskName)
 	if err != nil {
 		return persistentDisk{}, shadowTestFields{}, daisy.Errf("Failed to create shadow disk: %v", err)
 	}
@@ -101,6 +113,31 @@ func (inflater *apiInflater) Inflate() (persistentDisk, shadowTestFields, error)
 	default:
 	}
 
+	pd, ii, err := inflater.getDiskAttributes(ctx, diskName, cd, startTime)
+	if err != nil {
+		return pd, ii, err
+	}
+
+	// Calculate checksum by daisy workflow
+	inflater.logger.Debug("Started checksum calculation.")
+	ii.checksum, err = inflater.calculateChecksum(ctx, pd.uri)
+	if err != nil {
+		err = daisy.Errf("Failed to calculate checksum: %v", err)
+	}
+	return pd, ii, err
+}
+
+func (inflater *apiInflater) createDisk(diskName string) (compute.Disk, error) {
+	cd := compute.Disk{
+		Name:                diskName,
+		SourceStorageObject: inflater.request.Source.Path(),
+		GuestOsFeatures:     inflater.guestOsFeatures,
+	}
+	err := inflater.computeClient.CreateDisk(inflater.request.Project, inflater.request.Zone, &cd)
+	return cd, err
+}
+
+func (inflater *apiInflater) getDiskAttributes(ctx context.Context, diskName string, cd compute.Disk, startTime time.Time) (persistentDisk, shadowTestFields, error) {
 	// Prepare return value
 	bkt, objPath, err := storage.GetGCSObjectPathElements(inflater.request.Source.Path())
 	if err != nil {
@@ -125,13 +162,7 @@ func (inflater *apiInflater) Inflate() (persistentDisk, shadowTestFields, error)
 		inflationTime: time.Since(startTime),
 	}
 
-	// Calculate checksum by daisy workflow
-	inflater.logger.Debug("Started checksum calculation.")
-	ii.checksum, err = inflater.calculateChecksum(ctx, diskURI)
-	if err != nil {
-		err = daisy.Errf("Failed to calculate checksum: %v", err)
-	}
-	return pd, ii, err
+	return pd, ii, nil
 }
 
 func (inflater *apiInflater) getShadowDiskName() string {
@@ -139,6 +170,10 @@ func (inflater *apiInflater) getShadowDiskName() string {
 }
 
 func (inflater *apiInflater) Cancel(reason string) bool {
+	if !inflater.isShadowInflater {
+		return false
+	}
+
 	// Send cancel signal
 	inflater.cancelChan <- reason
 

--- a/cli_tools/common/image/importer/api_inflater_test.go
+++ b/cli_tools/common/image/importer/api_inflater_test.go
@@ -50,18 +50,16 @@ func TestCreateInflater_File(t *testing.T) {
 	facade, ok := inflater.(*inflaterFacade)
 	assert.True(t, ok)
 
-	mainInflater, ok := facade.mainInflater.(*daisyInflater)
 	assert.True(t, ok)
-	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", mainInflater.inflatedDiskURI)
-	assert.Equal(t, "gs://bucket/vmdk", mainInflater.wf.Vars["source_disk_file"].Value)
-	assert.Equal(t, "projects/subnet/subnet", mainInflater.wf.Vars["import_subnet"].Value)
-	assert.Equal(t, "projects/network/network", mainInflater.wf.Vars["import_network"].Value)
+	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", facade.daisyInflater.inflatedDiskURI)
+	assert.Equal(t, "gs://bucket/vmdk", facade.daisyInflater.wf.Vars["source_disk_file"].Value)
+	assert.Equal(t, "projects/subnet/subnet", facade.daisyInflater.wf.Vars["import_subnet"].Value)
+	assert.Equal(t, "projects/network/network", facade.daisyInflater.wf.Vars["import_network"].Value)
 
-	network := getWorkerNetwork(t, mainInflater.wf)
+	network := getWorkerNetwork(t, facade.daisyInflater.wf)
 	assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
 
-	realInflater, _ := facade.shadowInflater.(*apiInflater)
-	assert.NotContains(t, realInflater.guestOsFeatures,
+	assert.NotContains(t, facade.apiInflater.guestOsFeatures,
 		&compute.GuestOsFeature{Type: "UEFI_COMPATIBLE"})
 }
 
@@ -86,12 +84,12 @@ func TestCreateAPIInflater_IncludesUEFIGuestOSFeature(t *testing.T) {
 	request := ImageImportRequest{
 		UefiCompatible: true,
 	}
-	realInflater, _ := createAPIInflater(request, nil, &storage.Client{}, logging.NewToolLogger(t.Name())).(*apiInflater)
-	assert.Contains(t, realInflater.guestOsFeatures,
+	apiInflater := createAPIInflater(request, nil, &storage.Client{}, logging.NewToolLogger(t.Name()), true)
+	assert.Contains(t, apiInflater.guestOsFeatures,
 		&compute.GuestOsFeature{Type: "UEFI_COMPATIBLE"})
 }
 
-func TestAPIInflater_Inflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing.T) {
+func TestAPIInflater_ShadowInflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
@@ -101,7 +99,7 @@ func TestAPIInflater_Inflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing
 	mockLogger := mocks.NewMockLogger(mockCtrl)
 	mockLogger.EXPECT().Debug("apiInflater.inflate is canceled: cancel")
 
-	inflater := createAPIInflater(ImageImportRequest{
+	apiInflater := createAPIInflater(ImageImportRequest{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
 		Subnet:       "projects/subnet/subnet",
 		Network:      "projects/network/network",
@@ -109,10 +107,7 @@ func TestAPIInflater_Inflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing
 		ExecutionID:  "1234",
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
-	}, mockComputeClient, &storage.Client{}, mockLogger)
-
-	apiInflater, ok := inflater.(*apiInflater)
-	assert.True(t, ok)
+	}, mockComputeClient, &storage.Client{}, mockLogger, true)
 
 	// Send a cancel signal in prior to guarantee cancellation logic can be executed.
 	cancelResult := apiInflater.Cancel("cancel")
@@ -122,7 +117,7 @@ func TestAPIInflater_Inflate_CreateDiskFailed_CancelWithoutDeleteDisk(t *testing
 	assert.Error(t, err)
 }
 
-func TestAPIInflater_Inflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T) {
+func TestAPIInflater_ShadowInflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
@@ -133,7 +128,7 @@ func TestAPIInflater_Inflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T
 	mockLogger := mocks.NewMockLogger(mockCtrl)
 	mockLogger.EXPECT().Debug("apiInflater.inflate is canceled: cancel")
 
-	inflater := createAPIInflater(ImageImportRequest{
+	apiInflater := createAPIInflater(ImageImportRequest{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
 		Subnet:       "projects/subnet/subnet",
 		Network:      "projects/network/network",
@@ -141,10 +136,7 @@ func TestAPIInflater_Inflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T
 		ExecutionID:  "1234",
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
-	}, mockComputeClient, &storage.Client{}, mockLogger)
-
-	apiInflater, ok := inflater.(*apiInflater)
-	assert.True(t, ok)
+	}, mockComputeClient, &storage.Client{}, mockLogger, true)
 
 	// Send a cancel signal in prior to guarantee cancellation logic can be executed.
 	cancelResult := apiInflater.Cancel("cancel")
@@ -154,7 +146,7 @@ func TestAPIInflater_Inflate_CreateDiskSuccess_CancelWithDeleteDisk(t *testing.T
 	assert.NoError(t, err)
 }
 
-func TestAPIInflater_Inflate_Cancel_CleanupFailedToVerify(t *testing.T) {
+func TestAPIInflater_ShadowInflate_Cancel_CleanupFailedToVerify(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
@@ -163,7 +155,7 @@ func TestAPIInflater_Inflate_Cancel_CleanupFailedToVerify(t *testing.T) {
 	mockLogger := mocks.NewMockLogger(mockCtrl)
 	mockLogger.EXPECT().Debug("apiInflater.inflate is canceled, cleanup failed to verify: cancel")
 
-	inflater := createAPIInflater(ImageImportRequest{
+	apiInflater := createAPIInflater(ImageImportRequest{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
 		Subnet:       "projects/subnet/subnet",
 		Network:      "projects/network/network",
@@ -171,16 +163,13 @@ func TestAPIInflater_Inflate_Cancel_CleanupFailedToVerify(t *testing.T) {
 		ExecutionID:  "1234",
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
-	}, mockComputeClient, &storage.Client{}, mockLogger)
-
-	apiInflater, ok := inflater.(*apiInflater)
-	assert.True(t, ok)
+	}, mockComputeClient, &storage.Client{}, mockLogger, true)
 
 	cancelResult := apiInflater.Cancel("cancel")
 	assert.False(t, cancelResult)
 }
 
-func TestAPIInflater_Inflate_Cancel_CleanupFailed(t *testing.T) {
+func TestAPIInflater_ShadowInflate_Cancel_CleanupFailed(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
@@ -189,7 +178,7 @@ func TestAPIInflater_Inflate_Cancel_CleanupFailed(t *testing.T) {
 	mockLogger := mocks.NewMockLogger(mockCtrl)
 	mockLogger.EXPECT().Debug("apiInflater.inflate is canceled, cleanup is failed: cancel")
 
-	inflater := createAPIInflater(ImageImportRequest{
+	apiInflater := createAPIInflater(ImageImportRequest{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
 		Subnet:       "projects/subnet/subnet",
 		Network:      "projects/network/network",
@@ -197,17 +186,14 @@ func TestAPIInflater_Inflate_Cancel_CleanupFailed(t *testing.T) {
 		ExecutionID:  "1234",
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
-	}, mockComputeClient, &storage.Client{}, mockLogger)
-
-	apiInflater, ok := inflater.(*apiInflater)
-	assert.True(t, ok)
+	}, mockComputeClient, &storage.Client{}, mockLogger, true)
 
 	cancelResult := apiInflater.Cancel("cancel")
 	assert.False(t, cancelResult)
 }
 
 func TestAPIInflater_getCalculateChecksumWorkflow(t *testing.T) {
-	inflater := createAPIInflater(ImageImportRequest{
+	apiInflater := createAPIInflater(ImageImportRequest{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
 		Subnet:       "projects/subnet/subnet",
 		Network:      "projects/network/network",
@@ -215,13 +201,10 @@ func TestAPIInflater_getCalculateChecksumWorkflow(t *testing.T) {
 		ExecutionID:  "1234",
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
-	}, nil, &storage.Client{}, logging.NewToolLogger(t.Name()))
-
-	apiInflater, ok := inflater.(*apiInflater)
-	assert.True(t, ok)
+	}, nil, &storage.Client{}, logging.NewToolLogger(t.Name()), true)
 
 	w := apiInflater.getCalculateChecksumWorkflow("")
-	_, ok = w.Vars["compute_service_account"]
+	_, ok := w.Vars["compute_service_account"]
 	assert.False(t, ok)
 
 	apiInflater.request.ComputeServiceAccount = "email"

--- a/cli_tools/common/image/importer/daisy_inflater.go
+++ b/cli_tools/common/image/importer/daisy_inflater.go
@@ -1,0 +1,206 @@
+//  Copyright 2021  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
+	daisyUtils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	string_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/string"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+const (
+	inflateFilePath  = "image_import/inflate_file.wf.json"
+	inflateImagePath = "image_import/inflate_image.wf.json"
+
+	// When exceeded, we use default values for PDs, rather than more accurate
+	// values used by inspection. When using default values, the worker may
+	// need to resize the PDs, which requires escalated privileges.
+	inspectionTimeout = time.Second * 3
+
+	// 10GB is the default disk size used in inflate_file.wf.json.
+	defaultInflationDiskSizeGB = 10
+)
+
+// daisyInflater implements an inflater using daisy workflows, and is capable
+// of inflating GCP disk images and qemu-img compatible disk files.
+type daisyInflater struct {
+	wf              *daisy.Workflow
+	source          Source
+	inflatedDiskURI string
+	logger          logging.Logger
+}
+
+func (inflater *daisyInflater) Inflate() (persistentDisk, shadowTestFields, error) {
+	if inflater.source != nil {
+		inflater.logger.User("Creating Google Compute Engine disk from " + inflater.source.Path())
+	}
+	startTime := time.Now()
+	err := inflater.wf.Run(context.Background())
+	if inflater.wf.Logger != nil {
+		for _, trace := range inflater.wf.Logger.ReadSerialPortLogs() {
+			inflater.logger.Trace(trace)
+		}
+	}
+	inflater.logger.User("Finished creating Google Compute Engine disk")
+	// See `daisy_workflows/image_import/import_image.sh` for generation of these values.
+	targetSizeGB := inflater.wf.GetSerialConsoleOutputValue("target-size-gb")
+	sourceSizeGB := inflater.wf.GetSerialConsoleOutputValue("source-size-gb")
+	importFileFormat := inflater.wf.GetSerialConsoleOutputValue("import-file-format")
+	checksum := inflater.wf.GetSerialConsoleOutputValue("disk-checksum")
+	return persistentDisk{
+			uri:        inflater.inflatedDiskURI,
+			sizeGb:     string_utils.SafeStringToInt(targetSizeGB),
+			sourceGb:   string_utils.SafeStringToInt(sourceSizeGB),
+			sourceType: importFileFormat,
+		}, shadowTestFields{
+			checksum:      checksum,
+			inflationTime: time.Since(startTime),
+			inflationType: "qemu",
+		}, err
+}
+
+// NewDaisyInflater returns an Inflater that uses a Daisy workflow.
+func NewDaisyInflater(request ImageImportRequest, fileInspector imagefile.Inspector, logger logging.Logger) (*daisyInflater, error) {
+	diskName := "disk-" + request.ExecutionID
+	var wfPath string
+	var vars map[string]string
+	var inflationDiskIndex int
+	if isImage(request.Source) {
+		wfPath = inflateImagePath
+		vars = map[string]string{
+			"source_image": request.Source.Path(),
+			"disk_name":    diskName,
+		}
+		inflationDiskIndex = 0 // Workflow only uses one disk.
+	} else {
+		wfPath = inflateFilePath
+		vars = createDaisyVarsForFile(request, fileInspector, diskName)
+		inflationDiskIndex = 1 // First disk is for the worker
+	}
+
+	wf, err := daisycommon.ParseWorkflow(path.Join(request.WorkflowDir, wfPath), vars,
+		request.Project, request.Zone, request.ScratchBucketGcsPath, request.Oauth, request.Timeout.String(), request.ComputeEndpoint,
+		request.GcsLogsDisabled, request.CloudLogsDisabled, request.StdoutLogsDisabled)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range vars {
+		wf.AddVar(k, v)
+	}
+	daisyUtils.UpdateAllInstanceNoExternalIP(wf, request.NoExternalIP)
+	if request.UefiCompatible {
+		addFeatureToDisk(wf, "UEFI_COMPATIBLE", inflationDiskIndex)
+	}
+	if strings.Contains(request.OS, "windows") {
+		addFeatureToDisk(wf, "WINDOWS", inflationDiskIndex)
+	}
+
+	logPrefix := request.DaisyLogLinePrefix
+	if logPrefix != "" {
+		logPrefix += "-"
+	}
+	wf.Name = logPrefix + "inflate"
+	return &daisyInflater{
+		wf:              wf,
+		inflatedDiskURI: fmt.Sprintf("zones/%s/disks/%s", request.Zone, diskName),
+		logger:          logger,
+		source:          request.Source,
+	}, nil
+}
+
+// addFeatureToDisk finds the first `CreateDisk` step, and adds `feature` as
+// a guestOsFeature to the disk at index `diskIndex`.
+func addFeatureToDisk(workflow *daisy.Workflow, feature string, diskIndex int) {
+	disk := getDisk(workflow, diskIndex)
+	disk.GuestOsFeatures = append(disk.GuestOsFeatures, &compute.GuestOsFeature{
+		Type: feature,
+	})
+}
+
+func getDisk(workflow *daisy.Workflow, diskIndex int) *daisy.Disk {
+	for _, step := range workflow.Steps {
+		if step.CreateDisks != nil {
+			disks := *step.CreateDisks
+			if diskIndex < len(disks) {
+				return disks[diskIndex]
+			}
+			panic(fmt.Sprintf("CreateDisks step did not have disk at index %d", diskIndex))
+		}
+	}
+
+	panic("Did not find CreateDisks step.")
+}
+
+func (inflater *daisyInflater) Cancel(reason string) bool {
+	inflater.wf.CancelWithReason(reason)
+	return true
+}
+
+func createDaisyVarsForFile(request ImageImportRequest,
+	fileInspector imagefile.Inspector, diskName string) map[string]string {
+	vars := map[string]string{
+		"source_disk_file": request.Source.Path(),
+		"import_network":   request.Network,
+		"import_subnet":    request.Subnet,
+		"disk_name":        diskName,
+	}
+
+	if request.ComputeServiceAccount != "" {
+		vars["compute_service_account"] = request.ComputeServiceAccount
+	}
+
+	// To reduce the runtime permissions used on the inflation worker, we pre-allocate
+	// disks sufficient to hold the disk file and the inflated disk. If inspection fails,
+	// then the default values in the daisy workflow will be used. The scratch disk gets
+	// a padding factor to account for filesystem overhead.
+	deadline, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(inspectionTimeout))
+	defer cancelFunc()
+	metadata, err := fileInspector.Inspect(deadline, request.Source.Path())
+	if err == nil {
+		vars["inflated_disk_size_gb"] = fmt.Sprintf("%d", calculateInflatedSize(metadata))
+		vars["scratch_disk_size_gb"] = fmt.Sprintf("%d", calculateScratchDiskSize(metadata))
+	}
+	return vars
+}
+
+// Allocate extra room for filesystem overhead, and
+// ensure a minimum of 10GB (the minimum size of a GCP disk).
+func calculateScratchDiskSize(metadata imagefile.Metadata) int64 {
+	// This uses the historic padding calculation from import_image.sh: add ten percent,
+	// and round up.
+	padded := int64(float64(metadata.PhysicalSizeGB)*1.1) + 1
+	if padded < defaultInflationDiskSizeGB {
+		return defaultInflationDiskSizeGB
+	}
+	return padded
+}
+
+// Ensure a minimum of 10GB (the minimum size of a GCP disk)
+func calculateInflatedSize(metadata imagefile.Metadata) int64 {
+	if metadata.VirtualSizeGB < defaultInflationDiskSizeGB {
+		return defaultInflationDiskSizeGB
+	}
+	return metadata.VirtualSizeGB
+}

--- a/cli_tools/common/image/importer/daisy_inflater.go
+++ b/cli_tools/common/image/importer/daisy_inflater.go
@@ -80,8 +80,8 @@ func (inflater *daisyInflater) Inflate() (persistentDisk, shadowTestFields, erro
 		}, err
 }
 
-// NewDaisyInflater returns an Inflater that uses a Daisy workflow.
-func NewDaisyInflater(request ImageImportRequest, fileInspector imagefile.Inspector, logger logging.Logger) (*daisyInflater, error) {
+// newDaisyInflater returns an inflater that uses a Daisy workflow.
+func newDaisyInflater(request ImageImportRequest, fileInspector imagefile.Inspector, logger logging.Logger) (*daisyInflater, error) {
 	diskName := "disk-" + request.ExecutionID
 	var wfPath string
 	var vars map[string]string

--- a/cli_tools/common/image/importer/daisy_inflater.go
+++ b/cli_tools/common/image/importer/daisy_inflater.go
@@ -80,7 +80,11 @@ func (inflater *daisyInflater) Inflate() (persistentDisk, shadowTestFields, erro
 		}, err
 }
 
-// newDaisyInflater returns an inflater that uses a Daisy workflow.
+// NewDaisyInflater returns an inflater that uses a Daisy workflow.
+func NewDaisyInflater(request ImageImportRequest, fileInspector imagefile.Inspector, logger logging.Logger) (Inflater, error) {
+	return newDaisyInflater(request, fileInspector, logger)
+}
+
 func newDaisyInflater(request ImageImportRequest, fileInspector imagefile.Inspector, logger logging.Logger) (*daisyInflater, error) {
 	diskName := "disk-" + request.ExecutionID
 	var wfPath string

--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -295,7 +295,7 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 func createDaisyInflaterSafe(t *testing.T, request ImageImportRequest,
 	inspector imagefile.Inspector) *daisyInflater {
 	request.WorkflowDir = "../../../../daisy_workflows"
-	daisyInflater, err := NewDaisyInflater(request, inspector, logging.NewToolLogger("test"))
+	daisyInflater, err := newDaisyInflater(request, inspector, logging.NewToolLogger("test"))
 	assert.NoError(t, err)
 	return daisyInflater
 }

--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -295,11 +295,9 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 func createDaisyInflaterSafe(t *testing.T, request ImageImportRequest,
 	inspector imagefile.Inspector) *daisyInflater {
 	request.WorkflowDir = "../../../../daisy_workflows"
-	inflater, err := NewDaisyInflater(request, inspector, logging.NewToolLogger("test"))
+	daisyInflater, err := NewDaisyInflater(request, inspector, logging.NewToolLogger("test"))
 	assert.NoError(t, err)
-	realInflater, ok := inflater.(*daisyInflater)
-	assert.True(t, ok)
-	return realInflater
+	return daisyInflater
 }
 
 func createDaisyInflaterForImageSafe(t *testing.T, request ImageImportRequest) *daisyInflater {

--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -1,4 +1,4 @@
-//  Copyright 2020 Google Inc. All Rights Reserved.
+//  Copyright 2021 Google Inc. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/cli_tools/common/image/importer/inflater.go
+++ b/cli_tools/common/image/importer/inflater.go
@@ -49,7 +49,7 @@ type shadowTestFields struct {
 func newInflater(request ImageImportRequest, computeClient daisyCompute.Client, storageClient domain.StorageClientInterface,
 	inspector imagefile.Inspector, logger logging.Logger) (Inflater, error) {
 
-	di, err := NewDaisyInflater(request, inspector, logger)
+	di, err := newDaisyInflater(request, inspector, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +80,8 @@ func isShadowTestFormat(request ImageImportRequest) bool {
 
 // inflaterFacade implements an inflater using other concrete implementations.
 type inflaterFacade struct {
-	apiInflater   *apiInflater
-	daisyInflater *daisyInflater
+	apiInflater   Inflater
+	daisyInflater Inflater
 	logger        logging.Logger
 }
 
@@ -102,7 +102,7 @@ func (facade *inflaterFacade) Inflate() (persistentDisk, shadowTestFields, error
 
 	if !isCausedByUnsupportedFormat(err) {
 		facade.logger.Metric(&pb.OutputInfo{
-			InflationType:  "api_failed",
+			InflationType:   "api_failed",
 			InflationTimeMs: []int64{tf.inflationTime.Milliseconds()},
 		})
 		return pd, tf, err

--- a/cli_tools/common/image/importer/inflater.go
+++ b/cli_tools/common/image/importer/inflater.go
@@ -25,8 +25,6 @@ import (
 
 // Inflater constructs a new persistentDisk, typically starting from a
 // frozen representation of a disk, such as a VMDK file or a GCP disk image.
-//
-// Implementers can expose detailed logs using the traceLogs() method.
 type Inflater interface {
 	Inflate() (persistentDisk, shadowTestFields, error)
 	Cancel(reason string) bool

--- a/cli_tools/common/image/importer/inflater_test.go
+++ b/cli_tools/common/image/importer/inflater_test.go
@@ -1,0 +1,152 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package importer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+)
+
+func TestCreateInflater_File(t *testing.T) {
+	inflater, err := newInflater(ImageImportRequest{
+		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:       "projects/subnet/subnet",
+		Network:      "projects/network/network",
+		Zone:         "us-west1-c",
+		ExecutionID:  "1234",
+		NoExternalIP: false,
+		WorkflowDir:  daisyWorkflows,
+	}, nil, &storage.Client{}, mockInspector{
+		t:                 t,
+		expectedReference: "gs://bucket/vmdk",
+		errorToReturn:     nil,
+		metaToReturn:      imagefile.Metadata{},
+	}, nil)
+	assert.NoError(t, err)
+	facade, ok := inflater.(*inflaterFacade)
+	assert.True(t, ok)
+
+	daisyInflater, ok := facade.daisyInflater.(*daisyInflater)
+	assert.True(t, ok)
+	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", daisyInflater.inflatedDiskURI)
+	assert.Equal(t, "gs://bucket/vmdk", daisyInflater.wf.Vars["source_disk_file"].Value)
+	assert.Equal(t, "projects/subnet/subnet", daisyInflater.wf.Vars["import_subnet"].Value)
+	assert.Equal(t, "projects/network/network", daisyInflater.wf.Vars["import_network"].Value)
+
+	network := getWorkerNetwork(t, daisyInflater.wf)
+	assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+
+	apiInflater, ok := facade.apiInflater.(*apiInflater)
+	assert.True(t, ok)
+	assert.NotContains(t, apiInflater.guestOsFeatures,
+		&compute.GuestOsFeature{Type: "UEFI_COMPATIBLE"})
+}
+
+func TestCreateInflater_Image(t *testing.T) {
+	inflater, err := newInflater(ImageImportRequest{
+		Source:      imageSource{uri: "projects/test/uri/image"},
+		Zone:        "us-west1-b",
+		ExecutionID: "1234",
+		WorkflowDir: daisyWorkflows,
+	}, nil, &storage.Client{}, nil, nil)
+	assert.NoError(t, err)
+	realInflater, ok := inflater.(*daisyInflater)
+	assert.True(t, ok)
+	assert.Equal(t, "zones/us-west1-b/disks/disk-1234", realInflater.inflatedDiskURI)
+	assert.Equal(t, "projects/test/uri/image", realInflater.wf.Vars["source_image"].Value)
+	inflatedDisk := getDisk(realInflater.wf, 0)
+	assert.Contains(t, inflatedDisk.Licenses,
+		"projects/compute-image-tools/global/licenses/virtual-disk-import")
+}
+
+func TestInflaterFacade_SuccessOnApiInflater(t *testing.T) {
+	facade := inflaterFacade{
+		apiInflater: &mockInflater{
+			pd: persistentDisk{
+				uri: "disk1",
+			},
+		},
+		daisyInflater: &mockInflater{
+			pd: persistentDisk{
+				uri: "disk2",
+			},
+		},
+		logger: logging.NewToolLogger(t.Name()),
+	}
+
+	pd, _, err := facade.Inflate()
+	assert.NoError(t, err)
+	assert.Equal(t, "disk1", pd.uri)
+}
+
+func TestInflaterFacade_FailedOnApiInflater(t *testing.T) {
+	apiError := fmt.Errorf("any failure")
+	facade := inflaterFacade{
+		apiInflater: &mockInflater{
+			err: apiError,
+		},
+		daisyInflater: &mockInflater{
+			pd: persistentDisk{
+				uri: "disk2",
+			},
+		},
+		logger: logging.NewToolLogger(t.Name()),
+	}
+
+	_, _, err := facade.Inflate()
+	assert.Equal(t, apiError, err)
+}
+
+func TestInflaterFacade_SuccessOnDaisyInflater(t *testing.T) {
+	apiError := fmt.Errorf("failed on INVALID_IMAGE_FILE")
+	facade := inflaterFacade{
+		apiInflater: &mockInflater{
+			err: apiError,
+		},
+		daisyInflater: &mockInflater{
+			pd: persistentDisk{
+				uri: "disk2",
+			},
+		},
+		logger: logging.NewToolLogger(t.Name()),
+	}
+
+	pd, _, err := facade.Inflate()
+	assert.NoError(t, err)
+	assert.Equal(t, "disk2", pd.uri)
+}
+
+func TestInflaterFacade_FailedOnDaisyInflater(t *testing.T) {
+	apiError := fmt.Errorf("failed on INVALID_IMAGE_FILE")
+	daisyError := fmt.Errorf("failed on daisy")
+	facade := inflaterFacade{
+		apiInflater: &mockInflater{
+			err: apiError,
+		},
+		daisyInflater: &mockInflater{
+			err: daisyError,
+		},
+		logger: logging.NewToolLogger(t.Name()),
+	}
+
+	_, _, err := facade.Inflate()
+	assert.Equal(t, daisyError, err)
+}

--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -7,11 +7,11 @@ require (
 	cloud.google.com/go/logging v1.2.0 // indirect
 	cloud.google.com/go/storage v1.13.0
 	cos.googlesource.com/cos/tools.git v0.0.0-20210104210903-4b3bc7d49b79 // indirect
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20210204013302-8240807dedc1
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20210204232849-5bf13ea3342e
 	github.com/GoogleCloudPlatform/compute-image-tools/mocks v0.0.0-20200414213327-359251a2c860
 	github.com/GoogleCloudPlatform/compute-image-tools/proto/go v0.0.0
 	github.com/GoogleCloudPlatform/osconfig v0.0.0-20210202205636-8f5a30e8969f
-	github.com/aws/aws-sdk-go v1.37.3
+	github.com/aws/aws-sdk-go v1.37.5
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-ole/go-ole v1.2.5
@@ -29,7 +29,7 @@ require (
 	github.com/minio/highwayhash v1.0.1
 	github.com/stretchr/testify v1.6.1
 	github.com/vmware/govmomi v0.24.0
-	go.chromium.org/luci v0.0.0-20210204170102-f25dc79418e4 // indirect
+	go.chromium.org/luci v0.0.0-20210204234011-34a994fe5aec // indirect
 	go.opencensus.io v0.22.6 // indirect
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c // indirect

--- a/cli_tools/go.sum
+++ b/cli_tools/go.sum
@@ -93,6 +93,8 @@ github.com/aws/aws-sdk-go v1.34.22 h1:7V2sKilVVgHqdjbW+O/xaVWYfnmuLwZdF/+6JuUh6C
 github.com/aws/aws-sdk-go v1.34.22/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.3 h1:1f0groABc4AuapskpHf6EBRaG2tqw0Sx3ebCMwfp1Ys=
 github.com/aws/aws-sdk-go v1.37.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.37.5 h1:9zJ1aXRk1gLSWEeaMXa7Hbv1pIM915T2tpaIJi0+mkA=
+github.com/aws/aws-sdk-go v1.37.5/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
@@ -282,6 +284,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
@@ -304,6 +307,8 @@ go.chromium.org/luci v0.0.0-20200722211809-bab0c30be68b/go.mod h1:MIQewVTLvOvc0U
 go.chromium.org/luci v0.0.0-20201204084249-3e81ee3e83fe/go.mod h1:MIQewVTLvOvc0UioV0JNqTNO/RspKFS0XEeoKrOxsdM=
 go.chromium.org/luci v0.0.0-20210204170102-f25dc79418e4 h1:AtCxbPvBRvMsfozYWvO0s5iOMkJI9b63h6PoZfO2FmU=
 go.chromium.org/luci v0.0.0-20210204170102-f25dc79418e4/go.mod h1:MIQewVTLvOvc0UioV0JNqTNO/RspKFS0XEeoKrOxsdM=
+go.chromium.org/luci v0.0.0-20210204234011-34a994fe5aec h1:aSbA4K0rE41QQ9M7SZCX8ZgmY+PaYNxCeIuIX2n3HhE=
+go.chromium.org/luci v0.0.0-20210204234011-34a994fe5aec/go.mod h1:MIQewVTLvOvc0UioV0JNqTNO/RspKFS0XEeoKrOxsdM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.1/go.mod h1:Ap50jQcDJrx6rB6VgeeFPtuPIf3wMRvRfrfYDO6+BmA=
@@ -722,6 +727,7 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
@@ -81,8 +81,6 @@ func CLITestSuite(
 			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with different network param styles"))
 		imageImportWithSubnetWithoutNetworkSpecifiedTestCase := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with subnet but without network"))
-		imageImportShadowDiskCleanedUpWhenMainInflaterFails := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import shadow disk is cleaned up when main inflater fails"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -92,7 +90,11 @@ func CLITestSuite(
 		testsMap[testType][imageImportWithRichParamsTestCase] = runImageImportWithRichParamsTest
 		testsMap[testType][imageImportWithDifferentNetworkParamStylesTestCase] = runImageImportWithDifferentNetworkParamStyles
 		testsMap[testType][imageImportWithSubnetWithoutNetworkSpecifiedTestCase] = runImageImportWithSubnetWithoutNetworkSpecified
-		testsMap[testType][imageImportShadowDiskCleanedUpWhenMainInflaterFails] = runImageImportShadowDiskCleanedUpWhenMainInflaterFails
+
+		// TODO: recover this test only when shadow test is enabled.
+		//imageImportShadowDiskCleanedUpWhenMainInflaterFails := junitxml.NewTestCase(
+		//	testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import shadow disk is cleaned up when main inflater fails"))
+		//testsMap[testType][imageImportShadowDiskCleanedUpWhenMainInflaterFails] = runImageImportShadowDiskCleanedUpWhenMainInflaterFails
 	}
 
 	// Only test service account scenario for wrapper, till gcloud support it.

--- a/cli_tools_tests/module/import/inflater_test.go
+++ b/cli_tools_tests/module/import/inflater_test.go
@@ -128,7 +128,7 @@ func runDaisyInflate(t *testing.T, fileURI string) string {
 		Timeout:     time.Hour,
 		Zone:        zone,
 	}
-	inflater, err := importer.NewDaisyInflater(request, imagefile.NewGCSInspector(), logging.NewToolLogger("TODO"))
+	inflater, err := importer.newDaisyInflater(request, imagefile.NewGCSInspector(), logging.NewToolLogger("TODO"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli_tools_tests/module/import/inflater_test.go
+++ b/cli_tools_tests/module/import/inflater_test.go
@@ -128,7 +128,7 @@ func runDaisyInflate(t *testing.T, fileURI string) string {
 		Timeout:     time.Hour,
 		Zone:        zone,
 	}
-	inflater, err := importer.newDaisyInflater(request, imagefile.NewGCSInspector(), logging.NewToolLogger("TODO"))
+	inflater, err := importer.NewDaisyInflater(request, imagefile.NewGCSInspector(), logging.NewToolLogger("TODO"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR will start using API inflater as the main inflater.
Shadow test mode: daisy inflater as main inflater; API inflater as shadow test.
Fallback mode: api inflater as main inflater; daisy inflater as fallback inflater (expect to be used by non-vmdk).

Changes:
1. api_inflater: use a flag "isShadowTest" to determine whether to run shadow-test-only logic (calculate checksum for example).
2. Split "inflater.go" to "daisy_inflater.go" and "inflater.go"; "inflater_test.go" is split accordingly.
3. Renamed original "inflaterFacade" to "shadowTestInflaterFacade", which handles shadow-test mode; added a new "inflaterFacade" to handle fallback mode. Added tests accordingly.

New logic is only in api_inflater.go and inflater.go. Others are only code movement or trivial changes.