### PR TITLE
Daisy: Remove disk.IsWindows

### DIFF
--- a/cli_tools/test_data/test_import_ovf_to_instance.wf.json
+++ b/cli_tools/test_data/test_import_ovf_to_instance.wf.json
@@ -41,10 +41,6 @@
     "network_tier": {
       "Value": "PREMIUM",
       "Description": "Network tier that will be used to configure the instance"
-    },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
     }
   },
   "Steps": {

--- a/cli_tools/test_data/test_import_ovf_to_machine_image.wf.json
+++ b/cli_tools/test_data/test_import_ovf_to_machine_image.wf.json
@@ -41,10 +41,6 @@
     "network_tier": {
       "Value": "PREMIUM",
       "Description": "Network tier that will be used to configure the instance"
-    },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
     }
   },
   "Steps": {

--- a/daisy/disk.go
+++ b/daisy/disk.go
@@ -63,13 +63,6 @@ type Disk struct {
 	compute.Disk
 	Resource
 
-	// If this is enabled, then WINDOWS will be added to the
-	// disk's guestOsFeatures. This is a string since daisy
-	// replaces variables after JSON has been parsed.
-	// (If it were boolean, the JSON marshaller throws
-	// an error when it sees something like `${is_windows}`)
-	IsWindows string `json:"isWindows,omitempty"`
-
 	// Size of this disk.
 	SizeGb string `json:"sizeGb,omitempty"`
 
@@ -93,16 +86,6 @@ func (d *Disk) populate(ctx context.Context, s *Step) DError {
 			errs = addErrs(errs, Errf("cannot parse SizeGb: %s, err: %v", d.SizeGb, err))
 		}
 		d.Disk.SizeGb = size
-	}
-
-	if d.IsWindows != "" {
-		isWindows, err := strconv.ParseBool(d.IsWindows)
-		if err != nil {
-			errs = addErrs(errs, Errf("cannot parse IsWindows as boolean: %s, err: %v", d.IsWindows, err))
-		}
-		if isWindows {
-			d.GuestOsFeatures = CombineGuestOSFeatures(d.GuestOsFeatures, "WINDOWS")
-		}
 	}
 
 	if imageURLRgx.MatchString(d.SourceImage) {

--- a/daisy/disk_test.go
+++ b/daisy/disk_test.go
@@ -62,20 +62,6 @@ func TestDiskPopulate(t *testing.T) {
 			false,
 		},
 		{
-			"Add WINDOWS guest feature",
-			&Disk{Disk: compute.Disk{Name: name}, IsWindows: "true"},
-			&Disk{
-				Disk:      compute.Disk{Name: genName, Type: defType, Zone: w.Zone, GuestOsFeatures: featuresOf("WINDOWS")},
-				IsWindows: "true"},
-			false,
-		},
-		{
-			"Fail if IsWindows cannot be parsed as boolean",
-			&Disk{Disk: compute.Disk{Name: name}, IsWindows: "garbage"},
-			nil,
-			true,
-		},
-		{
 			"bad SizeGb case",
 			&Disk{Disk: compute.Disk{Name: "foo"}, SizeGb: "ten"},
 			nil,

--- a/daisy_workflows/image_import/import_and_translate.wf.json
+++ b/daisy_workflows/image_import/import_and_translate.wf.json
@@ -35,10 +35,6 @@
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
-    },
     "sysprep_windows": {
       "Value": "false",
       "Description": "If enabled, run sysprep. This is a no-op for Linux."
@@ -53,7 +49,6 @@
           "disk_name": "${translation-disk-name}",
           "import_network": "${import_network}",
           "import_subnet": "${import_subnet}",
-          "is_windows": "${is_windows}",
           "import_license": "projects/compute-image-tools/global/licenses/virtual-disk-import"
         }
       }

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -35,10 +35,6 @@
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
-    },
     "sysprep_windows": {
       "Value": "false",
       "Description": "If enabled, run sysprep. This is a no-op for Linux."
@@ -51,7 +47,6 @@
         "Type": "pd-ssd",
         "ExactName": true,
         "SourceImage": "${source_image}",
-        "isWindows": "${is_windows}",
         "FallbackToPdStandard": true,
         "Licenses": ["projects/compute-image-tools/global/licenses/virtual-disk-import"]
       }]

--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -31,10 +31,6 @@
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
-    },
     "import_license": {
       "Value": "projects/compute-image-tools/global/licenses/virtual-disk-import",
       "Description": "Import License used for tracking migration workflow use."
@@ -64,7 +60,6 @@
           "Type": "pd-ssd",
           "ExactName": true,
           "NoCleanup": true,
-          "isWindows": "${is_windows}",
           "FallbackToPdStandard": true,
           "Licenses": ["${import_license}"]
         },

--- a/daisy_workflows/ovf_import/import_ovf_to_instance.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf_to_instance.wf.json
@@ -41,10 +41,6 @@
       "Value": "PREMIUM",
       "Description": "Network tier that will be used to configure the instance"
     },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
-    }
   },
   "Steps": {
     "import-boot-disk": {
@@ -55,7 +51,6 @@
           "disk_name": "${translation_disk_name}",
           "import_network": "${network}",
           "import_subnet": "${subnet}",
-          "is_windows": "${is_windows}",
           "import_license": "projects/compute-image-tools/global/licenses/virtual-appliance-import"
         }
       }

--- a/daisy_workflows/ovf_import/import_ovf_to_machine_image.wf.json
+++ b/daisy_workflows/ovf_import/import_ovf_to_machine_image.wf.json
@@ -42,10 +42,6 @@
       "Value": "PREMIUM",
       "Description": "Network tier that will be used to configure the instance"
     },
-    "is_windows": {
-      "Value": "false",
-      "Description": "If enabled, WINDOWS will be added to GuestOsFeatures for the disk."
-    }
   },
   "Steps": {
     "import-boot-disk": {
@@ -56,7 +52,6 @@
           "disk_name": "${translation_disk_name}",
           "import_network": "${network}",
           "import_subnet": "${subnet}",
-          "is_windows": "${is_windows}",
           "import_license": "projects/compute-image-tools/global/licenses/virtual-appliance-import"
         }
       }


### PR DESCRIPTION
We added `disk.IsWindows` in #935 to assist feature development in the CLI tool. The `isWindows` param is no longer required since we handle it manually now:

https://github.com/GoogleCloudPlatform/compute-image-tools/blob/7964ff4bbecbb5c6e253be250d8083821f9a194a/cli_tools/common/image/importer/daisy_inflater.go#L121
