### PR TITLE
add export metadata for windows

### DIFF
--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -46,16 +46,21 @@ function Export-ImageMetadata {
     [array]::sort($out)
 
     foreach ($package_line in $out) {
-        $name = $package_line.Trim().Split(' ')[0]
-        # Get Package Info for each package
-        $info = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed' '-info' $name
-        $version = $info[4].Split(":")[1].Trim()
-        $source = $info[8].Split(":")
-        $source = [String]::Concat($source[1..$source.length])
-        $package_metadata = @{'name' = $name;
-                            'version' = $version;
-                            'commmit_hash' = $source}
-        $image_metadata['packages'] += $package_metadata
+        try {
+            $name = $package_line.Trim().Split(' ')[0]
+            # Get Package Info for each package
+            $info = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed' '-info' $name
+            $version = $info[4].Split(":")[1].Trim()
+            $source = $info[8].Split(":")
+            $source = [String]::Concat($source[1..$source.length])
+            $package_metadata = @{'name' = $name;
+                                'version' = $version;
+                                'commmit_hash' = $source}
+            $image_metadata['packages'] += $package_metadata
+        }
+        catch {
+            Write-Host "Failed to retrieve metadata for $package_line, skiping."
+        }
     }
 
     # Save the JSON image_metadata.

--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -1,0 +1,100 @@
+function Get-MetadataValue {
+    <#
+    .SYNOPSIS
+      Returns a value for a given metadata key.
+
+    .PARAMETER $key
+      The metadata key to retrieve.
+
+    .PARAMETER $default
+      The value to return if the key is not found.
+
+    .RETURNS
+      The value for the key or null.
+  #>
+    param (
+        [parameter(Mandatory=$true)]
+        [string]$key,
+        [parameter(Mandatory=$false)]
+        [string]$default
+    )
+
+    # Returns the provided metadata value for a given key.
+    $url = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$key"
+    try {
+        $client = New-Object Net.WebClient
+        $client.Headers.Add('Metadata-Flavor', 'Google')
+        return ($client.DownloadString($url)).Trim()
+    }
+    catch [System.Net.WebException] {
+        if ($default) {
+            return $default
+        }
+        else {
+            Write-Host "Failed to retrieve value for $key."
+            return $null
+        }
+    }
+}
+
+function Run-Command {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [string]$Executable,
+        [Parameter(ValueFromRemainingArguments=$true,
+                ValueFromPipelineByPropertyName=$true)]
+        $Arguments = $null
+    )
+    Write-Host "Running $Executable with arguments $Arguments."
+    $out = &$executable $arguments 2>&1 | Out-String
+    $out.Trim()
+}
+
+function Export-ImageMetadata {
+    $computer_info = Get-ComputerInfo
+    $version = $computer_info.OsVersion
+    $family = 'windows-' + $computer_info.windowsversion
+    $name =  $computer_info.OSName
+    $release_date = (Get-Date).ToUniversalTime()
+    $image_metadata = @{'family' = $family;
+    'version' = $edition;
+    'name' = $name;
+    'location' = ${script:outs_dir};
+    'build_date' = $release_date;
+    'packages' = @()}
+
+    # Get Googet packages.
+    $out = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed'
+    $out = $out[1..$out.length]
+    [array]::sort($out)
+
+    foreach ($package_line in $out) {
+        $name = $package_line.Trim().Split(' ')[0]
+        # Get Package Info for each package
+        $info = Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed' '-info' $name
+        $version = $info[2]
+        $source = $info[6]
+        $package_metadata = @{'name' = $name;
+        'version' = $version;
+        'commmit_hash' = $source}
+        $image_metadata['packages'] += $package_metadata
+    }
+
+    # Save the JSON image_metadata.
+    $image_metadata_json = $image_metadata | ConvertTo-Json -Compress
+    $image_metadata_json | & 'gsutil' -m cp - "${metadata_dest}/metadata.json"
+}
+
+try {
+    Write-Host 'Beginning export windows package metadata'
+    $metadata_dest = Get-MetadataValue -key 'metadata_dest'
+    Export-ImageMetadata
+}
+catch {
+    Write-Host 'Exception caught in script:'
+    Write-Host $_.InvocationInfo.PositionMessage
+    Write-Host "Message: $($_.Exception.Message)"
+    Write-Host 'Windows export package metadata failed.'
+    exit 1
+}

