### PR TITLE
OVF import: Apply user-provided tags to final instance

### DIFF
--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -94,6 +94,7 @@ type OVFImportParams struct {
 	Deadline time.Time
 
 	UserLabels            map[string]string
+	UserTags              []string
 	NodeAffinities        []*compute.SchedulingNodeAffinity
 	NodeAffinitiesBeta    []*computeBeta.SchedulingNodeAffinity
 	InstanceAccessScopes  []string

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer.go
@@ -191,6 +191,14 @@ func (oi *OVFImporter) updateImportedInstance(w *daisy.Workflow) {
 		instance.Scheduling.NodeAffinities = oi.params.NodeAffinities
 		instanceBeta.Scheduling.NodeAffinities = oi.params.NodeAffinitiesBeta
 	}
+	if len(oi.params.UserTags) > 0 {
+		instance.Tags = &compute.Tags{
+			Items: oi.params.UserTags,
+		}
+		instanceBeta.Tags = &computeBeta.Tags{
+			Items: oi.params.UserTags,
+		}
+	}
 	if oi.params.Hostname != "" {
 		instance.Hostname = oi.params.Hostname
 		instanceBeta.Hostname = oi.params.Hostname

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
@@ -16,6 +16,7 @@ package ovfimporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -154,6 +155,18 @@ func (p *ParamValidatorAndPopulator) ValidateAndPopulate(params *ovfdomain.OVFIm
 		params.UserLabels, err = param.ParseKeyValues(params.Labels)
 		if err != nil {
 			return err
+		}
+	}
+
+	if params.Tags != "" {
+		params.UserTags = strings.Split(params.Tags, ",")
+		for _, tag := range params.UserTags {
+			if tag == "" {
+				return errors.New("tags cannot be empty")
+			}
+			if err := validation.ValidateRfc1035Label(tag); err != nil {
+				return fmt.Errorf("tag `%v` is not RFC1035 compliant", tag)
+			}
 		}
 	}
 

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
@@ -239,6 +239,18 @@ func Test_ValidateAndParseParams_ErrorMessages(t *testing.T) {
 			},
 			expectErrorToContain: "failed to parse key-value pair",
 		}, {
+			name: "don't allow empty tag",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.Tags = "a,,b"
+			},
+			expectErrorToContain: "tags cannot be empty",
+		}, {
+			name: "tags must be RFC1035 compliant",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.Tags = "a,&,b"
+			},
+			expectErrorToContain: "tag `&` is not RFC1035 compliant",
+		}, {
 			name: "Don't allow invalid timeout",
 			paramModifier: func(params *domain.OVFImportParams) {
 				params.Timeout = "300"
@@ -390,6 +402,14 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 			},
 			checkResult: func(t *testing.T, params *domain.OVFImportParams, importType string) {
 				assert.Equal(t, map[string]string{"env": "test", "region": "us"}, params.UserLabels)
+			},
+		}, {
+			name: "Parse tags",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.Tags = "a,b,c"
+			},
+			checkResult: func(t *testing.T, params *domain.OVFImportParams, importType string) {
+				assert.Equal(t, []string{"a", "b", "c"}, params.UserTags)
 			},
 		}, {
 			name: "Convert empty release track to GA",

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -89,8 +89,6 @@ func TestSuite(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 1604 from Virtualbox"))
 		instanceImportUbuntu16FromAWS := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 1604 from AWS"))
-		instanceImportWithNetworkTags := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with network tags"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -101,7 +99,6 @@ func TestSuite(
 		testsMap[testType][instanceImportDebian9] = runOVFInstanceImportDebian9
 		testsMap[testType][instanceImportUbuntu16FromVirtualBox] = runOVFInstanceImportUbuntu16FromVirtualBox
 		testsMap[testType][instanceImportUbuntu16FromAWS] = runOVFInstanceImportUbuntu16FromAWS
-		testsMap[testType][instanceImportWithNetworkTags] = runInstanceImportWithNetworkTags
 	}
 
 	// gcloud only tests
@@ -149,6 +146,7 @@ func runOVFInstanceImportUbuntu3DisksNetworkSettingsName(ctx context.Context, te
 			MachineType:           "n1-standard-4",
 			Network:               fmt.Sprintf("%v-vpc-1", testProjectConfig.TestProjectID),
 			Subnet:                fmt.Sprintf("%v-subnet-1", testProjectConfig.TestProjectID),
+			Tags:                  []string{"tag1", "tag2", "tag3"},
 		}}
 
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
@@ -173,6 +171,7 @@ func runOVFInstanceImportWindows2012R2TwoDisksNetworkSettingsPath(ctx context.Co
 			Network:               fmt.Sprintf("global/networks/%v-vpc-1", testProjectConfig.TestProjectID),
 			Subnet: fmt.Sprintf("projects/%v/regions/%v/subnetworks/%v-subnet-1",
 				testProjectConfig.TestProjectID, region, testProjectConfig.TestProjectID),
+			Tags: []string{"tag1", "tag2", "tag3"},
 		}}
 
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
@@ -266,26 +265,6 @@ func runOVFInstanceImportUbuntu16FromAWS(ctx context.Context, testCase *junitxml
 			MachineType: "n1-standard-4",
 		}}
 
