### PR TITLE
Added compute-image-test-pool-001-1 and compute-image-test-pool-001-2 projects to cleanerupper config

### DIFF
--- a/test-infra/prow/config.yaml
+++ b/test-infra/prow/config.yaml
@@ -46,7 +46,7 @@ periodics:
       args:
       - "-dry_run=false"
       - "-duration=24h"
-      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc"
+      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2"
       volumeMounts:
       - name: compute-image-tools-test-service-account
         mountPath: /etc/compute-image-tools-test-service-account


### PR DESCRIPTION
Added compute-image-test-pool-001-1 and compute-image-test-pool-001-2 projects to cleanerupper config after noticing stale disks from the past 3 months in these two projects.