### PR TITLE
CLI Tools: Make client_id optional

### DIFF
--- a/cli_tools/gce_onestep_image_import/README.md
+++ b/cli_tools/gce_onestep_image_import/README.md
@@ -18,8 +18,6 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_onestep_
 
 #### Required flags
 + `-image_name=IMAGE_NAME` Name of the disk image to create.
-+ `-client_id=CLIENT_ID` Identifies the client of the importer. For example: `gcloud` or
-  `pantheon`.
 + `-os=OS` Specifies the OS of the image being imported. Execute the tool with `-help` to
   see the list of currently-supported operating systems.
   
@@ -48,6 +46,8 @@ To import from AWS, exactly one of the groups must be specified:
       where you want to export the image.
 
 #### Optional flags
++ `-client_id=CLIENT_ID` Identifies the client of the importer. For example: `gcloud` or
+  `pantheon`.
 + `-no_guest_environment` Google Guest Environment will not be installed on the image.
 + `-family=FAMILY` Family to set for the translated image.
 + `-description=DESCRIPTION` Description to set for the translated image.
@@ -85,12 +85,13 @@ To import from AWS, exactly one of the groups must be specified:
 ### Usage
 
 ```
-gce_onestep_image_import -image_name=IMAGE_NAME -client_id=CLIENT_ID -os=OS
+gce_onestep_image_import -image_name=IMAGE_NAME -os=OS
         -aws_access_key_id=AWS_ACCESS_KEY_ID -aws_secret_access_key=AWS_SECRET_ACCESS_KEY
         -aws_session_token=AWS_SESSION_TOKEN -aws_region=AWS_REGION
         (-aws_source_ami_file_path=AWS_SOURCE_AMI_FILE_PATH |
          -aws_ami_id=AWS_AMI_ID -aws_ami_export_location=AWS_AMI_EXPORT_LOCATION)
-         [-no-guest-environment] [-family=FAMILY] [-description=DESCRIPTION] [-network=NETWORK]
+        [-client_id=CLIENT_ID] [-no-guest-environment] [-family=FAMILY]
+        [-description=DESCRIPTION] [-network=NETWORK]
         [-subnet=SUBNET] [-zone=ZONE] [-timeout=TIMEOUT] [-project=PROJECT]
         [-scratch_bucket_gcs_path=PATH] [-oauth=OAUTH_PATH] 
         [-compute_endpoint_override=ENDPOINT] [-disable_gcs_logging]

--- a/cli_tools/gce_onestep_image_import/onestep_importer/importer.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/importer.go
@@ -235,9 +235,6 @@ func (args *OneStepImportArguments) validate() error {
 	if err := daisyUtils.ValidateOS(args.OS); err != nil {
 		return err
 	}
-	if err := validation.ValidateStringFlagNotEmpty(args.ClientID, clientFlag); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/cli_tools/gce_onestep_image_import/onestep_importer/importer_test.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/importer_test.go
@@ -32,9 +32,13 @@ func TestTrimAndLowerImageName(t *testing.T) {
 	assert.Equal(t, "imagename", expectSuccessfulParse(t, args...).ImageName)
 }
 
-func TestFailWhenClientIDNotProvided(t *testing.T) {
+func TestAllowMissingClientID(t *testing.T) {
 	args := setUpArgs(clientFlag)
-	assert.EqualError(t, expectFailedValidation(t, args), "The flag -client_id must be provided")
+	importArgs, err := NewOneStepImportArguments(args)
+	assert.NoError(t, err)
+	err = importArgs.validate()
+	assert.NoError(t, err)
+	assert.Equal(t, "", importArgs.ClientID)
 }
 
 func TestTrimAndLowerClientID(t *testing.T) {

--- a/cli_tools/gce_ovf_export/README.md
+++ b/cli_tools/gce_ovf_export/README.md
@@ -26,14 +26,14 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_expo
 
 #### Required flags
 + `-destination-uri` GCS path to the exported OVF package or OVA archive.
-+ `-client-id` Identifies the client of the OVF exporter. For example: `gcloud` or
-  `pantheon`.
 
 Exactly one of these must be specified:
 + `-instance-name` Name of the VM instances to export.
 + `-machine-image-name` Name of the machine image to export.
 
 #### Optional flags
++ `-client-id` Identifies the client of the OVF exporter. For example: `gcloud` or
+  `pantheon`.
 + `-ovf-format=OVF_FORMAT` One of: `ovf` or `ova`. Defaults to `ovf`. If `ova`
   is specified, exported OVF package will be packed as an OVA archive and
   individual files will be removed from GCS.  
@@ -65,8 +65,8 @@ Exactly one of these must be specified:
 
 Export a VM instance:
 ```
