### PR TITLE
Adding "server sent GOAWAY" as a response that should be retried.

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -222,7 +222,7 @@ func shouldRetryWithWait(tripper http.RoundTripper, err error, multiplier int) b
 	apiErr, ok := err.(*googleapi.Error)
 	var retry bool
 	switch {
-	case !ok && (strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "unexpected EOF")):
+	case !ok && (strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "unexpected EOF")) || strings.Contains(err.Error(), "server sent GOAWAY"):
 		retry = true
 	case !ok && tkValid:
 		// Not a googleapi.Error and the token is still valid.
@@ -346,7 +346,7 @@ func (c *client) operationsWaitHelper(project, name string, getOperation operati
 
 		switch op.Status {
 		case "PENDING", "RUNNING":
-			time.Sleep(1 * time.Second)
+			time.Sleep(5 * time.Second)
 			continue
 		case "DONE":
 			if op.Error != nil {

--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -219,14 +219,13 @@ func shouldRetryWithWait(tripper http.RoundTripper, err error, multiplier int) b
 		}
 	}
 
-
 	apiErr, ok := err.(*googleapi.Error)
 	var retry bool
 	switch {
 	case !ok && (strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "unexpected EOF")):
 		retry = true
 	case !ok && (strings.Contains(err.Error(), "server sent GOAWAY") || strings.Contains(err.Error(), "ENHANCE_YOUR_CALM")):
-		// The wait operation can return GOAWAY/ENHANCE_YOUR_CALM messages,
+		// The wait operation can return GOAWAY/ENHANCE_YOUR_CALM messages, so doubling the wait multiplier as it based on the retry count.
 		multiplier = multiplier * 2
 		retry = true
 	case !ok && tkValid:


### PR DESCRIPTION
- Adding "server sent GOAWAY" as a response that should be retried.
- Sleeping 5 seconds instead of 1 second, when a "PENDING", "RUNNING" operation status is received.