### PR TITLE
Windows: Wait 5 seconds before dismounting registry files

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -176,7 +176,8 @@ function Configure-Network {
     # because it will recursively add any necessary subkeys.
     Run-Command reg add $WPAD /v AutoDetect /t REG_DWORD /d 0 /f
   }
-
+  # Delay to ensure registry changes are completed.
+  Start-Sleep -s 5
   # Unmount default user hive.
   Run-Command reg unload 'HKLM\DefaultUser'
 

--- a/daisy_workflows/image_import/windows/translate_bootstrap.ps1
+++ b/daisy_workflows/image_import/windows/translate_bootstrap.ps1
@@ -84,6 +84,8 @@ function Setup-ScriptRunner {
   # Garbage collect before unmounting.
   [gc]::collect()
 
+  # Delay to ensure registry changes are completed.
+  Start-Sleep -s 5
   Run-Command reg unload 'HKLM\MountedSoftware'
 }
 
@@ -227,6 +229,9 @@ try {
   # See http://support.microsoft.com/kb/2955372/en-us
   Run-Command reg load 'HKLM\MountedSoftware' "${script:os_drive}\Windows\System32\config\SOFTWARE"
   Run-Command reg add 'HKLM\MountedSoftware\Microsoft\Windows\CurrentVersion\Authentication\LogonUI' /v 'AnimationDisabled' /t 'REG_DWORD' /d 1 /f
+
+  # Delay to ensure reg add is completed.
+  Start-Sleep -s 5
   Run-Command reg unload 'HKLM\MountedSoftware'
 
   Write-Output 'TranslateBootstrap: Rewriting boot files.'


### PR DESCRIPTION
Adding a 5 second delay prior to dismounting a registry hive when the registry has been modified to allow updates to complete.

This is to address Access Denied issues when attempting to dismount the registry.
- I initially adding retries by changing run-command to use Process objects and that introduced unexpected issues with long arguments strings.
- I attempted to use cmdlets to update the registry entries and found they cannot be used on mounted registry hives.