### PR TITLE
Improve error message when detected OS doesn't match specified OS.

### DIFF
--- a/cli_tools/common/distro/distro.go
+++ b/cli_tools/common/distro/distro.go
@@ -183,6 +183,17 @@ func newLinuxRelease(distro string, major string, minor string) (Release, error)
 	}
 }
 
+// FromGcloudOSArgumentMustParse parses the argument provided to the `--os` flag of
+// `gcloud compute images import`, and returns a Release if it represents a
+// release we *may* support. If osFlagValue does not parse, the call panics.
+func FromGcloudOSArgumentMustParse(osFlagValue string) Release {
+	r, err := FromGcloudOSArgument(osFlagValue)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
 // FromGcloudOSArgument parses the argument provided to the `--os` flag of
 // `gcloud compute images import`, and returns a Release if it represents a
 // release we *may* support. The caller is responsible for verifying

--- a/cli_tools/common/distro/distro_test.go
+++ b/cli_tools/common/distro/distro_test.go
@@ -24,7 +24,7 @@ import (
 	daisy_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 )
 
-func TestParseGcloudOsParam_HappyCases(t *testing.T) {
+func TestFromGcloudOSArgument_HappyCases(t *testing.T) {
 	daisy_utils.GetSortedOSIDs()
 	for _, osID := range daisy_utils.GetSortedOSIDs() {
 		t.Run(osID, func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestParseGcloudOsParam_HappyCases(t *testing.T) {
 	}
 }
 
-func TestParseGcloudOsParam_DistroNameErrors(t *testing.T) {
+func TestFromGcloudOSArgument_DistroNameErrors(t *testing.T) {
 	var cases = []struct {
 		in  string
 		err string
@@ -78,7 +78,7 @@ func TestParseGcloudOsParam_DistroNameErrors(t *testing.T) {
 	}
 }
 
-func TestParseGcloudOsParam_VersionErrors(t *testing.T) {
+func TestFromGcloudOSArgument_VersionErrors(t *testing.T) {
 	var cases = []struct {
 		in  string
 		err string
@@ -103,6 +103,17 @@ func TestParseGcloudOsParam_VersionErrors(t *testing.T) {
 			assert.Contains(t, e.Error(), tt.err)
 		})
 	}
+}
+
+func TestFromGcloudOSArgumentMustParse_HappyCase(t *testing.T) {
+	expected, _ := FromGcloudOSArgument("debian-10")
+	assert.Equal(t, expected, FromGcloudOSArgumentMustParse("debian-10"))
+}
+
+func TestFromGcloudOSArgumentMustParse_PanicsOnParseFailure(t *testing.T) {
+	assert.PanicsWithError(t, "expected pattern of `distro-version`. Actual: `notadistro`", func() {
+		FromGcloudOSArgumentMustParse("notadistro")
+	})
 }
 
 func TestDistroFromComponents_HappyCasesLinux(t *testing.T) {

--- a/cli_tools/common/image/importer/bootable_disk_processor.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor.go
@@ -42,8 +42,7 @@ func (b *bootableDiskProcessor) process(pd persistentDisk) (persistentDisk, erro
 	if err != nil {
 		b.logger.User("Finished making disk bootable")
 		daisy_utils.PostProcessDErrorForNetworkFlag("image import", err, b.request.Network, b.workflow)
-		err = customizeErrorToDetectionResults2(b.request.OS,
-			b.detectedOs, err)
+		err = customizeErrorToDetectionResults(b.request.OS, b.detectedOs, err)
 	}
 	if b.workflow.Logger != nil {
 		for _, trace := range b.workflow.Logger.ReadSerialPortLogs() {

--- a/cli_tools/common/image/importer/bootable_disk_processor.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
 	daisy_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisycommon"
@@ -27,9 +28,10 @@ import (
 )
 
 type bootableDiskProcessor struct {
-	request  ImageImportRequest
-	workflow *daisy.Workflow
-	logger   logging.Logger
+	request    ImageImportRequest
+	workflow   *daisy.Workflow
+	logger     logging.Logger
+	detectedOs distro.Release
 }
 
 func (b *bootableDiskProcessor) process(pd persistentDisk) (persistentDisk, error) {
@@ -40,10 +42,8 @@ func (b *bootableDiskProcessor) process(pd persistentDisk) (persistentDisk, erro
 	if err != nil {
 		b.logger.User("Finished making disk bootable")
 		daisy_utils.PostProcessDErrorForNetworkFlag("image import", err, b.request.Network, b.workflow)
-		err = customizeErrorToDetectionResults(b.request.OS,
-			b.workflow.GetSerialConsoleOutputValue("detected_distro"),
-			b.workflow.GetSerialConsoleOutputValue("detected_major_version"),
-			b.workflow.GetSerialConsoleOutputValue("detected_minor_version"), err)
+		err = customizeErrorToDetectionResults2(b.request.OS,
+			b.detectedOs, err)
 	}
 	if b.workflow.Logger != nil {
 		for _, trace := range b.workflow.Logger.ReadSerialPortLogs() {
@@ -58,7 +58,7 @@ func (b *bootableDiskProcessor) cancel(reason string) bool {
 	return true
 }
 
-func newBootableDiskProcessor(request ImageImportRequest, wfPath string, logger logging.Logger) (processor, error) {
+func newBootableDiskProcessor(request ImageImportRequest, wfPath string, logger logging.Logger, detectedOs distro.Release) (processor, error) {
 	vars := map[string]string{
 		"image_name":           request.ImageName,
 		"install_gce_packages": strconv.FormatBool(!request.NoGuestEnvironment),
@@ -89,9 +89,10 @@ func newBootableDiskProcessor(request ImageImportRequest, wfPath string, logger 
 	workflow.Name = logPrefix + "translate"
 
 	return &bootableDiskProcessor{
-		request:  request,
-		workflow: workflow,
-		logger:   logger,
+		request:    request,
+		workflow:   workflow,
+		logger:     logger,
+		detectedOs: detectedOs,
 	}, err
 }
 

--- a/cli_tools/common/image/importer/bootable_disk_processor.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor.go
@@ -42,7 +42,7 @@ func (b *bootableDiskProcessor) process(pd persistentDisk) (persistentDisk, erro
 	if err != nil {
 		b.logger.User("Finished making disk bootable")
 		daisy_utils.PostProcessDErrorForNetworkFlag("image import", err, b.request.Network, b.workflow)
-		err = customizeErrorToDetectionResults(b.request.OS, b.detectedOs, err)
+		err = customizeErrorToDetectionResults(b.logger, b.request.OS, b.detectedOs, err)
 	}
 	if b.workflow.Logger != nil {
 		for _, trace := range b.workflow.Logger.ReadSerialPortLogs() {

--- a/cli_tools/common/image/importer/bootable_disk_processor_test.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
 	daisy_utils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
@@ -41,7 +42,8 @@ func TestBootableDiskProcessor_Process_WritesSourceDiskVar(t *testing.T) {
 	request := ImageImportRequest{
 		OS: "opensuse-15",
 	}
-	p, err := newBootableDiskProcessor(request, opensuse15workflow, logging.NewToolLogger(t.Name()))
+	p, err := newBootableDiskProcessor(request, opensuse15workflow, logging.NewToolLogger(t.Name()),
+		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
 	assert.NoError(t, err)
 	_, err = p.process(persistentDisk{uri: "uri"})
 	assert.Equal(t, "uri", p.(*bootableDiskProcessor).workflow.Vars["source_disk"].Value)
@@ -52,7 +54,8 @@ func TestBootableDiskProcessor_Process_WritesSourceDiskVar(t *testing.T) {
 func TestBootableDiskProcessor_SetsWorkflowNameToGcloudPrefix(t *testing.T) {
 	args := defaultImportArgs()
 	args.DaisyLogLinePrefix = "disk-1"
-	processor, e := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()))
+	processor, e := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()),
+		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
 	assert.NoError(t, e)
 	assert.Equal(t, "disk-1-translate", (processor.(*bootableDiskProcessor)).workflow.Name)
 }
@@ -165,7 +168,8 @@ func TestBootableDiskProcessor_PermitsUnsetStorageLocation(t *testing.T) {
 
 func TestBootableDiskProcessor_SupportsCancel(t *testing.T) {
 	args := defaultImportArgs()
-	processor, e := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()))
+	processor, e := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()),
+		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
 	assert.NoError(t, e)
 
 	realProcessor := processor.(*bootableDiskProcessor)
@@ -175,7 +179,8 @@ func TestBootableDiskProcessor_SupportsCancel(t *testing.T) {
 }
 
 func createAndRunPrePostFunctions(t *testing.T, request ImageImportRequest) *bootableDiskProcessor {
-	translator, e := newBootableDiskProcessor(request, opensuse15workflow, logging.NewToolLogger(t.Name()))
+	translator, e := newBootableDiskProcessor(request, opensuse15workflow, logging.NewToolLogger(t.Name()),
+		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
 	assert.NoError(t, e)
 	realTranslator := translator.(*bootableDiskProcessor)
 	// A concrete logger is required since the import/export logging framework writes a log entry

--- a/cli_tools/common/image/importer/errors.go
+++ b/cli_tools/common/image/importer/errors.go
@@ -30,3 +30,14 @@ func customizeErrorToDetectionResults(osID, detectedDistro, detectedMajor,
 	}
 	return original
 }
+
+func customizeErrorToDetectionResults2(osID string, detected distro.Release, original error) error {
+	fromUser, _ := distro.FromGcloudOSArgument(osID)
+	if fromUser != nil && detected != nil && !fromUser.ImportCompatible(detected) {
+		// The error is already logged by Daisy, so skipping re-logging it here.
+		return fmt.Errorf("%q was detected on your disk, "+
+			"but %q was specified. Please verify and re-import",
+			detected.AsGcloudArg(), fromUser.AsGcloudArg())
+	}
+	return original
+}

--- a/cli_tools/common/image/importer/errors.go
+++ b/cli_tools/common/image/importer/errors.go
@@ -18,26 +18,14 @@ import (
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
 )
 
-func customizeErrorToDetectionResults(osID, detectedDistro, detectedMajor,
-	detectedMinor string, original error) error {
-	fromUser, _ := distro.FromGcloudOSArgument(osID)
-	detected, _ := distro.FromComponents(detectedDistro, detectedMajor, detectedMinor, "")
-	if fromUser != nil && detected != nil && !fromUser.ImportCompatible(detected) {
+// customizeErrorToDetectionResults returns a custom error message when the detected OS doesn't match the detected OS.
+func customizeErrorToDetectionResults(osIDFromUser string, detectionResults distro.Release, original error) error {
+	fromUser, _ := distro.FromGcloudOSArgument(osIDFromUser)
+	if fromUser != nil && detectionResults != nil && !fromUser.ImportCompatible(detectionResults) {
 		// The error is already logged by Daisy, so skipping re-logging it here.
 		return fmt.Errorf("%q was detected on your disk, "+
 			"but %q was specified. Please verify and re-import",
-			detected.AsGcloudArg(), fromUser.AsGcloudArg())
-	}
-	return original
-}
-
-func customizeErrorToDetectionResults2(osID string, detected distro.Release, original error) error {
-	fromUser, _ := distro.FromGcloudOSArgument(osID)
-	if fromUser != nil && detected != nil && !fromUser.ImportCompatible(detected) {
-		// The error is already logged by Daisy, so skipping re-logging it here.
-		return fmt.Errorf("%q was detected on your disk, "+
-			"but %q was specified. Please verify and re-import",
-			detected.AsGcloudArg(), fromUser.AsGcloudArg())
+			detectionResults.AsGcloudArg(), fromUser.AsGcloudArg())
 	}
 	return original
 }

--- a/cli_tools/common/image/importer/errors.go
+++ b/cli_tools/common/image/importer/errors.go
@@ -16,13 +16,14 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 )
 
 // customizeErrorToDetectionResults returns a custom error message when the detected OS doesn't match the detected OS.
-func customizeErrorToDetectionResults(osIDFromUser string, detectionResults distro.Release, original error) error {
+func customizeErrorToDetectionResults(logger logging.Logger, osIDFromUser string, detectionResults distro.Release, original error) error {
 	fromUser, _ := distro.FromGcloudOSArgument(osIDFromUser)
 	if fromUser != nil && detectionResults != nil && !fromUser.ImportCompatible(detectionResults) {
-		// The error is already logged by Daisy, so skipping re-logging it here.
+		logger.User(original.Error())
 		return fmt.Errorf("%q was detected on your disk, "+
 			"but %q was specified. Please verify and re-import",
 			detectionResults.AsGcloudArg(), fromUser.AsGcloudArg())

--- a/cli_tools/common/image/importer/errors_test.go
+++ b/cli_tools/common/image/importer/errors_test.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 )
 
 func Test_customizeErrorToDetectionResults(t *testing.T) {
@@ -50,7 +51,8 @@ func Test_customizeErrorToDetectionResults(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := customizeErrorToDetectionResults(tt.fromUser, tt.detectedDistro, tt.original)
+			actual := customizeErrorToDetectionResults(logging.NewToolLogger("test"),
+				tt.fromUser, tt.detectedDistro, tt.original)
 			assert.EqualError(t, actual, tt.wantErr)
 		})
 	}

--- a/cli_tools/common/image/importer/errors_test.go
+++ b/cli_tools/common/image/importer/errors_test.go
@@ -4,44 +4,38 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_createError(t *testing.T) {
+func Test_customizeErrorToDetectionResults(t *testing.T) {
 	cause := errors.New("cause")
 	tests := []struct {
 		name           string
 		fromUser       string
-		detectedDistro string
-		detectedMajor  string
-		detectedMinor  string
+		detectedDistro distro.Release
 		original       error
 		wantErr        string
 	}{
 		{
 			name:           "return original error - when detection matches actual",
 			fromUser:       "centos-7",
-			detectedDistro: "centos",
-			detectedMajor:  "7",
-			detectedMinor:  "",
+			detectedDistro: distro.FromGcloudOSArgumentMustParse("centos-7"),
 			original:       cause,
 			wantErr:        cause.Error(),
 		},
 		{
 			name:           "return original error - when failure to parse user's input",
 			fromUser:       "not-a-distro",
-			detectedDistro: "centos",
-			detectedMajor:  "7",
-			detectedMinor:  "",
+			detectedDistro: distro.FromGcloudOSArgumentMustParse("centos-7"),
 			original:       cause,
 			wantErr:        cause.Error(),
 		},
 		{
 			name:           "return new error - when detection doesn't match actual - and detection fully specified",
 			fromUser:       "ubuntu-1804",
-			detectedDistro: "centos",
-			detectedMajor:  "7",
-			detectedMinor:  "",
+			detectedDistro: distro.FromGcloudOSArgumentMustParse("centos-7"),
 			original:       cause,
 			wantErr: "\"centos-7\" was detected on your disk, but \"ubuntu-1804\" was specified. " +
 				"Please verify and re-import",
@@ -49,52 +43,14 @@ func Test_createError(t *testing.T) {
 		{
 			name:           "return original error - when detection empty",
 			fromUser:       "ubuntu-1804",
-			detectedDistro: "",
-			detectedMajor:  "",
-			detectedMinor:  "",
-			original:       cause,
-			wantErr:        cause.Error(),
-		},
-		{
-			name:           "return original error - when detection empty",
-			fromUser:       "ubuntu-1804",
-			detectedDistro: "unknown",
-			detectedMajor:  "",
-			detectedMinor:  "",
-			original:       cause,
-			wantErr:        cause.Error(),
-		},
-		{
-			name:           "return original error - when detected debian has major version 0",
-			fromUser:       "debian-9",
-			detectedDistro: "debian",
-			detectedMajor:  "0",
-			detectedMinor:  "",
-			original:       cause,
-			wantErr:        cause.Error(),
-		},
-		{
-			name:           "return original error - when detected rhel has major version 0",
-			fromUser:       "rhel-7",
-			detectedDistro: "rhel",
-			detectedMajor:  "0",
-			detectedMinor:  "",
-			original:       cause,
-			wantErr:        cause.Error(),
-		},
-		{
-			name:           "return original error - when detected centos has major version 0",
-			fromUser:       "centos-7",
-			detectedDistro: "centos",
-			detectedMajor:  "0",
-			detectedMinor:  "",
+			detectedDistro: nil,
 			original:       cause,
 			wantErr:        cause.Error(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := customizeErrorToDetectionResults(tt.fromUser, tt.detectedDistro, tt.detectedMajor, tt.detectedMinor, tt.original)
+			actual := customizeErrorToDetectionResults(tt.fromUser, tt.detectedDistro, tt.original)
 			assert.EqualError(t, actual, tt.wantErr)
 		})
 	}

--- a/cli_tools/common/image/importer/process_planner_test.go
+++ b/cli_tools/common/image/importer/process_planner_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk"
 	mock_disk "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk/mocks"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/distro"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/proto/go/pb"
 )
@@ -131,6 +132,7 @@ func Test_DefaultPlanner_Plan_InspectionSucceeds(t *testing.T) {
 			expectedResults: &processingPlan{
 				requiredLicenses:        []string{"projects/debian-cloud/global/licenses/debian-8-jessie"},
 				translationWorkflowPath: "workflowroot/image_import/debian/translate_debian_8.wf.json",
+				detectedOs:              distro.FromGcloudOSArgumentMustParse("windows-10"),
 			},
 		},
 		{
@@ -148,6 +150,7 @@ func Test_DefaultPlanner_Plan_InspectionSucceeds(t *testing.T) {
 			expectedResults: &processingPlan{
 				requiredLicenses:        []string{"projects/rhel-cloud/global/licenses/rhel-8-byos"},
 				translationWorkflowPath: "workflowroot/image_import/enterprise_linux/translate_rhel_8_byol.wf.json",
+				detectedOs:              distro.FromGcloudOSArgumentMustParse("rhel-8"),
 			},
 		},
 		{

--- a/cli_tools/common/image/importer/processor.go
+++ b/cli_tools/common/image/importer/processor.go
@@ -64,7 +64,7 @@ func (d defaultProcessorProvider) provide(pd persistentDisk) ([]processor, error
 		processors = append(processors, p)
 	}
 
-	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImageImportRequest, plan.translationWorkflowPath, d.logger)
+	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImageImportRequest, plan.translationWorkflowPath, d.logger, plan.detectedOs)
 	if err != nil {
 		return nil, err
 	}

--- a/daisy_workflows/linux_common/utils/diskutils.py
+++ b/daisy_workflows/linux_common/utils/diskutils.py
@@ -71,10 +71,6 @@ def MountDisk(disk) -> guestfs.GuestFS:
   g.gcp_image_major = str(g.inspect_get_major_version(roots[0]))
   g.gcp_image_minor = str(g.inspect_get_minor_version(roots[0]))
 
-  log_key_value('detected_distro', g.gcp_image_distro)
-  log_key_value('detected_major_version', g.gcp_image_major)
-  log_key_value('detected_minor_version', g.gcp_image_minor)
-
   for device in sorted(list(mps.keys()), key=len):
     try:
       g.mount(mps[device], device)


### PR DESCRIPTION
When Linux import fails, and the detected OS doesn't match the specified OS, we show a customized error message (added in https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1206). 

This PR provides the following improvements:
1. Support Windows in addition to Linux
2. Differentiate between flavors of SLES

To achieve this, we use the [new OS detection module](https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/daisy_workflows/image_import/inspection) that is run against all bootable disks, rather than the quick detection that was used in #1206 which ran only for Linux.