### PR TITLE
Update dual-region to region mappings

### DIFF
--- a/cli_tools/common/utils/storage/resource_location_retriever.go
+++ b/cli_tools/common/utils/storage/resource_location_retriever.go
@@ -39,8 +39,9 @@ var (
 		"EU":   {[]string{"europe-west1", "europe-west4", "europe-north1", "europe-west2", "europe-west3", "europe-west6"}, true},
 		"ASIA": {[]string{"asia-east1", "asia-south1", "asia-southeast1", "asia-northeast1", "asia-northeast2", "asia-northeast3", "asia-southeast2", "asia-east2"}, true},
 
-		"EUR4": {[]string{"europe-west4", "europe-north1"}, false},
-		"NAM4": {[]string{"us-central1", "us-east1"}, false},
+		"EUR4":  {[]string{"europe-west4", "europe-north1"}, false},
+		"NAM4":  {[]string{"us-central1", "us-east1"}, false},
+		"ASIA1": {[]string{"asia-northeast1", "asia-northeast2"}, false},
 	}
 )
 

--- a/cli_tools/common/utils/storage/resource_location_retriever.go
+++ b/cli_tools/common/utils/storage/resource_location_retriever.go
@@ -39,7 +39,7 @@ var (
 		"EU":   {[]string{"europe-west1", "europe-west4", "europe-north1", "europe-west2", "europe-west3", "europe-west6"}, true},
 		"ASIA": {[]string{"asia-east1", "asia-south1", "asia-southeast1", "asia-northeast1", "asia-northeast2", "asia-northeast3", "asia-southeast2", "asia-east2"}, true},
 
-		"EUR4": {[]string{"europe-north1", "europe-west4"}, false},
+		"EUR4": {[]string{"europe-west4", "europe-north1"}, false},
 		"NAM4": {[]string{"us-central1", "us-east1"}, false},
 	}
 )


### PR DESCRIPTION
* Prefer `europe-west4` over `europe-north` when source file is in `eur4` dual region as `europe-west4` is supported by Cloud Build as of now.
* Added support for `ASIA1` dual region when determining zone to run operations in.