### PR TITLE
Enable onestep-import gcloud e2e

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
@@ -52,7 +52,6 @@ func OnestepImageImportSuite(
 		e2e.Wrapper,
 		e2e.GcloudBetaProdWrapperLatest,
 		e2e.GcloudBetaLatestWrapperLatest,
-		e2e.GcloudGaLatestWrapperRelease,
 	}
 
 	testsMap := map[e2e.CLITestType]map[*junitxml.TestCase]func(

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
@@ -50,6 +50,9 @@ func OnestepImageImportSuite(
 
 	testTypes := []e2e.CLITestType{
 		e2e.Wrapper,
+		e2e.GcloudBetaProdWrapperLatest,
+		e2e.GcloudBetaLatestWrapperLatest,
+		e2e.GcloudGaLatestWrapperRelease,
 	}
 
 	testsMap := map[e2e.CLITestType]map[*junitxml.TestCase]func(


### PR DESCRIPTION
Enable onestep-import gcloud e2e due that we will land gcloud surface soon.

It needs to be merged earlier than gcloud cl submitting so that the gcloud code can be tested before it's TUE publishing.