### PR TITLE
GMI import worker: Use alphabetic prefix on data disks

### DIFF
--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -280,9 +280,16 @@ func (oi *OVFImporter) modifyWorkflowPreValidate(w *daisy.Workflow) {
 		createInstanceStepName := "create-instance"
 		cleanupStepName := "cleanup"
 
+		var dataDiskPrefix string
+		if oi.params.IsInstanceImport() {
+			dataDiskPrefix = oi.params.InstanceNames
+		} else {
+			dataDiskPrefix = oi.params.MachineImageName
+		}
+
 		daisyovfutils.CreateDisksOnInstance(
 			w.Steps[createInstanceStepName].CreateInstances.Instances[0],
-			oi.params.InstanceNames, oi.imageURIs[1:])
+			dataDiskPrefix, oi.imageURIs[1:])
 
 		// Delete the images after the instance is created.
 		w.Steps[cleanupStepName].DeleteResources.Images = append(

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -291,6 +291,7 @@ func verifyModuleImport(t *testing.T, wfPath string, params *domain.OVFImportPar
 	for i, diskURI := range testCase.imageURIs[1:] {
 		dataDisk := instance.Disks[i+1]
 		assert.Equal(t, diskURI, dataDisk.InitializeParams.SourceImage, "Include data disk on final instance.")
+		assert.Regexp(t, "^[a-z].*", dataDisk.InitializeParams.DiskName, "Disk name should start with letter.")
 		assert.True(t, dataDisk.AutoDelete, "Delete the disk when the instance is deleted.")
 		assert.False(t, dataDisk.Boot, "Data disk are not configured to boot.")
 		assert.Contains(t, cleanup.Images, testCase.imageURIs[i+1], "Delete the data disk image after instance creation.")


### PR DESCRIPTION
This bug was caused by #1512, and was observed in the e2e tests:

`cannot create instance: bad InitializeParams.DiskName: "-1"; * cannot create disk "-1"; resource lookup error: unknown resource type: "projects/compute-image-test-pool-001/zones/us-central1-c/disks/-1"`

https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-ovf-import-e2e-tests-daily/1357763952053850112

It occurred since the instance name was being used as a prefix for data disk names; in GMI import, the use doesn't specify an instance name.