### PR TITLE
Daisy:support guestattrs in WaitForInstancesSignal

### DIFF
--- a/daisy/compute/compute.go
+++ b/daisy/compute/compute.go
@@ -75,6 +75,7 @@ type Client interface {
 	GetDiskBeta(project, zone, name string) (*computeBeta.Disk, error)
 	GetForwardingRule(project, region, name string) (*compute.ForwardingRule, error)
 	GetFirewallRule(project, name string) (*compute.Firewall, error)
+	GetGuestAttributes(project, zone, name, queryPath, variableKey string) (*compute.GuestAttributes, error)
 	GetImage(project, name string) (*compute.Image, error)
 	GetImageAlpha(project, name string) (*computeAlpha.Image, error)
 	GetImageBeta(project, name string) (*computeBeta.Image, error)
@@ -110,7 +111,6 @@ type Client interface {
 	SetDiskAutoDelete(project, zone, instance string, autoDelete bool, deviceName string) error
 
 	// Beta API calls
-	GetGuestAttributes(project, zone, name, queryPath, variableKey string) (*computeBeta.GuestAttributes, error)
 	ListMachineImages(project string, opts ...ListCallOption) ([]*computeBeta.MachineImage, error)
 	DeleteMachineImage(project, name string) error
 	CreateMachineImage(project string, i *computeBeta.MachineImage) error
@@ -969,7 +969,7 @@ func (c *client) GetInstance(project, zone, name string) (*compute.Instance, err
 	return i, err
 }
 
-// GetInstance gets a GCE Instance using Alpha API.
+// GetInstanceAlpha gets a GCE Instance using Alpha API.
 func (c *client) GetInstanceAlpha(project, zone, name string) (*computeAlpha.Instance, error) {
 	i, err := c.rawAlpha.Instances.Get(project, zone, name).Do()
 	if shouldRetryWithWait(c.hc.Transport, err, 2) {
@@ -978,7 +978,7 @@ func (c *client) GetInstanceAlpha(project, zone, name string) (*computeAlpha.Ins
 	return i, err
 }
 
-// GetInstance gets a GCE Instance using Beta API.
+// GetInstanceBeta gets a GCE Instance using Beta API.
 func (c *client) GetInstanceBeta(project, zone, name string) (*computeBeta.Instance, error) {
 	i, err := c.rawBeta.Instances.Get(project, zone, name).Do()
 	if shouldRetryWithWait(c.hc.Transport, err, 2) {
@@ -1542,8 +1542,8 @@ func (c *client) SetCommonInstanceMetadata(project string, md *compute.Metadata)
 }
 
 // GetGuestAttributes gets a Guest Attributes.
-func (c *client) GetGuestAttributes(project, zone, name, queryPath, variableKey string) (*computeBeta.GuestAttributes, error) {
-	call := c.rawBeta.Instances.GetGuestAttributes(project, zone, name)
+func (c *client) GetGuestAttributes(project, zone, name, queryPath, variableKey string) (*compute.GuestAttributes, error) {
+	call := c.raw.Instances.GetGuestAttributes(project, zone, name)
 	if queryPath != "" {
 		call = call.QueryPath(queryPath)
 	}

--- a/daisy/compute/test_client.go
+++ b/daisy/compute/test_client.go
@@ -75,6 +75,7 @@ type TestClient struct {
 	ListMachineTypesFn          func(project, zone string, opts ...ListCallOption) ([]*compute.MachineType, error)
 	GetProjectFn                func(project string) (*compute.Project, error)
 	GetSerialPortOutputFn       func(project, zone, name string, port, start int64) (*compute.SerialPortOutput, error)
+	GetGuestAttributesFn        func(project, zone, name, queryPath, variableKey string) (*compute.GuestAttributes, error)
 	GetZoneFn                   func(project, zone string) (*compute.Zone, error)
 	ListZonesFn                 func(project string, opts ...ListCallOption) ([]*compute.Zone, error)
 	GetInstanceFn               func(project, zone, name string) (*compute.Instance, error)
@@ -113,7 +114,6 @@ type TestClient struct {
 	CreateInstanceAlphaFn func(project, zone string, i *computeAlpha.Instance) error
 
 	// Beta API calls
-	GetGuestAttributesFn func(project, zone, name, queryPath, variableKey string) (*computeBeta.GuestAttributes, error)
 	ListMachineImagesFn  func(project string, opts ...ListCallOption) ([]*computeBeta.MachineImage, error)
 	DeleteMachineImageFn func(project, name string) error
 	CreateMachineImageFn func(project string, i *computeBeta.MachineImage) error
@@ -558,7 +558,7 @@ func (c *TestClient) GetSerialPortOutput(project, zone, name string, port, start
 }
 
 // GetGuestAttributes uses the override method GetGuestAttributesFn or the real implementation.
-func (c *TestClient) GetGuestAttributes(project, zone, name, queryPath, variableKey string) (*computeBeta.GuestAttributes, error) {
+func (c *TestClient) GetGuestAttributes(project, zone, name, queryPath, variableKey string) (*compute.GuestAttributes, error) {
 	if c.GetGuestAttributesFn != nil {
 		return c.GetGuestAttributesFn(project, zone, name, queryPath, variableKey)
 	}

--- a/daisy/compute/test_client_test.go
+++ b/daisy/compute/test_client_test.go
@@ -210,7 +210,7 @@ func TestTestClient(t *testing.T) {
 	c.zoneOperationsWaitFn = func(_, _, _ string) error { fakeCalled = true; return nil }
 	c.regionOperationsWaitFn = func(_, _, _ string) error { fakeCalled = true; return nil }
 	c.globalOperationsWaitFn = func(_, _ string) error { fakeCalled = true; return nil }
-	c.GetGuestAttributesFn = func(_, _, _, _, _ string) (*computeBeta.GuestAttributes, error) { fakeCalled = true; return nil, nil }
+	c.GetGuestAttributesFn = func(_, _, _, _, _ string) (*compute.GuestAttributes, error) { fakeCalled = true; return nil, nil }
 	c.CreateMachineImageFn = func(_ string, _ *computeBeta.MachineImage) error { fakeCalled = true; return nil }
 	c.GetMachineImageFn = func(_, _ string) (*computeBeta.MachineImage, error) { fakeCalled = true; return nil, nil }
 	c.ListMachineImagesFn = func(_ string, _ ...ListCallOption) ([]*computeBeta.MachineImage, error) {

--- a/daisy/step_wait_for_instances_signal_test.go
+++ b/daisy/step_wait_for_instances_signal_test.go
@@ -123,6 +123,19 @@ func testWaitForSignalRun(t *testing.T, waitAny bool) {
 		}
 		return "STOPPED", nil
 	}
+	w.ComputeClient.(*daisyCompute.TestClient).GetGuestAttributesFn = func(_, _, n, _, _ string) (*compute.GuestAttributes, error) {
+		ret := &compute.GuestAttributes{}
+		switch n {
+		case w.genName("i1"):
+			ret.VariableValue = "success"
+		case w.genName("i2"):
+			ret.VariableValue = "failure"
+		default:
+			return nil, &googleapi.Error{Code: 404}
+		}
+
+		return ret, nil
+	}
 	w.ComputeClient.(*daisyCompute.TestClient).RetryFn = func(_ func(_ ...googleapi.CallOption) (*compute.Operation, error), _ ...googleapi.CallOption) (*compute.Operation, error) {
 		return nil, nil
 	}
@@ -137,9 +150,11 @@ func testWaitForSignalRun(t *testing.T, waitAny bool) {
 	}
 	// Normal run, no error.
 	ws := getStep(waitAny, []*InstanceSignal{
-		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{StatusMatch: "success", SuccessMatch: "success"}},
+		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success", StatusMatch: "success"}},
 		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success", FailureMatch: []string{"fail"}}},
 		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success", FailureMatch: []string{"fail", "fail2"}}},
+		{Name: "i1", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{KeyName: "mynamespace/mykey"}},
+		{Name: "i1", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{KeyName: "mynamespace/mykey", SuccessValue: "success"}},
 		{Name: "i3", interval: 1 * time.Microsecond, Stopped: true},
 	})
 	if err := ws.run(ctx, s); err != nil {
@@ -149,6 +164,7 @@ func testWaitForSignalRun(t *testing.T, waitAny bool) {
 	ws = getStep(waitAny, []*InstanceSignal{
 		{Name: "i2", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{FailureMatch: []string{"fail"}, SuccessMatch: "success"}},
 		{Name: "i3", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{FailureMatch: []string{"fail"}}},
+		{Name: "i2", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{KeyName: "mynamespace/mykey", SuccessValue: "success"}},
 	})
 	if err := ws.run(ctx, s); err == nil {
 		t.Error("expected error")

--- a/daisy_integration_tests/step_wait_for_instance_signal.wf.json
+++ b/daisy_integration_tests/step_wait_for_instance_signal.wf.json
@@ -34,6 +34,19 @@
           "metadata": {
             "startup-script": "echo 'SUCCESS ovqTO8AgH65shhPMLoot'"
           }
+        },
+        {
+          "disks": [
+            {
+              "initializeParams": {
+                "sourceImage": "projects/debian-cloud/global/images/family/debian-10"
+              }
+            }
+          ],
+          "name": "guest-attr-outputter",
+          "metadata": {
+            "startup-script": "curl -H Metadata-Flavor:Google -d 'SUCCESS ovqTO8AgH65shhPMLoot' -X PUT http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/integtest/successkey"
+          }
         }
       ]
     },
@@ -49,6 +62,13 @@
           "SerialOutput": {
             "Port": 1,
             "SuccessMatch": "SUCCESS ovqTO8AgH65shhPMLoot"
+          }
+        },
+        {
+          "Name": "guest-attr-outputter",
+          "GuestAttribute": {
+            "KeyName": "integtest/successkey",
+            "SuccessValue": "SUCCESS ovqTO8AgH65shhPMLoot"
           }
         }
       ]

--- a/daisy_integration_tests/step_wait_for_instance_signal.wf.json
+++ b/daisy_integration_tests/step_wait_for_instance_signal.wf.json
@@ -3,7 +3,7 @@
   "Vars": {
     "about-this-test": {
       "Value": "",
-      "Description": "This test creates two instances, and then waits for two different kinds of signals from them: Stopped, and SerialOutput."
+      "Description": "This test creates three instances, and then waits for two different kinds of signals from them: Stopped, and SerialOutput."
     }
   },
   "Steps": {


### PR DESCRIPTION
* Move GetGuestAttributes out of beta compute client
* Add support for GuestAttributes config in WaitForInstancesSignal

Test results. Using this config:
```
    "wait": {
      "WaitForInstancesSignal": [
        {
          "Name": "inst-builder",
          "GuestAttribute": {
            "KeyName": "heh/fake-key",
            "SuccessValue": "heh"
          }
        }
      ]
    }

```

Test instance that has wrong value fails:
```
[test-guest-attrs]: 2021-08-11T18:15:18-07:00 Running step "wait" (WaitForInstancesSignal)
[test-guest-attrs.wait]: 2021-08-11T18:15:18-07:00 WaitForInstancesSignal: Instance "inst-builder-test-guest-attrs-gw3yn": watching for key heh/fake-key, SuccessValue: "heh".
[test-guest-attrs]: 2021-08-11T18:15:28-07:00 Error running workflow: step "wait" run error: WaitForInstancesSignal bad guest attribute value found for "inst-builder-test-guest-attrs-gw3yn": "badvalue"
[test-guest-attrs]: 2021-08-11T18:15:28-07:00 Workflow "test-guest-attrs" cleaning up (this may take up to 2 minutes).
[test-guest-attrs]: 2021-08-11T18:15:58-07:00 Workflow "test-guest-attrs" finished cleanup.
[Daisy] Errors in one or more workflows:
  test-guest-attrs: step "wait" run error: WaitForInstancesSignal bad guest attribute value found for "inst-builder-test-guest-attrs-gw3yn": "wrong-value"
exit status 1
```

Test instance that has correct value succeeds:
```
[test-guest-attrs]: 2021-08-11T18:18:34-07:00 Running step "wait" (WaitForInstancesSignal)
[test-guest-attrs.wait]: 2021-08-11T18:18:34-07:00 WaitForInstancesSignal: Instance "inst-builder-test-guest-attrs-gq6ll": watching for key heh/fake-key, SuccessValue: "heh".
[test-guest-attrs.wait]: 2021-08-11T18:18:45-07:00 WaitForInstancesSignal: Instance "inst-builder-test-guest-attrs-gq6ll": SuccessValue found for key "heh/fake-key"
[test-guest-attrs]: 2021-08-11T18:18:45-07:00 Step "wait" (WaitForInstancesSignal) successfully finished.
[test-guest-attrs]: 2021-08-11T18:18:45-07:00 Workflow "test-guest-attrs" cleaning up (this may take up to 2 minutes).
[test-guest-attrs]: 2021-08-11T18:19:17-07:00 Workflow "test-guest-attrs" finished cleanup.
[Daisy] Workflow "test-guest-attrs" finished
[Daisy] All workflows completed successfully.
```

Modify workflow and remove `SuccessValue` parameter.

Test instance that emits any value succeeds:
```
[test-guest-attrs]: 2021-08-11T18:31:10-07:00 Running step "wait" (WaitForInstancesSignal)
[test-guest-attrs.wait]: 2021-08-11T18:31:10-07:00 WaitForInstancesSignal: Instance "inst-builder-test-guest-attrs-1bpdr": watching for key heh/fake-key.
[test-guest-attrs.wait]: 2021-08-11T18:31:21-07:00 WaitForInstancesSignal: Instance "inst-builder-test-guest-attrs-1bpdr" found key "heh/fake-key"
[test-guest-attrs]: 2021-08-11T18:31:21-07:00 Step "wait" (WaitForInstancesSignal) successfully finished.
[test-guest-attrs]: 2021-08-11T18:31:21-07:00 Workflow "test-guest-attrs" cleaning up (this may take up to 2 minutes).

[test-guest-attrs]: 2021-08-11T18:31:55-07:00 Workflow "test-guest-attrs" finished cleanup.
[Daisy] Workflow "test-guest-attrs" finished
[Daisy] All workflows completed successfully.
```

Test instance that never creates the key (workflow times out):
```
[test-guest-attrs]: 2021-08-11T18:32:55-07:00 Running step "wait" (WaitForInstancesSignal)
[test-guest-attrs.wait]: 2021-08-11T18:32:55-07:00 WaitForInstancesSignal: Instance "inst-builder-test-guest-attrs-sb1mv": watching for key heh/fake-key.
[test-guest-attrs]: 2021-08-11T18:37:55-07:00 Error running workflow: step "wait" did not complete within the specified timeout of 5m0s
[test-guest-attrs]: 2021-08-11T18:37:55-07:00 Workflow "test-guest-attrs" cleaning up (this may take up to 2 minutes).
[test-guest-attrs]: 2021-08-11T18:37:55-07:00 Step "wait" (WaitForInstancesSignal) is canceled.
[test-guest-attrs]: 2021-08-11T18:38:26-07:00 Workflow "test-guest-attrs" finished cleanup.
[Daisy] Errors in one or more workflows:
  test-guest-attrs: step "wait" did not complete within the specified timeout of 5m0s
exit status 1
```