### PR TITLE
Image export: Only validate non-URI images

### DIFF
--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -17,7 +17,6 @@ package exporter
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -241,7 +240,7 @@ func validateImageExists(computeClient daisyCompute.Client, project string, imag
 	_, err = computeClient.GetImage(project, imageName)
 	if err != nil {
 		log.Printf("Error when fetching image %q: %q.", imageName, err)
-		return fmt.Errorf("Image %q not found", imageName)
+		return daisy.Errf("Image %q not found", imageName)
 	}
 	return nil
 }

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -226,11 +226,22 @@ func Run(clientID string, destinationURI string, sourceImage string, sourceDiskS
 	return w, nil
 }
 
-func validateImageExists(computeClient daisyCompute.Client, project string, sourceImage string) (err error) {
-	_, err = computeClient.GetImage(project, sourceImage)
+// validateImageExists checks whether imageName exists in the specified project.
+//
+// This validates when imageName is a valid image name, and skips validation if
+// the imageName is a URI, or something that's not recognized as an image.
+// The simplistic validation avoids false negatives; Daisy has robust logic for
+// interpreting the various permutations of specifying an image and project,
+// and we don't want to copy that here, since this is a convenience method to create
+// user-friendly messages.
+func validateImageExists(computeClient daisyCompute.Client, project string, imageName string) (err error) {
+	if err := validation.ValidateImageName(imageName); err != nil {
+		return nil
+	}
+	_, err = computeClient.GetImage(project, imageName)
 	if err != nil {
-		log.Printf("Error when fetching image %q: %q.", sourceImage, err)
-		return fmt.Errorf("Image %q not found", sourceImage)
+		log.Printf("Error when fetching image %q: %q.", imageName, err)
+		return fmt.Errorf("Image %q not found", imageName)
 	}
 	return nil
 }

--- a/cli_tools/gce_vm_image_export/exporter/exporter_test.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter_test.go
@@ -181,6 +181,15 @@ func TestValidateImageExists_ReturnsNoError_WhenImageFound(t *testing.T) {
 	assert.NoError(t, validateImageExists(mockComputeClient, "project", "image"))
 }
 
+func TestValidateImageExists_SkipsValidation_WhenSourceImageIsURI(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	// No expectations on the mockComputeClient means the test fails if the mock detects calls.
+	assert.NoError(t, validateImageExists(mockComputeClient,
+		"project", "projects/project/global/image/image-name"))
+}
+
 func TestValidateImageExists_ReturnsError_WhenImageNotFound(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
This is a follow-up to #1666, which introduced a regression such that exports are blocked when the user specifies the source images as a URI. This PR limits validation to obvious image names. This avoids false negatives where the user specifies a source image that Daisy understands, but hasn't been implemented here. 

Failure message: https://github.com/GoogleCloudPlatform/compute-image-tools/commit/58a99dea0dd1703c93a1b8a7f04a658401528f10#commitcomment-52286130