--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -52,17 +52,14 @@ function Run-Command {
 }
 
 function Export-ImageMetadata {
-    $computer_info = Get-ComputerInfo
-    $version = $computer_info.OsVersion
-    $family = 'windows-' + $computer_info.windowsversion
-    $name =  $computer_info.OSName
-    $release_date = (Get-Date).ToUniversalTime()
-    $image_metadata = @{'family' = $family;
-    'version' = $edition;
-    'name' = $name;
-    'location' = ${script:outs_dir};
-    'build_date' = $release_date;
-    'packages' = @()}
+    $version = Get-Date -Format "yyyyMMdd"
+    $build_date = (Get-Date).ToUniversalTime()
+    $image_metadata = @{'id' = $image_id;
+                        'name' = $image_name;
+                        'family' = $image_family;
+                        'version' = $version;
+                        'build_date' = $build_date;
+                        'packages' = @()}
 
     # Get Googet packages.
     $out = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed'
@@ -76,8 +73,8 @@ function Export-ImageMetadata {
         $version = $info[2]
         $source = $info[6]
         $package_metadata = @{'name' = $name;
-        'version' = $version;
-        'commmit_hash' = $source}
+                            'version' = $version;
+                            'commmit_hash' = $source}
         $image_metadata['packages'] += $package_metadata
     }
 