-gce_ovf_export -destination-uri=GCS_PATH -client-id=CLIENT_ID
--instance-name=INSTANCE_NAME [-ovf-format=OVF_FORMAT]
+gce_ovf_export -destination-uri=GCS_PATH -instance-name=INSTANCE_NAME
+[-client-id=CLIENT_ID] [-ovf-format=OVF_FORMAT]
 [-disk-export-format=DISK_FORMAT] [--os] [-network=NETWORK] [-subnet=SUBNET]
 [-timeout=TIMEOUT; default="2h"] [-project=PROJECT]
 [-scratch-bucket-gcs-path=SCRATCH_BUCKET_PATH] [-oauth=OAUTH_FILE_PATH]
@@ -77,8 +77,8 @@ gce_ovf_export -destination-uri=GCS_PATH -client-id=CLIENT_ID
 
 Export a machine image:
 ```
-gce_ovf_export -destination-uri=GCS_PATH -client-id=CLIENT_ID
--machine-image-name=MACHINE_IMAGE [-ovf-format=OVF_FORMAT] 
+gce_ovf_export -destination-uri=GCS_PATH -machine-image-name=MACHINE_IMAGE 
+[-client-id=CLIENT_ID] [-ovf-format=OVF_FORMAT] 
 [-disk-export-format=DISK_FORMAT] [--os] [-network=NETWORK] [-subnet=SUBNET]
 [-timeout=TIMEOUT; default="2h"] [-project=PROJECT]
 [-scratch-bucket-gcs-path=SCRATCH_BUCKET_PATH] [-oauth=OAUTH_FILE_PATH]

--- a/cli_tools/gce_ovf_export/exporter/param_validator.go
+++ b/cli_tools/gce_ovf_export/exporter/param_validator.go
@@ -51,9 +51,6 @@ func (validator *ovfExportParamValidatorImpl) ValidateAndParseParams(params *ovf
 		return daisy.Errf("-%v and -%v can't be provided at the same time", ovfexportdomain.InstanceNameFlagKey, ovfexportdomain.MachineImageNameFlagKey)
 	}
 
-	if err := validation.ValidateStringFlagNotEmpty(params.ClientID, ovfexportdomain.ClientIDFlagKey); err != nil {
-		return err
-	}
 	if err := validation.ValidateStringFlagNotEmpty(params.DestinationURI, ovfexportdomain.DestinationURIFlagKey); err != nil {
 		return err
 	}

--- a/cli_tools/gce_ovf_export/exporter/param_validator_test.go
+++ b/cli_tools/gce_ovf_export/exporter/param_validator_test.go
@@ -18,10 +18,11 @@ import (
 	"fmt"
 	"testing"
 
-	ovfexportdomain "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_export/domain"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	ovfexportdomain "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_export/domain"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
 )
 
 var validReleaseTracks = []string{"ga", "beta", "alpha"}
@@ -76,12 +77,13 @@ func TestInstanceExportZoneInvalid(t *testing.T) {
 	assert.Equal(t, zoneError, validator.ValidateAndParseParams(params))
 }
 
-func TestInstanceExportFlagsClientIdNotProvided(t *testing.T) {
+func TestInstanceExportFlagsAllowsClientIdNotProvided(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+	validator := createDefaultParamValidator(mockCtrl, true)
 	params := ovfexportdomain.GetAllInstanceExportArgs()
 	params.ClientID = ""
-	assertErrorOnValidate(t, params, createDefaultParamValidator(mockCtrl, false))
+	assert.Nil(t, validator.ValidateAndParseParams(params))
 }
 
 func TestInstanceExportFlagsInvalidReleaseTrack(t *testing.T) {
@@ -156,13 +158,13 @@ func TestMachineImageExportFlagsOvfGcsPathFlagNotValid(t *testing.T) {
 	assertErrorOnValidate(t, params, validator)
 }
 
-func TestMachineImageExportFlagsClientIdNotProvided(t *testing.T) {
+func TestMachineImageExportFlagsAllowsClientIdNotProvided(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-	validator := createDefaultParamValidator(mockCtrl, false)
+	validator := createDefaultParamValidator(mockCtrl, true)
 	params := ovfexportdomain.GetAllMachineImageExportArgs()
 	params.ClientID = ""
-	assertErrorOnValidate(t, params, validator)
+	assert.Nil(t, validator.ValidateAndParseParams(params))
 }
 
 func TestMachineImageExportFlagsAllValidBucketOnlyPathTrailingSlash(t *testing.T) {

--- a/cli_tools/gce_ovf_import/README.md
+++ b/cli_tools/gce_ovf_import/README.md
@@ -26,14 +26,14 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_impo
 
 #### Required flags
 + `-ovf-gcs-path` GCS path to OVF descriptor, OVA file or a directory with OVF package.
-+ `-client-id` Identifies the client of the OVF importer. For example: `gcloud` or
-  `pantheon`.
  
 Exactly one of these must be specified:
 + `-instance-names` Name of the VM instances to create.
 + `-machine-image-name` Name of the machine image to create.
 
 #### Optional flags
++ `-client-id` Identifies the client of the OVF importer. For example: `gcloud` or
+  `pantheon`.
 + `-no-guest-environment` Google Guest Environment will not be installed on the image
 + `-can-ip-forward` If provided, allows the instances to send and receive packets with non-matching
   destination or source IP addresses.
@@ -121,8 +121,8 @@ Exactly one of these must be specified:
 
 Import into a VM instance:
 ```
