### PR TITLE
Replace 'google.com' with 'google_com' in bucket names.

### DIFF
--- a/cli_tools/common/utils/storage/scratch_bucket_creator.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator.go
@@ -152,7 +152,8 @@ func (c *ScratchBucketCreator) getBucketAttrsIfInProject(project string, bucketN
 }
 
 func (c *ScratchBucketCreator) formatScratchBucketName(project string, location string) string {
-	bucket := strings.Replace(strings.Replace(project, "google.com", "google_com", -1), ":", "-", -1) + "-daisy-bkt"
+	bucket := strings.Replace(project, "google.com", "elgoog.com", -1)
+	bucket = strings.Replace(bucket, ":", "-", -1) + "-daisy-bkt"
 	if location != "" {
 		bucket = bucket + "-" + location
 	}

--- a/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
@@ -68,7 +68,7 @@ func TestCreateScratchBucketNoSourceFileTranslateGoogleDomainDefaultBucketCreate
 	defer mockCtrl.Finish()
 
 	project := "google.com:proJect1"
-	expectedBucket := "elgoog.com_project1-daisy-bkt-us"
+	expectedBucket := "elgoog.com-project1-daisy-bkt-us"
 	expectedRegion := "US"
 	ctx := context.Background()
 

--- a/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
@@ -63,6 +63,29 @@ func TestCreateScratchBucketNoSourceFileDefaultBucketCreatedBasedOnDefaultRegion
 	assert.Nil(t, err)
 }
 
+func TestCreateScratchBucketNoSourceFileTranslateGoogleDomainDefaultBucketCreatedBasedOnDefaultRegion(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	project := "google.com:proJect1"
+	expectedBucket := "elgoog.com_project1-daisy-bkt-us"
+	expectedRegion := "US"
+	ctx := context.Background()
+
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().CreateBucket(expectedBucket, project, &storage.BucketAttrs{
+		Name:         expectedBucket,
+		Location:     defaultRegion,
+		StorageClass: defaultStorageClass,
+	}).Return(nil)
+
+	c := ScratchBucketCreator{mockStorageClient, ctx, createMockBucketIteratorWithRandomBuckets(mockCtrl, &ctx, mockStorageClient, project)}
+	bucket, region, err := c.CreateScratchBucket("", project, "")
+	assert.Equal(t, expectedBucket, bucket)
+	assert.Equal(t, expectedRegion, region)
+	assert.Nil(t, err)
+}
+
 func TestCreateScratchBucketNoSourceFileBucketCreatedBasedOnInputZone(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
Cloud Bucket policy prevents the use of 'google.com' in the name. Replace it with the friendlier 'google_com' so we don't also chop off the front of the scratch bucket name.