### PR TITLE
EL import: Improve initramfs rebuild messaging

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -303,8 +303,8 @@ def DistroSpecific(spec: TranslateSpec):
         logging.debug('`{cmd}` error: {err}'.format(cmd=cmd_string, err=e))
         msg = ('Failed to write initramfs for {kver}. If the image '
                'fails to boot: Boot the original machine, remove unused '
-               'kernel versions, verify that `{cmd}` runs, and '
-               're-export the disks.').format(kver=kver, cmd=cmd_string)
+               'kernel versions, verify that `{cmd}` runs, re-export '
+               'the disks, and re-import.').format(kver=kver, cmd=cmd_string)
         logging.info(msg)
         break
 


### PR DESCRIPTION
A recent RHEL7 import failed while rebuilding initramfs.  When updating the kernel, `yum` keeps the old versions in case the user wants to roll back. This machine had over 30 kernel versions, and was only booting from the newest.

1. If rebuild of initramfs fails, emit a warning and continue. (We currently have that behavior for `depmod`; this PR extends that behavior to `dracut`)
1. In the warning message, suggest removing old kernel versions that aren't required.

Testing:
- Ran:
   - daisy_integration_tests/centos_8_translate.wf.json
   - daisy_integration_tests/rhel_8_translate.wf.json
   - daisy_integration_tests/centos_7_qcow2_translate.wf.json 