### PR TITLE
Fix OVF import E2E tests so they respect custom zones when verifying test instances

### DIFF
--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_import_e2e_common.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_import_e2e_common.go
@@ -65,15 +65,15 @@ func BuildArgsMap(props *OvfImportTestProperties, testProjectConfig *testconfig.
 	project := GetProject(props, testProjectConfig)
 	gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--project=%v", project))
 	gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--source-uri=%v", props.SourceURI))
-	gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--zone=%v", testProjectConfig.TestZone))
+	gcloudBetaArgs = append(gcloudBetaArgs, fmt.Sprintf("--zone=%v", props.Zone))
 
 	gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--project=%v", project))
 	gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--source-uri=%v", props.SourceURI))
-	gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--zone=%v", testProjectConfig.TestZone))
+	gcloudArgs = append(gcloudBetaArgs, fmt.Sprintf("--zone=%v", props.Zone))
 
 	wrapperArgs = append(wrapperArgs, fmt.Sprintf("-project=%v", project))
 	wrapperArgs = append(wrapperArgs, fmt.Sprintf("-ovf-gcs-path=%v", props.SourceURI))
-	wrapperArgs = append(wrapperArgs, fmt.Sprintf("-zone=%v", testProjectConfig.TestZone))
+	wrapperArgs = append(wrapperArgs, fmt.Sprintf("-zone=%v", props.Zone))
 	wrapperArgs = append(wrapperArgs, fmt.Sprintf("-build-id=%v", path.RandString(10)))
 
 	if len(props.Tags) > 0 {

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -466,7 +466,7 @@ func verifyImportedInstance(
 	logger.Printf("Verifying imported instance...")
 	instance, err := gcp.CreateInstanceBetaObject(ctx, project, props.Zone, props.instanceName, props.IsWindows)
 	if err != nil {
-		e2e.Failure(testCase, logger, fmt.Sprintf("Image '%v' doesn't exist after import: %v", props.instanceName, err))
+		e2e.Failure(testCase, logger, fmt.Sprintf("Instance '%v' doesn't exist after import: %v", props.instanceName, err))
 		return
 	}
 


### PR DESCRIPTION
Fix OVF import E2E tests so they respect custom zones when verifying test instances (not use the default zone when looking up test instances)