### PR TITLE
OVF Import: added -scope flag to allow custom instance access scopes

### DIFF
--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -76,6 +76,7 @@ type OVFImportParams struct {
 	Oauth                       string
 	Ce                          string
 	ComputeServiceAccount       string
+	InstanceAccessScopesFlag    string
 	GcsLogsDisabled             bool
 	CloudLogsDisabled           bool
 	StdoutLogsDisabled          bool
@@ -88,12 +89,15 @@ type OVFImportParams struct {
 	// Non-flags
 
 	// Deadline of when timeout will occur.
-	Deadline              time.Time
+	Deadline time.Time
+
 	UserLabels            map[string]string
 	NodeAffinities        []*compute.SchedulingNodeAffinity
 	NodeAffinitiesBeta    []*computeBeta.SchedulingNodeAffinity
+	InstanceAccessScopes  []string
 	CurrentExecutablePath string
 	Region                string
+
 	// Path to daisy_workflows directory.
 	WorkflowDir string
 }

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -64,6 +64,7 @@ var (
 	oauth                       = flag.String("oauth", "", "path to oauth json file, overrides what is set in workflow")
 	ce                          = flag.String("compute-endpoint-override", "", "API endpoint to override default")
 	computeServiceAccount       = flag.String("compute-service-account", "", "Compute service account to be used by importer Virtual Machine and the resulting VM or Machine Image. When empty, the Compute Engine default service account is used.")
+	scopes                      = flag.String("scopes", "", "Access scopes to be assigned to the instance. A comma separated list of either full URI of the scope or an alias.")
 	gcsLogsDisabled             = flag.Bool("disable-gcs-logging", false, "do not stream logs to GCS")
 	cloudLogsDisabled           = flag.Bool("disable-cloud-logging", false, "do not stream logs to Cloud Logging")
 	stdoutLogsDisabled          = flag.Bool("disable-stdout-logging", false, "do not display individual workflow logs on stdout")
@@ -101,7 +102,7 @@ func buildOVFImportParams() *domain.OVFImportParams {
 		BootDiskKmsKeyring: *bootDiskKmsKeyring, BootDiskKmsLocation: *bootDiskKmsLocation,
 		BootDiskKmsProject: *bootDiskKmsProject, Timeout: *timeout, Project: project,
 		ScratchBucketGcsPath: *scratchBucketGcsPath, Oauth: *oauth,
-		Ce: *ce, ComputeServiceAccount: *computeServiceAccount,
+		Ce: *ce, ComputeServiceAccount: *computeServiceAccount, InstanceAccessScopesFlag: *scopes,
 		GcsLogsDisabled: *gcsLogsDisabled, CloudLogsDisabled: *cloudLogsDisabled,
 		StdoutLogsDisabled: *stdoutLogsDisabled, NodeAffinityLabelsFlag: nodeAffinityLabelsFlag,
 		CurrentExecutablePath: currentExecutablePath, ReleaseTrack: *releaseTrack,

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -55,6 +55,26 @@ const (
 	instanceConstructionTime = 10 * time.Minute
 )
 
+var (
+	//default instance scopes https://cloud.google.com/sdk/gcloud/reference/compute/instances/create#--scopes
+	defaultInstanceAccessScopes = []string{
+		"https://www.googleapis.com/auth/devstorage.read_only",
+		"https://www.googleapis.com/auth/logging.write",
+		"https://www.googleapis.com/auth/monitoring.write",
+		"https://www.googleapis.com/auth/pubsub",
+		"https://www.googleapis.com/auth/service.management.readonly",
+		"https://www.googleapis.com/auth/servicecontrol",
+		"https://www.googleapis.com/auth/trace.append",
+	}
+)
+
+// GetDefaultInstanceAccessScopes returns default VM instance access scopes
+func GetDefaultInstanceAccessScopes() []string {
+	tmp := make([]string, len(defaultInstanceAccessScopes))
+	copy(tmp, defaultInstanceAccessScopes)
+	return tmp
+}
+
 // OVFImporter is responsible for importing OVF into GCE
 type OVFImporter struct {
 	ctx                 context.Context

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -133,7 +133,6 @@ func (oi *OVFImporter) buildDaisyVars(bootDiskImageURI string, machineType strin
 	if oi.params.ComputeServiceAccount != "" {
 		varMap["compute_service_account"] = oi.params.ComputeServiceAccount
 	}
-
 	if oi.params.Subnet != "" {
 		varMap["subnet"] = oi.params.Subnet
 		// When subnet is set, we need to grant a value to network to avoid fallback to default
@@ -184,6 +183,14 @@ func (oi *OVFImporter) updateImportedInstance(w *daisy.Workflow) {
 	if oi.params.Hostname != "" {
 		instance.Hostname = oi.params.Hostname
 		instanceBeta.Hostname = oi.params.Hostname
+	}
+	if len(oi.params.InstanceAccessScopes) > 0 {
+		for _, serviceAccount := range instance.ServiceAccounts {
+			serviceAccount.Scopes = oi.params.InstanceAccessScopes
+		}
+		for _, serviceAccount := range instanceBeta.ServiceAccounts {
+			serviceAccount.Scopes = oi.params.InstanceAccessScopes
+		}
 	}
 }
 

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
@@ -53,6 +53,9 @@ const (
 
 	// HostnameFlagKey is key for hostname CLI flag
 	HostnameFlagKey = "hostname"
+
+	// Prefix for valid instance access config scopes
+	instanceAccessScopePrefix = "https://www.googleapis.com/auth/"
 )
 
 // ParamValidatorAndPopulator validates parameters and infers missing values.
@@ -101,6 +104,15 @@ func (p *ParamValidatorAndPopulator) ValidateAndPopulate(params *ovfdomain.OVFIm
 	params.PrivateNetworkIP = strings.TrimSpace(params.PrivateNetworkIP)
 	params.NetworkTier = strings.TrimSpace(params.NetworkTier)
 	params.ComputeServiceAccount = strings.TrimSpace(params.ComputeServiceAccount)
+	params.InstanceAccessScopesFlag = strings.TrimSpace(params.InstanceAccessScopesFlag)
+	if params.InstanceAccessScopesFlag != "" {
+		params.InstanceAccessScopes = strings.Split(params.InstanceAccessScopesFlag, ",")
+		for _, scope := range params.InstanceAccessScopes {
+			if !strings.HasPrefix(scope, instanceAccessScopePrefix) {
+				return daisy.Errf("Scope `%v` is invalid because it doesn't start with `%v`", scope, instanceAccessScopePrefix)
+			}
+		}
+	}
 
 	if params.InstanceNames == "" && params.MachineImageName == "" {
 		return daisy.Errf("Either the flag -%v or -%v must be provided", InstanceNameFlagKey, MachineImageNameFlagKey)

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
@@ -112,6 +112,8 @@ func (p *ParamValidatorAndPopulator) ValidateAndPopulate(params *ovfdomain.OVFIm
 				return daisy.Errf("Scope `%v` is invalid because it doesn't start with `%v`", scope, instanceAccessScopePrefix)
 			}
 		}
+	} else {
+		params.InstanceAccessScopes = GetDefaultInstanceAccessScopes()
 	}
 
 	if params.InstanceNames == "" && params.MachineImageName == "" {

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -261,6 +262,18 @@ func Test_ValidateAndParseParams_ErrorMessages(t *testing.T) {
 				params.ReleaseTrack = "garbage"
 			},
 			expectErrorToContain: "invalid value for release-track flag",
+		}, {
+			name: "validate scopes, first invalid, second valid",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.InstanceAccessScopesFlag = "garbage," + instanceAccessScopePrefix + "pubsub"
+			},
+			expectErrorToContain: "is invalid because it doesn't start with",
+		}, {
+			name: "validate scopes, one invalid",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.InstanceAccessScopesFlag = "garbage"
+			},
+			expectErrorToContain: "is invalid because it doesn't start with",
 		},
 	}
 
@@ -456,6 +469,16 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 				assert.Equal(t, "127.0.0.1", params.PrivateNetworkIP)
 				assert.Equal(t, "PREMIUM", params.NetworkTier)
 				assert.Equal(t, "ce@project.google.com", params.ComputeServiceAccount)
+			},
+		}, {
+			name: "instance access scopes parsed",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.InstanceAccessScopesFlag = " https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore		"
+			},
+			checkResult: func(t *testing.T, params *domain.OVFImportParams, importType string) {
+				assert.True(t, reflect.DeepEqual(
+					[]string{"https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/datastore"},
+					params.InstanceAccessScopes))
 			},
 		},
 	}

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
@@ -480,6 +480,11 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 					[]string{"https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/datastore"},
 					params.InstanceAccessScopes))
 			},
