### PR TITLE
Image import: Increase debug support when translation fails

### DIFF
--- a/daisy_workflows/export_metadata/export_metadata.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata.wf.json
@@ -31,8 +31,7 @@
     }
   },
   "Sources": {
-    "export_metadata/utils/common.py": "../linux_common/utils/common.py",
-    "export_metadata/utils/__init__.py": "../linux_common/utils/__init__.py",
+    "export_metadata/utils": "../linux_common/utils",
     "export_metadata/export-metadata.py": "./export-metadata.py",
     "startup_script": "../linux_common/bootstrap.sh"
   },

--- a/daisy_workflows/image_build/debian/debian.wf.json
+++ b/daisy_workflows/image_build/debian/debian.wf.json
@@ -9,9 +9,7 @@
   },
   "Sources": {
     "build_files/build.py": "./build.py",
-    "build_files/utils/common.py": "../../linux_common/utils/common.py",
-    "build_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "build_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "build_files/utils": "../../linux_common/utils",
     "build_files/google_cloud_test_repos": "./google_cloud_test_repos/",
     "startup_script": "../../linux_common/bootstrap.sh"
   },

--- a/daisy_workflows/image_build/debian/debian_fai.wf.json
+++ b/daisy_workflows/image_build/debian/debian_fai.wf.json
@@ -19,9 +19,7 @@
     "build_files/fai_config/sources/repository.GCE_SPECIFIC": "./fai_config/sources/repository.GCE_SPECIFIC",
     "build_files/fai_config/sources/repository.GCE_STAGING": "./fai_config/sources/repository.GCE_STAGING",
     "build_files/fai_config/sources/repository.GCE_UNSTABLE": "./fai_config/sources/repository.GCE_UNSTABLE",
-    "build_files/utils/common.py": "../../linux_common/utils/common.py",
-    "build_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "build_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "build_files/utils": "../../linux_common/utils",
     "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
@@ -34,9 +34,7 @@
   "Sources": {
     "build_files/build_installer.py": "./build_installer.py",
     "build_files/installer.iso": "${installer_iso}",
-    "build_files/utils/common.py": "../../linux_common/utils/common.py",
-    "build_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "build_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "build_files/utils": "../../linux_common/utils",
     "build_files/kickstart": "./kickstart/",
     "build_files/ks_helpers.py": "./ks_helpers.py",
     "installerprep_startup_script": "../../linux_common/bootstrap.sh"

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -28,10 +28,7 @@
   },
   "Sources": {
     "import_files/translate.py": "./translate.py",
-    "import_files/utils/common.py": "../../linux_common/utils/common.py",
-    "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
-    "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "import_files/utils": "../../linux_common/utils",
     "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -30,6 +30,7 @@
     "import_files/translate.py": "./translate.py",
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
+    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
     "startup_script": "../../linux_common/bootstrap.sh"
   },

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -110,11 +110,11 @@ def check_repos(spec: TranslateSpec) -> str:
   YUM fails if any of its repos are unreachable. Running `yum updateinfo`
   will have a non-zero return code when it fail to update any of its repos.
   """
-  if run(spec.g, 'yum --help | grep updateinfo', check=False).code != 0:
+  if run(spec.g, 'yum --help | grep updateinfo', raiseOnError=False).code != 0:
     logging.debug('command `yum updateinfo` not available. skipping test.')
     return ''
   v = 'yum updateinfo -v'
-  p = run(spec.g, v, check=False)
+  p = run(spec.g, v, raiseOnError=False)
   logging.debug('yum updateinfo -v: {}'.format(p))
   if p.code != 0:
     return 'Ensure all configured repos are reachable.'
@@ -125,7 +125,7 @@ def check_yum_on_path(spec: TranslateSpec) -> str:
 
   If `yum` isn't found, errs is updated.
   """
-  p = run(spec.g, 'yum --version', check=False)
+  p = run(spec.g, 'yum --version', raiseOnError=False)
   logging.debug('yum --version: {}'.format(p))
   if p.code != 0:
     return 'Verify the disk\'s OS: `yum` not found.'
@@ -139,7 +139,7 @@ def check_rhel_license(spec: TranslateSpec) -> str:
   if spec.distro != Distro.RHEL or spec.use_rhel_gce_license:
     return ''
 
-  p = run(spec.g, 'subscription-manager status', check=False)
+  p = run(spec.g, 'subscription-manager status', raiseOnError=False)
   logging.debug('subscription-manager: {}'.format(p))
   if p.code != 0:
     return 'subscription-manager did not find an active subscription. ' \
