### PR TITLE
Daisy: Don't clobber child variables from parent workflow

### DIFF
--- a/daisy/common.go
+++ b/daisy/common.go
@@ -125,6 +125,12 @@ func substitute(v reflect.Value, replacer *strings.Replacer) {
 			val.SetString(replacer.Replace(val.String()))
 		}
 		return nil
+	}, func(v reflect.Value) traverseAction {
+		_, ok := v.Interface().(*Workflow)
+		if ok {
+			return prune
+		}
+		return continueTraversal
 	})
 }
 

--- a/daisy/test_data/TestNewFromFile_SupportsNestedVariables.child.wf.json
+++ b/daisy/test_data/TestNewFromFile_SupportsNestedVariables.child.wf.json
@@ -1,4 +1,5 @@
 {
+  "Name": "child",
   "Vars": {
     "k1": {
       "Required": true,
@@ -9,7 +10,7 @@
     "create-disks": {
       "createDisks": [
         {
-          "SourceImage": "image-${k1}",
+          "SourceImage": "${NAME}-image-${k1}",
           "SizeGb": "50",
           "Type": "pd-ssd"
         }

--- a/daisy/test_data/TestNewFromFile_SupportsNestedVariables.parent.wf.json
+++ b/daisy/test_data/TestNewFromFile_SupportsNestedVariables.parent.wf.json
@@ -1,4 +1,5 @@
 {
+  "Name": "parent",
   "vars": {
     "var_name_is_variable": {
       "Value": "k1"

--- a/daisy/test_data/TestNewFromFile_SupportsNestedVariables_VarInFilename.child.wf.json
+++ b/daisy/test_data/TestNewFromFile_SupportsNestedVariables_VarInFilename.child.wf.json
@@ -1,4 +1,5 @@
 {
+  "Name": "child",
   "Vars": {
     "k1": {
       "Required": true,
@@ -9,7 +10,7 @@
     "create-disks": {
       "createDisks": [
         {
-          "SourceImage": "image-${k1}",
+          "SourceImage": "${NAME}-image-${k1}",
           "SizeGb": "50",
           "Type": "pd-ssd"
         }

--- a/daisy/test_data/TestNewFromFile_SupportsNestedVariables_VarInFilename.parent.wf.json
+++ b/daisy/test_data/TestNewFromFile_SupportsNestedVariables_VarInFilename.parent.wf.json
@@ -1,4 +1,5 @@
 {
+  "Name": "parent",
   "vars": {
     "filename_is_variable": {
       "Value": "TestNewFromFile_SupportsNestedVariables_VarInFilename.child.wf.json"

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -614,7 +614,7 @@ func TestNewFromFile_SupportsNestedVariables(t *testing.T) {
 
 			child := wf.Steps["include-workflow"].IncludeWorkflow
 			assert.Equal(t, "v1", child.Vars["k1"])
-			assert.Equal(t, "image-v1", (*child.Workflow.Steps["create-disks"].CreateDisks)[0].SourceImage)
+			assert.Equal(t, "include-workflow-image-v1", (*child.Workflow.Steps["create-disks"].CreateDisks)[0].SourceImage)
 		})
 	}
 }


### PR DESCRIPTION
This fixes a regression from #1701 where child workflows were receiving the autovars from their parents.

Example failure [source](https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-daisy-e2e/1420369751300902912).

```
[image-import-and-translate-custom-network-test]: 2021-07-28T13:07:26Z Validating workflow
[image-import-and-translate-custom-network-test]: 2021-07-28T13:07:26Z Validating step "create-network"
[image-import-and-translate-custom-network-test]: 2021-07-28T13:07:26Z Validating step "create-subnetwork"
[image-import-and-translate-custom-network-test]: 2021-07-28T13:07:27Z Validating step "import-and-translate-image"
[image-import-and-translate-custom-network-test.import-and-translate-image]: 2021-07-28T13:07:27Z Validating step "import"
[image-import-and-translate-custom-network-test.import-and-translate-image.import]: 2021-07-28T13:07:27Z Validating step "setup-disks"
[image-import-and-translate-custom-network-test]: 2021-07-28T13:07:27Z Error validating workflow: step "import-and-translate-image" validation error: step "import" validation error: step "setup-disks" validation error: cannot create disk "disk-image-import-and-translate-custom-network-test-scratch-nw3nl": bad name: "disk-image-import-and-translate-custom-network-test-scratch-nw3nl"
```

The test failed since the generated disk name exceeded the length of 64 due to using the parent workflow's `NAME` autovar of `disk-image-import-and-translate-custom-network-test`, rather than the step's autovar `NAME`. Source: https://github.com/GoogleCloudPlatform/compute-image-tools/blob/8ba90bd33f6b8a56795e1d998a818cde9f0b31fe/daisy_workflows/image_import/inflate_file.wf.json#L72

# Testing
- Added tests to validate problem, and confirm that the issue is fixed
- Ran subset of failed e2e tests