### PR TITLE
Add missing variables to Windows image build workflow

### DIFF
--- a/daisy_workflows/image_build/windows/windows-server-2016-dc-bios-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2016-dc-bios-byol.wf.json
@@ -14,6 +14,11 @@
       "Required": true,
       "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
     },
+    "cloudsdk": {
+      "Required": true,
+      "Value": "gs://gce-image-build-resources/windows/GoogleCloudSDKInstaller.exe",
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
     "description": {
       "Value": "Microsoft, Windows Server, 2016 Datacenter, Server with Desktop Experience, x64 built on ${TIMESTAMP}"
     },
@@ -51,11 +56,12 @@
           "install_disk": "${install_disk}",
           "install_disk_size": "50",
           "updates": "${updates}",
-          "dotnet48": "${dotnet48}",
           "drivers_bucket": "gs://gce-windows-drivers-public/release/win6.3/",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
           "edition": "Windows Server 2016 SERVERDATACENTER",
           "media": "${media}",
-          "cloud_sdk": "gs://gce-image-build-resources/windows/GoogleCloudSDKInstaller.exe",
+          "cloud_sdk": "${cloudsdk}",
           "product_key": "CB7KF-BWN84-R7R2Y-793K2-8XDDG",
           "uefi_build": "false",
           "google_cloud_repo": "${google_cloud_repo}",

--- a/daisy_workflows/image_build/windows/windows-server-2019-dc-bios-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2019-dc-bios-byol.wf.json
@@ -14,6 +14,11 @@
       "Required": true,
       "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
     },
+    "cloudsdk": {
+      "Required": true,
+      "Value": "gs://gce-image-build-resources/windows/GoogleCloudSDKInstaller.exe",
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
     "description": {
       "Value": "Microsoft, Windows Server, 2019 Datacenter, Server with Desktop Experience, x64 built on ${TIMESTAMP}"
     },
@@ -53,9 +58,10 @@
           "updates": "${updates}",
           "drivers_bucket": "gs://gce-windows-drivers-public/release/win6.3/",
           "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
           "edition": "Windows Server 2019 SERVERDATACENTER",
           "media": "${media}",
-          "cloud_sdk": "gs://gce-image-build-resources/windows/GoogleCloudSDKInstaller.exe",
+          "cloud_sdk": "${cloudsdk}",
           "product_key": "WMDGN-G9PQG-XVVXX-R3X43-63DFG",
           "uefi_build": "false",
           "google_cloud_repo": "${google_cloud_repo}",


### PR DESCRIPTION
* Add 'cloudsdk' variable to let users specify a custom
  URL to the Cloud SDK installer. This fixes the problem
  that the default GCS path is not publicly accessible.
* Pass 'pwsh' to 'windows-build' step. This fixes an infinite
  loop in the SetupComplete stage.