### PR TITLE
Revert "Image import: Don't re-zero PDs (#1709)"

### DIFF
--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -235,15 +235,7 @@ ensureCapacityOfDisk "${DISKNAME}" "${SIZE_GB}" "${ZONE}" /dev/sdc
 
 # Convert the image and write it to the disk referenced by $DISKNAME.
 # /dev/sdc is used since it's the third disk that's attached in inflate_file.wf.json.
-#
-#  Args:
-#    -O raw, decode the image to raw bytes.
-#    -n, don't create a target volume (this is used for output formats other than RAW).
-#    --target-is-zero, don't re-zero the destination PD, since new PDs are blank:
-#        https://cloud.google.com/compute/docs/disks/add-persistent-disk
-#    -p, print progress.
-#    -S 512b, require 512 bytes before creating sparse images.
-if ! out=$(qemu-img convert -O raw -n --target-is-zero -S 512b "${IMAGE_PATH}" /dev/sdc 2>&1); then
+if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); then
   if [[ "${IMAGE_PATH}" =~ \.vmdk$ ]]; then
     if file "${IMAGE_PATH}" | grep -qiP ascii; then
       hint="When importing a VMDK disk image, ensure that you specify the VMDK disk "


### PR DESCRIPTION
Using `--target-is-zero` caused test failures since `qemu-img` on the inflation worker instance doesn't have the `--target-is-zero` flag: that was added in qemu-img 5. The worker instance has version 2.8.1.

Failed tests:
- https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-daisy-e2e/1423045403158253568
- https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1422944487633588224