### PR TITLE
[e2e fix] adjust err msg for disabled-account-service testcase

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
@@ -516,7 +516,7 @@ func runImageImportOSWithDisabledDefaultServiceAccountServiceFailTest(ctx contex
 		},
 	}
 
-	e2e.RunTestCommandAssertErrorMessage(cmds[testType], argsMap[testType], "ImportFailed: Failed to download image to worker instance", logger, testCase)
+	e2e.RunTestCommandAssertErrorMessage(cmds[testType], argsMap[testType], "Failed to download GCS path", logger, testCase)
 }
 
 // With insufficient permissions on default service account, import failed.


### PR DESCRIPTION
The reason of this change: when switched to API inflater from the daisy infalter, the inflation step won't fail on service account permission. Instead, it will fail on the inspection step. Thus, we need to modify the expected error message.