### PR TITLE
Increase build timeout to 4h

### DIFF
--- a/daisy_workflows/image_build/windows/windows-10-20h2-ent-x64-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-20h2-ent-x64-uefi-byol.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios-byol.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-bios.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2016-dc-core-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2016-dc-core-uefi-byol.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2016-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2016-dc-core-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2016-dc-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2016-dc-uefi-byol.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2016-dc-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2016-dc-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2019-dc-core-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2019-dc-core-uefi-byol.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2019-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2019-dc-core-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2019-dc-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2019-dc-uefi-byol.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-2019-dc-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2019-dc-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-sac-1909-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-sac-1909-dc-core-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-sac-2004-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-sac-2004-dc-core-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-server-sac-20h2-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-sac-20h2-dc-core-uefi-payg.wf.json
@@ -48,7 +48,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "3h",
+      "Timeout": "4h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {


### PR DESCRIPTION
The current 3h timeout is often not enough to complete a build.