### PR TITLE
Update export_disk_ext.sh

### DIFF
--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -19,7 +19,7 @@ function serialOutputPrefixedKeyValue() {
 }
 
 # Verify VM has network access to Storage API by checking a public bucket
-curl --silent --fail "https://storage.googleapis.com/storage/v1/b/gcp-public-data-landsat" &> /dev/null;
+gsutil ls &> /dev/null;
 if [[ $? -ne 0 ]]; then
   echo "ExportFailed: Cannot access Google APIs. Ensure that VPC settings allow VMs to access Google APIs either via external IP or Private Google Access. More info at: https://cloud.google.com/vpc/docs/configure-private-google-access"
   exit

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -18,8 +18,8 @@ function serialOutputPrefixedKeyValue() {
   stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
 }
 
-# Verify VM has access to Google APIs
-curl --silent --fail "https://www.googleapis.com/discovery/v1/apis" &> /dev/null;
+# Verify VM has network access to Storage API by checking a public bucket
+curl --silent --fail "https://storage.googleapis.com/storage/v1/b/gcp-public-data-landsat" &> /dev/null;
 if [[ $? -ne 0 ]]; then
   echo "ExportFailed: Cannot access Google APIs. Ensure that VPC settings allow VMs to access Google APIs either via external IP or Private Google Access. More info at: https://cloud.google.com/vpc/docs/configure-private-google-access"
   exit


### PR DESCRIPTION
The test on line 22 introduces unexpected errors by testing for access to something different than what's actually needed. I've modified it to test reachability to the Storage API, not www.googleapis.com.

Most enterprise GCP customers will configure firewall and DNS controls for the Restricted VIP. In that environment, the attempt to curl www.googleapis.com will fail, even though Storage and other APIs can be accessed. This forces a weird workaround to change DNS and firewall rules to allow some limited egress to the private VIP, which adds complexity and compromises security. Improving the test condition allows this code to run without forcing weird workarounds.