### PR TITLE
Image import: Disable calling PD API.

### DIFF
--- a/cli_tools/common/image/importer/inflater.go
+++ b/cli_tools/common/image/importer/inflater.go
@@ -52,7 +52,9 @@ func newInflater(request ImageImportRequest, computeClient daisyCompute.Client, 
 		return nil, err
 	}
 
-	if isImage(request.Source) {
+	// TODO: Remove boolean guard when PD API is ready.
+	tryNativePDInflation := false
+	if isImage(request.Source) || !tryNativePDInflation {
 		return di, nil
 	}
 


### PR DESCRIPTION
This adds a new filed `ImageImportRequest.FormatsWithParallelInflation` which controls which disk file formats are processed in parallel using the PD API. Currently the map is empty, therefore calling the PD API is disabled.

# Testing

Ran an OVF import using the three-disk OVA that was failing with deadlock.  When run with this PR and https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1561, the import failed as expected rather than deadlocking.
