### PR TITLE
Image import: Don't re-zero PDs

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -235,7 +235,14 @@ ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 
 # Convert the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdc is used since it's the third disk that's attached in inflate_file.wf.json.
-if ! out=$(qemu-img convert -O raw -n --target-is-zero -p "${IMAGE_PATH}" /dev/sdc 2>&1); then
+#
+#  Args:
+#    -O raw, Decode the image to raw bytes.
+#    -n, Don't create a target volume (this is used for output formats other than RAW).
+#    --target-is-zero, Don't re-zero the destination PD.
+#    -p, Print progress.
+#    -S 512b,
+if ! out=$(qemu-img convert -O raw -n --target-is-zero -S 512b "${IMAGE_PATH}" /dev/sdc 2>&1); then
   if [[ "${IMAGE_PATH}" =~ \.vmdk$ ]]; then
     if file "${IMAGE_PATH}" | grep -qiP ascii; then
       hint="When importing a VMDK disk image, ensure that you specify the VMDK disk "

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -237,11 +237,11 @@ ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 # /dev/sdc is used since it's the third disk that's attached in inflate_file.wf.json.
 #
 #  Args:
-#    -O raw, Decode the image to raw bytes.
-#    -n, Don't create a target volume (this is used for output formats other than RAW).
-#    --target-is-zero, Don't re-zero the destination PD.
-#    -p, Print progress.
-#    -S 512b,
+#    -O raw, decode the image to raw bytes.
+#    -n, don't create a target volume (this is used for output formats other than RAW).
+#    --target-is-zero, don't re-zero the destination PD.
+#    -p, print progress.
+#    -S 512b, require 512 bytes before creating sparse images.
 if ! out=$(qemu-img convert -O raw -n --target-is-zero -S 512b "${IMAGE_PATH}" /dev/sdc 2>&1); then
   if [[ "${IMAGE_PATH}" =~ \.vmdk$ ]]; then
     if file "${IMAGE_PATH}" | grep -qiP ascii; then

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -239,7 +239,8 @@ ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 #  Args:
 #    -O raw, decode the image to raw bytes.
 #    -n, don't create a target volume (this is used for output formats other than RAW).
-#    --target-is-zero, don't re-zero the destination PD.
+#    --target-is-zero, don't re-zero the destination PD, since new PDs are blank:
+#        https://cloud.google.com/compute/docs/disks/add-persistent-disk
 #    -p, print progress.
 #    -S 512b, require 512 bytes before creating sparse images.
 if ! out=$(qemu-img convert -O raw -n --target-is-zero -S 512b "${IMAGE_PATH}" /dev/sdc 2>&1); then

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -235,7 +235,7 @@ ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 
 # Convert the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdc is used since it's the third disk that's attached in inflate_file.wf.json.
-if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); then
+if ! out=$(qemu-img convert -O raw -n --target-is-zero -p "${IMAGE_PATH}" /dev/sdc 2>&1); then
   if [[ "${IMAGE_PATH}" =~ \.vmdk$ ]]; then
     if file "${IMAGE_PATH}" | grep -qiP ascii; then
       hint="When importing a VMDK disk image, ensure that you specify the VMDK disk "


### PR DESCRIPTION
This change enables qemu-img's `--target-is-zero` option. Since we're writing to new persistent disks, we don't need to re-zero the destination.

This table shows the elapsed  time (minutes:seconds) for running `daisy_workflows/image_import/inflate_file.wf.json` against four different disk files. Overall, applying this PR results in ~2x speedup for inflation. Notably, this speedup includes file types other than VMDK; the one VHD example had a nearly 3x speedup.

FileGB | DiskGB | Type | Operation | Duration
-- | -- | -- | -- | --
24 | 82 | VMDK | Legacy | 33:47
24 | 82 | VMDK | NoZero | 17:54
24 | 82 | VMDK | NoZeroS512 | 17:34
24 | 82 | VMDK | Native | 1:58
2 | 10 | VMDK | Legacy | 5:14
2 | 10 | VMDK | NoZero | 1:59
2 | 10 | VMDK | NoZeroS512 | 1:51
2 | 10 | VMDK | Native | 0:34
0.3 | 10 | VMDK | Legacy | 1:45
0.3 | 10 | VMDK | NoZero | 0:56
0.3 | 10 | VMDK | NoZeroS512 | 1:05
0.3 | 10 | VMDK | Native | 0:23
31 | 31 | VHD | Legacy | 22:10
31 | 31 | VHD | NoZero | 8:12
31 | 31 | VHD | NoZeroS512 | 7:52



* NoZero: This PR, with the `-S 512` flag omitted.
* NoZeroS512: This PR, with the `-S 512` flag included.
* Legacy: Before this PR
* Native: Using the [disks.insert](https://cloud.google.com/compute/docs/reference/rest/v1/disks/insert) API.