### PR TITLE
Fix Windows 10 x86 workflow

### DIFF
--- a/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios-byol.wf.json
@@ -55,13 +55,14 @@
           "install_disk": "${install_disk}",
           "install_disk_size": "50",
           "updates": "${updates}",
-          "drivers_bucket": "gs://gce-windows-drivers-public/release/win6.3/",
+          "drivers_bucket": "gs://gce-windows-drivers-public/release/win10-32bit/",
           "dotnet48": "${dotnet48}",
           "pwsh": "${pwsh}",
           "edition": "Windows 10 ENTERPRISE",
           "media": "${media}",
           "cloud_sdk": "${cloudsdk}",
           "google_cloud_repo": "${google_cloud_repo}",
+          "x86_build": "true",
           "workflow_root": "${workflow_root}"
         }
       }

--- a/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios-byol.wf.json
@@ -46,6 +46,15 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     }
   },
+  "Sources": {
+    "components/googet.exe": "gs://win-32bit-files/googet/googet.exe",
+    "components/google-compute-engine-windows-x86.x86_32.4.6.0@1.goo": "gs://win-32bit-files/googet/google-compute-engine-windows-x86.x86_32.4.6.0@1.goo",
+    "components/google-compute-engine-powershell.noarch.1.1.1@4.goo": "gs://win-32bit-files/googet/google-compute-engine-powershell.noarch.1.1.1@4.goo",
+    "components/certgen-x86.x86_32.1.0.0@2.goo": "gs://win-32bit-files/googet/certgen-x86.x86_32.1.0.0@2.goo",
+    "components/google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo": "gs://win-32bit-files/googet/google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo",
+    "components/google-compute-engine-sysprep.noarch.3.10.1@1.goo": "gs://win-32bit-files/googet/google-compute-engine-sysprep.noarch.3.10.1@1.goo",
+    "components/googet-x86.x86_32.2.16.3@1.goo": "gs://win-32bit-files/googet/googet-x86.x86_32.2.16.3@1.goo"
+  },
   "Steps": {
     "windows-build": {
       "Timeout": "4h",

--- a/daisy_workflows/image_build/windows/windows-build-bios.wf.json
+++ b/daisy_workflows/image_build/windows/windows-build-bios.wf.json
@@ -56,10 +56,6 @@
     "bginfo": {
       "Description": "GCS or local path to BGInfo installer"
     },
-    "uefi_build": {
-      "Value": "true",
-      "Description": "Is this a UEFI build"
-    },
     "x86_build": {
       "Value": "false",
       "Description": "A build of a Windows 32-bit OS"


### PR DESCRIPTION
* Remove unused uefi_build variable
* Use proper drivers bucket
* Set x86 flag
* Use googet packages from public bucket

I am not sure if referencing the `gs://win-32bit-files/` bucket is the right way to go here, but I am not aware of a different public source for the googet packages.

Also, `gs://win-32bit-files/googet/googet.exe` is outdated and has [this bug](https://github.com/google/googet/issues/58), this currently causes x86 builds to fail.

**do not merge yet**