@@ -190,8 +190,8 @@ def DistroSpecific(spec: TranslateSpec):
       # The `--disablerepo` flag does the following:
       #  1. Skip the epel repo for *this* operation only.
       #  2. Block update if the epel repo isn't found.
-      p = run(g,
-              'yum update -y ca-certificates --disablerepo=epel', check=False)
+      p = run(g, 'yum update -y ca-certificates --disablerepo=epel',
+              raiseOnError=False)
       logging.debug('Attempted conditional update of '
                     'ca-certificates. Success expected only '
                     'if epel repo is installed. Result={}'.format(p))
@@ -314,7 +314,7 @@ def yum_install(g, *packages):
     #   proxy=_none_: Disables proxies set in /etc/yum.conf.
     cmd = 'no_proxy="*" yum install --setopt=proxy=_none_ -y ' + ' '.join(
         '"{0}"'.format(p) for p in packages)
-    p = run(g, cmd, check=False)
+    p = run(g, cmd, raiseOnError=False)
     if p.code == 0:
       return
     logging.debug('Yum install failed: {}'.format(p))

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -110,11 +110,11 @@ def check_repos(spec: TranslateSpec) -> str:
   YUM fails if any of its repos are unreachable. Running `yum updateinfo`
   will have a non-zero return code when it fail to update any of its repos.
   """
-  if run(spec.g, 'yum --help | grep updateinfo').code != 0:
+  if run(spec.g, 'yum --help | grep updateinfo', check=False).code != 0:
     logging.debug('command `yum updateinfo` not available. skipping test.')
     return ''
   v = 'yum updateinfo -v'
-  p = run(spec.g, v)
+  p = run(spec.g, v, check=False)
   logging.debug('yum updateinfo -v: {}'.format(p))
   if p.code != 0:
     return 'Ensure all configured repos are reachable.'
@@ -125,7 +125,7 @@ def check_yum_on_path(spec: TranslateSpec) -> str:
 
   If `yum` isn't found, errs is updated.
   """
-  p = run(spec.g, 'yum --version')
+  p = run(spec.g, 'yum --version', check=False)
   logging.debug('yum --version: {}'.format(p))
   if p.code != 0:
     return 'Verify the disk\'s OS: `yum` not found.'
@@ -139,7 +139,7 @@ def check_rhel_license(spec: TranslateSpec) -> str:
   if spec.distro != Distro.RHEL or spec.use_rhel_gce_license:
     return ''
 
-  p = run(spec.g, 'subscription-manager status')
+  p = run(spec.g, 'subscription-manager status', check=False)
   logging.debug('subscription-manager: {}'.format(p))
   if p.code != 0:
     return 'subscription-manager did not find an active subscription. ' \
@@ -190,7 +190,8 @@ def DistroSpecific(spec: TranslateSpec):
       # The `--disablerepo` flag does the following:
       #  1. Skip the epel repo for *this* operation only.
       #  2. Block update if the epel repo isn't found.
-      p = run(g, 'yum update -y ca-certificates --disablerepo=epel')
+      p = run(g,
+              'yum update -y ca-certificates --disablerepo=epel', check=False)
       logging.debug('Attempted conditional update of '
                     'ca-certificates. Success expected only '
                     'if epel repo is installed. Result={}'.format(p))
@@ -313,7 +314,7 @@ def yum_install(g, *packages):
     #   proxy=_none_: Disables proxies set in /etc/yum.conf.
     cmd = 'no_proxy="*" yum install --setopt=proxy=_none_ -y ' + ' '.join(
         '"{0}"'.format(p) for p in packages)
-    p = run(g, cmd)
+    p = run(g, cmd, check=False)
     if p.code == 0:
       return
     logging.debug('Yum install failed: {}'.format(p))

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -36,10 +36,7 @@
   },
   "Sources": {
     "import_files/translate.py": "./translate.py",
-    "import_files/utils/common.py": "../../linux_common/utils/common.py",
-    "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
-    "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "import_files/utils": "../../linux_common/utils",
     "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -40,10 +40,7 @@
   },
   "Sources": {
     "import_files/translate.py": "./translate.py",
-    "import_files/utils/common.py": "../../linux_common/utils/common.py",
-    "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
-    "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "import_files/utils": "../../linux_common/utils",
     "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -42,6 +42,7 @@
     "import_files/translate.py": "./translate.py",
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
+    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
     "startup_script": "../../linux_common/bootstrap.sh"
   },

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -28,10 +28,7 @@
   },
   "Sources": {
     "import_files/translate.py": "./translate.py",
-    "import_files/utils/common.py": "../../linux_common/utils/common.py",
-    "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
-    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
-    "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
+    "import_files/utils": "../../linux_common/utils",
     "startup_script": "../../linux_common/bootstrap.sh"
   },
   "Steps": {

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -30,6 +30,7 @@
     "import_files/translate.py": "./translate.py",
     "import_files/utils/common.py": "../../linux_common/utils/common.py",
     "import_files/utils/diskutils.py": "../../linux_common/utils/diskutils.py",
+    "import_files/utils/guestfsprocess.py": "../../linux_common/utils/guestfsprocess.py",
     "import_files/utils/__init__.py": "../../linux_common/utils/__init__.py",
     "startup_script": "../../linux_common/bootstrap.sh"
   },

