### PR TITLE
Adding detection and remediation of static IP & DNS

### DIFF
--- a/daisy_workflows/image_import/windows/network.ps1
+++ b/daisy_workflows/image_import/windows/network.ps1
@@ -19,36 +19,36 @@ $adapter = Get-NetAdapter | ? {$_.Status -eq "up"}
 $interface = $adapter | Get-NetIPInterface -AddressFamily IPv4
 
 If ($interface.Dhcp -eq "Disabled") {
-  Write-Output "Translate: $($interface.InterfaceAlias) does not have DHCP enabled. Enabling DHCP."
+  Write-Host "Translate: $($interface.InterfaceAlias) does not have DHCP enabled. Enabling DHCP."
   # Remove existing gateway
   If (($interface | Get-NetIPConfiguration).Ipv4DefaultGateway) {
-    Write-Output "Translate: Removing IPv4 default gateway for $($interface.InterfaceAlias)."
+    Write-Host "Translate: Removing IPv4 default gateway for $($interface.InterfaceAlias)."
     $interface | Remove-NetRoute -Confirm:$false
   }
 
   # Enable DHCP
-  Write-Output "Translate: Enabling DHCP for $($interface.InterfaceAlias)."
+  Write-Host "Translate: Enabling DHCP for $($interface.InterfaceAlias)."
   $interface | Set-NetIPInterface -DHCP Enabled
 
   # Configure the DNS Servers automatically
-  Write-Output "Translate: Configure the DNS to use DNS servers from DHCP for $($interface.InterfaceAlias)."
+  Write-Host "Translate: Configure the DNS to use DNS servers from DHCP for $($interface.InterfaceAlias)."
   $interface | Set-DnsClientServerAddress -ResetServerAddresses
 
   # Restart the network adapter
-  Write-Output "Translate: Restarting network adapter: $($adapter.Name)."
+  Write-Host "Translate: Restarting network adapter: $($adapter.Name)."
   $adapter | Restart-NetAdapter
 
   # Give the network time to initialize.
   & ping 127.0.0.1 -n 30
 } else {
-  Write-Output "Translate: $($interface.InterfaceAlias) is configured for DHCP."
+  Write-Host "Translate: $($interface.InterfaceAlias) is configured for DHCP."
 }
 
 # Log DNS Server information
-Write-Output 'DNS client configuration:'
+Write-Host 'DNS client configuration:'
 $interface | Get-DnsClientServerAddress
 
 # Test connection to packages.cloud.google.com and log results.
-Write-Output 'Testing connection to packages.cloud.google.com:'
+Write-Host 'Testing connection to packages.cloud.google.com:'
 Test-NetConnection -ComputerName packages.cloud.google.com -Port 443
 Test-NetConnection -ComputerName packages.cloud.google.com -Port 80

--- a/daisy_workflows/image_import/windows/network.ps1
+++ b/daisy_workflows/image_import/windows/network.ps1
@@ -1,0 +1,54 @@
+#  Copyright 2021 Google Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Ensure the network interface is configured to use DHCP.
+# This script assumes there is only one network adapter.
+
+$adapter = Get-NetAdapter | ? {$_.Status -eq "up"}
+$interface = $adapter | Get-NetIPInterface -AddressFamily IPv4
+
+If ($interface.Dhcp -eq "Disabled") {
+  Write-Output "Translate: $($interface.InterfaceAlias) does not have DHCP enabled. Enabling DHCP."
+  # Remove existing gateway
+  If (($interface | Get-NetIPConfiguration).Ipv4DefaultGateway) {
+    Write-Output "Translate: Removing IPv4 default gateway for $($interface.InterfaceAlias)."
+    $interface | Remove-NetRoute -Confirm:$false
+  }
+
+  # Enable DHCP
+  Write-Output "Translate: Enabling DHCP for $($interface.InterfaceAlias)."
+  $interface | Set-NetIPInterface -DHCP Enabled
+
+  # Configure the DNS Servers automatically
+  Write-Output "Translate: Configure the DNS to use DNS servers from DHCP for $($interface.InterfaceAlias)."
+  $interface | Set-DnsClientServerAddress -ResetServerAddresses
+
+  # Restart the network adapter
+  Write-Output "Translate: Restarting network adapter: $($adapter.Name)."
+  $adapter | Restart-NetAdapter
+
+  # Give the network time to initialize.
+  & ping 127.0.0.1 -n 30
+} else {
+  Write-Output "Translate: $($interface.InterfaceAlias) is configured for DHCP."
+}
+
+# Log DNS Server information
+Write-Output 'DNS client configuration:'
+$interface | Get-DnsClientServerAddress
+
+# Test connection to packages.cloud.google.com and log results.
+Write-Output 'Testing connection to packages.cloud.google.com:'
+Test-NetConnection -ComputerName packages.cloud.google.com -Port 443
+Test-NetConnection -ComputerName packages.cloud.google.com -Port 80