@@ -89,6 +86,9 @@ function Export-ImageMetadata {
 try {
     Write-Host 'Beginning export windows package metadata'
     $metadata_dest = Get-MetadataValue -key 'metadata_dest'
+    $image_id = Get-MetadataValue -key 'image_id'
+    $image_name = Get-MetadataValue -key 'image_name'
+    $image_family = Get-MetadataValue -key 'image_family'
     Export-ImageMetadata
 }
 catch {

--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -57,7 +57,8 @@ function Export-ImageMetadata {
         # Get Package Info for each package
         $info = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed' '-info' $name
         $version = $info[4].Split(":")[1].Trim()
-        $source = $info[8].Split(":")[1].Trim()
+        $source = $info[8].Split(":")
+        $source = [String]::Concat($source[1..$source.length])
         $package_metadata = @{'name' = $name;
                             'version' = $version;
                             'commmit_hash' = $source}

--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -32,12 +32,12 @@ function Get-MetadataValue {
 
 function Export-ImageMetadata {
     $image_version = Get-Date -Format "yyyyMMdd"
-    $build_date = Get-Date -Format "o"
+    $publish_date = Get-Date -Format "o"
     $image_metadata = @{'id' = $image_id;
                         'name' = $image_name;
                         'family' = $image_family;
                         'version' = $image_version;
-                        'build_date' = $build_date;
+                        'publish_date' = $publish_date;
                         'packages' = @()}
 
     # Get Googet packages.

--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -50,9 +50,15 @@ function Export-ImageMetadata {
             $name = $package_line.Trim().Split(' ')[0]
             # Get Package Info for each package
             $info = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed' '-info' $name
-            $version = $info[4].Split(":")[1].Trim()
-            $source = $info[8].Split(":")
-            $source = [String]::Concat($source[1..$source.length])
+            foreach ($line in $info) {
+                if ($line -match "Version") {
+                    $version = $line.Split(":")[1].Trim()
+                }
+                if ($line -match "Source") {
+                    $source = $line.Split(":")
+                    $source = [String]::Concat($source[1..$source.length]).Trim()
+                }
+            }
             $package_metadata = @{'name' = $name;
                                 'version' = $version;
                                 'commmit_hash' = $source}
@@ -69,13 +75,13 @@ function Export-ImageMetadata {
 }
 
 try {
-    Write-Host 'Beginning export windows package metadata'
+    Write-Host 'Beginning export windows image metadata'
     $metadata_dest = Get-MetadataValue -key 'metadata_dest'
     $image_id = Get-MetadataValue -key 'image_id'
     $image_name = Get-MetadataValue -key 'image_name'
     $image_family = Get-MetadataValue -key 'image_family'
     Export-ImageMetadata
-    Write-Host 'Endding export windows package metadata'
+    Write-Host 'Finished export windows image metadata'
 }
 catch {
     Write-Host 'Exception caught in script:'

--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -38,13 +38,13 @@ def main():
 
   utc_time = datetime.datetime.now(datetime.timezone.utc)
   image_version = utc_time.strftime('%Y%m%d')
-  build_date = utc_time.astimezone().isoformat()
+  publish_date = utc_time.astimezone().isoformat()
   image = {
       'id': image_id,
       'name': image_name,
       'family': image_family,
       'version': image_version,
-      'build_date': build_date,
+      'publish_date': publish_date,
       'packages': [],
   }
   # All the guest environment packages maintained by guest-os team.

--- a/daisy_workflows/export_metadata/export_metadata_windows.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata_windows.wf.json
@@ -1,0 +1,95 @@
+{
+  "Name": "export-metadata",
+  "Vars": {
+    "metadata_dest": {
+      "Required": true,
+      "Description": "The GCS path for the destination image metadata json"
+    },
+    "image_id": {
+      "Required": false,
+      "Description": "The image id used in project"
+    },
+    "image_name": {
+      "Required": false,
+      "Description": "The image name used in project"
+    },
+    "image_family": {
+      "Required": false,
+      "Description": "Image Family"
+    },
+    "source_image": {
+      "Required": true,
+      "Description": "The image that need to export metadata"
+    },
+    "distribution": {
+      "Required":true,
+      "Description": "Use image distribution, enterprise_linux, debian, centos"
+    },
+    "uefi": {
+      "Required":false,
+      "Description": "Whether RHEL is an UEFI image."
+    }
+  },
+  "Sources": {
+    "startup_script": "./export-metadata.ps1"
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "source-disk",
+          "SourceImage": "${source_image}",
+          "Type": "pd-ssd"
+        }
+      ]
+    },
+    "run": {
+      "CreateInstances": [
+        {
+          "Name": "inst-exporter",
+          "Disks": [{"Source": "source-disk"}],
+          "MachineType": "n1-highcpu-4",
+          "Metadata": {
+            "files_gcs_dir": "${SOURCESPATH}/export_metadata",
+            "script": "export-metadata.py",
+            "metadata_dest": "${metadata_dest}",
+            "image_id": "${image_id}",
+            "image_name": "${image_name}",
+            "image_family": "${image_family}",
+            "prefix": "Export",
+            "distribution": "${distribution}",
+            "uefi": "${uefi}"
+          },
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write"
+          ],
+          "StartupScript": "startup_script"
+        }
+      ]
+    },
+    "wait": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-exporter",
+          "SerialOutput": {
+            "Port": 1,
+            "FailureMatch": "ExportFailed:",
+            "SuccessMatch": "ExportSuccess:",
+            "StatusMatch": "ExportStatus:"
+          }
+        }
+      ]
+    },
+    "delete-inst": {
+      "DeleteResources": {
+        "Instances": ["inst-exporter"],
+        "Disks":["disk-exporterprep", "source-disk"]
+      }
+    }
+  },
+  "Dependencies": {
+    "run": ["setup-disks"],
+    "wait": ["run"],
+    "delete-inst": ["wait"]
+  }
+}

