### PR TITLE
Image export and OVF import regional E2E tests to use asia-northeast1

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/export/image_export_test_suite.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/export/image_export_test_suite.go
@@ -98,19 +98,19 @@ func runImageExportRawTest(ctx context.Context, testCase *junitxml.TestCase, log
 
 	argsMap := map[e2e.CLITestType][]string{
 		e2e.Wrapper: {"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-			"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI),
+			"-source_image=global/images/e2e-test-image-10g-eu", fmt.Sprintf("-destination_uri=%v", fileURI),
 			fmt.Sprintf("-zone=%v", zone),
 		},
 		e2e.GcloudBetaProdWrapperLatest: {"beta", "compute", "images", "export", "--quiet",
-			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g",
+			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g-eu",
 			fmt.Sprintf("--destination-uri=%v", fileURI), fmt.Sprintf("--zone=%v", zone),
 		},
 		e2e.GcloudBetaLatestWrapperLatest: {"beta", "compute", "images", "export", "--quiet",
-			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g",
+			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g-eu",
 			fmt.Sprintf("--destination-uri=%v", fileURI), fmt.Sprintf("--zone=%v", zone),
 		},
 		e2e.GcloudGaLatestWrapperRelease: {"compute", "images", "export", "--quiet",
-			fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g",
+			fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g-eu",
 			fmt.Sprintf("--destination-uri=%v", fileURI), fmt.Sprintf("--zone=%v", zone),
 		},
 	}
@@ -125,23 +125,23 @@ func runImageExportVMDKTest(ctx context.Context, testCase *junitxml.TestCase, lo
 	bucketName := fmt.Sprintf("%v-test-image-asia", testProjectConfig.TestProjectID)
 	objectName := fmt.Sprintf("e2e-export-vmdk-test-%v", suffix)
 	fileURI := fmt.Sprintf("gs://%v/%v", bucketName, objectName)
-	zone := "asia-east1-c"
+	zone := "asia-northeast1-a"
 
 	argsMap := map[e2e.CLITestType][]string{
 		e2e.Wrapper: {"-client_id=e2e", fmt.Sprintf("-project=%v", testProjectConfig.TestProjectID),
-			"-source_image=global/images/e2e-test-image-10g", fmt.Sprintf("-destination_uri=%v", fileURI), "-format=vmdk",
+			"-source_image=global/images/e2e-test-image-10g-asia", fmt.Sprintf("-destination_uri=%v", fileURI), "-format=vmdk",
 			fmt.Sprintf("-zone=%v", zone),
 		},
 		e2e.GcloudBetaProdWrapperLatest: {"beta", "compute", "images", "export", "--quiet",
-			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g",
+			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g-asia",
 			fmt.Sprintf("--destination-uri=%v", fileURI), "--export-format=vmdk", fmt.Sprintf("--zone=%v", zone),
 		},
 		e2e.GcloudBetaLatestWrapperLatest: {"beta", "compute", "images", "export", "--quiet",
-			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g",
+			"--docker-image-tag=latest", fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g-asia",
 			fmt.Sprintf("--destination-uri=%v", fileURI), "--export-format=vmdk", fmt.Sprintf("--zone=%v", zone),
 		},
 		e2e.GcloudGaLatestWrapperRelease: {"compute", "images", "export", "--quiet",
-			fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g",
+			fmt.Sprintf("--project=%v", testProjectConfig.TestProjectID), "--image=e2e-test-image-10g-asia",
 			fmt.Sprintf("--destination-uri=%v", fileURI), "--export-format=vmdk", fmt.Sprintf("--zone=%v", zone),
 		},
 	}

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -185,7 +185,7 @@ func runOVFInstanceImportWindows2016(ctx context.Context, testCase *junitxml.Tes
 		instanceName: fmt.Sprintf("test-instance-w2k16-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
 			"daisy_integration_tests/scripts/post_translate_test.ps1", logger),
-			Zone:                  "asia-east2-a",
+			Zone:                  "asia-northeast1-a",
 			ExpectedStartupOutput: "All Tests Passed",
 			FailureMatches:        []string{"Test Failed:"},
 			SourceURI:             fmt.Sprintf("gs://%v-asia/ova/w2k16/w2k16.ovf", ovaBucket),

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -169,11 +169,11 @@ func runOVFMachineImageImportCentos74StorageLocation(ctx context.Context, testCa
 	suffix := path.RandString(5)
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-gmi-storage-location-%v", suffix),
-		storageLocation:  "asia-east2",
+		storageLocation:  "asia-northeast1",
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
 			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
 				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
-			Zone:                  "asia-east2-a",
+			Zone:                  "asia-northeast1-a",
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
 			SourceURI:             fmt.Sprintf("gs://%v-asia/ova/centos-7.4/", ovaBucket),


### PR DESCRIPTION
Image export and OVF import regional E2E tests to use asia-northeast1 due to stockouts in asia-east1 and due to inability to run Google workloads in asia-east2.

Also, use multiregional images for export tests to avoid cross-multiregion transfers.