### PR TITLE
OVF import fixes to support Oracle provided Oracle Linux OVAs

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/export/image_export_test_suite.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/export/image_export_test_suite.go
@@ -57,15 +57,15 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 
 	for _, testType := range testTypes {
 		imageExportRawTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", testType, "Export Raw"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Raw"))
 		imageExportVMDKTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", testType, "Export VMDK"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "VMDK"))
 		imageExportWithRichParamsTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", testType, "Export with rich params"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "With rich params"))
 		imageExportWithDifferentNetworkParamStyles := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", testType, "Export with different network param styles"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "With different network param styles"))
 		imageExportWithSubnetWithoutNetworkTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", testType, "Export with subnet but without network"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "With subnet but without network"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -78,9 +78,9 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 
 	// Only test service account scenario for wrapper, until gcloud support it.
 	imageExportRawWithoutDefaultServiceAccountTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", e2e.Wrapper, "Export Raw without default service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Raw without default service account"))
 	imageExportVMDKDefaultServiceAccountWithMissingPermissionsTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][ImageExport] %v", e2e.Wrapper, "Export VMDK without default service account permission"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "VMDK without default service account permission"))
 	testsMap[e2e.Wrapper][imageExportRawWithoutDefaultServiceAccountTestCase] = runImageExportRawWithoutDefaultServiceAccountTest
 	testsMap[e2e.Wrapper][imageExportVMDKDefaultServiceAccountWithMissingPermissionsTestCase] = runImageExportVMDKDefaultServiceAccountWithMissingPermissionsTest
 

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
@@ -70,17 +70,17 @@ func CLITestSuite(
 
 	for _, testType := range testTypes {
 		imageImportDataDiskTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import data disk"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import data disk"))
 		imageImportOSTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import OS"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import OS"))
 		imageImportOSFromImageTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import OS from image"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import OS from image"))
 		imageImportWithRichParamsTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with rich params"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with rich params"))
 		imageImportWithDifferentNetworkParamStylesTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with different network param styles"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with different network param styles"))
 		imageImportWithSubnetWithoutNetworkSpecifiedTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import with subnet but without network"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with subnet but without network"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -93,19 +93,19 @@ func CLITestSuite(
 
 		// TODO: recover this test only when shadow test is enabled.
 		//imageImportShadowDiskCleanedUpWhenMainInflaterFails := junitxml.NewTestCase(
-		//	testSuiteName, fmt.Sprintf("[%v][CLI] %v", testType, "Import shadow disk is cleaned up when main inflater fails"))
+		//	testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import shadow disk is cleaned up when main inflater fails"))
 		//testsMap[testType][imageImportShadowDiskCleanedUpWhenMainInflaterFails] = runImageImportShadowDiskCleanedUpWhenMainInflaterFails
 	}
 
 	// Only test service account scenario for wrapper, till gcloud support it.
 	imageImportOSWithDisabledDefaultServiceAccountSuccessTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Import OS without default service account, success by specifying a custom account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Import OS without default service account, success by specifying a custom account"))
 	imageImportOSDefaultServiceAccountWithMissingPermissionsSuccessTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Import OS without permission on default service account, success by specifying a custom account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Import OS without permission on default service account, success by specifying a custom account"))
 	imageImportOSWithDisabledDefaultServiceAccountFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Import OS without default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Import OS without default service account failed"))
 	imageImportOSDefaultServiceAccountWithMissingPermissionsFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.Wrapper, "Import OS without permission on default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Import OS without permission on default service account failed"))
 	testsMap[e2e.Wrapper][imageImportOSWithDisabledDefaultServiceAccountSuccessTestCase] = runImageImportOSWithDisabledDefaultServiceAccountServiceSuccessTest
 	testsMap[e2e.Wrapper][imageImportOSDefaultServiceAccountWithMissingPermissionsSuccessTestCase] = runImageImportOSDefaultServiceAccountWithMissingPermissionsSuccessTest
 	testsMap[e2e.Wrapper][imageImportOSWithDisabledDefaultServiceAccountFailTestCase] = runImageImportOSWithDisabledDefaultServiceAccountServiceFailTest

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
@@ -59,9 +59,9 @@ func OnestepImageImportSuite(
 
 	for _, testType := range testTypes {
 		onestepImageImportFromAWSUbuntuAMI := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OnestepImageImport] %v", testType, "Onestep image import from AWS Ubuntu-1804 AMI"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "From AWS Ubuntu-1804 AMI"))
 		onestepImageImportFromAWSUbuntuVMDK := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OnestepImageImport] %v", testType, "Onestep image import from AWS Ubuntu-1804 VMDK"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "From AWS Ubuntu-1804 VMDK"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -73,17 +73,17 @@ func OnestepImageImportSuite(
 	// logic for windows are exactly the same as for linux, so no need to
 	// duplicate them too much.
 	onestepImageImportFromAWSWindowsAMI := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][OnestepImageImport] %v", e2e.Wrapper, "Onestep image import from AWS Windows-2019 AMI"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "From AWS Windows-2019 AMI"))
 	onestepImageImportFromAWSWindowsVMDK := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][OnestepImageImport] %v", e2e.Wrapper, "Onestep image import from AWS Windows-2019 VMDK"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "From AWS Windows-2019 VMDK"))
 	testsMap[e2e.Wrapper][onestepImageImportFromAWSWindowsAMI] = runOnestepImageImportFromAWSWindowsAMI
 	testsMap[e2e.Wrapper][onestepImageImportFromAWSWindowsVMDK] = runOnestepImageImportFromAWSWindowsVMDK
 
 	// Only test service account scenario for wrapper, till gcloud support it.
 	onestepImageImportWithDisabledDefaultServiceAccountSuccess := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][OnestepImageImport] %v", e2e.Wrapper, "Onestep import without default service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Without default service account"))
 	onestepImageImportDefaultServiceAccountWithMissingPermissionsSuccess := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][OnestepImageImport] %v", e2e.Wrapper, "Onestep import without default service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "Without default service account"))
 	testsMap[e2e.Wrapper][onestepImageImportWithDisabledDefaultServiceAccountSuccess] = runOnestepImageImportWithDisabledDefaultServiceAccountSuccess
 	testsMap[e2e.Wrapper][onestepImageImportDefaultServiceAccountWithMissingPermissionsSuccess] = runOnestepImageImportDefaultServiceAccountWithMissingPermissionsSuccess
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -76,19 +76,19 @@ func TestSuite(
 	}
 	for _, testType := range testTypes {
 		instanceImportUbuntu3DisksTestCaseNetworkSettingsName := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Ubuntu 3 disks, one data disk larger than 10GB, network setting (name only)"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 3 disks, one data disk larger than 10GB, network setting (name only)"))
 		instanceImportWindows2012R2TwoDisksNetworkSettingsPath := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Windows 2012 R2 two disks, network setting (path)"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Windows 2012 R2 two disks, network setting (path)"))
 		instanceImportWindows2016 := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Windows 2016"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Windows 2016"))
 		instanceImportWindows2008R2FourNICs := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Windows 2008r2 - Four NICs"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Windows 2008r2 - Four NICs"))
 		instanceImportDebian9 := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Debian 9"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Debian 9"))
 		instanceImportUbuntu16FromVirtualBox := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Ubuntu 1604 from Virtualbox"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 1604 from Virtualbox"))
 		instanceImportUbuntu16FromAWS := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFInstanceImport] %v", testType, "Ubuntu 1604 from AWS"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 1604 from AWS"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -100,21 +100,22 @@ func TestSuite(
 		testsMap[testType][instanceImportUbuntu16FromVirtualBox] = runOVFInstanceImportUbuntu16FromVirtualBox
 		testsMap[testType][instanceImportUbuntu16FromAWS] = runOVFInstanceImportUbuntu16FromAWS
 	}