-	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
-}
-
-func runInstanceImportWithNetworkTags(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
-	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
-
-	suffix := path.RandString(5)
-	props := &ovfInstanceImportTestProperties{
-		instanceName: fmt.Sprintf("test-instance-aws-ova-ubuntu-1604-%v", suffix),
-		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
-			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
-			Zone:                  testProjectConfig.TestZone,
-			ExpectedStartupOutput: "All tests passed!",
-			FailureMatches:        []string{"FAILED:", "TestFailed:"},
-			SourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
-			Os:                    "centos-7",
-			MachineType:           "n2-standard-2",
-			Tags:                  []string{"tag1", "tag2"},
-		}}
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -89,6 +89,8 @@ func TestSuite(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 1604 from Virtualbox"))
 		instanceImportUbuntu16FromAWS := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Ubuntu 1604 from AWS"))
+		instanceImportWithNetworkTags := junitxml.NewTestCase(
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with network tags"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
@@ -99,6 +101,7 @@ func TestSuite(
 		testsMap[testType][instanceImportDebian9] = runOVFInstanceImportDebian9
 		testsMap[testType][instanceImportUbuntu16FromVirtualBox] = runOVFInstanceImportUbuntu16FromVirtualBox
 		testsMap[testType][instanceImportUbuntu16FromAWS] = runOVFInstanceImportUbuntu16FromAWS
+		testsMap[testType][instanceImportWithNetworkTags] = runInstanceImportWithNetworkTags
 	}
 
 	// gcloud only tests
@@ -263,6 +266,26 @@ func runOVFInstanceImportUbuntu16FromAWS(ctx context.Context, testCase *junitxml
 			MachineType: "n1-standard-4",
 		}}
 
+	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
+}
+
+func runInstanceImportWithNetworkTags(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
+	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
+
+	suffix := path.RandString(5)
+	props := &ovfInstanceImportTestProperties{
+		instanceName: fmt.Sprintf("test-instance-aws-ova-ubuntu-1604-%v", suffix),
+		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
+			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
+				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			Zone:                  testProjectConfig.TestZone,
+			ExpectedStartupOutput: "All tests passed!",
+			FailureMatches:        []string{"FAILED:", "TestFailed:"},
+			SourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+			Os:                    "centos-7",
+			MachineType:           "n2-standard-2",
+			Tags:                  []string{"tag1", "tag2"},
+		}}
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -85,15 +85,12 @@ func TestSuite(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Windows 2012 R2 two disks, Network setting (path)"))
 		machineImageImportStorageLocationTestCase := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Centos 7.4, Storage location"))
-		machineImageImportNetworkTagsTestCase := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with network tags"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
 		testsMap[testType][machineImageImportUbuntu3DisksNetworkSettingsNameTestCase] = runOVFMachineImageImportUbuntu3DisksNetworkSettingsName
 		testsMap[testType][machineImageImportWindows2012R2TwoDisksNetworkSettingsPathTestCase] = runOVFMachineImageImportWindows2012R2TwoDisksNetworkSettingsPath
 		testsMap[testType][machineImageImportStorageLocationTestCase] = runOVFMachineImageImportCentos74StorageLocation
-		testsMap[testType][machineImageImportNetworkTagsTestCase] = runOVFMachineImageImportWithNetworkTags
 	}
 
 	// gcloud only tests
@@ -135,6 +132,7 @@ func runOVFMachineImageImportUbuntu3DisksNetworkSettingsName(ctx context.Context
 			MachineType:           "n1-standard-4",
 			Network:               fmt.Sprintf("%v-vpc-1", testProjectConfig.TestProjectID),
 			Subnet:                fmt.Sprintf("%v-subnet-1", testProjectConfig.TestProjectID),
+			Tags:                  []string{"tag1", "tag2", "tag3"},
 		},
 	}
 
