### PR TITLE
publish empty metadata

### DIFF
--- a/daisy_workflows/export_metadata/export-metadata.py
+++ b/daisy_workflows/export_metadata/export-metadata.py
@@ -89,7 +89,7 @@ def main():
                                check=True)
     except subprocess.CalledProcessError as e:
       logging.info('failed to execute cmd: %s stdout: %s stderr: %s', e,
-                    e.stdout, e.stderr)
+                   e.stdout, e.stderr)
       continue
 
     stdout = process.stdout.decode()
@@ -129,7 +129,7 @@ def make_pkg_metadata(name, version, epoch, commit_hash):
   if epoch:
     version = '%s:%s' % (epoch, version)
 
-  return { 'name': name, 'version': version, 'commit_hash': commit_hash }
+  return {'name': name, 'version': version, 'commit_hash': commit_hash}
 
 
 if __name__ == '__main__':

--- a/daisy_workflows/export_metadata/export_metadata.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata.wf.json
@@ -60,7 +60,6 @@
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/export_metadata",
             "script": "export-metadata.py",
-            "metadata_dest": "${metadata_dest}",
             "image_id": "${image_id}",
             "image_name": "${image_name}",
             "image_family": "${image_family}",
@@ -94,11 +93,20 @@
         "Instances": ["inst-exporter"],
         "Disks":["disk-exporterprep", "source-disk"]
       }
+    },
+    "copy-to-destination": {
+      "CopyGCSObjects": [
+        {
+          "Source": "${OUTSPATH}/metadata.json",
+          "Destination": "${metadata_dest}"
+        }
+      ]
     }
   },
   "Dependencies": {
     "run": ["setup-disks"],
     "wait": ["run"],
-    "delete-inst": ["wait"]
+    "delete-inst": ["wait"],
+    "copy-to-destination": ["wait"]
   }
 }


### PR DESCRIPTION
* continue on per-package errors, allowing empty package metadata
* move final copy to daisy workflow for cleaner soc and permissions
* capture all exceptions during upload to give better error messages