### PR TITLE
Revert "Disabling CentOS image import tests"

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -237,6 +237,10 @@ var basicCases = []*testCase{
 		source:   "projects/compute-image-tools-test/global/images/centos-7-8",
 		os:       "centos-7",
 	}, {
+		caseName: "el-centos-8-0",
+		source:   "projects/compute-image-tools-test/global/images/centos-8-import",
+		os:       "centos-8",
+	}, {
 		caseName: "el-centos-8-3",
 		source:   "projects/compute-image-tools-test/global/images/centos-8-3",
 		os:       "centos-8",

--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -41,6 +41,9 @@
     "centos7 qcow2 translate": {
       "Path": "./centos_7_qcow2_translate.wf.json"
     },
+    "centos8 translate": {
+      "Path": "./centos_8_translate.wf.json"
+    },
     "debian8 translate": {
       "Path": "./debian_8_translate.wf.json"
     },


### PR DESCRIPTION
Reverts GoogleCloudPlatform/compute-image-tools#1616