--- a/daisy_workflows/linux_common/tests/test_guestfsprocess.py
+++ b/daisy_workflows/linux_common/tests/test_guestfsprocess.py
@@ -17,7 +17,6 @@ import tempfile
 from unittest.mock import MagicMock
 
 import pytest
-
 from utils.guestfsprocess import CompletedProcess, GuestFSInterface, run
 
 
@@ -27,23 +26,19 @@ class TestWithoutCheck:
     result = run(_make_local_guestfs(), cmd, check=False)
     assert result == CompletedProcess('abc123\n', '', 0, cmd)
 
-
   def test_capture_stderr(self):
     cmd = 'echo error msg > /dev/stderr'
     result = run(_make_local_guestfs(), cmd, check=False)
     assert result == CompletedProcess('', 'error msg\n', 0, cmd)
-
 
   def test_support_positive_code(self):
     cmd = 'exit 100'
     result = run(_make_local_guestfs(), cmd, check=False)
     assert result == CompletedProcess('', '', 100, cmd)
 
-
   def test_support_array_args(self):
     result = run(_make_local_guestfs(), ['echo', 'hi'], check=False)
     assert result == CompletedProcess('hi\n', '', 0, 'echo hi')
-
 
   def test_escape_array_members(self):
     result = run(_make_local_guestfs(),
@@ -51,12 +46,10 @@ class TestWithoutCheck:
     assert result == CompletedProcess('hello ; ls *\n', '', 0,
                                       "echo hello '; ls *'")
 
-
   def test_capture_runtime_errors(self):
     result = run(_make_local_guestfs(), 'not-a-command', check=False)
     assert result.code != 0
     assert 'not-a-command' in result.stderr
-
 
   def test_capture_output_when_non_zero_return(self):
     cmd = 'printf content; printf err > /dev/stderr; exit 1'
@@ -69,7 +62,6 @@ class TestWithCheck:
     cmd = 'echo abc123'
     result = run(_make_local_guestfs(), cmd)
     assert result == CompletedProcess('abc123\n', '', 0, cmd)
-
 
   def test_raise_error_when_failure(self):
     cmd = '>&2 echo stderr msg; exit 1'

--- a/daisy_workflows/linux_common/tests/test_guestfsprocess.py
+++ b/daisy_workflows/linux_common/tests/test_guestfsprocess.py
@@ -23,37 +23,37 @@ from utils.guestfsprocess import CompletedProcess, GuestFSInterface, run
 class TestWithoutCheck:
   def test_capture_stdout(self):
     cmd = 'echo abc123'
-    result = run(_make_local_guestfs(), cmd, check=False)
+    result = run(_make_local_guestfs(), cmd, raiseOnError=False)
     assert result == CompletedProcess('abc123\n', '', 0, cmd)
 
   def test_capture_stderr(self):
     cmd = 'echo error msg > /dev/stderr'
-    result = run(_make_local_guestfs(), cmd, check=False)
+    result = run(_make_local_guestfs(), cmd, raiseOnError=False)
     assert result == CompletedProcess('', 'error msg\n', 0, cmd)
 
   def test_support_positive_code(self):
     cmd = 'exit 100'
-    result = run(_make_local_guestfs(), cmd, check=False)
+    result = run(_make_local_guestfs(), cmd, raiseOnError=False)
     assert result == CompletedProcess('', '', 100, cmd)
 
   def test_support_array_args(self):
-    result = run(_make_local_guestfs(), ['echo', 'hi'], check=False)
+    result = run(_make_local_guestfs(), ['echo', 'hi'], raiseOnError=False)
     assert result == CompletedProcess('hi\n', '', 0, 'echo hi')
 
   def test_escape_array_members(self):
     result = run(_make_local_guestfs(),
-                 ['echo', 'hello', '; ls *'], check=False)
+                 ['echo', 'hello', '; ls *'], raiseOnError=False)
     assert result == CompletedProcess('hello ; ls *\n', '', 0,
                                       "echo hello '; ls *'")
 
   def test_capture_runtime_errors(self):
