### PR TITLE
[onestep import] output help link for customers

### DIFF
--- a/cli_tools/gce_onestep_image_import/main.go
+++ b/cli_tools/gce_onestep_image_import/main.go
@@ -30,11 +30,16 @@ func main() {
 	importerArgs, err := importer.NewOneStepImportArguments(os.Args[1:])
 	if err != nil {
 		log.Println(err)
+		printHelpLink()
 		os.Exit(1)
 	}
 
 	importEntry := func() (service.Loggable, error) {
-		return importer.Run(importerArgs)
+		loggable, importErr := importer.Run(importerArgs)
+		if importErr != nil {
+			printHelpLink()
+		}
+		return loggable, importErr
 	}
 
 	// 2. Run Onestep Importer
@@ -42,6 +47,10 @@ func main() {
 		service.OneStepImageImportAction, initLoggingParams(importerArgs), importerArgs.ProjectPtr, importEntry); err != nil {
 		os.Exit(1)
 	}
+}
+
+func printHelpLink() {
+	log.Println("Reference to https://cloud.google.com/compute/docs/import/import-aws-image for more detailed help.")
 }
 
 func initLoggingParams(args *importer.OneStepImportArguments) service.InputParams {

--- a/cli_tools/gce_onestep_image_import/main.go
+++ b/cli_tools/gce_onestep_image_import/main.go
@@ -50,7 +50,7 @@ func main() {
 }
 
 func printHelpLink() {
-	log.Println("Reference to https://cloud.google.com/compute/docs/import/import-aws-image for more detailed help.")
+	log.Println("Refer to https://cloud.google.com/compute/docs/import/import-aws-image for more detailed help.")
 }
 
 func initLoggingParams(args *importer.OneStepImportArguments) service.InputParams {


### PR DESCRIPTION
To help customers easily find the guide, output the help link when onestep import failed.