### PR TITLE
add debian 9 build deps

### DIFF
--- a/daisy_workflows/image_build/debian/build.py
+++ b/daisy_workflows/image_build/debian/build.py
@@ -36,7 +36,7 @@ import utils
 
 utils.AptGetInstall(
     ['python-pip', 'python-termcolor', 'python-fysom', 'python-jsonschema',
-     'python-yaml', 'python-docopt'])
+     'python-yaml', 'python3-yaml', 'python-docopt', 'python-requests'])
 utils.PipInstall(
     ['json_minify'])
 


### PR DESCRIPTION
python3-yaml is needed for the subsequent 'import yaml' line in build.py
python-requests is needed for bootstrap-vz (although not declared in their documentation)