-    result = run(_make_local_guestfs(), 'not-a-command', check=False)
+    result = run(_make_local_guestfs(), 'not-a-command', raiseOnError=False)
     assert result.code != 0
     assert 'not-a-command' in result.stderr
 
   def test_capture_output_when_non_zero_return(self):
     cmd = 'printf content; printf err > /dev/stderr; exit 1'
-    result = run(_make_local_guestfs(), cmd, check=False)
+    result = run(_make_local_guestfs(), cmd, raiseOnError=False)
     assert result == CompletedProcess('content', 'err', 1, cmd)
 
 

--- a/daisy_workflows/linux_common/tests/test_guestfsprocess.py
+++ b/daisy_workflows/linux_common/tests/test_guestfsprocess.py
@@ -16,48 +16,65 @@ import subprocess
 import tempfile
 from unittest.mock import MagicMock
 
+import pytest
+
 from utils.guestfsprocess import CompletedProcess, GuestFSInterface, run
 
 
-def test_capture_stdout():
-  cmd = 'echo abc123'
-  result = run(_make_local_guestfs(), cmd)
-  assert result == CompletedProcess('abc123\n', '', 0, cmd)
+class TestWithoutCheck:
+  def test_capture_stdout(self):
+    cmd = 'echo abc123'
+    result = run(_make_local_guestfs(), cmd, check=False)
+    assert result == CompletedProcess('abc123\n', '', 0, cmd)
 
 
-def test_capture_stderr():
-  cmd = 'echo error msg > /dev/stderr'
-  result = run(_make_local_guestfs(), cmd)
-  assert result == CompletedProcess('', 'error msg\n', 0, cmd)
+  def test_capture_stderr(self):
+    cmd = 'echo error msg > /dev/stderr'
+    result = run(_make_local_guestfs(), cmd, check=False)
+    assert result == CompletedProcess('', 'error msg\n', 0, cmd)
 
 
-def test_support_positive_code():
-  cmd = 'exit 100'
-  result = run(_make_local_guestfs(), cmd)
-  assert result == CompletedProcess('', '', 100, cmd)
+  def test_support_positive_code(self):
+    cmd = 'exit 100'
+    result = run(_make_local_guestfs(), cmd, check=False)
+    assert result == CompletedProcess('', '', 100, cmd)
 
 
-def test_support_array_args():
-  result = run(_make_local_guestfs(), ['echo', 'hi'])
-  assert result == CompletedProcess('hi\n', '', 0, 'echo hi')
+  def test_support_array_args(self):
+    result = run(_make_local_guestfs(), ['echo', 'hi'], check=False)
+    assert result == CompletedProcess('hi\n', '', 0, 'echo hi')
 
 
-def test_escape_array_members():
-  result = run(_make_local_guestfs(), ['echo', 'hello', '; ls *'])
-  assert result == CompletedProcess('hello ; ls *\n', '', 0,
-                                    "echo hello '; ls *'")
+  def test_escape_array_members(self):
+    result = run(_make_local_guestfs(),
+                 ['echo', 'hello', '; ls *'], check=False)
+    assert result == CompletedProcess('hello ; ls *\n', '', 0,
+                                      "echo hello '; ls *'")
 
 
-def test_capture_runtime_errors():
-  result = run(_make_local_guestfs(), 'not-a-command')
-  assert result.code != 0
-  assert 'not-a-command' in result.stderr
+  def test_capture_runtime_errors(self):
+    result = run(_make_local_guestfs(), 'not-a-command', check=False)
+    assert result.code != 0
+    assert 'not-a-command' in result.stderr
 
 
-def test_capture_output_when_non_zero_return():
-  cmd = 'printf content; printf err > /dev/stderr; exit 1'
-  result = run(_make_local_guestfs(), cmd)
-  assert result == CompletedProcess('content', 'err', 1, cmd)
+  def test_capture_output_when_non_zero_return(self):
+    cmd = 'printf content; printf err > /dev/stderr; exit 1'
+    result = run(_make_local_guestfs(), cmd, check=False)
+    assert result == CompletedProcess('content', 'err', 1, cmd)
+
+
+class TestWithCheck:
+  def test_return_completed_process_when_success(self):
+    cmd = 'echo abc123'
+    result = run(_make_local_guestfs(), cmd)
+    assert result == CompletedProcess('abc123\n', '', 0, cmd)
+
+
+  def test_raise_error_when_failure(self):
+    cmd = '>&2 echo stderr msg; exit 1'
+    with pytest.raises(RuntimeError, match='stderr msg'):
+        run(_make_local_guestfs(), cmd)
 
 
 def _make_local_guestfs():

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -784,7 +784,7 @@ class MetadataManager:
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def install_apt_packages(g, *pkgs):
   cmd = 'DEBIAN_FRONTEND=noninteractive apt-get ' \
