### PR TITLE
[cli-tools] fix buffered writer err log prefix so it can be picked up by 'waitForInstanceSignals'

### DIFF
--- a/cli_tools/common/utils/storage/buffered_writer.go
+++ b/cli_tools/common/utils/storage/buffered_writer.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-var gcsPermissionErrorRegExp = regexp.MustCompile(".*does not have storage.objects.create access to .*")
+var gcsPermissionErrorRegExp = regexp.MustCompile(".*does not have storage.objects.* access to .*")
 
 type gcsClient func(ctx context.Context, oauth string) (domain.StorageClientInterface, error)
 
@@ -48,6 +48,8 @@ type BufferedWriter struct {
 	id       string
 	bkt, obj string
 
+	errLogPrefix string
+
 	upload    chan string
 	tmpObjs   []string
 	tmpObjsMx sync.Mutex
@@ -60,7 +62,7 @@ type BufferedWriter struct {
 }
 
 // NewBufferedWriter creates a BufferedWriter
-func NewBufferedWriter(ctx context.Context, size, workers int64, client gcsClient, oauth, prefix, bkt, obj string) *BufferedWriter {
+func NewBufferedWriter(ctx context.Context, size, workers int64, client gcsClient, oauth, prefix, bkt, obj, errLogPrefix string) *BufferedWriter {
 	b := &BufferedWriter{
 		cSize:  size / workers,
 		prefix: prefix,
@@ -117,12 +119,13 @@ func (b *BufferedWriter) uploadWorker() {
 				// Don't retry if permission error as it's not recoverable.
 				gAPIErr, isGAPIErr := err.(*googleapi.Error)
 				if isGAPIErr && gAPIErr.Code == 403 && gcsPermissionErrorRegExp.MatchString(gAPIErr.Message) {
-					fmt.Printf("GCEExport: %v", err)
+					fmt.Printf("%v: %v", b.errLogPrefix, err)
 					os.Exit(2)
 				}
 
 				fmt.Printf("Failed %v time(s) to upload '%v', error: %v\n", i, in, err)
 				if i > 16 {
+					fmt.Printf("%v: %v", b.errLogPrefix, err)
 					log.Fatal(err)
 				}
 

--- a/cli_tools/common/utils/storage/buffered_writer.go
+++ b/cli_tools/common/utils/storage/buffered_writer.go
@@ -123,7 +123,7 @@ func (b *BufferedWriter) uploadWorker() {
 			}()
 			if err != nil {
 				// Don't retry if permission error as it's not recoverable.
- 				gAPIErr, isGAPIErr := err.(*googleapi.Error)
+				gAPIErr, isGAPIErr := err.(*googleapi.Error)
 				if isGAPIErr && gAPIErr.Code == 403 && gcsPermissionErrorRegExp.MatchString(gAPIErr.Message) {
 					fmt.Printf("%v: %v\n", b.errLogPrefix, err)
 					exit(2)

--- a/cli_tools/common/utils/storage/buffered_writer_test.go
+++ b/cli_tools/common/utils/storage/buffered_writer_test.go
@@ -361,12 +361,6 @@ func TestErrorWhenCopyFails(t *testing.T) {
 
 func TestErrorWhenComposeFails(t *testing.T) {
 	resetArgs()
-	err := mockComposeWithErrorReturned(t, "Fail to compose")
-	assert.NotNil(t, err)
-	assert.Equal(t, "Fail to compose", err.Error())
-}
-
-func mockComposeWithErrorReturned(t *testing.T, errorMsg string) error {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockStorageObject := mocks.NewMockStorageObject(mockCtrl)
@@ -395,10 +389,11 @@ func mockComposeWithErrorReturned(t *testing.T, errorMsg string) error {
 	time.Sleep(time.Second * 2)
 	assert.Len(t, buf.tmpObjs, 33)
 
-	mockStorageObject.EXPECT().Compose(gomock.Any()).Return(nil, fmt.Errorf(errorMsg)).AnyTimes()
+	mockStorageObject.EXPECT().Compose(gomock.Any()).Return(nil, fmt.Errorf("Fail to compose")).AnyTimes()
 
 	err = buf.Close()
-	return err
+	assert.NotNil(t, err)
+	assert.Equal(t, "Fail to compose", err.Error())
 }
 
 func TestBufferedWriterGetPermissionErrorOutput(t *testing.T) {

--- a/cli_tools/common/utils/storage/buffered_writer_test.go
+++ b/cli_tools/common/utils/storage/buffered_writer_test.go
@@ -47,7 +47,7 @@ func TestCreateNewChunkOnFirstWrite(t *testing.T) {
 
 	data := []byte("This is a sample data to write")
 
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	_, err := buf.Write(data)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, buf.part)
@@ -64,7 +64,7 @@ func TestCreateNewChunkWhenCurrentChunkFull(t *testing.T) {
 	data := []byte("This is a sample data to write")
 
 	// passing in mock error client so upload file behavior is not tested
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj, "GCEExport")
 	err := buf.newChunk()
 	assert.Nil(t, err)
 	curPart := buf.part
@@ -85,7 +85,7 @@ func TestUseSameFileWhenCurrentChunkNotFull(t *testing.T) {
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
 	mockStorageClient = mocks.NewMockStorageClientInterface(mockCtrl)
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	_, err := buf.Write(data)
 	assert.Nil(t, err)
 
@@ -105,7 +105,7 @@ func TestFlushErrorWhenInvalidFile(t *testing.T) {
 
 	ctx := context.Background()
 	prefix = "//"
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	err := buf.flush()
 	assert.NotNil(t, err)
 }
@@ -117,7 +117,7 @@ func TestWriteErrorWhenFlushError(t *testing.T) {
 	mockStorageClient = mocks.NewMockStorageClientInterface(mockCtrl)
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	buf.newChunk()
 	buf.bytes = buf.cSize
 	buf.file, _ = os.Open("//")
@@ -134,7 +134,7 @@ func TestWriteErrorWhenChunkError(t *testing.T) {
 	mockStorageClient.EXPECT().Close().Return(nil).AnyTimes()
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj, "GCEExport")
 	err := buf.newChunk()
 	assert.Nil(t, err)
 	buf.bytes = buf.cSize
@@ -150,7 +150,7 @@ func TestWriteErrorWhenInvalidFilePermission(t *testing.T) {
 	mockStorageClient = mocks.NewMockStorageClientInterface(mockCtrl)
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	buf.newChunk()
 	buf.file, _ = os.OpenFile("//", os.O_RDONLY, 0666)
 	_, err := buf.Write(data)
@@ -164,7 +164,7 @@ func TestWriteErrorWhenInvalidFilePrefix(t *testing.T) {
 	mockStorageClient = mocks.NewMockStorageClientInterface(mockCtrl)
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj, "GCEExport")
 	buf.prefix = "non_existant_directory/test"
 	_, err := buf.Write(data)
 	assert.NotNil(t, err)
@@ -178,7 +178,7 @@ func TestUploadErrorWhenInvalidFile(t *testing.T) {
 	mockStorageClient.EXPECT().Close().Return(nil).AnyTimes()
 	ctx := context.Background()
 	prefix = "not_an_existing_file.go"
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 	buf.upload <- prefix
@@ -202,7 +202,7 @@ func TestUploadErrorWhenCopyError(t *testing.T) {
 	ctx := context.Background()
 	// using this as file name will succeed in os.Open() and fail in io.Copy
 	prefix = "//"
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 	buf.upload <- prefix
@@ -229,7 +229,7 @@ func TestAddObjectWhenWorkerUploaded(t *testing.T) {
 
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	_, err := buf.Write(data)
 	assert.Nil(t, err)
 	buf.flush()
@@ -253,7 +253,7 @@ func TestWriteToGCS(t *testing.T) {
 
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	_, err := buf.Write(data)
 	assert.Nil(t, err)
 	err = buf.flush()
@@ -267,7 +267,7 @@ func TestClientError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	ctx := context.Background()
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj, "GCEExport")
 	err := buf.Close()
 	assert.NotNil(t, err)
 }
@@ -289,7 +289,7 @@ func TestCopyObjectWhenOneChunk(t *testing.T) {
 
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	_, err := buf.Write(data)
 	assert.Nil(t, err)
 
@@ -316,7 +316,7 @@ func TestCopyObjectWithMultipleIterations(t *testing.T) {
 	ctx := context.Background()
 	var err error
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	for i := 0; i < 33; i++ {
 		_, err = buf.Write(data)
 		assert.Nil(t, err)
@@ -346,7 +346,7 @@ func TestErrorWhenCopyFails(t *testing.T) {
 
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	_, err := buf.Write(data)
 	assert.Nil(t, err)
 
@@ -374,7 +374,7 @@ func TestErrorWhenComposeFails(t *testing.T) {
 
 	ctx := context.Background()
 	data := []byte("This is a sample data to write")
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClient, oauth, prefix, bkt, obj, "GCEExport")
 	var err error
 	for i := 0; i < 33; i++ {
 		_, err = buf.Write(data)
@@ -399,7 +399,7 @@ func TestClientErrorWhenUploadFailed(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	ctx := context.Background()
-	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj)
+	buf := NewBufferedWriter(ctx, bufferSize, workerNum, mockGcsClientError, oauth, prefix, bkt, obj, "GCEExport")
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 	buf.upload <- "file"

--- a/cli_tools/gce_export/main.go
+++ b/cli_tools/gce_export/main.go
@@ -219,7 +219,7 @@ func stream(ctx context.Context, src *os.File, size int64, prefix, bkt, obj stri
 			return err
 		}
 
-		buf := storageutils.NewBufferedWriter(ctx, int64(bs), int64(*workers), gcsClient, *oauth, prefix, bkt, obj)
+		buf := storageutils.NewBufferedWriter(ctx, int64(bs), int64(*workers), gcsClient, *oauth, prefix, bkt, obj, "GCEExport")
 
 		fmt.Printf("GCEExport: Using %q as the buffer prefix, %s as the buffer size, and %d as the number of workers.\n", prefix, humanize.IBytes(bs), *workers)
 		return gzipDisk(src, size, buf)

--- a/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer.go
@@ -422,7 +422,7 @@ func (importer *awsImporter) copyFromS3ToGCS() (string, error) {
 		return "", err
 	}
 	workers := int64(runtime.NumCPU())
-	writer := storageutils.NewBufferedWriter(importer.ctx, int64(bs), workers, createGCSClient, importer.oauth, path, bkt, obj)
+	writer := storageutils.NewBufferedWriter(importer.ctx, int64(bs), workers, createGCSClient, importer.oauth, path, bkt, obj, logPrefix)
 
 	// 4. Transfer file from S3 to GCS
 	if err := importer.transferFile(writer); err != nil {


### PR DESCRIPTION
Motivation: customer faced issue: the failed msg is only in serial log, not in gcloud console. Fixed by allowing setting proper err log prefix.

Also, the err match regex is changed from storage.object.create to to storage.object.* because a customer failed due to the lack of storage.object.get.

There will be another fix on gcloud: the permission issue was not caught by gcloud permission check.