### PR TITLE
avoid interleaved output

### DIFF
--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -291,7 +291,7 @@ func (inflater *apiInflater) getCalculateChecksumWorkflow(diskURI string) *daisy
 // Dup logic in import_image.sh. If change anything here, please change in both places.
 const (
 	checksumScriptConst = `
-		function serialOutputKeyValuePair() {
+		function serialOutputPrefixedKeyValue() {
 			stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 		}
 		CHECK_DEVICE=sdb
@@ -303,6 +303,6 @@ const (
 		CHECKSUM2=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 2000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
 		CHECKSUM3=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 20000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
 		CHECKSUM4=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( $BLOCK_COUNT - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
-		serialOutputKeyValuePair "Checksum" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
+		serialOutputPrefixedKeyValue "Checksum" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
 		echo "Checksum calculated."`
 )

--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -292,7 +292,7 @@ func (inflater *apiInflater) getCalculateChecksumWorkflow(diskURI string) *daisy
 const (
 	checksumScriptConst = `
 		function serialOutputKeyValuePair() {
-			echo "<serial-output key:'$1' value:'$2'>"
+			stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 		}
 		CHECK_DEVICE=sdb
 		BLOCK_COUNT=$(cat /sys/class/block/$CHECK_DEVICE/size)
@@ -303,6 +303,6 @@ const (
 		CHECKSUM2=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 2000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
 		CHECKSUM3=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 20000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
 		CHECKSUM4=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( $BLOCK_COUNT - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
-		echo "Checksum: $(serialOutputKeyValuePair "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4")"
+		serialOutputKeyValuePair "Checksum" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
 		echo "Checksum calculated."`
 )

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function serialOutputKeyValuePair() {
+function serialOutputPrefixedKeyValue() {
   stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
@@ -34,7 +34,7 @@ mkdir ~/upload
 # Source disk size info.
 SOURCE_SIZE_BYTES=$(lsblk /dev/sdb --output=size -b | sed -n 2p)
 SOURCE_SIZE_GB=$(awk "BEGIN {print int(((${SOURCE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
-serialOutputKeyValuePair "GCEExport" "source-size-gb" "${SOURCE_SIZE_GB}"
+serialOutputPrefixedKeyValue "GCEExport" "source-size-gb" "${SOURCE_SIZE_GB}"
 
 echo "GCEExport: Running export tool."
 if [[ -n $LICENSES ]]; then
@@ -55,7 +55,7 @@ fi
 # Exported image size info.
 TARGET_SIZE_BYTES=$(gsutil ls -l "${GCS_PATH}" | head -n 1 | awk '{print $1}')
 TARGET_SIZE_GB=$(awk "BEGIN {print int(((${TARGET_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
-serialOutputKeyValuePair "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
+serialOutputPrefixedKeyValue "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
 
 echo "ExportSuccess"
 sync

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 function serialOutputKeyValuePair() {
-  echo "<serial-output key:'$1' value:'$2'>"
+  stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
 # Verify VM has access to Google APIs
@@ -34,7 +34,7 @@ mkdir ~/upload
 # Source disk size info.
 SOURCE_SIZE_BYTES=$(lsblk /dev/sdb --output=size -b | sed -n 2p)
 SOURCE_SIZE_GB=$(awk "BEGIN {print int(((${SOURCE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
-echo "GCEExport: $(serialOutputKeyValuePair "source-size-gb" "${SOURCE_SIZE_GB}")"
+serialOutputKeyValuePair "GCEExport" "source-size-gb" "${SOURCE_SIZE_GB}"
 
 echo "GCEExport: Running export tool."
 if [[ -n $LICENSES ]]; then
@@ -55,7 +55,7 @@ fi
 # Exported image size info.
 TARGET_SIZE_BYTES=$(gsutil ls -l "${GCS_PATH}" | head -n 1 | awk '{print $1}')
 TARGET_SIZE_GB=$(awk "BEGIN {print int(((${TARGET_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
-echo "GCEExport: $(serialOutputKeyValuePair "target-size-gb" "${TARGET_SIZE_GB}")"
+serialOutputKeyValuePair "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
 
 echo "ExportSuccess"
 sync

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -x
 
-function serialOutputKeyValuePair() {
+function serialOutputPrefixedKeyValue() {
   stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
@@ -47,7 +47,7 @@ SIZE_OUTPUT_GB=$(awk "BEGIN {print int(((${SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
 MAX_BUFFER_DISK_SIZE_GB=$(awk "BEGIN {print int(${SIZE_OUTPUT_GB} + 5)}")
 
 set +x
-serialOutputKeyValuePair "GCEExport" "source-size-gb" "${SIZE_OUTPUT_GB}"
+serialOutputPrefixedKeyValue "GCEExport" "source-size-gb" "${SIZE_OUTPUT_GB}"
 set -x
 
 # Prepare buffer disk.
@@ -83,7 +83,7 @@ echo ${out}
 TARGET_SIZE_BYTES=$(du -b /gs/${IMAGE_OUTPUT_PATH} | awk '{print $1}')
 TARGET_SIZE_GB=$(awk "BEGIN {print int(((${TARGET_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
 set +x
-serialOutputKeyValuePair "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
+serialOutputPrefixedKeyValue "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
 set -x
 
 echo "GCEExport: Copying output image to target GCS path..."

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -15,7 +15,7 @@
 set -x
 
 function serialOutputKeyValuePair() {
-  echo "<serial-output key:'$1' value:'$2'>"
+  stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
 # Verify VM has access to Google APIs
@@ -47,7 +47,7 @@ SIZE_OUTPUT_GB=$(awk "BEGIN {print int(((${SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
 MAX_BUFFER_DISK_SIZE_GB=$(awk "BEGIN {print int(${SIZE_OUTPUT_GB} + 5)}")
 
 set +x
-echo "GCEExport: $(serialOutputKeyValuePair "source-size-gb" "${SIZE_OUTPUT_GB}")"
+serialOutputKeyValuePair "GCEExport" "source-size-gb" "${SIZE_OUTPUT_GB}"
 set -x
 
 # Prepare buffer disk.
@@ -83,7 +83,7 @@ echo ${out}
 TARGET_SIZE_BYTES=$(du -b /gs/${IMAGE_OUTPUT_PATH} | awk '{print $1}')
 TARGET_SIZE_GB=$(awk "BEGIN {print int(((${TARGET_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
 set +x
-echo "GCEExport: $(serialOutputKeyValuePair "target-size-gb" "${TARGET_SIZE_GB}")"
+serialOutputKeyValuePair "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
 set -x
 
 echo "GCEExport: Copying output image to target GCS path..."

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -177,7 +177,7 @@ function copyImageToScratchDisk() {
 }
 
 function serialOutputKeyValuePair() {
-  echo "<serial-output key:'$1' value:'$2'>"
+  stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
 # Dup logic in api_inflater.go. If change anything here, please change in both places.
@@ -191,7 +191,7 @@ function diskChecksum() {
   CHECKSUM2=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 2000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   CHECKSUM3=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 20000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   CHECKSUM4=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( $BLOCK_COUNT - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
-  echo "Import: $(serialOutputKeyValuePair "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4")"
+  serialOutputKeyValuePair "Import" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
 }
 
 copyImageToScratchDisk
@@ -227,9 +227,9 @@ IMPORT_FILE_FORMAT=$(qemu-img info "${IMAGE_PATH}" | grep -m1 "file format" | gr
 SIZE_GB=$(awk "BEGIN {print int(((${SIZE_BYTES} - 1)/${BYTES_1GB}) + 1)}")
 echo "Import: Importing ${IMAGE_PATH} of size ${SIZE_GB}GB to ${DISKNAME} in ${ZONE}." 2> /dev/null
 
-echo "Import: $(serialOutputKeyValuePair "target-size-gb" "${SIZE_GB}")"
-echo "Import: $(serialOutputKeyValuePair "source-size-gb" "${SOURCE_SIZE_GB}")"
-echo "Import: $(serialOutputKeyValuePair "import-file-format" "${IMPORT_FILE_FORMAT}")"
+serialOutputKeyValuePair "Import" "target-size-gb" "${SIZE_GB}"
+serialOutputKeyValuePair "Import" "source-size-gb" "${SOURCE_SIZE_GB}"
+serialOutputKeyValuePair "Import" "import-file-format" "${IMPORT_FILE_FORMAT}"
 
 ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -176,7 +176,7 @@ function copyImageToScratchDisk() {
   echo "Import: Copied image from ${SOURCE_URL} to ${IMAGE_PATH}: ${out}"
 }
 
-function serialOutputKeyValuePair() {
+function serialOutputPrefixedKeyValue() {
   stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
@@ -191,7 +191,7 @@ function diskChecksum() {
   CHECKSUM2=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 2000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   CHECKSUM3=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 20000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   CHECKSUM4=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( $BLOCK_COUNT - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
-  serialOutputKeyValuePair "Import" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
+  serialOutputPrefixedKeyValue "Import" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
 }
 
 copyImageToScratchDisk
@@ -227,9 +227,9 @@ IMPORT_FILE_FORMAT=$(qemu-img info "${IMAGE_PATH}" | grep -m1 "file format" | gr
 SIZE_GB=$(awk "BEGIN {print int(((${SIZE_BYTES} - 1)/${BYTES_1GB}) + 1)}")
 echo "Import: Importing ${IMAGE_PATH} of size ${SIZE_GB}GB to ${DISKNAME} in ${ZONE}." 2> /dev/null
 
-serialOutputKeyValuePair "Import" "target-size-gb" "${SIZE_GB}"
-serialOutputKeyValuePair "Import" "source-size-gb" "${SOURCE_SIZE_GB}"
-serialOutputKeyValuePair "Import" "import-file-format" "${IMPORT_FILE_FORMAT}"
+serialOutputPrefixedKeyValue "Import" "target-size-gb" "${SIZE_GB}"
+serialOutputPrefixedKeyValue "Import" "source-size-gb" "${SOURCE_SIZE_GB}"
+serialOutputPrefixedKeyValue "Import" "import-file-format" "${IMPORT_FILE_FORMAT}"
 
 ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 


### PR DESCRIPTION
Add "stdbuf -oL" to "echo" for serial-output key so the format won't be broken.
ref to b/167607270.

Tested by running export locally.