### PR TITLE
Add -byol flag to OVF import

### DIFF
--- a/cli_tools/common/image/importer/request.go
+++ b/cli_tools/common/image/importer/request.go
@@ -105,6 +105,21 @@ type ImageImportRequest struct {
 	Zone                  string `name:"zone" validate:"required"`
 }
 
+// MergeBYOLIntoOSID interprets the user's --os and --byol flags, and returns a semantically-equivalent
+// tuple. The returned values follow the invariants from ImageImportRequest's validation where --byol may only
+// be specified when --os is empty (implying that detection is being used).
+//
+// For example, given `--byol --os=rhel-8`, this will return `--os=rhel-8-byol`.
+func MergeBYOLIntoOSID(osID string, byol bool) (resolvedOSID string, resolvedBYOL bool) {
+	if osID == "" || !byol {
+		return osID, byol
+	}
+	if strings.HasSuffix(osID, "byol") {
+		return osID, false
+	}
+	return osID + "-byol", false
+}
+
 // EnvironmentSettings returns the subset of EnvironmentSettings that are required to instantiate
 // a daisy workflow.
 func (args ImageImportRequest) EnvironmentSettings() daisycommon.EnvironmentSettings {

--- a/cli_tools/common/image/importer/request_test.go
+++ b/cli_tools/common/image/importer/request_test.go
@@ -26,47 +26,45 @@ import (
 )
 
 func Test_FixBYOLAndOSFlags(t *testing.T) {
-	type test struct {
+	for _, tt := range []struct {
 		originalOSID, expectedOSID string
 		originalBYOL, expectedBYOL bool
-	}
-	for _, tc := range []test{
-		{
-			originalOSID: "rhel-8",
-			originalBYOL: true,
-			expectedOSID: "rhel-8-byol",
-			expectedBYOL: false,
-		}, {
-			originalOSID: "rhel-8-byol",
-			originalBYOL: true,
-			expectedOSID: "rhel-8-byol",
-			expectedBYOL: false,
-		}, {
-			originalOSID: "rhel-8",
-			originalBYOL: false,
-			expectedOSID: "rhel-8",
-			expectedBYOL: false,
-		}, {
-			originalOSID: "rhel-8-byol",
-			originalBYOL: false,
-			expectedOSID: "rhel-8-byol",
-			expectedBYOL: false,
-		}, {
-			originalOSID: "",
-			originalBYOL: true,
-			expectedOSID: "",
-			expectedBYOL: true,
-		}, {
-			originalOSID: "",
-			originalBYOL: false,
-			expectedOSID: "",
-			expectedBYOL: false,
-		},
+	}{{
+		originalOSID: "rhel-8",
+		originalBYOL: true,
+		expectedOSID: "rhel-8-byol",
+		expectedBYOL: false,
+	}, {
+		originalOSID: "rhel-8-byol",
+		originalBYOL: true,
+		expectedOSID: "rhel-8-byol",
+		expectedBYOL: false,
+	}, {
+		originalOSID: "rhel-8",
+		originalBYOL: false,
+		expectedOSID: "rhel-8",
+		expectedBYOL: false,
+	}, {
+		originalOSID: "rhel-8-byol",
+		originalBYOL: false,
+		expectedOSID: "rhel-8-byol",
+		expectedBYOL: false,
+	}, {
+		originalOSID: "",
+		originalBYOL: true,
+		expectedOSID: "",
+		expectedBYOL: true,
+	}, {
+		originalOSID: "",
+		originalBYOL: false,
+		expectedOSID: "",
+		expectedBYOL: false,
+	},
 	} {
-		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
-			actualOSID, actualBYOL := FixBYOLAndOSFlags(tc.originalOSID, tc.originalBYOL)
-			assert.Equal(t, tc.expectedOSID, actualOSID)
-			assert.Equal(t, tc.expectedBYOL, actualBYOL)
+		t.Run(fmt.Sprintf("%+v", tt), func(t *testing.T) {
+			FixBYOLAndOSArguments(&tt.originalOSID, &tt.originalBYOL)
+			assert.Equal(t, tt.expectedOSID, tt.originalOSID)
+			assert.Equal(t, tt.expectedBYOL, tt.originalBYOL)
 		})
 	}
 }

--- a/cli_tools/common/image/importer/request_test.go
+++ b/cli_tools/common/image/importer/request_test.go
@@ -15,6 +15,7 @@
 package importer
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,6 +24,52 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/validation"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
 )
+
+func Test_MergeBYOLIntoOSID(t *testing.T) {
+	type test struct {
+		originalOSID, expectedOSID string
+		originalBYOL, expectedBYOL bool
+	}
+	for _, tc := range []test{
+		{
+			originalOSID: "rhel-8",
+			originalBYOL: true,
+			expectedOSID: "rhel-8-byol",
+			expectedBYOL: false,
+		}, {
+			originalOSID: "rhel-8-byol",
+			originalBYOL: true,
+			expectedOSID: "rhel-8-byol",
+			expectedBYOL: false,
+		}, {
+			originalOSID: "rhel-8",
+			originalBYOL: false,
+			expectedOSID: "rhel-8",
+			expectedBYOL: false,
+		}, {
+			originalOSID: "rhel-8-byol",
+			originalBYOL: false,
+			expectedOSID: "rhel-8-byol",
+			expectedBYOL: false,
+		}, {
+			originalOSID: "",
+			originalBYOL: true,
+			expectedOSID: "",
+			expectedBYOL: true,
+		}, {
+			originalOSID: "",
+			originalBYOL: false,
+			expectedOSID: "",
+			expectedBYOL: false,
+		},
+	} {
+		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
+			actualOSID, actualBYOL := MergeBYOLIntoOSID(tc.originalOSID, tc.originalBYOL)
+			assert.Equal(t, tc.expectedOSID, actualOSID)
+			assert.Equal(t, tc.expectedBYOL, actualBYOL)
+		})
+	}
+}
 
 func Test_validate_RequiresImageName(t *testing.T) {
 	request := makeValidRequest()

--- a/cli_tools/common/image/importer/request_test.go
+++ b/cli_tools/common/image/importer/request_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
 )
 