@@ -159,29 +157,9 @@ func runOVFMachineImageImportWindows2012R2TwoDisksNetworkSettingsPath(ctx contex
 			IsWindows:             true,
 			Network:               fmt.Sprintf("global/networks/%v-vpc-1", testProjectConfig.TestProjectID),
 			Subnet:                fmt.Sprintf("projects/%v/regions/%v/subnetworks/%v-subnet-1", testProjectConfig.TestProjectID, region, testProjectConfig.TestProjectID),
+			Tags:                  []string{"tag1", "tag2", "tag3"},
 		}}
 
-	runOVFMachineImageImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
-}
-
-func runOVFMachineImageImportWithNetworkTags(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
-	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
-
-	suffix := path.RandString(5)
-	props := &ovfMachineImageImportTestProperties{
-		machineImageName: fmt.Sprintf("test-gmi-storage-location-%v", suffix),
-		storageLocation:  "us-west2",
-		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
-			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
-			Zone:                  testProjectConfig.TestZone,
-			ExpectedStartupOutput: "All tests passed!",
-			FailureMatches:        []string{"FAILED:", "TestFailed:"},
-			SourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
-			Os:                    "centos-7",
-			MachineType:           "n2-standard-2",
-			Tags:                  []string{"tag1", "tag2"},
-		}}
 	runOVFMachineImageImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -85,12 +85,15 @@ func TestSuite(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Windows 2012 R2 two disks, Network setting (path)"))
 		machineImageImportStorageLocationTestCase := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Centos 7.4, Storage location"))
+		machineImageImportNetworkTagsTestCase := junitxml.NewTestCase(
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "Import with network tags"))
 
 		testsMap[testType] = map[*junitxml.TestCase]func(
 			context.Context, *junitxml.TestCase, *log.Logger, *testconfig.Project, e2e.CLITestType){}
 		testsMap[testType][machineImageImportUbuntu3DisksNetworkSettingsNameTestCase] = runOVFMachineImageImportUbuntu3DisksNetworkSettingsName
 		testsMap[testType][machineImageImportWindows2012R2TwoDisksNetworkSettingsPathTestCase] = runOVFMachineImageImportWindows2012R2TwoDisksNetworkSettingsPath
 		testsMap[testType][machineImageImportStorageLocationTestCase] = runOVFMachineImageImportCentos74StorageLocation
+		testsMap[testType][machineImageImportNetworkTagsTestCase] = runOVFMachineImageImportWithNetworkTags
 	}
 
 	// gcloud only tests
@@ -158,6 +161,27 @@ func runOVFMachineImageImportWindows2012R2TwoDisksNetworkSettingsPath(ctx contex
 			Subnet:                fmt.Sprintf("projects/%v/regions/%v/subnetworks/%v-subnet-1", testProjectConfig.TestProjectID, region, testProjectConfig.TestProjectID),
 		}}
 
+	runOVFMachineImageImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
+}
+
+func runOVFMachineImageImportWithNetworkTags(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
+	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
+
+	suffix := path.RandString(5)
+	props := &ovfMachineImageImportTestProperties{
+		machineImageName: fmt.Sprintf("test-gmi-storage-location-%v", suffix),
+		storageLocation:  "us-west2",
+		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
+			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
+				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			Zone:                  testProjectConfig.TestZone,
+			ExpectedStartupOutput: "All tests passed!",
+			FailureMatches:        []string{"FAILED:", "TestFailed:"},
+			SourceURI:             fmt.Sprintf("gs://%v/ova/centos-7.4/", ovaBucket),
+			Os:                    "centos-7",
+			MachineType:           "n2-standard-2",
+			Tags:                  []string{"tag1", "tag2"},
+		}}
 	runOVFMachineImageImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)
 }
 


### PR DESCRIPTION
During OVF import, the user can provide tags using the `--tags` flag. A user reported this feature wasn't working. It's unclear where this functionality was lost. Running an import prior to the recent refactoring doesn't yield an instance with tags applied; eg:

```
gcloud beta compute instances import  tagtest \
   --source-uri=gs://<yourbucket>/ubuntu-ova/ \
   --zone=us-central1-c \
   --tags=tag1,tag2,tag3  \
   --docker-image-tag=8f8fff9d757e70b8a09257e038ed7ecf51ab606f  \
   --os ubuntu-1604
```

## Testing
* Added e2e tests for instance import and GMI import that verify tags were applied
* Manually imported an instance and a GMI and verified that tags were applied