### PR TITLE
enable guest attrs in wait integ test

### DIFF
--- a/daisy_integration_tests/step_wait_for_instance_signal.wf.json
+++ b/daisy_integration_tests/step_wait_for_instance_signal.wf.json
@@ -45,7 +45,8 @@
           ],
           "name": "guest-attr-outputter",
           "metadata": {
-            "startup-script": "curl -H Metadata-Flavor:Google -d 'SUCCESS ovqTO8AgH65shhPMLoot' -X PUT http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/integtest/successkey"
+            "startup-script": "curl -H Metadata-Flavor:Google -d 'SUCCESS ovqTO8AgH65shhPMLoot' -X PUT http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/integtest/successkey",
+            "enable-guest-attributes": "TRUE"
           }
         }
       ]


### PR DESCRIPTION
my previous invocation of the integ test worked because i have this key set at the project level. set it in the workflow to be sure it works.