### PR TITLE
apt update: use --allow-releaseinfo-change

### DIFF
--- a/daisy_workflows/image_build/debian/debian_10_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_10_worker.sh
@@ -21,10 +21,10 @@ GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
 echo "deb http://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" | tee /etc/apt/sources.list.d/gcsfuse.list
 
 echo "BuildStatus: Updating package cache."
-apt -y update
+apt -y update --allow-releaseinfo-change
 if [[ $? -ne 0 ]]; then
   echo "Trying cache update again."
-  apt -y update
+  apt -y update --allow-releaseinfo-change
   if [[ $? -ne 0 ]]; then
     echo "BuildFailed: Apt cache is failing to update."
     exit 1

--- a/daisy_workflows/linux_common/bootstrap.sh
+++ b/daisy_workflows/linux_common/bootstrap.sh
@@ -25,14 +25,14 @@ GetMetadataAttribute() {
 DebianInstallGoogleApiPythonClient() {
     logger -p daemon.info "Status: Installing google-api-python-client"
 
-    apt -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
+    apt -y update --allow-releaseinfo-change && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
     pip3 install -U google-api-python-client google-cloud-storage
 }
 
 DebianInstallNetaddrPythonLibrary() {
     logger -p daemon.info "Status: Installing netaddr python module"
 
-    apt -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-netaddr
+    apt -y update --allow-releaseinfo-change && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-netaddr
 }
 
 GetAccessToken() {

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -96,7 +96,7 @@ def AptGetInstall(package_list, suite=None):
   # had one successful install.
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=778357
   if not AptGetInstall.prior_success:
-    Execute(['apt', '-y', 'update'])
+    Execute(['apt', '-y', 'update', '--allow-releaseinfo-change'])
 
   env = os.environ.copy()
   env['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -819,4 +819,4 @@ def install_apt_packages(g, *pkgs):
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def update_apt(g):
-  run(g, 'apt -y update')
+  run(g, 'apt -y update --allow-releaseinfo-change')


### PR DESCRIPTION
This is a followup to #1721; in image import, we're now seeing failures for Debian 10 when executing `apt -y update`:

```
apt -y update
Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
```

Testing:
* Ran `daisy_integration_tests/debian_10_translate.wf.json `, which emitted the above error. Applied this PR, and the error was fixed.