### PR TITLE
[daisy] fix output breakage for waitForInstanceSignal

### DIFF
--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -160,8 +160,8 @@ func waitForSerialOutput(s *Step, project, zone, name string, so *SerialOutput, 
 				}
 
 				// If the content is not ended with a "\n", we want to store the last line as tail string, so it can be concat with the next block of content.
-				if i == len(lines)-1 && ln != "" {
-					tailString = lines[len(lines)-1]
+				if i == len(lines)-1 && lines[len(lines)-1] != "" {
+					tailString = ln
 					break
 				}
 

--- a/daisy/step_wait_for_instances_signal.go
+++ b/daisy/step_wait_for_instances_signal.go
@@ -150,16 +150,16 @@ func waitForSerialOutput(s *Step, project, zone, name string, so *SerialOutput, 
 
 				return Errf("WaitForInstancesSignal: instance %q: error getting serial port: %v", name, err)
 			}
-
 			start = resp.Next
 			lines := strings.Split(resp.Contents, "\n")
 			for i, ln := range lines {
-				// First line combine with tail string
+				// If there is a unconsumed tail string from the previous block of content, concat it with the 1st line of the new block of content.
 				if i == 0 && tailString != "" {
 					ln = tailString + ln
 					tailString = ""
 				}
-				// Last line hold
+
+				// If the content is not ended with a "\n", we want to store the last line as tail string, so it can be concat with the next block of content.
 				if i == len(lines)-1 && ln != "" {
 					tailString = lines[len(lines)-1]
 					break
@@ -187,7 +187,6 @@ func waitForSerialOutput(s *Step, project, zone, name string, so *SerialOutput, 
 					}
 				}
 			}
-
 			errs = 0
 		}
 	}

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -250,7 +250,10 @@ func TestWaitForAnyInstancesSignalGetOutputValue(t *testing.T) {
 func testWaitForSignalGetOutputValue(t *testing.T, waitAny bool) {
 	ctx := context.Background()
 	w := testWorkflow()
-	w.ComputeClient.(*daisyCompute.TestClient).GetSerialPortOutputFn = func(_, _, n string, _, _ int64) (*compute.SerialPortOutput, error) {
+	w.ComputeClient.(*daisyCompute.TestClient).GetSerialPortOutputFn = func(_, _, n string, _, start int64) (*compute.SerialPortOutput, error) {
+		if start > 0 {
+			return &compute.SerialPortOutput{Contents: ""}, nil
+		}
 		ret := &compute.SerialPortOutput{Next: 20}
 		switch n {
 		case w.genName("i1"):

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -308,9 +308,9 @@ func TestWaitForSignalGetSplitOutput(t *testing.T) {
 		output := "status: <serial-output key:'my-key' value:'my-value'>"
 		var splitPoint1 int64 = 20
 		var splitPoint2 int64 = 30
-		var subStr1 = output[:splitPoint1] // "status: <serial-outp"
+		var subStr1 = output[:splitPoint1]            // "status: <serial-outp"
 		var subStr2 = output[splitPoint1:splitPoint2] // "ut key:'my"
-		var subStr3 = output[splitPoint2:] // "-key' value:'my-value'>"
+		var subStr3 = output[splitPoint2:]            // "-key' value:'my-value'>"
 		ret := &compute.SerialPortOutput{}
 		if start == 0 {
 			ret.Next = splitPoint1

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -254,8 +254,8 @@ if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); th
 fi
 echo "${out}"
 
-diskChecksum
-
 sync
+
+diskChecksum
 
 echo "ImportSuccess: Finished import." 2> /dev/null

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -257,8 +257,8 @@ if ! out=$(qemu-img convert "${IMAGE_PATH}" -p -O raw -S 512b /dev/sdc 2>&1); th
 fi
 echo "${out}"
 
-sync
-
 diskChecksum
 
-echo "ImportSuccess: Finished import."
+sync
+
+echo "ImportSuccess: Finished import." 2> /dev/null

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -192,9 +192,6 @@ function diskChecksum() {
   CHECKSUM3=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 20000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   CHECKSUM4=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( $BLOCK_COUNT - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   serialOutputPrefixedKeyValue "Import" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
-  for i in {1..5000}; do
-    serialOutputPrefixedKeyValue "Import" "disk-checksum" "~~~$i~~~ $CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
-  done
 }
 
 copyImageToScratchDisk

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -258,4 +258,4 @@ sync
 
 diskChecksum
 
-echo "ImportSuccess: Finished import." 2> /dev/null
+echo "ImportSuccess: Finished import."

--- a/daisy_workflows/image_import/import_image.sh
+++ b/daisy_workflows/image_import/import_image.sh
@@ -192,6 +192,9 @@ function diskChecksum() {
   CHECKSUM3=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( 20000000 - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   CHECKSUM4=$(sudo dd if=/dev/$CHECK_DEVICE ibs=512 skip=$(( $BLOCK_COUNT - $CHECK_COUNT )) count=$CHECK_COUNT | md5sum)
   serialOutputPrefixedKeyValue "Import" "disk-checksum" "$CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
+  for i in {1..5000}; do
+    serialOutputPrefixedKeyValue "Import" "disk-checksum" "~~~$i~~~ $CHECKSUM1-$CHECKSUM2-$CHECKSUM3-$CHECKSUM4"
+  done
 }
 
 copyImageToScratchDisk


### PR DESCRIPTION
We detected broken <serial-output> line, which caused checksum mismatch for disk checksum verification.
After a serial of test, we realized that any serial output streamed to daisy-log may be broken, because each "ComputeClient.GetSerialPortOutput" can get a incomplete output result. Example:

Full output:
123456789
abcdefg
987654321

ComputeClient.GetSerialPortOutput call1 get:
123456789
abc

ComputeClient.GetSerialPortOutput call2 get:
defg
987654321

The possible reason is that, stdout output (like "echo") relies on a buffer, whose size is usually PIPE_BUF=512 bytes, which can't be modified. Once the buffer is full, it will be flushed, even though the whole line hasn't been written.

The checksum output is much longer than others (302 bytes), so it has much higher chance to hit this issue. However, some other output also hit his this during the test with a lower probability (example: target-size-gb).

To fix the root cause, we always check the last line of the ComputeClient.GetSerialPortOutput response. If it's without a "\n", we keep it as a tail string, so it can be concat with the next ComputeClient.GetSerialPortOutput response. Per my testing, it resolved this issue perfectly.

Notice: some other bugs may also be caused by this issue, for example, if the "Import Success" output is split to 2 lines, the instance may not stop. It will cause a import timeout ultimately.