### PR TITLE
Daisy: Don't panic when workflow is canceled twice

### DIFF
--- a/cli_tools/common/utils/daisy/daisy_utils.go
+++ b/cli_tools/common/utils/daisy/daisy_utils.go
@@ -24,10 +24,11 @@ import (
 	"sort"
 	"strings"
 
-	stringutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/string"
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
+
+	stringutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/string"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
 const (
@@ -382,7 +383,7 @@ func RunWorkflowWithCancelSignal(ctx context.Context, w *daisy.Workflow) error {
 		select {
 		case <-c:
 			w.LogWorkflowInfo("\nCtrl-C caught, sending cancel signal to %q...\n", w.Name)
-			close(w.Cancel)
+			w.CancelWorkflow()
 		case <-w.Cancel:
 		}
 	}(w)

--- a/cli_tools/gce_image_publish/main.go
+++ b/cli_tools/gce_image_publish/main.go
@@ -202,7 +202,7 @@ func main() {
 			select {
 			case <-c:
 				fmt.Printf("\nCtrl-C caught, sending cancel signal to %q...\n", w.Name)
-				close(w.Cancel)
+				w.CancelWorkflow()
 				errors <- fmt.Errorf("workflow %q was canceled", w.Name)
 			case <-w.Cancel:
 			}

--- a/daisy/cli/main.go
+++ b/daisy/cli/main.go
@@ -261,7 +261,7 @@ func main() {
 			select {
 			case <-c:
 				fmt.Printf("\nCtrl-C caught, sending cancel signal to %q...\n", w.Name)
-				close(w.Cancel)
+				w.CancelWorkflow()
 				errors <- fmt.Errorf("workflow %q was canceled", w.Name)
 			case <-w.Cancel:
 			}

--- a/daisy/daisy_test_runner/main.go
+++ b/daisy/daisy_test_runner/main.go
@@ -526,7 +526,7 @@ func runTestCase(ctx context.Context, test *test, tc *junitTestCase, errors chan
 		select {
 		case <-c:
 			fmt.Printf("\nCtrl-C caught, sending cancel signal to %q...\n", test.name)
-			close(test.testCase.w.Cancel)
+			test.testCase.w.CancelWorkflow()
 			err := fmt.Errorf("test case %q was canceled", test.name)
 			errors <- err
 			tc.Failure = &junitFailure{FailMessage: err.Error(), FailType: "Canceled"}

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -111,7 +111,7 @@ Loop:
 				continue
 			}
 
-			if w.isCanceled() {
+			if w.isCanceled {
 				break Loop
 			}
 		}

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -89,7 +89,9 @@ func (v *Var) UnmarshalJSON(b []byte) error {
 // Workflow is a single Daisy workflow workflow.
 type Workflow struct {
 	// Populated on New() construction.
-	Cancel chan struct{} `json:"-"`
+	Cancel       chan struct{} `json:"-"`
+	isCanceled   bool
+	inCanceledMx sync.Mutex
 
 	// Workflow template fields.
 	// Workflow name.
@@ -235,24 +237,24 @@ func (w *Workflow) SetLogProcessHook(hook func(string) string) {
 // Validate runs validation on the workflow.
 func (w *Workflow) Validate(ctx context.Context) DError {
 	if err := w.PopulateClients(ctx); err != nil {
-		close(w.Cancel)
+		w.CancelWorkflow()
 		return Errf("error populating workflow: %v", err)
 	}
 
 	if err := w.validateRequiredFields(); err != nil {
-		close(w.Cancel)
+		w.CancelWorkflow()
 		return Errf("error validating workflow: %v", err)
 	}
 
 	if err := w.populate(ctx); err != nil {
-		close(w.Cancel)
+		w.CancelWorkflow()
 		return Errf("error populating workflow: %v", err)
 	}
 
 	w.LogWorkflowInfo("Validating workflow")
 	if err := w.validate(ctx); err != nil {
 		w.LogWorkflowInfo("Error validating workflow: %v", err)
-		close(w.Cancel)
+		w.CancelWorkflow()
 		return err
 	}
 	w.LogWorkflowInfo("Validation Complete")
@@ -299,7 +301,7 @@ func (w *Workflow) RunWithModifiers(
 	w.LogWorkflowInfo("Uploading sources")
 	if err = w.uploadSources(ctx); err != nil {
 		w.LogWorkflowInfo("Error uploading sources: %v", err)
-		close(w.Cancel)
+		w.CancelWorkflow()
 		return err
 	}
 	w.LogWorkflowInfo("Running workflow")
@@ -338,7 +340,7 @@ func (w *Workflow) cleanup() {
 	select {
 	case <-w.Cancel:
 	default:
-		close(w.Cancel)
+		w.CancelWorkflow()
 	}
 
 	// Allow goroutines that are watching w.Cancel an opportunity
@@ -748,15 +750,6 @@ func (w *Workflow) traverseDAG(f func(*Step) DError) DError {
 	return nil
 }
 
-func (w *Workflow) isCanceled() bool {
-	select {
-	case <-w.Cancel:
-		return true
-	default:
-		return false
-	}
-}
-
 // New instantiates a new workflow.
 func New() *Workflow {
 	// We can't use context.WithCancel as we use the context even after cancel for cleanup.
@@ -894,7 +887,22 @@ func (w *Workflow) IterateWorkflowSteps(cb func(step *Step)) {
 // CancelWithReason cancels workflow with a specific reason. The specific reason replaces "is canceled" in the default error message.
 func (w *Workflow) CancelWithReason(reason string) {
 	w.cancelReason = reason
-	close(w.Cancel)
+	w.CancelWorkflow()
+}
+
+// CancelWorkflow cancels the workflow. Safe to call multiple times.
+// Prefer this to closing the w.Cancel channel,
+// which will panic if it has already been closed.
+func (w *Workflow) CancelWorkflow() {
+	w.cleanupHooksMx.Lock()
+	defer w.cleanupHooksMx.Unlock()
+
+	if !w.isCanceled {
+		w.isCanceled = true
+		// Extra guard in case something manually closed the channel.
+		defer func() { recover() }()
+		close(w.Cancel)
+	}
 }
 
 func (w *Workflow) getCancelReason() string {

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -91,7 +91,7 @@ type Workflow struct {
 	// Populated on New() construction.
 	Cancel       chan struct{} `json:"-"`
 	isCanceled   bool
-	inCanceledMx sync.Mutex
+	isCanceledMx sync.Mutex
 
 	// Workflow template fields.
 	// Workflow name.
@@ -894,8 +894,8 @@ func (w *Workflow) CancelWithReason(reason string) {
 // Prefer this to closing the w.Cancel channel,
 // which will panic if it has already been closed.
 func (w *Workflow) CancelWorkflow() {
-	w.cleanupHooksMx.Lock()
-	defer w.cleanupHooksMx.Unlock()
+	w.isCanceledMx.Lock()
+	defer w.isCanceledMx.Unlock()
 
 	if !w.isCanceled {
 		w.isCanceled = true

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -167,16 +167,17 @@ func TestCancelWorkflow_IsIdempotent(t *testing.T) {
 	}
 }
 
-func TestCancelWithReason_IsIdempotent(t *testing.T) {
+func TestCancelWithReason_IsCallableMultipleTimes_AndKeepsFirstCancelReason(t *testing.T) {
 	w := testWorkflow()
-	reason := "reason"
-	w.CancelWithReason(reason)
-	w.CancelWithReason(reason)
+	reason1 := "reason1"
+	reason2 := "reason2"
+	w.CancelWithReason(reason1)
+	w.CancelWithReason(reason2)
 	if !w.isCanceled {
 		t.Error("Expect workflow to be canceled.")
 	}
-	if w.getCancelReason() != reason {
-		t.Errorf("Expected reason mismatch. got=%q, want=%q", w.getCancelReason(), reason)
+	if w.getCancelReason() != reason1 {
+		t.Errorf("Expected reason1 mismatch. got=%q, want=%q", w.getCancelReason(), reason1)
 	}
 }
 


### PR DESCRIPTION
This PR adds a method called `daisy.Workflow.CancelWorkflow()` that is idempotent, and protects against closing an already-closed channel.

Background: Image import has had panics when manually closing workflows, since we (currently) close a workflow by closing its `Cancel` channel.

Here's an example scenario that would cause a panic:

1. Daisy fails here: https://github.com/GoogleCloudPlatform/compute-image-tools/blob/423907b63e7430a8e9dbe5edb296e4811f73797a/daisy/workflow.go#L302
2. The shadow inflater reaches here: https://github.com/GoogleCloudPlatform/compute-image-tools/blob/b5310952cee40f215182002d869188396582b0c6/cli_tools/common/image/importer/inflater.go#L188