-gce_ovf_import -instance-names=INSTANCE_NAME -client-id=CLIENT_ID 
--source-uri=OVF_GCS_FILE_PATH
+gce_ovf_import -instance-names=INSTANCE_NAME -source-uri=OVF_GCS_FILE_PATH
+[-client-id=CLIENT_ID]
 [-can-ip-forward] [-custom-cpu=CUSTOM_CPU -custom-memory=CUSTOM_MEMORY]
 [-deletion-protection] [-description=DESCRIPTION]
 [-labels=[KEY=VALUE,…]] [-machine-type=MACHINE_TYPE]
@@ -144,8 +144,8 @@ gce_ovf_import -instance-names=INSTANCE_NAME -client-id=CLIENT_ID
 
 Import into a machine image:
 ```
-gce_ovf_import -machine-image-name=MACHINE_IMAGE_NAME -client-id=CLIENT_ID 
--source-uri=OVF_GCS_FILE_PATH
+gce_ovf_import -machine-image-name=MACHINE_IMAGE_NAME -source-uri=OVF_GCS_FILE_PATH
+[-client-id=CLIENT_ID]
 [-can-ip-forward] [-custom-cpu=CUSTOM_CPU -custom-memory=CUSTOM_MEMORY]
 [-deletion-protection] [-description=DESCRIPTION]
 [-labels=[KEY=VALUE,…]] [-machine-type=MACHINE_TYPE]

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator.go
@@ -142,10 +142,6 @@ func (p *ParamValidatorAndPopulator) ValidateAndPopulate(params *ovfdomain.OVFIm
 		return err
 	}
 
-	if err := validation.ValidateStringFlagNotEmpty(params.ClientID, ClientIDFlagKey); err != nil {
-		return err
-	}
-
 	if _, err := storageutils.GetBucketNameFromGCSPath(params.OvfOvaGcsPath); err != nil {
 		return daisy.Errf("%v should be a path to OVF or OVA package in Cloud Storage", OvfGcsPathFlagKey)
 	}

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
@@ -203,35 +203,25 @@ func Test_ValidateAndParseParams_ErrorMessages(t *testing.T) {
 				params.MachineImageName = ""
 			},
 			expectErrorToContain: "Either the flag -instance-names or -machine-image-name must be provided",
-		},
-		{
+		}, {
 			name: "Only one of {InstanceNames, MachineImageNames} allowed",
 			paramModifier: func(params *domain.OVFImportParams) {
 				params.InstanceNames = "a"
 				params.MachineImageName = "a"
 			},
 			expectErrorToContain: "-instance-names and -machine-image-name can't be provided at the same time",
-		},
-		{
+		}, {
 			name: "hostname is validated for syntax",
 			paramModifier: func(params *domain.OVFImportParams) {
 				params.Hostname = "host|name"
 			},
 			expectErrorToContain: "The flag `hostname` must conform to RFC 1035 requirements for valid hostnames",
-		},
-		{
+		}, {
 			name: "hostname is validated for length",
 			paramModifier: func(params *domain.OVFImportParams) {
 				params.Hostname = "host.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain.domain"
 			},
 			expectErrorToContain: "The flag `hostname` must conform to RFC 1035 requirements for valid hostnames",
-		},
-		{
-			name: "require ClientID",
-			paramModifier: func(params *domain.OVFImportParams) {
-				params.ClientID = ""
-			},
-			expectErrorToContain: "flag -client-id must be provided",
 		}, {
 			name: "labels must be parseable",
 			paramModifier: func(params *domain.OVFImportParams) {
@@ -316,6 +306,14 @@ func Test_ValidateAndParseParams_SuccessfulCases(t *testing.T) {
 
 	cases := []testCase{
 		{
+			name: "allow empty clientID",
+			paramModifier: func(params *domain.OVFImportParams) {
+				params.ClientID = ""
+			},
+			checkResult: func(t *testing.T, params *domain.OVFImportParams, importType string) {
+				assert.Equal(t, "", params.ClientID)
+			},
+		}, {
 			name: "replace empty network with default when subnet empty",
 			paramModifier: func(params *domain.OVFImportParams) {
 				params.Network = ""

--- a/cli_tools/gce_vm_image_export/README.md
+++ b/cli_tools/gce_vm_image_export/README.md
@@ -16,8 +16,6 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image
 ### Flags
 
 #### Required flags
-+ `-client_id=CLIENT_ID` Identifies the client of the importer. For example: `gcloud` or
-  `pantheon`.
 + `-destination_uri=DESTINATION_URI` The Google Cloud Storage URI destination for the exported
   virtual disk file. For example: gs://my-bucket/my-exported-image.vmdk.
 
@@ -29,6 +27,8 @@ Exactly one of these must be specified:
 
 
 #### Optional flags
++ `-client_id=CLIENT_ID` Identifies the client of the importer. For example: `gcloud` or
+  `pantheon`.
 + `-format=FORMAT` Specify the format to export to, such as vmdk, vhdx, vpc, or qcow2.
 + `-project=PROJECT` Project to run in, overrides what is set in workflow.
 + `-network=NETWORK` Name of the network in your project to use for the image import. The network 
@@ -58,7 +58,7 @@ Exactly one of these must be specified:
 ### Usage
 
 ```
