### PR TITLE
CLI Tools: Use deb10 worker for EL8 import and inspection

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_8.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
           "SizeGb": "10",
           "Type": "pd-ssd",
           "FallbackToPdStandard": true

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -4,7 +4,8 @@
   "Vars": {
     "pd_uri": {
       "Required": true,
-      "Description": "PD that will be inspected (URI)."
+      "Description": "PD that will be inspected (URI).",
+      "Value": "projects/edens-test/zones/us-west1-b/disks/b194189632"
     },
     "network": {
       "Value": "global/networks/default",
@@ -35,7 +36,7 @@
               "AutoDelete": true,
               "boot": true,
               "initializeParams": {
-                "sourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker"
+                "sourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker"
               }
             },
             {

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -4,8 +4,7 @@
   "Vars": {
     "pd_uri": {
       "Required": true,
-      "Description": "PD that will be inspected (URI).",
-      "Value": "projects/edens-test/zones/us-west1-b/disks/b194189632"
+      "Description": "PD that will be inspected (URI)."
     },
     "network": {
       "Value": "global/networks/default",


### PR DESCRIPTION
During import, a disk using LVM is failing to mount with guestfs 1.34, but successfully mounts with guestfs 1.40. 

We previously attempted to use the Debian 10 worker in https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1438; at that time 

Ultimately we'll need to migrate off Debian 9 completely. This change is a small step in that direction, and unblocks the user who is blocked on their import. 

## Testing

- Ran the daisy e2e tests that had previously failed.