--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -23,8 +23,8 @@ REM This is to address initial boot issues, mostly on 2008R2, where the network 
 echo "Scheduling restart in 5 minutes. Translate.ps1 will cancel this restart." > COM1:
 shutdown /r /t 300
 
-echo "Running network.ps1 to reconfigure network to DHCP if needed and log DNS and connectivity tests."
-PowerShell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "%ProgramFiles%\Google\Compute Engine\metadata_scripts\network.ps1"
+echo "Running network.ps1 to reconfigure network to DHCP if needed and log DNS and connectivity tests." > COM1:
+PowerShell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "%ProgramFiles%\Google\Compute Engine\metadata_scripts\network.ps1" > COM1:
 
 echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.

--- a/daisy_workflows/image_import/windows/run_startup_scripts.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts.cmd
@@ -23,6 +23,9 @@ REM This is to address initial boot issues, mostly on 2008R2, where the network 
 echo "Scheduling restart in 5 minutes. Translate.ps1 will cancel this restart." > COM1:
 shutdown /r /t 300
 
+echo "Running network.ps1 to reconfigure network to DHCP if needed and log DNS and connectivity tests."
+PowerShell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "%ProgramFiles%\Google\Compute Engine\metadata_scripts\network.ps1"
+
 echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow

--- a/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
@@ -23,8 +23,8 @@ REM This is to address initial boot issues, mostly on 2008R2, where the network 
 echo "Scheduling restart in 5 minutes. Translate.ps1 will cancel this restart." > COM1:
 shutdown /r /t 300
 
-echo "Running network.ps1 to reconfigure network to DHCP if needed and log DNS and connectivity tests."
-PowerShell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "%ProgramFiles%\Google\Compute Engine\metadata_scripts\network.ps1"
+echo "Running network.ps1 to reconfigure network to DHCP if needed and log DNS and connectivity tests." > COM1:
+PowerShell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "%ProgramFiles%\Google\Compute Engine\metadata_scripts\network.ps1" > COM1:
 
 echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.

--- a/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
+++ b/daisy_workflows/image_import/windows/run_startup_scripts_x86.cmd
@@ -23,6 +23,9 @@ REM This is to address initial boot issues, mostly on 2008R2, where the network 
 echo "Scheduling restart in 5 minutes. Translate.ps1 will cancel this restart." > COM1:
 shutdown /r /t 300
 
