### PR TITLE
Remove workflow.RunWithModifiers

### DIFF
--- a/cli_tools/common/image/importer/bootable_disk_processor.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor.go
@@ -38,7 +38,7 @@ func (b *bootableDiskProcessor) process(pd persistentDisk) (persistentDisk, erro
 	b.logger.User("Making disk bootable on Google Compute Engine")
 	b.workflow.AddVar("source_disk", pd.uri)
 	var err error
-	err = b.workflow.RunWithModifiers(context.Background(), nil, nil)
+	err = b.workflow.Run(context.Background())
 	if err != nil {
 		b.logger.User("Finished making disk bootable")
 		daisy_utils.PostProcessDErrorForNetworkFlag("image import", err, b.request.Network, b.workflow)

--- a/cli_tools/daisycommon/daisy_worker.go
+++ b/cli_tools/daisycommon/daisy_worker.go
@@ -36,9 +36,9 @@ type DaisyWorker interface {
 // twice on the same instance.
 func NewDaisyWorker(wf *daisy.Workflow, env EnvironmentSettings, logger logging.Logger) DaisyWorker {
 	worker := &defaultDaisyWorker{wf, env, logger}
-	worker.env.ApplyToWorkflow(worker.wf)
-	worker.env.ApplyWorkerCustomizations(worker.wf)
-	daisy_utils.UpdateAllInstanceNoExternalIP(worker.wf, worker.env.NoExternalIP)
+	worker.env.ApplyToWorkflow(wf)
+	worker.env.ApplyWorkerCustomizations(wf)
+	daisy_utils.UpdateAllInstanceNoExternalIP(wf, env.NoExternalIP)
 	return worker
 }
 

--- a/cli_tools/daisycommon/daisy_worker_test.go
+++ b/cli_tools/daisycommon/daisy_worker_test.go
@@ -1,0 +1,85 @@
+//  Copyright 2021 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisycommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+func Test_NewDaisyWorker_AppliesEnvVariablesToWorkflow(t *testing.T) {
+	wf := daisy.New()
+	wf.Project = "old-project"
+	wf.Zone = "old-zone"
+	wf.GCSPath = "old-gcs-path"
+	wf.OAuthPath = "old-oauth-path"
+	wf.DefaultTimeout = "old-timeout"
+	wf.ComputeEndpoint = "old-endpoint"
+	env := EnvironmentSettings{
+		Project:         "lucky-lemur",
+		Zone:            "us-west1-c",
+		GCSPath:         "new-path",
+		OAuth:           "new-oauth",
+		Timeout:         "new-timeout",
+		ComputeEndpoint: "new-endpoint",
+	}
+	NewDaisyWorker(wf, env, logging.NewToolLogger("test"))
+	assert.Equal(t, env.Project, wf.Project)
+	assert.Equal(t, env.Zone, wf.Zone)
+	assert.Equal(t, env.GCSPath, wf.GCSPath)
+	assert.Equal(t, env.OAuth, wf.OAuthPath)
+	assert.Equal(t, env.Timeout, wf.DefaultTimeout)
+	assert.Equal(t, env.ComputeEndpoint, wf.ComputeEndpoint)
+}
+
+func Test_NewDaisyWorker_AppliesWorkerCustomizations(t *testing.T) {
+	wf := daisy.New()
+	env := EnvironmentSettings{
+		Network:               "network",
+		Subnet:                "subnet",
+		ComputeServiceAccount: "compute-service-account",
+	}
+	NewDaisyWorker(wf, env, logging.NewToolLogger("test"))
+	assert.Equal(t, env.Network, wf.Vars["network"].Value)
+	assert.Equal(t, env.Subnet, wf.Vars["subnet"].Value)
+	assert.Equal(t, env.ComputeServiceAccount, wf.Vars["compute_service_account"].Value)
+}
+
+func Test_NewDaisyWorker_UpdatesAllInstanceNoExternalIP(t *testing.T) {
+	wf := daisy.New()
+	step, err := wf.NewStep("worker-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	networkInterface := &compute.NetworkInterface{
+		AccessConfigs: nil,
+	}
+	step.CreateInstances = &daisy.CreateInstances{
+		Instances: []*daisy.Instance{{
+			Instance: compute.Instance{
+				NetworkInterfaces: []*compute.NetworkInterface{networkInterface},
+			},
+		}},
+	}
+	assert.Nil(t, networkInterface.AccessConfigs)
+	NewDaisyWorker(wf, EnvironmentSettings{NoExternalIP: true}, logging.NewToolLogger("test"))
+	assert.NotNil(t, networkInterface.AccessConfigs)
+	assert.Empty(t, networkInterface.AccessConfigs)
+}

--- a/cli_tools/gce_ovf_export/exporter/steps.go
+++ b/cli_tools/gce_ovf_export/exporter/steps.go
@@ -116,15 +116,11 @@ func generateWorkflowWithSteps(workflowName, timeout string, populateStepsFunc p
 		return w, err
 	}
 
-	//This only works for workflows with no included workflows. If included
-	// workflows are used, this func has to be called as wf.postValidateModifier.
-	//postValidateWorkflowModifier(w, params)
-
 	params.EnvironmentSettings().ApplyToWorkflow(w)
 	return w, nil
 }
 
-func postValidateWorkflowModifier(w *daisy.Workflow, params *ovfexportdomain.OVFExportArgs) {
+func labelResources(w *daisy.Workflow, params *ovfexportdomain.OVFExportArgs) {
 	rl := &daisyutils.ResourceLabeler{
 		BuildID:         params.BuildID,
 		BuildIDLabelKey: "gce-ovf-export-build-id",
@@ -138,7 +134,6 @@ func postValidateWorkflowModifier(w *daisy.Workflow, params *ovfexportdomain.OVF
 			return "gce-ovf-export-tmp"
 		}}
 	rl.LabelResources(w)
-	daisyutils.UpdateAllInstanceNoExternalIP(w, params.NoExternalIP)
 }
 
 //TODO: consolidate with gce_vm_image_import.runStep()

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_importer_test.go
@@ -594,12 +594,6 @@ func setupMocksAndRun(t *testing.T, params *domain.OVFImportParams, wfPath strin
 		Logger: logging.NewToolLogger("test"), params: params}
 	w, err := oi.setUpImportWorkflow()
 
-	if w != nil {
-		w.Logger = DummyLogger{}
-		oi.modifyWorkflowPreValidate(w)
-		oi.modifyWorkflowPostValidate(w)
-	}
-
 	return w, err
 }
 

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -265,27 +265,13 @@ func (w *Workflow) Validate(ctx context.Context) DError {
 type WorkflowModifier func(*Workflow)
 
 // Run runs a workflow.
-func (w *Workflow) Run(ctx context.Context) error {
-	return w.RunWithModifiers(ctx, nil, nil)
-}
-
-// RunWithModifiers runs a workflow with the ability to modify it before and/or after validation.
-func (w *Workflow) RunWithModifiers(
-	ctx context.Context,
-	preValidateWorkflowModifier WorkflowModifier,
-	postValidateWorkflowModifier WorkflowModifier) (err DError) {
+func (w *Workflow) Run(ctx context.Context) (err DError) {
 
 	w.externalLogging = true
-	if preValidateWorkflowModifier != nil {
-		preValidateWorkflowModifier(w)
-	}
 	if err = w.Validate(ctx); err != nil {
 		return err
 	}
 
-	if postValidateWorkflowModifier != nil {
-		postValidateWorkflowModifier(w)
-	}
 	defer w.cleanup()
 	defer func() {
 		if err != nil {
@@ -293,6 +279,9 @@ func (w *Workflow) RunWithModifiers(
 		}
 	}()
 
+	if os.Getenv("BUILD_ID") != "" {
+		w.LogWorkflowInfo("Cloud Build ID: %s", os.Getenv("BUILD_ID"))
+	}
 	w.LogWorkflowInfo("Workflow Project: %s", w.Project)
 	w.LogWorkflowInfo("Workflow Zone: %s", w.Zone)
 	w.LogWorkflowInfo("Workflow GCSPath: %s", w.GCSPath)


### PR DESCRIPTION
This is part of our initiative to move daisy out of `compute-image-tools`. It removes the method `RunWithModifiers` from the `daisy.Workflow` struct, and updates its call sites to use the `Run` method.