### PR TITLE
CLI Tools: Populate region prior to network

### DIFF
--- a/cli_tools/common/utils/param/populator.go
+++ b/cli_tools/common/utils/param/populator.go
@@ -71,12 +71,13 @@ func (p *populator) PopulateMissingParameters(project *string, clientID string, 
 		}
 	}
 
+	if err := PopulateRegion(region, *zone); err != nil {
+		return err
+	}
+
 	if *network, *subnet, err = p.NetworkResolver.Resolve(*network, *subnet, *region, *project); err != nil {
 		return err
 	}
 
-	if err := PopulateRegion(region, *zone); err != nil {
-		return err
-	}
 	return nil
 }

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -97,7 +97,7 @@ func TestPopulator_UsesReturnValuesFromNetworkResolver(t *testing.T) {
 	project := "a_project"
 	scratchBucketGcsPath := "gs://scratchbucket/scratchpath"
 	zone := "us-west2-a"
-	region := "region"
+	region := ""
 	file := "gs://a_bucket/a_file"
 	storageLocation := "US"
 	network := "original-network"
@@ -114,7 +114,7 @@ func TestPopulator_UsesReturnValuesFromNetworkResolver(t *testing.T) {
 	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: "us-west2"}, nil).Times(1)
 	mockNetworkResolver := mocks.NewMockNetworkResolver(mockCtrl)
 	mockNetworkResolver.EXPECT().ResolveAndValidateNetworkAndSubnet(
-		"original-network", "original-subnet", "region", "a_project").Return("fixed-network", "fixed-subnet", nil)
+		"original-network", "original-subnet", "us-west2", "a_project").Return("fixed-network", "fixed-subnet", nil)
 	err := NewPopulator(
 		mockNetworkResolver,
 		mockMetadataGce,

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -64,8 +64,8 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenZoneCantBeRetrieved(
 func TestPopulator_PropagatesErrorFromNetworkResolver(t *testing.T) {
 	project := "a_project"
 	scratchBucketGcsPath := "gs://scratchbucket/scratchpath"
-	zone := "zone"
-	region := "region"
+	zone := "us-west2-a"
+	region := ""
 	file := "gs://a_bucket/a_file"
 	storageLocation := "US"
 	network := "original-network"
@@ -81,7 +81,7 @@ func TestPopulator_PropagatesErrorFromNetworkResolver(t *testing.T) {
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: "us-west2"}, nil).Times(1)
 	mockNetworkResolver := mocks.NewMockNetworkResolver(mockCtrl)
-	mockNetworkResolver.EXPECT().ResolveAndValidateNetworkAndSubnet("original-network", "original-subnet", "region", "a_project").Return("", "", daisy.Errf("network cannot be found"))
+	mockNetworkResolver.EXPECT().ResolveAndValidateNetworkAndSubnet("original-network", "original-subnet", "us-west2", "a_project").Return("", "", daisy.Errf("network cannot be found"))
 	err := NewPopulator(
 		mockNetworkResolver,
 		mockMetadataGce,


### PR DESCRIPTION
This fixes a bug in #1699 where validation fails when region population is required. The failure was:

`Invalid value for field 'region': ''`

https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1422101173669728256