### PR TITLE
[importer] build onestep importer

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -138,6 +138,64 @@ steps:
   - --context=/workspace
   - --dockerfile=gce_vm_image_import.Dockerfile
 
+# Build gce_onestep_image_import.
+- name: 'golang'
+  dir: 'cli_tools/gce_onestep_image_import'
+  args: ['go', 'build', '-o=/workspace/linux/gce_onestep_image_import']
+  env: ['CGO_ENABLED=0']
+- name: 'gcr.io/kaniko-project/executor:v1.1.0'
+  args:
+  - --destination=gcr.io/$PROJECT_ID/gce_onestep_image_import:$_RELEASE
+  - --destination=gcr.io/$PROJECT_ID/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=us-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=us-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=us-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=us-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=us-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=us-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=us-east4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=us-east4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=southamerica-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=southamerica-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-north1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-north1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-west3-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-west3-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-west4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-west4-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=europe-west6-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=europe-west6-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-east1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-east2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-east2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-northeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-northeast2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-northeast2-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-south1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-south1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=asia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=asia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --destination=australia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$_RELEASE
+  - --destination=australia-southeast1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_onestep_image_import:$COMMIT_SHA
+  - --context=/workspace
+  - --dockerfile=gce_onestep_image_import.Dockerfile
+
 # Build gce_vm_image_export.
 - name: 'golang'
   dir: 'cli_tools/gce_vm_image_export'


### PR DESCRIPTION
onestep importer needs to be everywhere original importer located because gcloud use the same finding logic.