### PR TITLE
Revert "apt update: use --allow-releaseinfo-change (#1730)"

### DIFF
--- a/daisy_workflows/image_build/debian/debian_10_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_10_worker.sh
@@ -21,10 +21,10 @@ GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)"
 echo "deb http://packages.cloud.google.com/apt ${GCSFUSE_REPO} main" | tee /etc/apt/sources.list.d/gcsfuse.list
 
 echo "BuildStatus: Updating package cache."
-apt -y update --allow-releaseinfo-change
+apt -y update
 if [[ $? -ne 0 ]]; then
   echo "Trying cache update again."
-  apt -y update --allow-releaseinfo-change
+  apt -y update
   if [[ $? -ne 0 ]]; then
     echo "BuildFailed: Apt cache is failing to update."
     exit 1

--- a/daisy_workflows/linux_common/bootstrap.sh
+++ b/daisy_workflows/linux_common/bootstrap.sh
@@ -25,14 +25,14 @@ GetMetadataAttribute() {
 DebianInstallGoogleApiPythonClient() {
     logger -p daemon.info "Status: Installing google-api-python-client"
 
-    apt -y update --allow-releaseinfo-change && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
+    apt -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
     pip3 install -U google-api-python-client google-cloud-storage
 }
 
 DebianInstallNetaddrPythonLibrary() {
     logger -p daemon.info "Status: Installing netaddr python module"
 
-    apt -y update --allow-releaseinfo-change && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-netaddr
+    apt -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-netaddr
 }
 
 GetAccessToken() {

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -96,7 +96,7 @@ def AptGetInstall(package_list, suite=None):
   # had one successful install.
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=778357
   if not AptGetInstall.prior_success:
-    Execute(['apt', '-y', 'update', '--allow-releaseinfo-change'])
+    Execute(['apt', '-y', 'update'])
 
   env = os.environ.copy()
   env['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -819,4 +819,4 @@ def install_apt_packages(g, *pkgs):
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def update_apt(g):
-  run(g, 'apt -y update --allow-releaseinfo-change')
+  run(g, 'apt -y update')


### PR DESCRIPTION
#1730 was intended to fix Debian 10 import, but caused a regression where older versions of apt. eg: `Command line option --allow-releaseinfo-change is not understood in combination with the other options`

https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1430390246482120704