+		}, {
+			name: "instance access scopes defaults set",
+			checkResult: func(t *testing.T, params *domain.OVFImportParams, importType string) {
+				assert.True(t, reflect.DeepEqual(GetDefaultInstanceAccessScopes(), params.InstanceAccessScopes))
+			},
 		},
 	}
 
@@ -492,7 +497,9 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 				} else {
 					params = getAllMachineImageImportParams()
 				}
-				tt.paramModifier(params)
+				if tt.paramModifier != nil {
+					tt.paramModifier(params)
+				}
 				assertNoErrorOnValidate(t, params)
 				tt.checkResult(t, params, importType)
 			})

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -21,16 +21,17 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/common/gcp"
-
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/paramhelper"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools_tests/e2e"
+	"github.com/GoogleCloudPlatform/compute-image-tools/common/gcp"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/junitxml"
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/test_config"
@@ -70,6 +71,7 @@ type ovfInstanceImportTestProperties struct {
 	subnet                    string
 	project                   string
 	computeServiceAccount     string
+	instanceAccessScopes      string
 	instanceMetadata          map[string]string
 }
 
@@ -134,11 +136,14 @@ func TestSuite(
 	instanceImportDisabledDefaultServiceAccountFailTestCase := junitxml.NewTestCase(
 		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Instance import without default service account failed"))
 	instanceImportDefaultServiceAccountWithMissingPermissionsFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Instance mport without permission on default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Instance import without permission on default service account failed"))
+	instanceImportDefaultServiceAccountAccessScopeTestCase := junitxml.NewTestCase(
+		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Instance import with default service account access scopes set"))
 	testsMap[e2e.Wrapper][instanceImportDisabledDefaultServiceAccountSuccessTestCase] = runInstanceImportDisabledDefaultServiceAccountSuccessTest
 	testsMap[e2e.Wrapper][instanceImportDefaultServiceAccountWithMissingPermissionsSuccessTestCase] = runInstanceImportDefaultServiceAccountWithMissingPermissionsSuccessTest
 	testsMap[e2e.Wrapper][instanceImportDisabledDefaultServiceAccountFailTestCase] = runInstanceImportWithDisabledDefaultServiceAccountFailTest
 	testsMap[e2e.Wrapper][instanceImportDefaultServiceAccountWithMissingPermissionsFailTestCase] = runInstanceImportDefaultServiceAccountWithMissingPermissionsFailTest
+	testsMap[e2e.Wrapper][instanceImportDefaultServiceAccountAccessScopeTestCase] = runInstanceImportDefaultServiceAccountAccessScopeTestCaseSuccessTest
 
 	e2e.CLITestSuite(ctx, tswg, testSuites, logger, testSuiteRegex, testCaseRegex,
 		testProjectConfig, testSuiteName, testsMap)
@@ -357,6 +362,7 @@ func runInstanceImportDisabledDefaultServiceAccountSuccessTest(ctx context.Conte
 		machineType:           "n1-standard-4",
 		project:               testVariables.ProjectID,
 		computeServiceAccount: testVariables.ComputeServiceAccount,
+		instanceAccessScopes:  "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore",
 	}
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
@@ -434,6 +440,26 @@ func runInstanceImportDefaultServiceAccountWithMissingPermissionsFailTest(ctx co
 	e2e.RunTestCommandAssertErrorMessage(cmds[testType], buildTestArgs(props, testProjectConfig)[testType], "Failed to download GCS path", logger, testCase)
 }
 
+// Ensure custom access scopes are set on the instance even when default service account is used
+func runInstanceImportDefaultServiceAccountAccessScopeTestCaseSuccessTest(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
+	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
+	suffix := path.RandString(5)
+	props := &ovfInstanceImportTestProperties{
+		instanceName: fmt.Sprintf("test-scopes-on-default-cse-%v", suffix),
+		verificationStartupScript: loadScriptContent(
+			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+		zone:                  testProjectConfig.TestZone,
+		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
+		sourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+		os:                    "centos-7",
+		machineType:           "n1-standard-4",
+		project:               testProjectConfig.TestProjectID,
+		instanceAccessScopes:  "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore",
+	}
+	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
+}
+
 func getProject(props *ovfInstanceImportTestProperties, testProjectConfig *testconfig.Project) string {
 	if props.project != "" {
 		return props.project
@@ -489,6 +515,11 @@ func buildTestArgs(props *ovfInstanceImportTestProperties, testProjectConfig *te
 		gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--compute-service-account=%v", props.computeServiceAccount))
 		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--compute-service-account=%v", props.computeServiceAccount))
 		wrapperArgs = append(wrapperArgs, fmt.Sprintf("-compute-service-account=%v", props.computeServiceAccount))
+	}
+	if props.instanceAccessScopes != "" {
+		gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--scopes=%v", props.instanceAccessScopes))
+		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--scopes=%v", props.instanceAccessScopes))
+		wrapperArgs = append(wrapperArgs, fmt.Sprintf("-scopes=%v", props.instanceAccessScopes))
 	}
 
 	argsMap := map[e2e.CLITestType][]string{
@@ -588,6 +619,22 @@ func verifyImportedInstance(
 			e2e.Failure(testCase, logger, fmt.Sprintf("Instance service accounts (`%v`) don't contain custom service account `%v`",
 				strings.Join(instanceServiceAccountEmails, ","), props.computeServiceAccount))
 			return
+		}
+	}
+
+	if props.instanceAccessScopes != "" {
+		scopes := strings.Split(props.instanceAccessScopes, ",")
+
+		var instanceServiceAccountScopes []string
+		for _, instanceServiceAccount := range instance.ServiceAccounts {
+			sort.Strings(scopes)
+			sort.Strings(instanceServiceAccount.Scopes)
+			if !reflect.DeepEqual(scopes, instanceServiceAccount.Scopes) {
+				e2e.Failure(testCase, logger, fmt.Sprintf(
+					"Instance access scopes (%v) for service account `%v` don't match expected scopes: `%v`",
+					strings.Join(instanceServiceAccountScopes, ","), instanceServiceAccount.Email, strings.Join(scopes, ",")))
+				return
+			}
 		}
 	}
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -22,7 +22,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -74,6 +76,7 @@ type ovfMachineImageImportTestProperties struct {
 	instanceMetadata          map[string]string
 	project                   string
 	computeServiceAccount     string
+	instanceAccessScopes      string
 }
 
 // TestSuite is image import test suite.
@@ -122,10 +125,13 @@ func TestSuite(
 		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Machine image import without default service account failed"))
 	machineImageImportDefaultServiceAccountWithMissingPermissionsFailTestCase := junitxml.NewTestCase(
 		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Machine image import without permission on default service account failed"))
+	machineImageImportDefaultServiceAccountAccessScopeTestCase := junitxml.NewTestCase(
+		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Machine image import with default service account access scopes set"))
 	testsMap[e2e.Wrapper][machineImageImportDisabledDefaultServiceAccountSuccessTestCase] = runMachineImageImportDisabledDefaultServiceAccountSuccessTest
 	testsMap[e2e.Wrapper][machineImageImportDefaultServiceAccountWithMissingPermissionsSuccessTestCase] = runMachineImageImportOSDefaultServiceAccountWithMissingPermissionsSuccessTest
 	testsMap[e2e.Wrapper][machineImageImportDisabledDefaultServiceAccountFailTestCase] = runMachineImageImportWithDisabledDefaultServiceAccountFailTest
 	testsMap[e2e.Wrapper][machineImageImportDefaultServiceAccountWithMissingPermissionsFailTestCase] = runMachineImageImportDefaultServiceAccountWithMissingPermissionsFailTest
+	testsMap[e2e.Wrapper][machineImageImportDefaultServiceAccountAccessScopeTestCase] = runMachineImageImportDefaultServiceAccountAccessScopeTestCaseSuccessTest
 
 	e2e.CLITestSuite(ctx, tswg, testSuites, logger, testSuiteRegex, testCaseRegex,
 		testProjectConfig, testSuiteName, testsMap)
@@ -254,6 +260,7 @@ func runMachineImageImportDisabledDefaultServiceAccountSuccessTest(ctx context.C
 		machineType:           "n1-standard-4",
 		project:               testVariables.ProjectID,
 		computeServiceAccount: testVariables.ComputeServiceAccount,
+		instanceAccessScopes:  "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore",
 	}
 	runOVFMachineImageImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
@@ -331,6 +338,31 @@ func runMachineImageImportDefaultServiceAccountWithMissingPermissionsFailTest(ct
 	e2e.RunTestCommandAssertErrorMessage(cmds[testType], buildTestArgs(props, testProjectConfig)[testType], "Failed to download GCS path", logger, testCase)
 }
 
+// Ensure custom access scopes are set on the machine image even when default service account is used
+func runMachineImageImportDefaultServiceAccountAccessScopeTestCaseSuccessTest(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
+	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
+	testVariables, ok := e2e.GetServiceAccountTestVariables(argMap, false)
+	if !ok {
+		e2e.Failure(testCase, logger, fmt.Sprintln("Failed to get service account test args"))
+		return
+	}
+	suffix := path.RandString(5)
+	props := &ovfMachineImageImportTestProperties{
+		machineImageName: fmt.Sprintf("test-custom-scopes-on-default-cse-%v", suffix),
+		verificationStartupScript: loadScriptContent(
+			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+		zone:                  testProjectConfig.TestZone,
+		expectedStartupOutput: "All tests passed!",
+		failureMatches:        []string{"FAILED:", "TestFailed:"},
+		sourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+		os:                    "centos-7",
+		machineType:           "n1-standard-4",
+		project:               testVariables.ProjectID,
+		instanceAccessScopes:  "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore",
+	}
+	e2e.RunTestCommandAssertErrorMessage(cmds[testType], buildTestArgs(props, testProjectConfig)[testType], "Failed to download GCS path", logger, testCase)
+}
+
 func getProject(props *ovfMachineImageImportTestProperties, testProjectConfig *testconfig.Project) string {
 	if props.project != "" {
 		return props.project
@@ -390,6 +422,11 @@ func buildTestArgs(props *ovfMachineImageImportTestProperties, testProjectConfig
 		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--compute-service-account=%v", props.computeServiceAccount))
 		wrapperArgs = append(wrapperArgs, fmt.Sprintf("-compute-service-account=%v", props.computeServiceAccount))
 	}
+	if props.instanceAccessScopes != "" {
+		gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--scopes=%v", props.instanceAccessScopes))
+		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--scopes=%v", props.instanceAccessScopes))
+		wrapperArgs = append(wrapperArgs, fmt.Sprintf("-scopes=%v", props.instanceAccessScopes))
+	}
 
 	argsMap := map[e2e.CLITestType][]string{
 		e2e.Wrapper:                       wrapperArgs,
@@ -423,12 +460,9 @@ func verifyImportedMachineImage(
 	logger.Printf("Verifying imported machine image...")
 	testInstanceName := props.machineImageName + "-test-instance"
 	logger.Printf("Creating `%v` test instance.", testInstanceName)
-	computeServiceAccount := "default"
-	if props.computeServiceAccount != "" {
-		computeServiceAccount = props.computeServiceAccount
-	}
+
 	instance, err := gcp.CreateInstanceBeta(
-		ctx, project, props.zone, testInstanceName, props.isWindows, props.machineImageName, computeServiceAccount)
+		ctx, project, props.zone, testInstanceName, props.isWindows, props.machineImageName)
 	if err != nil {
 		e2e.Failure(testCase, logger, fmt.Sprintf("Error when creating test instance `%v` from machine image '%v': %v", testInstanceName, props.machineImageName, err))
 		return
@@ -487,6 +521,38 @@ func verifyImportedMachineImage(
 		e2e.Failure(testCase, logger, fmt.Sprintf("Instance zone `%v` doesn't match requested zone `%v`",
 			instance.Zone, props.zone))
 		return
+	}
+
+	if props.computeServiceAccount != "" {
+		serviceAccountMatch := false
+		var instanceServiceAccountEmails []string
+		for _, instanceServiceAccount := range instance.ServiceAccounts {
+			instanceServiceAccountEmails = append(instanceServiceAccountEmails, instanceServiceAccount.Email)
+			if instanceServiceAccount.Email == props.computeServiceAccount {
+				serviceAccountMatch = true
+			}
+		}
+		if !serviceAccountMatch {
+			e2e.Failure(testCase, logger, fmt.Sprintf("Instance service accounts (`%v`) don't contain custom service account `%v`",
+				strings.Join(instanceServiceAccountEmails, ","), props.computeServiceAccount))
+			return
+		}
+	}
+
+	if props.instanceAccessScopes != "" {
+		scopes := strings.Split(props.instanceAccessScopes, ",")
+
+		var instanceServiceAccountScopes []string
+		for _, instanceServiceAccount := range instance.ServiceAccounts {
+			sort.Strings(scopes)
+			sort.Strings(instanceServiceAccount.Scopes)
+			if !reflect.DeepEqual(scopes, instanceServiceAccount.Scopes) {
+				e2e.Failure(testCase, logger, fmt.Sprintf(
+					"Instance access scopes (%v) for service account `%v` don't match expected scopes: `%v`",
+					strings.Join(instanceServiceAccountScopes, ","), instanceServiceAccount.Email, strings.Join(scopes, ",")))
+				return
+			}
+		}
 	}
 
 	if props.verificationStartupScript == "" {

--- a/common/gcp/instance.go
+++ b/common/gcp/instance.go
@@ -185,7 +185,7 @@ func BuildInstanceMetadataItem(key, value string) *api.MetadataItems {
 
 // CreateInstanceBeta creates a VM instance (not just an object representing an existing VM) using Beta API
 func CreateInstanceBeta(ctx context.Context, project string, zone string, name string,
-	isWindows bool, machineImageName string, computeServiceAccount string) (*InstanceBeta, error) {
+	isWindows bool, machineImageName string) (*InstanceBeta, error) {
 	client, err := daisyCompute.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -196,12 +196,6 @@ func CreateInstanceBeta(ctx context.Context, project string, zone string, name s
 		SourceMachineImage: fmt.Sprintf("projects/%s/global/machineImages/%s", project, machineImageName),
 		Name:               name,
 		Zone:               zone,
-		ServiceAccounts: []*apiBeta.ServiceAccount{
-			{
-				Email:  computeServiceAccount,
-				Scopes: []string{"https://www.googleapis.com/auth/devstorage.read_write"},
-			},
-		},
 	}
 	i := &InstanceBeta{apiBetaInstance, client, project, zone, isWindows}
 


### PR DESCRIPTION
OVF Import: added -scope flag to allow custom instance access scopes. This is needed as the resulting instance/GMI will have custom service account set. Without the ability to set scopes as well, instance will be set with no scopes, potentially restricting what can be accessed from instance. 

Also added the check for service account in GMI E2E import test, since service accounts are preserved preserved by GMIs and transfered to any VMs screated from them.