### PR TITLE
Image import: Install OS Config agent in Ubuntu

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -79,16 +79,14 @@ type testCase struct {
 var basicCases = []*testCase{
 	// Disk image formats
 	{
-		caseName:             "vhd-ubuntu-1804",
-		source:               "gs://compute-image-tools-test-resources/ubuntu-1804-azure.vhd",
-		os:                   "ubuntu-1804",
-		osConfigNotSupported: true,
+		caseName: "vhd-ubuntu-1804",
+		source:   "gs://compute-image-tools-test-resources/ubuntu-1804-azure.vhd",
+		os:       "ubuntu-1804",
 	},
 	{
-		caseName:             "vpc-file-format-ubuntu-1804",
-		source:               "gs://compute-image-tools-test-resources/ubuntu-1804.vpc",
-		os:                   "ubuntu-1804",
-		osConfigNotSupported: true,
+		caseName: "vpc-file-format-ubuntu-1804",
+		source:   "gs://compute-image-tools-test-resources/ubuntu-1804.vpc",
+		os:       "ubuntu-1804",
 	},
 
 	// Error messages
@@ -124,25 +122,21 @@ var basicCases = []*testCase{
 		os:                   "ubuntu-1404",
 		osConfigNotSupported: true,
 	}, {
-		caseName:             "ubuntu-1604",
-		source:               "projects/compute-image-tools-test/global/images/ubuntu-1604-vmware-import",
-		os:                   "ubuntu-1604",
-		osConfigNotSupported: true,
+		caseName: "ubuntu-1604",
+		source:   "projects/compute-image-tools-test/global/images/ubuntu-1604-vmware-import",
+		os:       "ubuntu-1604",
 	}, {
-		caseName:             "ubuntu-1804",
-		source:               "gs://compute-image-tools-test-resources/ubuntu-1804-vmware.vmdk",
-		os:                   "ubuntu-1804",
-		osConfigNotSupported: true,
+		caseName: "ubuntu-1804",
+		source:   "gs://compute-image-tools-test-resources/ubuntu-1804-vmware.vmdk",
+		os:       "ubuntu-1804",
 	}, {
-		caseName:             "ubuntu-2004",
-		source:               "projects/compute-image-tools-test/global/images/ubuntu-2004",
-		os:                   "ubuntu-2004",
-		osConfigNotSupported: true,
+		caseName: "ubuntu-2004",
+		source:   "projects/compute-image-tools-test/global/images/ubuntu-2004",
+		os:       "ubuntu-2004",
 	}, {
-		caseName:             "ubuntu-2004-aws",
-		source:               "projects/compute-image-tools-test/global/images/ubuntu-2004-aws",
-		os:                   "ubuntu-2004",
-		osConfigNotSupported: true,
+		caseName: "ubuntu-2004-aws",
+		source:   "projects/compute-image-tools-test/global/images/ubuntu-2004-aws",
+		os:       "ubuntu-2004",
 	},
 
 	// OpenSUSE
@@ -341,21 +335,18 @@ var inspectUEFICases = []*testCase{
 		// source created from projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317
 		source:                    "gs://compute-image-tools-test-resources/uefi/linux-protective-mbr-ubuntu-1804.vmdk",
 		os:                        "ubuntu-1804",
-		osConfigNotSupported:      true,
 		notAllowedGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
 	}, {
 		caseName: "inspect-uefi-linux-dual-hybrid-mbr-ubuntu-2004",
 		// source created from scratch
 		source:                    "gs://compute-image-tools-test-resources/uefi/linux-hybrid-mbr-ubuntu-2004.vmdk",
 		os:                        "ubuntu-2004",
-		osConfigNotSupported:      true,
 		notAllowedGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
 	}, {
 		caseName: "inspect-uefi-linux-uefi-mbr-ubuntu-1804",
 		// source created from projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317 and converted from GPT to MBR
 		source:                  "gs://compute-image-tools-test-resources/uefi/linux-ubuntu-mbr-uefi.vmdk",
 		os:                      "ubuntu-1804",
-		osConfigNotSupported:    true,
 		requiredGuestOsFeatures: []string{"UEFI_COMPATIBLE"},
 	}, {
 		caseName: "inspect-uefi-windows-uefi",

--- a/cli_tools_tests/e2e/gce_ovf_export/test_suites/instance_ovf_export/instance_ovf_export_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_export/test_suites/instance_ovf_export/instance_ovf_export_test_suite.go
@@ -26,13 +26,14 @@ import (
 	"sync"
 	"time"
 
+	computeBeta "google.golang.org/api/compute/v0.beta"
+
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools_tests/e2e"
 	"github.com/GoogleCloudPlatform/compute-image-tools/common/gcp"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/junitxml"
 	testconfig "github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/test_config"
-	computeBeta "google.golang.org/api/compute/v0.beta"
 )
 
 const (
@@ -106,7 +107,6 @@ func runInstanceOVFExportUbuntu3Disks(ctx context.Context, testCase *junitxml.Te
 		expectedStartupOutput: "All tests passed!",
 		failureMatches:        []string{"FAILED:", "TestFailed:"},
 		sourceGMI:             "projects/compute-image-test-pool-001/global/machineImages/ubuntu-1604-three-disks-do-not-delete",
-		instanceMetadata:      skipOSConfigMetadata,
 		os:                    "ubuntu-1604",
 		destinationURI:        fmt.Sprintf("gs://%v/%v/", exportBucket, exportPath),
 		exportBucket:          exportBucket,

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -141,7 +141,6 @@ func runOVFInstanceImportUbuntu3DisksNetworkSettingsName(ctx context.Context, te
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
 			SourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-1604-three-disks", ovaBucket),
-			InstanceMetadata:      skipOSConfigMetadata,
 			Os:                    "ubuntu-1604",
 			MachineType:           "n1-standard-4",
 			Network:               fmt.Sprintf("%v-vpc-1", testProjectConfig.TestProjectID),
@@ -245,7 +244,6 @@ func runOVFInstanceImportUbuntu16FromVirtualBox(ctx context.Context, testCase *j
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
 			SourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-16.04-virtualbox.ova", ovaBucket),
 			Os:                    "ubuntu-1604",
-			InstanceMetadata:      skipOSConfigMetadata,
 			MachineType:           "n1-standard-4",
 		}}
 

--- a/daisy_integration_tests/ubuntu_1604_vmware_translate.wf.json
+++ b/daisy_integration_tests/ubuntu_1604_vmware_translate.wf.json
@@ -38,9 +38,6 @@
             }
           ],
           "machineType": "n1-standard-4",
-          "Metadata": {
-            "osconfig_not_supported": "true"
-          },
           "name": "inst-import-test",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1804_aws.wf.json
+++ b/daisy_integration_tests/ubuntu_1804_aws.wf.json
@@ -34,9 +34,6 @@
             }
           ],
           "machineType": "n1-standard-4",
-          "Metadata": {
-            "osconfig_not_supported": "true"
-          },
           "name": "test-the-image",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1804_azure.wf.json
+++ b/daisy_integration_tests/ubuntu_1804_azure.wf.json
@@ -34,9 +34,6 @@
             }
           ],
           "machineType": "n1-standard-4",
