### PR TITLE
EL import: Retry GuestFS cleanup on failure

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -363,7 +363,8 @@ def cleanup(g: guestfs.GuestFS):
       logging.debug('try again in 10 seconds')
       time.sleep(10)
   if not success:
-    logging.debug('Unmount failed. Continuing anyway.')
+    logging.debug('Shutdown failed. Continuing anyway.')
+
 
 def main():
   disk = '/dev/sdb'


### PR DESCRIPTION
The CentOS 8 import tests occasionally fail during post-translate-boot with an XFS corruption: `XFS (dm-1): Internal error XFS_WANT_CORRUPTED_RETURN at line 1526 of file fs/xfs/libxfs/xfs_ialloc.c.  Caller xfs_dialloc_ag+0x189/0x280`

https://prow.k8s.io/view/gs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1376882538995257344

Looking at translation logs for failing and successful test runs, there's a failure when unmounting the guest's filesystem:

```
Mar 30 15:37:47 inst-translator-translate-translate-disk-zzpg1 GCEMetadataScripts[824]: 2021/03/30 15:37:47 GCEMetadataScripts: startup-script-url: TranslateDebug: umount_all: umount: /sysroot/dev: umount: /sysroot/dev: target is busy
Mar 30 15:37:47 inst-translator-translate-translate-disk-zzpg1 GCEMetadataScripts[824]: 2021/03/30 15:37:47 GCEMetadataScripts: startup-script-url:         (In some cases useful info about processes that
Mar 30 15:37:47 inst-translator-translate-translate-disk-zzpg1 GCEMetadataScripts[824]: 2021/03/30 15:37:47 GCEMetadataScripts: startup-script-url:          use the device is found by lsof(8) or fuser(1).)
```

This PR introduces three changes:
1. Call `shutdown` and `close` as described in https://libguestfs.org/guestfs-python.3.html
2. Remove `umount`, since that is performed during `shutdown`.
3. If there's a failure during `shutdown` or `close`, wait and retry.

Why these changes? `umount` fails since a process is using the mount. It's  [shutdown](https://libguestfs.org/guestfs.3.html#guestfs_shutdown)'s job to end these processes *and* unmount the guest's filesystem.  

The fix is limited to EL for now; if this solves the intermittent XFS errors, we can update all distros to use this cleanup routine.