### PR TITLE
Updating DeprecationStatus in Daisy Alpha API

### DIFF
--- a/daisy/step_deprecate_images.go
+++ b/daisy/step_deprecate_images.go
@@ -46,7 +46,7 @@ func (d *DeprecateImages) populate(ctx context.Context, s *Step) DError {
 }
 
 func (d *DeprecateImages) validate(ctx context.Context, s *Step) DError {
-	deprecationStates := []string{"", "DEPRECATED", "OBSOLETE", "DELETED"}
+	deprecationStates := []string{"", "ACTIVE", "DEPRECATED", "OBSOLETE", "DELETED"}
 	for _, di := range *d {
 		if exists, err := projectExists(s.w.ComputeClient, di.Project); err != nil {
 			return Errf("cannot deprecate image %q: bad project lookup: %q, error: %v", di.Image, di.Project, err)
@@ -56,7 +56,7 @@ func (d *DeprecateImages) validate(ctx context.Context, s *Step) DError {
 
 		// Verify State is one of the deprecated states.
 		// The Alpha check also requires the value to not be emptry string as in that case the GA API will be used.
-		if di.DeprecationStatusAlpha.State != "" && strIn(di.DeprecationStatusAlpha.State, deprecationStates) {
+		if di.DeprecationStatusAlpha.State != "" && !strIn(di.DeprecationStatusAlpha.State, deprecationStates) {
 			return Errf("DeprecationStatusAlpha.State of %q not in %q", di.DeprecationStatusAlpha.State, deprecationStates)
 		} else if !strIn(di.DeprecationStatus.State, deprecationStates) {
 			return Errf("DeprecationStatus.State of %q not in %q", di.DeprecationStatus.State, deprecationStates)

--- a/daisy/step_deprecate_images_test.go
+++ b/daisy/step_deprecate_images_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -101,6 +102,21 @@ func TestDeprecateImagesValidate(t *testing.T) {
 		{
 			"bad project case",
 			&DeprecateImage{Image: "i1", Project: "bad"},
+			true,
+		},
+		{
+			"alpha DEPRECATED case",
+			&DeprecateImage{Image: "i1", Project: testProject, DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+			false,
+		},
+		{
+			"alpha unDEPRECATED case",
+			&DeprecateImage{Image: "i1", Project: testProject, DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "ACTIVE"}},
+			false,
+		},
+		{
+			"alpha bad case",
+			&DeprecateImage{Image: "i1", Project: testProject, DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "BAD"}},
 			true,
 		},
 	}


### PR DESCRIPTION
- Adding ACTIVE to the deprecated status, to make the possible values in the API https://pkg.go.dev/google.golang.org/api/compute/v0.alpha#DeprecationStatus
- Fixing bug to error when "not in list"
- Adding DeprecationStatus tests for Alpha API