-	// Only test service account scenario for wrapper, till gcloud supports it.
+
+	// gcloud only tests
 	instanceImportDisabledDefaultServiceAccountSuccessTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import without default service account, success by specifying a custom Compute service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No default service account, success by specifying custom Compute service account (Oracle Linux as CentOS)"))
 	instanceImportDefaultServiceAccountWithMissingPermissionsSuccessTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import without permission on default service account, success by specifying a custom Compute service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No permission on default service account, success by specifying a custom Compute service account"))
 	instanceImportDisabledDefaultServiceAccountFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import without default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No default service account, failed"))
 	instanceImportDefaultServiceAccountWithMissingPermissionsFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import without permission on default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No permission on default service account, failed"))
 	instanceImportDefaultServiceAccountCustomAccessScopeTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import with default service account custom access scopes"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No default service account, custom access scopes"))
 	instanceImportDefaultServiceAccountNoAccessScopeTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import with default service account no access scopes"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No default service account, no access scopes"))
 	instanceImportNoServiceAccountTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Instance import with no service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "No service account"))
 
 	testsMap[e2e.Wrapper][instanceImportDisabledDefaultServiceAccountSuccessTestCase] = runInstanceImportDisabledDefaultServiceAccountSuccessTest
 	testsMap[e2e.Wrapper][instanceImportDefaultServiceAccountWithMissingPermissionsSuccessTestCase] = runInstanceImportDefaultServiceAccountWithMissingPermissionsSuccessTest
