### PR TITLE
OVF Import: introduced instance service account flag

### DIFF
--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -77,6 +77,7 @@ type OVFImportParams struct {
 	Oauth                       string
 	Ce                          string
 	ComputeServiceAccount       string
+	InstanceServiceAccount      string
 	InstanceAccessScopesFlag    string
 	GcsLogsDisabled             bool
 	CloudLogsDisabled           bool

--- a/cli_tools/gce_ovf_import/main.go
+++ b/cli_tools/gce_ovf_import/main.go
@@ -64,7 +64,8 @@ var (
 	scratchBucketGcsPath        = flag.String("scratch-bucket-gcs-path", "", "GCS scratch bucket to use, overrides what is set in workflow")
 	oauth                       = flag.String("oauth", "", "path to oauth json file, overrides what is set in workflow")
 	ce                          = flag.String("compute-endpoint-override", "", "API endpoint to override default")
-	computeServiceAccount       = flag.String("compute-service-account", "", "Compute service account to be used by importer Virtual Machine and the resulting VM or Machine Image. When empty, the Compute Engine default service account is used.")
+	computeServiceAccount       = flag.String("compute-service-account", "", "Compute service account to be used by importer Virtual Machine. When empty, the Compute Engine default service account is used.")
+	serviceAccount              = flag.String("service-account", "", "A service account is an identity attached to the instance. If not provided, the instance will use the project's default service account.")
 	scopes                      = flag.String("scopes", "", "Access scopes to be assigned to the instance. A comma separated list of either full URI of the scope or an alias.")
 	gcsLogsDisabled             = flag.Bool("disable-gcs-logging", false, "do not stream logs to GCS")
 	cloudLogsDisabled           = flag.Bool("disable-cloud-logging", false, "do not stream logs to Cloud Logging")
@@ -103,8 +104,8 @@ func buildOVFImportParams() *domain.OVFImportParams {
 		BootDiskKmsKeyring: *bootDiskKmsKeyring, BootDiskKmsLocation: *bootDiskKmsLocation,
 		BootDiskKmsProject: *bootDiskKmsProject, Timeout: *timeout, Project: project,
 		ScratchBucketGcsPath: *scratchBucketGcsPath, Oauth: *oauth,
-		Ce: *ce, ComputeServiceAccount: *computeServiceAccount, InstanceAccessScopesFlag: *scopes,
-		GcsLogsDisabled: *gcsLogsDisabled, CloudLogsDisabled: *cloudLogsDisabled,
+		Ce: *ce, ComputeServiceAccount: *computeServiceAccount, InstanceServiceAccount: *serviceAccount,
+		InstanceAccessScopesFlag: *scopes, GcsLogsDisabled: *gcsLogsDisabled, CloudLogsDisabled: *cloudLogsDisabled,
 		StdoutLogsDisabled: *stdoutLogsDisabled, NodeAffinityLabelsFlag: nodeAffinityLabelsFlag,
 		CurrentExecutablePath: currentExecutablePath, ReleaseTrack: *releaseTrack,
 		UefiCompatible: *uefiCompatible, Hostname: *hostname,

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -142,7 +142,6 @@ func getImportWorkflowPath(params *ovfdomain.OVFImportParams) (workflow string) 
 }
 
 func (oi *OVFImporter) buildDaisyVars(bootDiskImageURI string, machineType string) map[string]string {
-
 	varMap := map[string]string{}
 	varMap["boot_disk_image_uri"] = bootDiskImageURI
 	if oi.params.IsInstanceImport() {
@@ -150,8 +149,8 @@ func (oi *OVFImporter) buildDaisyVars(bootDiskImageURI string, machineType strin
 	} else {
 		varMap["machine_image_name"] = oi.params.MachineImageName
 	}
-	if oi.params.ComputeServiceAccount != "" {
-		varMap["compute_service_account"] = oi.params.ComputeServiceAccount
+	if oi.params.InstanceServiceAccount != "" {
+		varMap["instance_service_account"] = oi.params.InstanceServiceAccount
 	}
 	if oi.params.Subnet != "" {
 		varMap["subnet"] = oi.params.Subnet

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
@@ -104,6 +104,7 @@ func (p *ParamValidatorAndPopulator) ValidateAndPopulate(params *ovfdomain.OVFIm
 	params.PrivateNetworkIP = strings.TrimSpace(params.PrivateNetworkIP)
 	params.NetworkTier = strings.TrimSpace(params.NetworkTier)
 	params.ComputeServiceAccount = strings.TrimSpace(params.ComputeServiceAccount)
+	params.InstanceServiceAccount = strings.TrimSpace(params.InstanceServiceAccount)
 	params.InstanceAccessScopesFlag = strings.TrimSpace(params.InstanceAccessScopesFlag)
 	if params.InstanceAccessScopesFlag != "" {
 		params.InstanceAccessScopes = strings.Split(params.InstanceAccessScopesFlag, ",")

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
@@ -458,6 +458,7 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 				params.PrivateNetworkIP = "127.0.0.1			 "
 				params.NetworkTier = " PREMIUM "
 				params.ComputeServiceAccount = " ce@project.google.com		"
+				params.InstanceServiceAccount = " ins-se@project.google.com		"
 			},
 			checkResult: func(t *testing.T, params *domain.OVFImportParams, importType string) {
 				if importType == "instance" {
@@ -469,6 +470,7 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 				assert.Equal(t, "127.0.0.1", params.PrivateNetworkIP)
 				assert.Equal(t, "PREMIUM", params.NetworkTier)
 				assert.Equal(t, "ce@project.google.com", params.ComputeServiceAccount)
+				assert.Equal(t, "ins-se@project.google.com", params.InstanceServiceAccount)
 			},
 		}, {
 			name: "instance access scopes parsed",

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -72,6 +72,7 @@ type ovfInstanceImportTestProperties struct {
 	subnet                    string
 	project                   string
 	computeServiceAccount     string
+	instanceServiceAccount    string
 	instanceAccessScopes      string
 	instanceMetadata          map[string]string
 }
@@ -355,15 +356,16 @@ func runInstanceImportDisabledDefaultServiceAccountSuccessTest(ctx context.Conte
 		instanceName: fmt.Sprintf("test-without-service-account-%v", suffix),
 		verificationStartupScript: loadScriptContent(
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
-		zone:                  testProjectConfig.TestZone,
-		expectedStartupOutput: "All tests passed!",
-		failureMatches:        []string{"FAILED:", "TestFailed:"},
-		sourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
-		os:                    "centos-7",
-		machineType:           "n1-standard-4",
-		project:               testVariables.ProjectID,
-		computeServiceAccount: testVariables.ComputeServiceAccount,
-		instanceAccessScopes:  "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore",
+		zone:                   testProjectConfig.TestZone,
+		expectedStartupOutput:  "All tests passed!",
+		failureMatches:         []string{"FAILED:", "TestFailed:"},
+		sourceURI:              fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+		os:                     "centos-7",
+		machineType:            "n1-standard-4",
+		project:                testVariables.ProjectID,
+		computeServiceAccount:  testVariables.ComputeServiceAccount,
+		instanceServiceAccount: testVariables.InstanceServiceAccount,
+		instanceAccessScopes:   "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/datastore",
 	}
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
@@ -381,14 +383,15 @@ func runInstanceImportDefaultServiceAccountWithMissingPermissionsSuccessTest(ctx
 		instanceName: fmt.Sprintf("test-missing-ce-permissions-%v", suffix),
 		verificationStartupScript: loadScriptContent(
 			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
-		zone:                  testProjectConfig.TestZone,
-		expectedStartupOutput: "All tests passed!",
-		failureMatches:        []string{"FAILED:", "TestFailed:"},
-		sourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
-		os:                    "centos-7",
-		machineType:           "n1-standard-4",
-		project:               testVariables.ProjectID,
-		computeServiceAccount: testVariables.ComputeServiceAccount,
+		zone:                   testProjectConfig.TestZone,
+		expectedStartupOutput:  "All tests passed!",
+		failureMatches:         []string{"FAILED:", "TestFailed:"},
+		sourceURI:              fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+		os:                     "centos-7",
+		machineType:            "n1-standard-4",
+		project:                testVariables.ProjectID,
+		computeServiceAccount:  testVariables.ComputeServiceAccount,
+		instanceServiceAccount: testVariables.InstanceServiceAccount,
 	}
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
@@ -517,6 +520,11 @@ func buildTestArgs(props *ovfInstanceImportTestProperties, testProjectConfig *te
 		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--compute-service-account=%v", props.computeServiceAccount))
 		wrapperArgs = append(wrapperArgs, fmt.Sprintf("-compute-service-account=%v", props.computeServiceAccount))
 	}
+	if props.instanceServiceAccount != "" {
+		gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--service-account=%v", props.instanceServiceAccount))
+		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--service-account=%v", props.instanceServiceAccount))
+		wrapperArgs = append(wrapperArgs, fmt.Sprintf("-service-account=%v", props.instanceServiceAccount))
+	}
 	if props.instanceAccessScopes != "" {
 		gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--scopes=%v", props.instanceAccessScopes))
 		gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--scopes=%v", props.instanceAccessScopes))
@@ -607,18 +615,18 @@ func verifyImportedInstance(
 		return
 	}
 
-	if props.computeServiceAccount != "" {
+	if props.instanceServiceAccount != "" {
 		serviceAccountMatch := false
 		var instanceServiceAccountEmails []string
 		for _, instanceServiceAccount := range instance.ServiceAccounts {
 			instanceServiceAccountEmails = append(instanceServiceAccountEmails, instanceServiceAccount.Email)
-			if instanceServiceAccount.Email == props.computeServiceAccount {
+			if instanceServiceAccount.Email == props.instanceServiceAccount {
 				serviceAccountMatch = true
 			}
 		}
 		if !serviceAccountMatch {
 			e2e.Failure(testCase, logger, fmt.Sprintf("Instance service accounts (`%v`) don't contain custom service account `%v`",
-				strings.Join(instanceServiceAccountEmails, ","), props.computeServiceAccount))
+				strings.Join(instanceServiceAccountEmails, ","), props.instanceServiceAccount))
 			return
 		}
 	}

--- a/cli_tools_tests/e2e/variables.go
+++ b/cli_tools_tests/e2e/variables.go
@@ -15,16 +15,19 @@
 package e2e
 
 const (
-	projectIDWithoutDefaultServiceAccountFlag                       = "project_id_without_default_service_account"
-	projectIDWithoutDefaultServiceAccountPermissionFlag             = "project_id_without_default_service_account_permission"
-	computeServiceAccountWithoutDefaultServiceAccountFlag           = "compute_service_account_without_default_service_account"
-	computeServiceAccountWithoutDefaultServiceAccountPermissionFlag = "compute_service_account_without_default_service_account_permission"
+	projectIDWithoutDefaultServiceAccountFlag                        = "project_id_without_default_service_account"
+	projectIDWithoutDefaultServiceAccountPermissionFlag              = "project_id_without_default_service_account_permission"
+	computeServiceAccountWithoutDefaultServiceAccountFlag            = "compute_service_account_without_default_service_account"
+	computeServiceAccountWithoutDefaultServiceAccountPermissionFlag  = "compute_service_account_without_default_service_account_permission"
+	instanceServiceAccountWithoutDefaultServiceAccountFlag           = "instance_service_account_without_default_service_account"
+	instanceServiceAccountWithoutDefaultServiceAccountPermissionFlag = "instance_service_account_without_default_service_account_permission"
 )
 
 // ServiceAccountTestVariables contains service-account related test variables.
 type ServiceAccountTestVariables struct {
-	ProjectID             string
-	ComputeServiceAccount string
+	ProjectID              string
+	ComputeServiceAccount  string
+	InstanceServiceAccount string
 }
 
 // GetServiceAccountTestVariables extract extra test variables related to service account from input variable map.
@@ -36,6 +39,8 @@ func GetServiceAccountTestVariables(argMap map[string]string, isDefaultServiceAc
 				v.ProjectID = val
 			case computeServiceAccountWithoutDefaultServiceAccountFlag:
 				v.ComputeServiceAccount = val
+			case instanceServiceAccountWithoutDefaultServiceAccountFlag:
+				v.InstanceServiceAccount = val
 			default:
 				// args not related
 			}
@@ -45,6 +50,8 @@ func GetServiceAccountTestVariables(argMap map[string]string, isDefaultServiceAc
 				v.ProjectID = val
 			case computeServiceAccountWithoutDefaultServiceAccountPermissionFlag:
 				v.ComputeServiceAccount = val
+			case instanceServiceAccountWithoutDefaultServiceAccountPermissionFlag:
+				v.InstanceServiceAccount = val
 			default:
 				// args not related
 			}

--- a/daisy_workflows/ovf_import/create_gmi.wf.json
+++ b/daisy_workflows/ovf_import/create_gmi.wf.json
@@ -32,7 +32,7 @@
       "Value": "PREMIUM",
       "Description": "Network tier that will be used to configure the instance"
     },
-    "compute_service_account": {
+    "instance_service_account": {
       "Value": "default",
       "Description": "Service account that will be used by the created instance"
     }
@@ -70,7 +70,7 @@
           "NoCleanup": true,
           "ServiceAccounts": [
             {
-              "Email": "${compute_service_account}"
+              "Email": "${instance_service_account}"
             }
           ]
         }

--- a/daisy_workflows/ovf_import/create_instance.wf.json
+++ b/daisy_workflows/ovf_import/create_instance.wf.json
@@ -31,7 +31,7 @@
       "Value": "PREMIUM",
       "Description": "Network tier that will be used to configure the instance"
     },
-    "compute_service_account": {
+    "instance_service_account": {
       "Value": "default",
       "Description": "Service account that will be used by the created instance"
     }
@@ -69,7 +69,7 @@
           "NoCleanup": true,
           "ServiceAccounts": [
             {
-              "Email": "${compute_service_account}"
+              "Email": "${instance_service_account}"
             }
           ]
         }

--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -175,6 +175,8 @@ periodics:
        - "-test_zone=us-central1-c"
        - "-variables=compute_service_account_without_default_service_account=pool-001-1-sa@compute-image-test-pool-001-1.iam.gserviceaccount.com,\
            compute_service_account_without_default_service_account_permission=pool-001-2-sa@compute-image-test-pool-001-2.iam.gserviceaccount.com,\
+           instance_service_account_without_default_service_account=pool-001-1-sa-2@compute-image-test-pool-001-1.iam.gserviceaccount.com,\
+           instance_service_account_without_default_service_account_permission=pool-001-2-sa-2@compute-image-test-pool-001-2.iam.gserviceaccount.com,\
            project_id_without_default_service_account=compute-image-test-pool-001-1,\
            project_id_without_default_service_account_permission=compute-image-test-pool-001-2"
        env:


### PR DESCRIPTION
OVF Import: introduced instance service account (applied on imported VMs/GMIs), separate from compute service account used for worker instances. This is to allow users to specify more restrictive service accounts on imported instances than needed for worker instances.