+echo "Running network.ps1 to reconfigure network to DHCP if needed and log DNS and connectivity tests."
+PowerShell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "%ProgramFiles%\Google\Compute Engine\metadata_scripts\network.ps1"
+
 echo "Translate: Opening firewall ports for GCE metadata server." > COM1:
 REM Enable inbound communication from the metadata server.
 netsh advfirewall firewall add rule name="Allow incoming from GCE metadata server" protocol=ANY remoteip=169.254.169.254 dir=in action=allow

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -366,7 +366,10 @@ try {
   # Only needed and applicable to 2008R2.
   $netkvm = Get-WMIObject Win32_NetworkAdapter -filter "ServiceName='netkvm'"
   $netkvm | ForEach-Object {
-    & netsh interface ipv4 set dnsservers "$($_.NetConnectionID)" dhcp | Out-Null
+    Write-Output "Translate: Setting IPv4 to use DHCP for $($_.NetConnectionID)"
+    & netsh interface ip set address "$($_.NetConnectionID)" dhcp
+    Write-Output "Translate: Setting DNS to use DHCP for $($_.NetConnectionID)"
+    & netsh interface ipv4 set dnsservers "$($_.NetConnectionID)" dhcp
   }
 
   Enable-RemoteDesktop
@@ -389,6 +392,12 @@ try {
 
   if ($script:is_byol.ToLower() -eq 'true') {
     'Image imported into GCE using BYOL worklfow' > 'C:\Program Files\Google\Compute Engine\sysprep\byol_image'
+  }
+
+  # Cleanup
+  if (Test-Path -Path "$Env:Programfiles\Google\Compute Engine\metadata_scripts\network.ps1") {
+    Write-Output "Deleting file $Env:Programfiles\Google\Compute Engine\metadata_scripts\network.ps1"
+    Remove-Item -Path "$Env:Programfiles\Google\Compute Engine\metadata_scripts\network.ps1" -Force
   }
 
   Write-Output 'Translate complete.'

--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -366,10 +366,7 @@ try {
   # Only needed and applicable to 2008R2.
   $netkvm = Get-WMIObject Win32_NetworkAdapter -filter "ServiceName='netkvm'"
   $netkvm | ForEach-Object {
-    Write-Output "Translate: Setting IPv4 to use DHCP for $($_.NetConnectionID)"
-    & netsh interface ip set address "$($_.NetConnectionID)" dhcp
-    Write-Output "Translate: Setting DNS to use DHCP for $($_.NetConnectionID)"
-    & netsh interface ipv4 set dnsservers "$($_.NetConnectionID)" dhcp
+    & netsh interface ipv4 set dnsservers "$($_.NetConnectionID)" dhcp | Out-Null
   }
 
   Enable-RemoteDesktop

--- a/daisy_workflows/image_import/windows/translate_bootstrap.ps1
+++ b/daisy_workflows/image_import/windows/translate_bootstrap.ps1
@@ -61,6 +61,7 @@ function Setup-ScriptRunner {
   $metadata_scripts = "${script:os_drive}\Program Files\Google\Compute Engine\metadata_scripts"
   New-Item "${metadata_scripts}\"  -Force -ItemType Directory | Out-Null
   Copy-Item "${script:components_dir}\run_startup_scripts.cmd" "${metadata_scripts}\run_startup_scripts.cmd" -Verbose
+  Copy-Item "${script:components_dir}\network.ps1" "${metadata_scripts}\network.ps1" -Verbose
   # This file must be unicode with no trailing new line and exactly match the source.
   (Get-Content "${script:components_dir}\GCEStartup" | Out-String).TrimEnd() | Out-File -Encoding Unicode -NoNewline "${script:os_drive}\Windows\System32\Tasks\GCEStartup"
 

--- a/daisy_workflows/image_import/windows/translate_windows_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_wf.json
@@ -53,6 +53,7 @@
     "translate_bootstrap.ps1": "./translate_bootstrap.ps1",
     "drivers": "${drivers}",
     "components/run_startup_scripts.cmd": "./run_startup_scripts.cmd",
+    "components/network.ps1": "./network.ps1",
     "components/GCEStartup.reg": "${task_reg}",
     "components/GCEStartup": "${task_xml}"
   },

--- a/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_x86_wf.json
@@ -57,6 +57,7 @@
     "translate_bootstrap.ps1": "./translate_bootstrap.ps1",
     "drivers": "${drivers}",
     "components/run_startup_scripts.cmd": "./run_startup_scripts_x86.cmd",
+    "components/network.ps1": "./network.ps1",
     "components/GCEStartup.reg": "${task_reg}",
     "components/GCEStartup": "${task_xml}",
     "components/googet.exe": "gs://win-32bit-files/googet/googet.exe",


### PR DESCRIPTION
- Adding network.ps1 which is launched by run_startup_scripts.cmd
- Added network.ps1 to workflow files so it's copied into the components GCS location
- Added copying network.ps1 to instance in translate_bootstrap.ps1
- network.ps1 does the following:
  - Verified that the connected adapter is set to DHCP, is set the static IP it will change the adapter to DHCP and set the DNS server to also be obtained by DHCP. If updated it will also restart the network adapter and wait 30 seconds via a ping test.
  - It will always test connectivity to packages.cloud.google.com and output the DNS configuration of the adapter.