-          "Metadata": {
-            "osconfig_not_supported": "true"
-          },
           "name": "test-the-image-instance",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_integration_tests/ubuntu_1804_vmware.wf.json
+++ b/daisy_integration_tests/ubuntu_1804_vmware.wf.json
@@ -34,9 +34,6 @@
             }
           ],
           "machineType": "n1-standard-4",
-          "Metadata": {
-            "osconfig_not_supported": "true"
-          },
           "name": "test-the-image-instance",
           "StartupScript": "post_translate_test.sh"
         }

--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -193,6 +193,16 @@ def install_cloud_sdk(g: guestfs.GuestFS, ubuntu_release: str) -> None:
     logging.debug('[%s] PATH not defined. Added:\n%s', p, diff)
 
 
+def install_osconfig_agent(g: guestfs.GuestFS):
+  try:
+    utils.install_apt_packages(g, 'google-osconfig-agent')
+  except RuntimeError:
+    logging.info(
+      'Failed to install the OS Config agent. '
+      'For manual install instructions, see '
+      'https://cloud.google.com/compute/docs/manage-os#agent-install .')
+
+
 def DistroSpecific(g):
   ubuntu_release = utils.GetMetadataAttribute('ubuntu_release')
   install_gce = utils.GetMetadataAttribute('install_gce_packages')
@@ -236,6 +246,8 @@ def DistroSpecific(g):
 
     g.write('/etc/cloud/cloud.cfg.d/91-gce-system.cfg', cloud_init_repos)
 
+    if g.gcp_image_major > '14':
+      install_osconfig_agent(g)
     utils.install_apt_packages(g, 'gce-compute-image-packages')
     install_cloud_sdk(g, ubuntu_release)
 


### PR DESCRIPTION
Following this PR, when an Ubuntu import includes the guest environment, the OS Config agent will be installed.

There are some caveats:
 - The agent is only available in 16.04 and newer: https://packages.ubuntu.com/search?keywords=google-osconfig-agent
 - The package is available in Ubuntu's `updates` repo, which is an optional repo. If installation fails, we write a log with manual install instructions.