--- a/daisy_workflows/export_metadata/export_metadata_windows.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata_windows.wf.json
@@ -23,11 +23,11 @@
     },
     "uefi": {
       "Required":false,
-      "Description": "Whether RHEL is an UEFI image."
+      "Description": "Whether windows is an UEFI image."
     }
   },
   "Sources": {
-    "startup_script": "./export-metadata.ps1"
+    "export-metadata.ps1": "./export-metadata.ps1"
   },
   "Steps": {
     "setup-disks": {
@@ -50,14 +50,13 @@
             "image_id": "${image_id}",
             "image_name": "${image_name}",
             "image_family": "${image_family}",
-            "windows-startup-script-ps1": "startup_script",
             "prefix": "Export",
             "uefi": "${uefi}"
           },
           "Scopes": [
             "https://www.googleapis.com/auth/devstorage.read_write"
           ],
-          "StartupScript": "startup_script"
+          "StartupScript": "export-metadata.ps1"
         }
       ]
     },

--- a/daisy_workflows/export_metadata/export_metadata_windows.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata_windows.wf.json
@@ -21,10 +21,6 @@
       "Required": true,
       "Description": "The image that need to export metadata"
     },
-    "distribution": {
-      "Required":true,
-      "Description": "Use image distribution, enterprise_linux, debian, centos"
-    },
     "uefi": {
       "Required":false,
       "Description": "Whether RHEL is an UEFI image."
@@ -50,14 +46,12 @@
           "Disks": [{"Source": "source-disk"}],
           "MachineType": "n1-highcpu-4",
           "Metadata": {
-            "files_gcs_dir": "${SOURCESPATH}/export_metadata",
-            "script": "export-metadata.py",
             "metadata_dest": "${metadata_dest}",
             "image_id": "${image_id}",
             "image_name": "${image_name}",
             "image_family": "${image_family}",
+            "windows-startup-script-ps1": "startup_script",
             "prefix": "Export",
-            "distribution": "${distribution}",
             "uefi": "${uefi}"
           },
           "Scopes": [
@@ -83,7 +77,7 @@
     "delete-inst": {
       "DeleteResources": {
         "Instances": ["inst-exporter"],
-        "Disks":["disk-exporterprep", "source-disk"]
+        "Disks":["source-disk"]
       }
     }
   },

--- a/daisy_workflows/export_metadata/export_metadata_windows.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata_windows.wf.json
@@ -21,6 +21,10 @@
       "Required": true,
       "Description": "The image that need to export metadata"
     },
+    "distribution": {
+      "Required":true,
+      "Description": "Use image distribution, enterprise_linux, debian, centos"
+    },
     "uefi": {
       "Required":false,
       "Description": "Whether windows is an UEFI image."
@@ -50,6 +54,7 @@
             "image_id": "${image_id}",
             "image_name": "${image_name}",
             "image_family": "${image_family}",
+            "distribution": "${distribution}",
             "prefix": "Export",
             "uefi": "${uefi}"
           },


### PR DESCRIPTION
This workflow is compare to linux export-metadata. 

Create a windows instance:
Using startup script run export-metadata powershell script
export image/package information as a json file and upload to GCS

Test: 
```daisy -gcs_path=gs://hanga-testing-daisy-bkt/daisy/hanga -project=hanga-testing \
-var:metadata_dest=gs://metadata-test-hanga \
-var:image_id=test-id \
-var:image_name=test-name \
-var:image_family=test-family \
-var:source_image="projects/windows-cloud/global/images/windows-server-1909-dc-core-v20210212" \
-var:uefi=true \
${HOME}/IdeaProjects/compute-image-tools/daisy_workflows/export_metadata/export_metadata_windows.wf.json
```

daisy log
https://storage.cloud.google.com/hanga-testing-daisy-bkt/daisy/hanga/daisy-export-metadata-20210223-20%3A17%3A52-3mxzr/logs/inst-exporter-export-metadata-3mxzr-serial-port1.log

metadata file

https://storage.cloud.google.com/metadata-test-hanga/metadata.json
