### PR TITLE
Precheck tool: Use common OS list

### DIFF
--- a/cli_tools/common/distro/distro_test.go
+++ b/cli_tools/common/distro/distro_test.go
@@ -55,10 +55,10 @@ func TestParseGcloudOsParam_DistroNameErrors(t *testing.T) {
 	}{
 		{"", "expected pattern of `distro-version`. Actual: ``"},
 		{"unknown", "expected pattern of `distro-version`. Actual: `unknown`"},
-		{"notSupported-18", "distro `notsupported` is not importable"},
-		{"notSupported-1804", "distro `notsupported` is not importable"},
+		{"notSupported-18", "Unrecognized distro `notsupported`"},
+		{"notSupported-1804", "Unrecognized distro `notsupported`"},
 		{"sles", "expected pattern of `distro-version`. Actual: `sles`"},
-		{"kali-12", "distro `kali` is not importable"},
+		{"kali-12", "Unrecognized distro `kali`"},
 		{"ubuntu", "expected pattern of `distro-version`"},
 		{"ubuntu-12", "expected version with length four"},
 		{"opensuse-15-leap", "expected pattern of `distro-version`. Actual: `opensuse-15-leap`"},
@@ -221,7 +221,7 @@ func TestDistroFromComponents_ArchitectureValidation(t *testing.T) {
 		{inputArch: "x86_32", expectedArch: "x86"},
 
 		{inputArch: "", expectedArch: ""},
-		{inputArch: "mips", expectErrorToContain: "Architecture `mips` is not supported for import"},
+		{inputArch: "mips", expectErrorToContain: "Unrecognized architecture `mips`"},
 	}
 	for _, tt := range cases {
 		t.Run(tt.inputArch, func(t *testing.T) {
@@ -308,11 +308,11 @@ func TestDistroFromComponents_DistroNameErrors(t *testing.T) {
 		},
 		{
 			distro: "a",
-			err:    "distro `a` is not importable",
+			err:    "Unrecognized distro `a`",
 		},
 		{
 			distro: "unknown",
-			err:    "distro `unknown` is not importable",
+			err:    "Unrecognized distro `unknown`",
 		},
 	}
 	for _, tt := range cases {

--- a/cli_tools/import_precheck/check_osversion.go
+++ b/cli_tools/import_precheck/check_osversion.go
@@ -15,18 +15,16 @@ package main
 import (
 	"fmt"
 	"strings"
+
+	"github.com/GoogleCloudPlatform/osconfig/osinfo"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
+	daisy_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 )
 
-var osVersions = map[string][]string{
-	"centos":  {"6", "7"},
-	"debian":  {"8", "9"},
-	"ol":      {"6", "7"},
-	"rhel":    {"6", "7"},
-	"ubuntu":  {"14.04", "16.04"},
-	"windows": {"6.1", "6.3", "10.0"},
+type osVersionCheck struct {
+	osInfo *osinfo.OSInfo
 }
-
-type osVersionCheck struct{}
 
 func (c *osVersionCheck) getName() string {
 	return "OS Version Check"
@@ -34,24 +32,72 @@ func (c *osVersionCheck) getName() string {
 
 func (c *osVersionCheck) run() (*report, error) {
 	r := &report{name: c.getName()}
-	var versions []string
-	var ok bool
-	r.Info(fmt.Sprintf("OSInfo: %+v", osInfo))
-
-	if versions, ok = osVersions[osInfo.ShortName]; !ok {
-		r.Fatal(osInfo.ShortName)
+	// Find osID from OS config's detection results.
+	major, minor := splitOSVersion(c.osInfo.Version)
+	osID, err := c.getOSID(major, minor, r)
+	if err != nil {
+		r.Info("Cannot determine OS. For supported versions, " +
+			"see https://cloud.google.com/sdk/gcloud/reference/compute/images/import")
+		r.skipped = true
 		return r, nil
 	}
 
-	found := false
-	for _, version := range versions {
-		if strings.Contains(osInfo.Version, version) {
-			found = true
+	// Check whether the osID is supported for import.
+	// Some systems are only available as BYOL, so check for both osID variants.
+	var supported bool
+	for _, suffix := range []string{"", "-byol"} {
+		if daisy_utils.ValidateOS(osID+suffix) == nil {
+			supported = true
 			break
 		}
 	}
-	if !found {
-		r.Fatal(fmt.Sprintf("version: %q not supported", osInfo.Version))
+	if supported {
+		if c.osInfo.ShortName == osinfo.Windows {
+			// Emit the NT version for Windows, since the same NT version is
+			// either Desktop or Server, and we don't want to emit a misleading message.
+			r.Info(fmt.Sprintf("Detected Windows version number: NT %s", c.osInfo.Version))
+		} else {
+			r.Info(fmt.Sprintf("Detected system: %s", osID))
+		}
+	} else {
+		r.Fatal(createFailureMessage(osID).Error())
 	}
 	return r, nil
+}
+
+func (c *osVersionCheck) getOSID(major string, minor string, r *report) (osID string, err error) {
+	if c.osInfo.ShortName == osinfo.Windows {
+		maj, min, err := distro.WindowsServerVersionforNTVersion(major, minor)
+		if err == nil {
+			major, minor = maj, min
+		}
+	}
+	release, err := distro.FromComponents(c.osInfo.ShortName, major, minor, c.osInfo.Architecture)
+	if err != nil {
+		return "", err
+	}
+	if release == nil {
+		return "", createFailureMessage("Your OS")
+	}
+	osID = release.AsGcloudArg()
+	if osID == "" {
+		return "", createFailureMessage("Your OS")
+	}
+	return osID, nil
+}
+
+func createFailureMessage(osID string) error {
+	return fmt.Errorf("%s is not supported for import. For supported versions, "+
+		"see https://cloud.google.com/sdk/gcloud/reference/compute/images/import", osID)
+}
+
+func splitOSVersion(version string) (major, minor string) {
+	if version == "" {
+		return "", ""
+	}
+	if !strings.Contains(version, ".") {
+		return version, ""
+	}
+	parts := strings.Split(version, ".")
+	return parts[0], parts[1]
 }

--- a/cli_tools/import_precheck/check_osversion_test.go
+++ b/cli_tools/import_precheck/check_osversion_test.go
@@ -1,0 +1,155 @@
+//  Copyright 2021 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/osconfig/osinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_osVersionCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		osInfo      *osinfo.OSInfo
+		expectedLog string
+		expectFail  bool
+	}{
+		{
+			name: "Linux happy case - no arch",
+			osInfo: &osinfo.OSInfo{
+				ShortName: "ubuntu",
+				Version:   "14.04",
+			},
+			expectedLog: "Detected system: ubuntu-1404",
+		}, {
+			name: "Linux happy case - with arch",
+			osInfo: &osinfo.OSInfo{
+				ShortName:    "ubuntu",
+				Version:      "14.04",
+				Architecture: "x86_64",
+			},
+			expectedLog: "Detected system: ubuntu-1404",
+		}, {
+			name: "Windows happy case - no arch",
+			osInfo: &osinfo.OSInfo{
+				ShortName: "windows",
+				Version:   "10",
+			},
+			expectedLog: "Detected Windows version number: NT 10",
+		}, {
+			name: "Windows happy case - with arch",
+			osInfo: &osinfo.OSInfo{
+				ShortName:    "windows",
+				Version:      "6.3",
+				Architecture: "x86_32",
+			},
+			expectedLog: "Detected Windows version number: NT 6.3",
+		}, {
+			name: "Windows supports NT versions",
+			osInfo: &osinfo.OSInfo{
+				ShortName:    "windows",
+				Version:      "6.1.1234",
+				Architecture: "x86_32",
+			},
+			expectedLog: "Detected Windows version number: NT 6.1.1234",
+		}, {
+			name: "Fail when version is not supported for the distro",
+			osInfo: &osinfo.OSInfo{
+				ShortName: "ubuntu",
+				Version:   "10.04",
+			},
+			expectedLog: "ubuntu-1004 is not supported for import",
+			expectFail:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, e := (&osVersionCheck{osInfo: tt.osInfo}).run()
+			assert.Nil(t, e, "Function always returns nil for error")
+			assert.Contains(t, r.String(), tt.expectedLog)
+			assert.Equal(t, tt.expectFail, r.Failed())
+		})
+	}
+}
+
+func Test_osVersionCheck_skipWhenOSDetectionFails(t *testing.T) {
+	tests := []struct {
+		name   string
+		osInfo *osinfo.OSInfo
+	}{
+		{
+			name: "skip when shortName is unknown distro",
+			osInfo: &osinfo.OSInfo{
+				ShortName: "distro-no-recognized",
+				Version:   "10",
+			},
+		}, {
+			name: "skip when arch is unknown",
+			osInfo: &osinfo.OSInfo{
+				ShortName:    "ubuntu",
+				Version:      "14.04",
+				Architecture: "mips",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, e := (&osVersionCheck{osInfo: tt.osInfo}).run()
+			assert.Nil(t, e, "Function always returns nil for error")
+			assert.Contains(t, r.String(), "Cannot determine OS. For supported versions, see https://cloud.google.com/sdk/gcloud/reference/compute/images/import")
+			assert.True(t, r.skipped)
+			t.Logf("\n%s", r)
+		})
+	}
+}
+
+func Test_splitOSVersion(t *testing.T) {
+	tests := []struct {
+		version       string
+		expectedMajor string
+		expectedMinor string
+	}{
+		{
+			version:       "",
+			expectedMajor: "",
+			expectedMinor: "",
+		}, {
+			version:       "vista",
+			expectedMajor: "vista",
+			expectedMinor: "",
+		}, {
+			version:       "14.04",
+			expectedMajor: "14",
+			expectedMinor: "04",
+		}, {
+			version:       "10.0",
+			expectedMajor: "10",
+			expectedMinor: "0",
+		}, {
+			version:       "6",
+			expectedMajor: "6",
+			expectedMinor: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			actualMajor, actualMinor := splitOSVersion(tt.version)
+			assert.Equal(t, tt.expectedMajor, actualMajor)
+			assert.Equal(t, tt.expectedMinor, actualMinor)
+		})
+	}
+}

--- a/cli_tools/import_precheck/check_sha2.go
+++ b/cli_tools/import_precheck/check_sha2.go
@@ -18,12 +18,15 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/osconfig/osinfo"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
 )
 
 const sha2Windows2008R2KB = "KB4474419"
 
-type sha2DriverSigningCheck struct{}
+type sha2DriverSigningCheck struct {
+	osInfo *osinfo.OSInfo
+}
 
 func (s *sha2DriverSigningCheck) getName() string {
 	return "SHA2 Driver Signing Check"
@@ -31,7 +34,7 @@ func (s *sha2DriverSigningCheck) getName() string {
 
 func (s *sha2DriverSigningCheck) run() (*report, error) {
 	r := &report{name: s.getName()}
-	if runtime.GOOS != "windows" || !strings.Contains(osInfo.Version, "6.1") {
+	if runtime.GOOS != "windows" || !strings.Contains(s.osInfo.Version, "6.1") {
 		r.skipped = true
 		r.Info("Only applicable on Windows 2008 systems.")
 		return r, nil

--- a/cli_tools/import_precheck/main.go
+++ b/cli_tools/import_precheck/main.go
@@ -25,17 +25,16 @@ import (
 const logPath = "out.log"
 
 var (
-	log    *logger.Logger
-	osInfo *osinfo.OSInfo
+	log *logger.Logger
 )
 
-func getChecks() []check {
+func getChecks(osInfo *osinfo.OSInfo) []check {
 	return []check{
-		&osVersionCheck{},
+		&osVersionCheck{osInfo},
 		&disksCheck{},
 		&sshCheck{},
 		&powershellCheck{},
-		&sha2DriverSigningCheck{},
+		&sha2DriverSigningCheck{osInfo},
 	}
 }
 
@@ -54,12 +53,12 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	osInfo, err = osinfo.Get()
+	osInfo, err := osinfo.Get()
 	if err != nil {
 		logger.Fatal(err)
 	}
 
-	checks := getChecks()
+	checks := getChecks(osInfo)
 	wg := sync.WaitGroup{}
 	for _, c := range checks {
 		wg.Add(1)


### PR DESCRIPTION
This updates the precheck tool to remove its hardcoded list of supported operating systems. 

# Output from running on various systems:


### Debian 10 (not supported)
```
##############################
# OS Version Check -- FAILED #
##############################
  * FATAL: debian-10 is not supported for import. For supported versions, see https://cloud.google.com/sdk/gcloud/reference/compute/images/import
```

### Fedora 33 (not recognized)
```
###############################
# OS Version Check -- SKIPPED #
###############################
  * INFO: Unrecognized distro `fedora`
  * INFO: Unable to determine whether your system is supported for import. For supported versions, see https://cloud.google.com/sdk/gcloud/reference/compute/images/import
```

### Debian 9 (supported)
```
##############################
# OS Version Check -- PASSED #
##############################
  * INFO: Detected system: debian-9
```

### Windows 2019 (supported)
```
##############################
# OS Version Check -- PASSED #
##############################
  * INFO: Detected Windows version number: NT 10.0.17763
```

### Windows 2012r2 (supported)
```
##############################
# OS Version Check -- PASSED #
##############################
  * INFO: Detected Windows version number: NT 6.3.9600
```