-func Test_MergeBYOLIntoOSID(t *testing.T) {
+func Test_FixBYOLAndOSFlags(t *testing.T) {
 	type test struct {
 		originalOSID, expectedOSID string
 		originalBYOL, expectedBYOL bool
@@ -64,7 +64,7 @@ func Test_MergeBYOLIntoOSID(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
-			actualOSID, actualBYOL := MergeBYOLIntoOSID(tc.originalOSID, tc.originalBYOL)
+			actualOSID, actualBYOL := FixBYOLAndOSFlags(tc.originalOSID, tc.originalBYOL)
 			assert.Equal(t, tc.expectedOSID, actualOSID)
 			assert.Equal(t, tc.expectedBYOL, actualBYOL)
 		})

--- a/cli_tools/gce_ovf_import/README.md
+++ b/cli_tools/gce_ovf_import/README.md
@@ -63,8 +63,8 @@ Exactly one of these must be specified:
 + `-os=OS` Specifies the OS of the image being imported. Execute the tool with `-help` to
   see the list of currently-supported operating systems. When omitted, the tool detects the OS.
 + `-byol` Import using an [existing license](https://cloud.google.com/compute/docs/nodes/bringing-your-own-licenses). These are equivalent:
-  * `-os=rhel-8 -byol`
-  * `-os=rhel-8-byol -byol`
+  * `-byol -os=rhel-8`
+  * `-byol -os=rhel-8-byol`
   * `-os=rhel-8-byol`
 + `-shielded-integrity-monitoring` Enables monitoring and attestation of the boot integrity of the
   instance. The attestation is performed against the integrity policy baseline. This baseline is

--- a/cli_tools/gce_ovf_import/README.md
+++ b/cli_tools/gce_ovf_import/README.md
@@ -61,7 +61,11 @@ Exactly one of these must be specified:
 + `-no-restart-on-failure` the instance will not be restarted if it’s terminated by Compute Engine.
   This does not affect terminations performed by the user.
 + `-os=OS` Specifies the OS of the image being imported. Execute the tool with `-help` to
-  see the list of currently-supported operating systems.
+  see the list of currently-supported operating systems. When omitted, the tool detects the OS.
++ `-byol` Import using an [existing license](https://cloud.google.com/compute/docs/nodes/bringing-your-own-licenses). These are equivalent:
+  * `-os=rhel-8 -byol`
+  * `-os=rhel-8-byol -byol`
+  * `-os=rhel-8-byol`
 + `-shielded-integrity-monitoring` Enables monitoring and attestation of the boot integrity of the
   instance. The attestation is performed against the integrity policy baseline. This baseline is
   initially derived from the implicitly trusted boot image when the instance is created. This
@@ -125,7 +129,7 @@ gce_ovf_import -instance-names=INSTANCE_NAME -client-id=CLIENT_ID
 [-network=NETWORK] [-network-interface=[PROPERTY=VALUE,…]]
 [-network-tier=NETWORK_TIER]  [-subnet=SUBNET]
 [-private-network-ip=PRIVATE_NETWORK_IP] [-no-external-ip]
-[-no-restart-on-failure] [-os=OS]
+[-no-restart-on-failure] [-os=OS] [-byol]
 [-shielded-integrity-monitoring] [-shielded-secure-boot] [-shielded-vtpm]
 [-tags=TAG,[TAG,…]] [-zone=ZONE] [-address=ADDRESS    | -no-address]
 [-boot-disk-kms-key=KMS_KEY : -boot-disk-kms-keyring=KMS_KEYRING
@@ -148,7 +152,7 @@ gce_ovf_import -machine-image-name=MACHINE_IMAGE_NAME -client-id=CLIENT_ID
 [-network=NETWORK] [-network-interface=[PROPERTY=VALUE,…]]
 [-network-tier=NETWORK_TIER]  [-subnet=SUBNET]
 [-private-network-ip=PRIVATE_NETWORK_IP] [-no-external-ip]
-[-no-restart-on-failure] [-os=OS]
+[-no-restart-on-failure] [-os=OS] [-byol]
 [-shielded-integrity-monitoring] [-shielded-secure-boot] [-shielded-vtpm]
 [-tags=TAG,[TAG,…]] [-zone=ZONE] [-address=ADDRESS    | -no-address]
 [-boot-disk-kms-key=KMS_KEY : -boot-disk-kms-keyring=KMS_KEYRING

--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -61,6 +61,7 @@ type OVFImportParams struct {
 	NoExternalIP                bool
 	NoRestartOnFailure          bool
 	OsID                        string
+	BYOL                        bool
 	ShieldedIntegrityMonitoring bool
 	ShieldedSecureBoot          bool
 	ShieldedVtpm                bool

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -49,6 +49,7 @@ var (
 	noExternalIP                = flag.Bool("no-external-ip", false, "Specifies that VPC into which instances is being imported doesn't allow external IPs.")
 	noRestartOnFailure          = flag.Bool("no-restart-on-failure", false, "the instance will not be restarted if it’s terminated by Compute Engine. This does not affect terminations performed by the user.")
 	osID                        = flag.String("os", "", "Specifies the OS of the image being imported. OS must be one of: "+strings.Join(daisy.GetSortedOSIDs(), ", ")+".")
+	byol                        = flag.Bool("byol", false, "Import using an existing license. These are equivalent: `-os=rhel-8 -byol`, `-os=rhel-8-byol -byol`, and `-os=rhel-8-byol`")
 	shieldedIntegrityMonitoring = flag.Bool("shielded-integrity-monitoring", false, "Enables monitoring and attestation of the boot integrity of the instance. The attestation is performed against the integrity policy baseline. This baseline is initially derived from the implicitly trusted boot image when the instance is created. This baseline can be updated by using --shielded-vm-learn-integrity-policy.")
 	shieldedSecureBoot          = flag.Bool("shielded-secure-boot", false, "The instance will boot with secure boot enabled.")
 	shieldedVtpm                = flag.Bool("shielded-vtpm", false, "The instance will boot with the TPM (Trusted Platform Module) enabled. A TPM is a hardware module that can be used for different security operations such as remote attestation, encryption and sealing of keys.")
@@ -95,7 +96,7 @@ func buildOVFImportParams() *domain.OVFImportParams {
 		CanIPForward: *canIPForward, DeletionProtection: *deletionProtection, Description: *description,
 		Labels: *labels, MachineType: *machineType, Network: *network, NetworkTier: *networkTier,
 		Subnet: *subnet, PrivateNetworkIP: *privateNetworkIP, NoExternalIP: *noExternalIP,
-		NoRestartOnFailure: *noRestartOnFailure, OsID: *osID,
+		NoRestartOnFailure: *noRestartOnFailure, OsID: *osID, BYOL: *byol,
 		ShieldedIntegrityMonitoring: *shieldedIntegrityMonitoring, ShieldedSecureBoot: *shieldedSecureBoot,
 		ShieldedVtpm: *shieldedVtpm, Tags: *tags, Zone: *zoneFlag, BootDiskKmskey: *bootDiskKmskey,
 		BootDiskKmsKeyring: *bootDiskKmsKeyring, BootDiskKmsLocation: *bootDiskKmsLocation,

--- a/cli_tools/gce_ovf_import/multi_image_importer/request_builder.go
+++ b/cli_tools/gce_ovf_import/multi_image_importer/request_builder.go
@@ -61,7 +61,7 @@ func (r *requestBuilder) buildRequests(params *ovfdomain.OVFImportParams, fileUR
 		}
 		bootable := i == 0
 		if bootable {
-			request.OS, request.BYOL = importer.MergeBYOLIntoOSID(params.OsID, params.BYOL)
+			request.OS, request.BYOL = importer.FixBYOLAndOSFlags(params.OsID, params.BYOL)
 		} else {
 			request.DataDisk = true
 		}

--- a/cli_tools/gce_ovf_import/multi_image_importer/request_builder.go
+++ b/cli_tools/gce_ovf_import/multi_image_importer/request_builder.go
@@ -61,7 +61,9 @@ func (r *requestBuilder) buildRequests(params *ovfdomain.OVFImportParams, fileUR
 		}
 		bootable := i == 0
 		if bootable {
-			request.OS, request.BYOL = importer.FixBYOLAndOSFlags(params.OsID, params.BYOL)
+			request.OS = params.OsID
+			request.BYOL = params.BYOL
+			importer.FixBYOLAndOSArguments(&request.OS, &request.BYOL)
 		} else {
 			request.DataDisk = true
 		}

--- a/cli_tools/gce_vm_image_import/README.md
+++ b/cli_tools/gce_vm_image_import/README.md
@@ -22,12 +22,6 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image
   `pantheon`.
   
 Exactly one of these must be specified:
-+ `-data_disk` Specifies that the disk has no bootable OS installed on it. 
-   Imports the disk without making it bootable or installing Google tools on it.   
-+ `-os=OS` Specifies the OS of the image being imported. Execute the tool with `-help` to
-  see the list of currently-supported operating systems.
-  
-Exactly one of these must be specified:
 + `-source_file=SOURCE_FILE` Google Cloud Storage URI of the virtual disk file
   to import. For example: gs://my-bucket/my-image.vmdk.
 + `-source_image=SOURCE_IMAGE` An existing Compute Engine image from which to 
@@ -74,14 +68,23 @@ Exactly one of these must be specified:
   Virtual Machine. When empty, the default Compute Engine service account is used.
 + `-uefi_compatible` Enables UEFI booting, which is an alternative system boot method. 
 + `-sysprep_windows` Generalize image using Windows Sysprep. Only applicable to Windows.
-+ `-byol` Specifies that a BYOL license should be applied.
 + `-client_version` Identifies the version of the client of the importer.
 + `-execution_id` The execution ID to differentiate GCE resources of each imports.
++ `-data_disk` Specifies that the disk has no bootable OS installed on it.
+    Imports the disk without making it bootable or installing Google tools on it.
+    It's an error to specify `-os` or `-byol` when `-data_disk` is specified.
++ `-os=OS` Specifies the OS of the image being imported. Execute the tool with `-help` to
+  see the list of currently-supported operating systems.
++ `-byol` Import using an [existing license](https://cloud.google.com/compute/docs/nodes/bringing-your-own-licenses).
+  These are functionally equivalent:
+  * `-os=rhel-8 -byol`
+  * `-os=rhel-8-byol -byol`
+  * `-os=rhel-8-byol`
   
 ### Usage
 
 ```
-gce_vm_image_import -image_name=IMAGE_NAME -client_id=CLIENT_ID (-data-disk | -os=OS)
+gce_vm_image_import -image_name=IMAGE_NAME -client_id=CLIENT_ID [--data-disk | --byol --os=OS]
         (-source-file=SOURCE_FILE | -source-image=SOURCE_IMAGE) [-no-guest-environment] 
         [-family=FAMILY] [-description=DESCRIPTION] [-network=NETWORK] [-subnet=SUBNET]
         [-zone=ZONE] [-timeout=TIMEOUT] [-project=PROJECT] [-scratch_bucket_gcs_path=PATH]
@@ -91,6 +94,6 @@ gce_vm_image_import -image_name=IMAGE_NAME -client_id=CLIENT_ID (-data-disk | -o
         -kms-project=KMS_PROJECT] [-no_external_ip] [-labels=KEY=VALUE,...] 
         [-storage_location=STORAGE_LOCATION]
         [-compute_service_account=COMPUTE_SERVICE_ACCOUNT] 
-        [-uefi_compatible] [-sysprep_windows] [-byol] 
+        [-uefi_compatible] [-sysprep_windows]
         [-client_version=CLIENT_VERSION] [-execution_id=EXECUTION_ID]
 ```

--- a/cli_tools/gce_vm_image_import/README.md
+++ b/cli_tools/gce_vm_image_import/README.md
@@ -77,8 +77,8 @@ Exactly one of these must be specified:
   see the list of currently-supported operating systems.
 + `-byol` Import using an [existing license](https://cloud.google.com/compute/docs/nodes/bringing-your-own-licenses).
   These are functionally equivalent:
-  * `-os=rhel-8 -byol`
-  * `-os=rhel-8-byol -byol`
+  * `-byol -os=rhel-8`
+  * `-byol -os=rhel-8-byol`
   * `-os=rhel-8-byol`
   
 ### Usage

--- a/cli_tools/gce_vm_image_import/cli/args.go
+++ b/cli_tools/gce_vm_image_import/cli/args.go
@@ -70,7 +70,7 @@ func (args *imageImportArgs) populateAndValidate(populator param.Populator,
 		return fmt.Errorf("%s has to be specified", importer.ClientFlag)
 	}
 
-	args.OS, args.BYOL = importer.MergeBYOLIntoOSID(args.OS, args.BYOL)
+	args.OS, args.BYOL = importer.FixBYOLAndOSFlags(args.OS, args.BYOL)
 
 	args.Source, err = sourceFactory.Init(args.SourceFile, args.SourceImage)
 	if err != nil {

--- a/cli_tools/gce_vm_image_import/cli/args.go
+++ b/cli_tools/gce_vm_image_import/cli/args.go
@@ -70,6 +70,8 @@ func (args *imageImportArgs) populateAndValidate(populator param.Populator,
 		return fmt.Errorf("%s has to be specified", importer.ClientFlag)
 	}
 
+	args.OS, args.BYOL = importer.MergeBYOLIntoOSID(args.OS, args.BYOL)
+
 	args.Source, err = sourceFactory.Init(args.SourceFile, args.SourceImage)
 	if err != nil {
 		return err
@@ -177,7 +179,8 @@ func (args *imageImportArgs) registerFlags(flagSet *flag.FlagSet) {
 		"An existing Compute Engine image from which to import.")
 
 	flagSet.BoolVar(&args.BYOL, importer.BYOLFlag, false,
-		"Specifies that a BYOL license should be applied.")
+		"Import using an existing license. These are equivalent: "+
+			"`-os=rhel-8 -byol`, `-os=rhel-8-byol -byol`, and `-os=rhel-8-byol`")
 
 	flagSet.BoolVar(&args.DataDisk, importer.DataDiskFlag, false,
 		"Specifies that the disk has no bootable OS installed on it. "+

--- a/cli_tools/gce_vm_image_import/cli/args.go
+++ b/cli_tools/gce_vm_image_import/cli/args.go
@@ -70,8 +70,7 @@ func (args *imageImportArgs) populateAndValidate(populator param.Populator,
 		return fmt.Errorf("%s has to be specified", importer.ClientFlag)
 	}
 
-	args.OS, args.BYOL = importer.FixBYOLAndOSFlags(args.OS, args.BYOL)
-
+	importer.FixBYOLAndOSArguments(&args.OS, &args.BYOL)
 	args.Source, err = sourceFactory.Init(args.SourceFile, args.SourceImage)
 	if err != nil {
 		return err

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -155,26 +155,29 @@ var basicCases = []*testCase{
 	},
 
 	// SLES: BYOL
+	// Uses a mixture of tactics for specifying BYOL, all of which should be successful.
 	{
 		caseName:             "sles-12-5-byol",
 		source:               "projects/compute-image-tools-test/global/images/sles-12-5-registered",
 		expectLicense:        "https://www.googleapis.com/compute/v1/projects/suse-byos-cloud/global/licenses/sles-12-byos",
-		extraArgs:            []string{"-byol"},
+		extraArgs:            []string{"-byol"}, // -byol with OS detection
 		osConfigNotSupported: true,
 	}, {
 		caseName:             "sles-sap-12-5-byol",
 		source:               "projects/compute-image-tools-test/global/images/sles-sap-12-5-registered",
 		os:                   "sles-sap-12-byol",
+		extraArgs:            []string{"-byol"}, // -byol specified when not required
 		osConfigNotSupported: true,
 	}, {
 		caseName:             "sles-15-2-byol",
 		source:               "projects/compute-image-tools-test/global/images/sles-15-2-registered",
-		os:                   "sles-15-byol",
+		os:                   "sles-15",
+		extraArgs:            []string{"-byol"}, // -byol transforms sles-15 to sles-15-byol
 		osConfigNotSupported: true,
 	}, {
 		caseName:             "sles-sap-15-2-byol",
 		source:               "projects/compute-image-tools-test/global/images/sles-sap-15-2-registered",
-		os:                   "sles-sap-15-byol",
+		os:                   "sles-sap-15-byol", // No -byol flag
 		osConfigNotSupported: true,
 	},
 


### PR DESCRIPTION
The `-byol` flag allows users to import systems with existing licenses when OS detection is enabled.

In addition to adding the flag, this adds logic to interpret when a user specifies both `-os` and `-byol`.