### PR TITLE
import_precheck: Fail when root device spans multiple physical disks

### DIFF
--- a/cli_tools/import_precheck/check_disks_linux.go
+++ b/cli_tools/import_precheck/check_disks_linux.go
@@ -106,7 +106,7 @@ func (m *mountPoints) listPhysicalDevicesForMount(mount string) (devices []strin
 			set[mp.hierarchy[0]] = struct{}{}
 		}
 	}
-	for k, _ := range set {
+	for k := range set {
 		devices = append(devices, k)
 	}
 	// sorted for stability in testing.
@@ -120,7 +120,7 @@ func (m *mountPoints) listMountPoints() (mounts []string) {
 	for _, mount := range m.mounts {
 		set[mount.dir] = struct{}{}
 	}
-	for k, _ := range set {
+	for k := range set {
 		mounts = append(mounts, k)
 	}
 	// sorted for stability in testing.

--- a/cli_tools/import_precheck/check_disks_linux_test.go
+++ b/cli_tools/import_precheck/check_disks_linux_test.go
@@ -54,7 +54,7 @@ func Test_readMounts(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, tc.expectedListMounts, actual.listMountPoints())
+			assert.Equal(t, tc.expectedListMounts, actual.listMountedDirectories())
 			for mountDir, expectedPhysicalDevices := range tc.expectedPhysicalDevices {
 				assert.Equal(t, expectedPhysicalDevices, actual.listPhysicalDevicesForMount(mountDir))
 			}
@@ -78,7 +78,8 @@ func Test_run(t *testing.T) {
 		{
 			lsblkOutputFile: "lsblk-multi-disk-lvm.json",
 			expectAllLogs: []string{
-				"FATAL: root filesystem spans multiple physical devices ([sda sdb]). Translation only supports single block device.",
+				"FATAL: root filesystem spans multiple block devices ([sda sdb]). Typically this occurs when an LVM " +
+					"logical volume spans multiple block devices. Image import only supports single block device.",
 			},
 			expectToPass: false,
 		}, {

--- a/cli_tools/import_precheck/check_disks_linux_test.go
+++ b/cli_tools/import_precheck/check_disks_linux_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_readMounts(t *testing.T) {
+	for _, tc := range []struct {
+		lsblkOutputFile         string
+		expectedPhysicalDevices map[string][]string
+		expectedListMounts      []string
+	}{
+		{
+			lsblkOutputFile:    "lsblk-one-partition.json",
+			expectedListMounts: []string{"/"},
+			expectedPhysicalDevices: map[string][]string{
+				"/": []string{"sda"},
+			},
+		}, {
+			lsblkOutputFile:    "lsblk-multi-disk-lvm.json",
+			expectedListMounts: []string{"/", "/boot", "/mnt/tmp"},
+			expectedPhysicalDevices: map[string][]string{
+				"/":        []string{"sda", "sdb"},
+				"/boot":    []string{"sda"},
+				"/mnt/tmp": []string{"sdc"},
+			},
+		}, {
+			lsblkOutputFile:    "lsblk-efi.json",
+			expectedListMounts: []string{"/", "/boot/efi"},
+			expectedPhysicalDevices: map[string][]string{
+				"/":         []string{"sda"},
+				"/boot/efi": []string{"sda"},
+			},
+		}, {
+			lsblkOutputFile:    "lsblk-single-disk-lvm.json",
+			expectedListMounts: []string{"/", "/boot", "/boot/efi", "[SWAP]"},
+			expectedPhysicalDevices: map[string][]string{
+				"/":         []string{"sda"},
+				"/boot":     []string{"sda"},
+				"/boot/efi": []string{"sda"},
+				"[SWAP]":    []string{"sda"},
+			},
+		},
+	} {
+		t.Run(tc.lsblkOutputFile, func(t *testing.T) {
+			actual, err := (&disksCheck{
+				lsblkOverride: func() ([]byte, error) {
+					return ioutil.ReadFile("testdata/" + tc.lsblkOutputFile)
+				},
+			}).readMounts()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.expectedListMounts, actual.listMountPoints())
+			for mountDir, expectedPhysicalDevices := range tc.expectedPhysicalDevices {
+				assert.Equal(t, expectedPhysicalDevices, actual.listPhysicalDevicesForMount(mountDir))
+			}
+		})
+	}
+}
+
+func Test_run(t *testing.T) {
+	for _, tc := range []struct {
+		lsblkOutputFile string
+		expectAllLogs   []string
+		expectToPass    bool
+	}{
+		{
+			lsblkOutputFile: "lsblk-one-partition.json",
+			expectAllLogs: []string{
+				"INFO: root filesystem found on device: sda",
+			},
+			expectToPass: true,
+		},
+		{
+			lsblkOutputFile: "lsblk-multi-disk-lvm.json",
+			expectAllLogs: []string{
+				"FATAL: root filesystem spans multiple physical devices ([sda sdb]). Translation only supports single block device.",
+			},
+			expectToPass: false,
+		}, {
+			lsblkOutputFile: "lsblk-efi.json",
+			expectAllLogs: []string{
+				"INFO: root filesystem found on device: sda",
+			},
+			expectToPass: true,
+		}, {
+			lsblkOutputFile: "lsblk-single-disk-lvm.json",
+			expectAllLogs: []string{
+				"INFO: root filesystem found on device: sda",
+			},
+			expectToPass: true,
+		},
+	} {
+		t.Run(tc.lsblkOutputFile, func(t *testing.T) {
+			report, err := (&disksCheck{
+				lsblkOverride: func() ([]byte, error) {
+					return ioutil.ReadFile("testdata/" + tc.lsblkOutputFile)
+				},
+				getMBROverride: func(devName string) ([]byte, error) {
+					bytes := make([]byte, 512)
+					copy(bytes, "GRUB")
+					bytes[510] = 0x55
+					bytes[511] = 0xAA
+					return bytes, nil
+				},
+			}).run()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, expectedLog := range tc.expectAllLogs {
+				assert.Contains(t, report.logs, expectedLog)
+			}
+
+			if tc.expectToPass {
+				assert.False(t, report.failed, "Expected check to pass")
+			} else {
+				assert.True(t, report.failed, "Expected check to fail")
+			}
+		})
+	}
+}

--- a/cli_tools/import_precheck/testdata/lsblk-efi.json
+++ b/cli_tools/import_precheck/testdata/lsblk-efi.json
@@ -1,0 +1,10 @@
+{
+  "blockdevices": [
+    {"name":"sda", "mountpoint":null, "type":"disk",
+      "children": [
+        {"name":"sda1", "mountpoint":"/boot/efi", "type":"part"},
+        {"name":"sda2", "mountpoint":"/", "type":"part"}
+      ]
+    }
+  ]
+}

--- a/cli_tools/import_precheck/testdata/lsblk-multi-disk-lvm.json
+++ b/cli_tools/import_precheck/testdata/lsblk-multi-disk-lvm.json
@@ -1,0 +1,29 @@
+{
+  "blockdevices": [
+    {"name":"fd0", "mountpoint":null, "type":"disk"},
+    {"name":"sda", "mountpoint":null, "type":"disk",
+      "children": [
+        {"name":"sda1", "mountpoint":"/boot", "type":"part"},
+        {"name":"sda2", "mountpoint":null, "type":"part",
+          "children": [
+            {"name":"vg1-lv1", "mountpoint":"/", "type":"lvm"}
+          ]
+        }
+      ]
+    },
+    {"name":"sdb", "mountpoint":null, "type":"disk",
+      "children": [
+        {"name":"sdb1", "mountpoint":null, "type":"part",
+          "children": [
+            {"name":"vg1-lv1", "mountpoint":"/", "type":"lvm"}
+          ]
+        }
+      ]
+    },
+    {"name":"sdc", "mountpoint":null, "type":"disk",
+      "children": [
+        {"name":"sdc1", "mountpoint":"/mnt/tmp", "type":"part"}
+      ]
+    }
+  ]
+}

--- a/cli_tools/import_precheck/testdata/lsblk-one-partition.json
+++ b/cli_tools/import_precheck/testdata/lsblk-one-partition.json
@@ -1,0 +1,9 @@
+{
+  "blockdevices": [
+    {"name": "sda", "mountpoint": null, "type": "disk",
+      "children": [
+        {"name": "sda1", "mountpoint": "/", "type": "part"}
+      ]
+    }
+  ]
+}

--- a/cli_tools/import_precheck/testdata/lsblk-single-disk-lvm.json
+++ b/cli_tools/import_precheck/testdata/lsblk-single-disk-lvm.json
@@ -1,0 +1,16 @@
+{
+  "blockdevices": [
+    {"name":"sda", "mountpoint":null, "type":"disk",
+      "children": [
+        {"name":"sda1", "mountpoint":"/boot/efi", "type":"part"},
+        {"name":"sda2", "mountpoint":"/boot", "type":"part"},
+        {"name":"sda3", "mountpoint":null, "type":"part",
+          "children": [
+            {"name":"root", "mountpoint":"/", "type":"lvm"},
+            {"name":"swap", "mountpoint":"[SWAP]", "type":"lvm"}
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Prior to this, the precheck tool falsely reported that a system was importable when the root device spanned multiple physical disks (typically due to usage of LVM). 

## Testing

- Created a multi-disk LVM system that reproduced the original issue, and confirmed that this PR solves it.
- Added unit tests that run against `lsblk` output from four representative disk layouts (single disk, EFI, multiple disks that should pass, multiple disks that should fail).