-gce_vm_image_export -client_id=CLIENT_ID -destination_uri=DESTINATION_URI
+gce_vm_image_export -destination_uri=DESTINATION_URI [-client_id=CLIENT_ID]
         (-source_image=SOURCE_IMAGE | -source_disk_snapshot=SOURCE_DISK_SNAPSHOT)
         [-format=FORMAT] [-project=PROJECT] [-network=NETWORK]
         [-subnet=SUBNET] [-zone=ZONE] [-timeout=TIMEOUT] [-scratch_bucket_gcs_path=PATH]

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -54,12 +54,8 @@ const (
 	logPrefix = "[image-export]"
 )
 
-func validateAndParseFlags(clientID string, destinationURI string, sourceImage string, sourceDiskSnapshot string, labels string) (
-	map[string]string, error) {
+func validateAndParseFlags(destinationURI string, sourceImage string, sourceDiskSnapshot string, labels string) (map[string]string, error) {
 
-	if err := validation.ValidateStringFlagNotEmpty(clientID, ClientIDFlagKey); err != nil {
-		return nil, err
-	}
 	if err := validation.ValidateStringFlagNotEmpty(destinationURI, DestinationURIFlagKey); err != nil {
 		return nil, err
 	}
@@ -180,7 +176,7 @@ func Run(clientID string, destinationURI string, sourceImage string, sourceDiskS
 
 	log.SetPrefix(logPrefix + " ")
 
-	userLabels, err := validateAndParseFlags(clientID, destinationURI, sourceImage, sourceDiskSnapshot, labels)
+	userLabels, err := validateAndParseFlags(destinationURI, sourceImage, sourceDiskSnapshot, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/gce_vm_image_export/exporter/exporter_test.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	clientID, destinationURI, sourceImage, sourceDiskSnapshot, format, network, subnet, labels string
+	destinationURI, sourceImage, sourceDiskSnapshot, format, network, subnet, labels string
 )
 
 func TestGetWorkflowPathWithoutFormatConversion(t *testing.T) {
@@ -61,12 +61,6 @@ func TestFlagsBothSourceImageAndSourceSnapshotProvided(t *testing.T) {
 	assertErrorOnValidate("Expected error for both source_image and source_disk_snapshot flags provided", t)
 }
 
-func TestFlagsClientIdNotProvided(t *testing.T) {
-	resetArgs()
-	clientID = ""
-	assertErrorOnValidate("Expected error for missing client_id flag", t)
-}
-
 func TestFlagsDestinationUriNotProvided(t *testing.T) {
 	resetArgs()
 	destinationURI = ""
@@ -74,7 +68,7 @@ func TestFlagsDestinationUriNotProvided(t *testing.T) {
 }
 
 func assertErrorOnValidate(errorMsg string, t *testing.T) {
-	if _, err := validateAndParseFlags(clientID, destinationURI, sourceImage, sourceDiskSnapshot, labels); err == nil {
+	if _, err := validateAndParseFlags(destinationURI, sourceImage, sourceDiskSnapshot, labels); err == nil {
 		t.Error(errorMsg)
 	}
 }
@@ -200,7 +194,6 @@ func TestValidateImageExists_ReturnsError_WhenImageNotFound(t *testing.T) {
 }
 
 func resetArgs() {
-	clientID = "aClient"
 	destinationURI = "gs://bucket/exported_image"
 	sourceImage = "global/images/anImage"
 	sourceDiskSnapshot = ""

--- a/cli_tools/gce_vm_image_import/README.md
+++ b/cli_tools/gce_vm_image_import/README.md
@@ -18,8 +18,6 @@ go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image
 
 #### Required flags
 + `-image_name=IMAGE_NAME` Name of the disk image to create.
-+ `-client_id=CLIENT_ID` Identifies the client of the importer. For example: `gcloud` or
-  `pantheon`.
   
 Exactly one of these must be specified:
 + `-source_file=SOURCE_FILE` Google Cloud Storage URI of the virtual disk file
@@ -28,6 +26,8 @@ Exactly one of these must be specified:
   import.
 
 #### Optional flags  
++ `-client_id=CLIENT_ID` Identifies the client of the importer. For example: `gcloud` or
+  `pantheon`.
 + `-no_guest_environment` Google Guest Environment will not be installed on the image.
 + `-family=FAMILY` Family to set for the translated image.
 + `-description=DESCRIPTION` Description to set for the translated image.
@@ -84,7 +84,7 @@ Exactly one of these must be specified:
 ### Usage
 
 ```
-gce_vm_image_import -image_name=IMAGE_NAME -client_id=CLIENT_ID [--data-disk | --byol --os=OS]
+gce_vm_image_import -image_name=IMAGE_NAME [-client_id=CLIENT_ID] [--data-disk | --byol --os=OS]
         (-source-file=SOURCE_FILE | -source-image=SOURCE_IMAGE) [-no-guest-environment] 
         [-family=FAMILY] [-description=DESCRIPTION] [-network=NETWORK] [-subnet=SUBNET]
         [-zone=ZONE] [-timeout=TIMEOUT] [-project=PROJECT] [-scratch_bucket_gcs_path=PATH]

--- a/cli_tools/gce_vm_image_import/cli/args.go
+++ b/cli_tools/gce_vm_image_import/cli/args.go
@@ -66,10 +66,6 @@ func (args *imageImportArgs) populateAndValidate(populator param.Populator,
 		args.ExecutionID = path.RandString(5)
 	}
 
-	if args.ClientID == "" {
-		return fmt.Errorf("%s has to be specified", importer.ClientFlag)
-	}
-
 	importer.FixBYOLAndOSArguments(&args.OS, &args.BYOL)
 	args.Source, err = sourceFactory.Init(args.SourceFile, args.SourceImage)
 	if err != nil {

--- a/cli_tools/gce_vm_image_import/cli/args_test.go
+++ b/cli_tools/gce_vm_image_import/cli/args_test.go
@@ -224,7 +224,7 @@ func Test_populateAndValidate_SupportsSysprep(t *testing.T) {
 	assert.True(t, parseAndPopulate(t, "-sysprep_windows").SysprepWindows)
 }
 
-func Test_populateAndValidate_FailsWhenClientIdMissing(t *testing.T) {
+func Test_populateAndValidate_ClientIdIsOptional(t *testing.T) {
 	args, err := parseArgsFromUser([]string{"-image_name=i", "-data_disk"})
 	assert.NoError(t, err)
 	err = args.populateAndValidate(mockPopulator{
@@ -232,7 +232,8 @@ func Test_populateAndValidate_FailsWhenClientIdMissing(t *testing.T) {
 		region:          "us-west2",
 		storageLocation: "us",
 	}, mockSourceFactory{})
-	assert.EqualError(t, err, "client_id has to be specified")
+	assert.NoError(t, err)
+	assert.Equal(t, "", args.ClientID)
 }
 
 func Test_populateAndValidate_BackfillsStorageLocationIfMissing(t *testing.T) {

--- a/cli_tools/gce_windows_upgrade/upgrader/validators.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/validators.go
@@ -19,14 +19,14 @@ import (
 	"regexp"
 	"strings"
 
+	"google.golang.org/api/compute/v1"
+
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
 	daisyutils "github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/param"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/validation"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
-	"google.golang.org/api/compute/v1"
 )
 
 const (
@@ -53,9 +53,6 @@ func (u *upgrader) validateAndDeriveParams() error {
 		u.derivedVars = &derivedVars{}
 	}
 
-	if err := validation.ValidateStringFlagNotEmpty(u.ClientID, ClientIDFlagKey); err != nil {
-		return err
-	}
 	if err := validateOSVersion(u.SourceOS, u.TargetOS); err != nil {
 		return err
 	}

--- a/cli_tools/gce_windows_upgrade/upgrader/validators_test.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/validators_test.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
-	"github.com/GoogleCloudPlatform/compute-image-tools/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/domain"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisy"
+	"github.com/GoogleCloudPlatform/compute-image-tools/mocks"
 )
 
 func init() {
@@ -45,7 +46,7 @@ func TestValidateParams(t *testing.T) {
 
 	u = newTestUpgrader().upgrader
 	u.ClientID = ""
-	tcs = append(tcs, testCase{"No client id", u, "The flag -client-id must be provided", DefaultTimeout})
+	tcs = append(tcs, testCase{"clientID is optional", u, "", DefaultTimeout})
 
 	u = newTestUpgrader().upgrader
 	u.SourceOS = "android"


### PR DESCRIPTION
`client_id` is used for logging and metrics, and we're seeing failures where operations are failing when this parameter is not passed. Following this PR, `client_id` will be optional for all CLI tools; when omitted, the value is the empty string.