### PR TITLE
CLI tools: Accept legacy apiary URL styles for resources

### DIFF
--- a/cli_tools/common/utils/paramhelper/resources.go
+++ b/cli_tools/common/utils/paramhelper/resources.go
@@ -20,10 +20,13 @@ import (
 
 var (
 	// Resource names are allowed to start with URL-style prefixes:
-	//   https://cloud.google.com/apis/design/resource_names
+
 	resourcePrefixes = []string{
+		// Modern prefixes:  https://cloud.google.com/apis/design/resource_names
 		"https://compute.googleapis.com/compute/v1/",
 		"//compute.googleapis.com/compute/",
+		// Legacy apiary prefix
+		"https://www.googleapis.com/compute/v1/",
 	}
 )
 

--- a/cli_tools/common/utils/paramhelper/resources_test.go
+++ b/cli_tools/common/utils/paramhelper/resources_test.go
@@ -35,6 +35,12 @@ func TestTrimResourcePrefix(t *testing.T) {
 			input:    "https://compute.googleapis.com/compute/v1/rest",
 			expected: "rest",
 		}, {
+			input:    "https://www.googleapis.com/compute/v1/",
+			expected: "",
+		}, {
+			input:    "https://www.googleapis.com/compute/v1/rest",
+			expected: "rest",
+		}, {
 			input:    "//compute.googleapis.com/compute/",
 			expected: "",
 		}, {


### PR DESCRIPTION
This fixes a bug in #1699 where validation fails when the network or subnetwork is specified using apiary style URLs. The failure was:

```
[image-export] 2021/08/02 07:45:19 "https://www.googleapis.com/compute/v1/projects/compute-image-test-pool-001/regions/us-central1/subnetworks/compute-image-test-pool-001-subnet-1" is not a valid subnet resource identifier. See https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/get for naming guidelines.
```

https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1422101173669728256

After this PR, the tool supports both full URI formats shown in go/gce-aips/2813.