### PR TITLE
Looping while install disk initialises

### DIFF
--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -43,16 +43,16 @@ online disk noerr
   }
 
   # Find the drive which contains install media.
-  For ($i=0; $i -le 5; $i++) {
+  For ($i=0; $i -lt 5; $i++) {
     $Drives = Get-WmiObject Win32_LogicalDisk
-  ForEach ($Drive in $Drives) {
-    if (Test-Path "$($Drive.DeviceID)\Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English") {
-      $script:install_media_drive = "$($Drive.DeviceID)"
+    ForEach ($Drive in $Drives) {
+      if (Test-Path "$($Drive.DeviceID)\Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English") {
+        $script:install_media_drive = "$($Drive.DeviceID)"
+      }
     }
-  }
-  if ($script:install_media_drive){break}
-  Write-Host "Disk not ready yet - waiting"
-  Start-Sleep -Seconds 5
+    if ($script:install_media_drive){break}
+    Write-Host "Disk not ready yet - waiting"
+    Start-Sleep -Seconds 5
   }
 
 

--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -50,14 +50,16 @@ online disk noerr
         $script:install_media_drive = "$($Drive.DeviceID)"
       }
     }
-    if ($script:install_media_drive){break}
-    Write-Host "Disk not ready yet - waiting"
+    if ($script:install_media_drive) {
+      break
+    }
+    Write-Host "Install media not found, retrying in 5 seconds. Attempt $i of 5."
     Start-Sleep -Seconds 5
   }
 
 
   if (!$script:install_media_drive) {
-    throw "No install media found."
+    throw "No install media found after 5 attempts."
   }
   Write-Host "Detected install media folder drive letter: $script:install_media_drive"
 

--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -43,7 +43,7 @@ online disk noerr
   }
 
   # Find the drive which contains install media.
-  For ($i=0; $i -lt 5; $i++) {
+  For ($i=1; $i -le 5; $i++) {
     $Drives = Get-WmiObject Win32_LogicalDisk
     ForEach ($Drive in $Drives) {
       if (Test-Path "$($Drive.DeviceID)\Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English") {

--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -51,7 +51,7 @@ online disk noerr
     }
   }
   if ($script:install_media_drive){break}
-  "Disk not ready yet - waiting"
+  Write-Host "Disk not ready yet - waiting"
   Start-Sleep -Seconds 5
   }
 

--- a/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
+++ b/cli_tools/gce_windows_upgrade/upgrade_script_2008r2_to_2012r2.ps1
@@ -43,12 +43,19 @@ online disk noerr
   }
 
   # Find the drive which contains install media.
-  $Drives = Get-WmiObject Win32_LogicalDisk
+  For ($i=0; $i -le 5; $i++) {
+    $Drives = Get-WmiObject Win32_LogicalDisk
   ForEach ($Drive in $Drives) {
     if (Test-Path "$($Drive.DeviceID)\Windows_Svr_Std_and_DataCtr_2012_R2_64Bit_English") {
       $script:install_media_drive = "$($Drive.DeviceID)"
     }
   }
+  if ($script:install_media_drive){break}
+  "Disk not ready yet - waiting"
+  Start-Sleep -Seconds 5
+  }
+
+
   if (!$script:install_media_drive) {
     throw "No install media found."
   }


### PR DESCRIPTION
The disk is not always ready when looping through the drives hence failing with no install media found - especially with multiple pd-standard
Added an extra loop to the loop for the installation disk, running 5 times while sleeping for 5 seconds in between - breaking when the disk is found.
