### PR TITLE
Image import: Add support for SLES 15.0

### DIFF
--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -122,6 +122,16 @@ _releases = [
     ),
     _SuseRelease(
         product='sles',
+        major='15',
+        minor='0',
+        cloud_product='sle-module-public-cloud/{major}/x86_64',
+        on_demand_rpms=_Tarball(
+            _on_demand_rpm_pattern.format(major=15, timestamp=1599058662),
+            '156e43507d4c74c532b2f03286f47a2b609d32521be3e96dbc8fbad0b2976231'
+        )
+    ),
+    _SuseRelease(
+        product='sles',
         major='12',
         minor='4|5',
         cloud_product='sle-module-public-cloud/{major}/x86_64',


### PR DESCRIPTION
This adds support for importing SLES 15.0 (we currently have support for SLES 15 SP1 and SP2). Manually tested (see below). E2E tests will come in a PR tomorrow; submitting this now to unblock a user.

## Testing
- Manually tested importing the following:
    - SLES  for SAP 15.0  BYOL
    -  SLES 15.0 on-demand  
    - SLES for SAP 15.0 on-demand 