### PR TITLE
Add -byol string to avoid building SPLA image

### DIFF
--- a/daisy_workflows/image_build/windows/windows-server-2019-dc-core-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2019-dc-core-uefi-byol.wf.json
@@ -76,7 +76,7 @@
           "Family": "${family}",
           "Description": "${description}",
           "Licenses": [
-            "projects/windows-cloud/global/licenses/windows-server-2019-dc",
+            "projects/windows-cloud/global/licenses/windows-server-2019-byol",
             "projects/windows-cloud/global/licenses/windows-server-core"
           ],
           "GuestOsFeatures": [


### PR DESCRIPTION
This PR changes the licensing string for Windows Server 2019 Core BYOL workflow (`windows-server-2019-dc-core-uefi-byol.wf.json`) from SPLA to BYOL.