-          'install -y --no-install-recommends ' + ' '.join(pkgs)
+        'install -y --no-install-recommends ' + ' '.join(pkgs)
   run(g, cmd)
 
 

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -31,6 +31,8 @@ import urllib.error
 import urllib.request
 import uuid
 
+from .guestfsprocess import run
+
 SUCCESS_LEVELNO = logging.ERROR - 5
 
 
@@ -781,10 +783,11 @@ class MetadataManager:
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def install_apt_packages(g, *pkgs):
-  g.sh('DEBIAN_FRONTEND=noninteractive apt-get '
-       'install -y --no-install-recommends ' + ' '.join(pkgs))
+  cmd = 'DEBIAN_FRONTEND=noninteractive apt-get ' \
+          'install -y --no-install-recommends ' + ' '.join(pkgs)
+  run(g, cmd)
 
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def update_apt(g):
-  g.sh('apt-get update')
+  run(g, 'apt-get update')

--- a/daisy_workflows/linux_common/utils/guestfsprocess.py
+++ b/daisy_workflows/linux_common/utils/guestfsprocess.py
@@ -42,6 +42,9 @@ def run(g: 'GuestFSInterface', command,
     raiseOnError (bool): When true and the process exits with a non-zero exit
     code, a RuntimeError exception will be raised, using standard error as its
     message. The process's stdout and stderr are written to logging.debug.
+    raiseOnError=True is good for commands where you don't inspect the output
+    and you want the failure to propagate automatically. For example:
+    `yum install package`; if it's successful you don't need the output.
 
   Examples:
     >>> run(g, 'date').stdout

--- a/daisy_workflows/linux_common/utils/guestfsprocess.py
+++ b/daisy_workflows/linux_common/utils/guestfsprocess.py
@@ -30,7 +30,8 @@ import textwrap
 import typing
 
 
-def run(g: 'GuestFSInterface', command, check: bool=True) -> 'CompletedProcess':
+def run(g: 'GuestFSInterface', command,
+        check: bool = True) -> 'CompletedProcess':
   """Runs a process in a mounted GuestFS instance, ensuring that
   standard output and standard error is always retained.
 
@@ -39,8 +40,8 @@ def run(g: 'GuestFSInterface', command, check: bool=True) -> 'CompletedProcess':
     command (str or List[str]): Script content that will be executed
     by a bash interpeter on the guest.
     check (bool): When true and the process exits with a non-zero exit code,
-    a RuntimeError exception will be raised, using standard error as its message.
-    The process's standard out and standard error are written to debug.
+    a RuntimeError exception will be raised, using standard error as its
+    message. The process's stdout and stderr are written to logging.debug.
 
   Examples:
     >>> run(g, 'date').stdout
@@ -68,13 +69,13 @@ def run(g: 'GuestFSInterface', command, check: bool=True) -> 'CompletedProcess':
   g.command(['/bin/bash', program_path])
 
   p = CompletedProcess(cmd=command,
-                          stdout=g.cat(stdout_path),
-                          stderr=g.cat(stderr_path),
-                          code=int(g.cat(return_code_path)))
-  if p.code == 0 or not check:
-    return p
-  logging.debug(p)
-  raise RuntimeError(p.stderr)
+                       stdout=g.cat(stdout_path),
+                       stderr=g.cat(stderr_path),
+                       code=int(g.cat(return_code_path)))
+  if check and p.code != 0:
+    logging.debug(p)
+    raise RuntimeError(p.stderr)
+  return p
 
 
 def _make_wrapping_program(


### PR DESCRIPTION
Recently we had test failures that said "Unable to correct problems, you have held broken packages", but did not include any useful debug information. This occurred since guestfs's `g.sh` and `g.command` hides stdout when a command fails.

https://prow.k8s.io/view/gcs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1359454353202614272
This PR does the following:
1. Replaces usages of  `g.sh` and `g.command` with `guestfsprocess.run` throughout import
2. Adds an optional parameter `check` to `guestfsprocess.run`. It  follows the semantics of [subprocess.run](https://docs.python.org/3/library/subprocess.html#subprocess.run), which this module is emulating.

## Testing
- Ran e2e tests for image import
- Ran image builds for workflows that were modified by this PR