@@ -282,7 +283,7 @@ func runInstanceImportDisabledDefaultServiceAccountSuccessTest(ctx context.Conte
 			Zone:                   testProjectConfig.TestZone,
 			ExpectedStartupOutput:  "All tests passed!",
 			FailureMatches:         []string{"FAILED:", "TestFailed:"},
-			SourceURI:              fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+			SourceURI:              fmt.Sprintf("gs://%v/ova/OL7U9_x86_64-olvm-b77.ova", ovaBucket),
 			Os:                     "centos-7",
 			MachineType:            "n1-standard-4",
 			Project:                testVariables.ProjectID,

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -80,11 +80,11 @@ func TestSuite(
 	}
 	for _, testType := range testTypes {
 		machineImageImportUbuntu3DisksNetworkSettingsNameTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFMachineImageImport] %v", testType, "Ubuntu 3 disks, one data disk larger than 10GB, Network setting (name only)"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 3 disks, one data disk larger than 10GB, Network setting (name only)"))
 		machineImageImportWindows2012R2TwoDisksNetworkSettingsPathTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFMachineImageImport] %v", testType, "Windows 2012 R2 two disks, Network setting (path)"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Windows 2012 R2 two disks, Network setting (path)"))
 		machineImageImportStorageLocationTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v][OVFMachineImageImport] %v", testType, "Centos 7.4, Storage location"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Centos 7.4, Storage location"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -93,17 +93,17 @@ func TestSuite(
 		testsMap[testType][machineImageImportStorageLocationTestCase] = runOVFMachineImageImportCentos74StorageLocation
 	}
 
-	// Only test service account scenario for wrapper, till gcloud supports it.
+	// gcloud only tests
 	machineImageImportDisabledDefaultServiceAccountSuccessTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without default service account, success by specifying a custom Compute service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without default service account, success by specifying a custom Compute service account"))
 	machineImageImportDefaultServiceAccountWithMissingPermissionsSuccessTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without permission on default service account, success by specifying a custom Compute service account"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without permission on default service account, success by specifying a custom Compute service account"))
 	machineImageImportDisabledDefaultServiceAccountFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without default service account failed"))
 	machineImageImportDefaultServiceAccountWithMissingPermissionsFailTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without permission on default service account failed"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import without permission on default service account failed"))
 	machineImageImportDefaultServiceAccountCustomAccessScopeTestCase := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v][CLI] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import with default service account custom access scopes set"))
+		testSuiteName, fmt.Sprintf("[%v] %v", e2e.GcloudBetaLatestWrapperLatest, "Machine image import with default service account custom access scopes set"))
 	testsMap[e2e.Wrapper][machineImageImportDisabledDefaultServiceAccountSuccessTestCase] = runMachineImageImportDisabledDefaultServiceAccountSuccessTest
 	testsMap[e2e.Wrapper][machineImageImportDefaultServiceAccountWithMissingPermissionsSuccessTestCase] = runMachineImageImportOSDefaultServiceAccountWithMissingPermissionsSuccessTest
 	testsMap[e2e.Wrapper][machineImageImportDisabledDefaultServiceAccountFailTestCase] = runMachineImageImportWithDisabledDefaultServiceAccountFailTest


### PR DESCRIPTION
OVF import fixes to support Oracle provided Oracle Linux OVAs: 
* disks that are not attached to any controllers in OVF descriptor
* another format for disk host resource prefix (`ovf:disk/`)
* added E2E test for Oracle Linux as CentOS
* E2E test naming cleanup 

Run the new E2E test and tested manually with https://yum.oracle.com/templates/OracleLinux/OL7/u9/x86_64/OL7U9_x86_64-olvm-b77.ova