### PR TITLE
Image Export: Add logging for snapshot export

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -122,6 +122,7 @@ type ImageExportParams struct {
 	SourceImage           string `json:"source_image,omitempty"`
 	Format                string `json:"format,omitempty"`
 	ComputeServiceAccount string `json:"compute_service_account,omitempty"`
+	SourceDiskSnapshot    string `json:"source_disk_snapshot,omitempty"`
 }
 
 // OnestepImageImportParams contains all input params for onestep image import

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -79,6 +79,7 @@ func main() {
 			SourceImage:           *sourceImage,
 			Format:                *format,
 			ComputeServiceAccount: *computeServiceAccount,
+			SourceDiskSnapshot:    *sourceDiskSnapshot,
 		},
 	}
 


### PR DESCRIPTION
This adds logging for snapshot export, which was implemented in https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1627.

For testing, I created a snapshot, exported it, and observed that the input params were captured.