### PR TITLE
OVF import: fix project IDs validation by supporting "google.com:" prefix

### DIFF
--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -34,7 +34,7 @@ const (
 	// lowercase letters,  digits, or hyphens. It must start with a letter.
 	// Trailing hyphens are prohibited."
 	// -- https://cloud.google.com/resource-manager/reference/rest/v1/projects
-	projectIDStr = "^[a-z][-a-z0-9]{4,28}[a-z0-9]$" //
+	projectIDStr = "^(google\\.com\\:)?[a-z][-a-z0-9]{4,28}[a-z0-9]$" //
 )
 
 var (

--- a/cli_tools/common/utils/validation/validation_utils_test.go
+++ b/cli_tools/common/utils/validation/validation_utils_test.go
@@ -126,6 +126,7 @@ func TestValidateProjectID_ExpectValid(t *testing.T) {
 		"dashes-allowed-inside",
 		"ending-numbers-allowed-1",
 		"a1-inside-numbers-allowed",
+		"google.com:test-project",
 		"o-----equal-to-max-30--------o",
 	} {
 		t.Run(projectID, func(t *testing.T) {
@@ -141,6 +142,7 @@ func TestValidateProjectID_ExpectInvalid(t *testing.T) {
 		"no-ending-dash-",
 		"1-no-leading-numbers",
 		"DontAllowCaps",
+		"joonix.com:test-project",
 		"o-----longer-than-max-30------o",
 	} {
 		t.Run(projectID, func(t *testing.T) {


### PR DESCRIPTION
OVF import: fix project IDs validation by supporting "google.com:" prefix. This was failing import for internal Google App Engine projects.