### PR TITLE
Modify scratch bucket creation name to not use "."

### DIFF
--- a/cli_tools/common/utils/storage/scratch_bucket_creator.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator.go
@@ -152,7 +152,7 @@ func (c *ScratchBucketCreator) getBucketAttrsIfInProject(project string, bucketN
 }
 
 func (c *ScratchBucketCreator) formatScratchBucketName(project string, location string) string {
-	bucket := strings.Replace(project, "google.com", "elgoog.com", -1)
+	bucket := strings.Replace(project, "google.com", "elgoog_com", -1)
 	bucket = strings.Replace(bucket, ":", "-", -1) + "-daisy-bkt"
 	if location != "" {
 		bucket = bucket + "-" + location

--- a/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
@@ -68,7 +68,7 @@ func TestCreateScratchBucketNoSourceFileTranslateGoogleDomainDefaultBucketCreate
 	defer mockCtrl.Finish()
 
 	project := "google.com:proJect1"
-	expectedBucket := "elgoog.com-project1-daisy-bkt-us"
+	expectedBucket := "elgoog_com-project1-daisy-bkt-us"
 	expectedRegion := "US"
 	ctx := context.Background()
 


### PR DESCRIPTION
Periods can be used in the creation of a GCS bucket, but if it exists
then there is a requirement that the domain that is used with the period
be owned or registered with the project. We can instead modify the project name to use
elgoog_com so that we do not rely on a project owning that domain.

https://cloud.google.com/storage/docs/naming-buckets#example_bucket_names