### PR TITLE
Image import: Support Debian 11

### DIFF
--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -139,6 +139,10 @@ var (
 			GcloudOsFlag: "debian-10",
 			WorkflowPath: "debian/translate_debian_10.wf.json",
 			LicenseURI:   "projects/debian-cloud/global/licenses/debian-10-buster",
+		}, {
+			GcloudOsFlag: "debian-11",
+			WorkflowPath: "debian/translate_debian_11.wf.json",
+			LicenseURI:   "projects/debian-cloud/global/licenses/debian-11-bullseye",
 		},
 
 		// Ubuntu

--- a/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
+++ b/cli_tools/gce_ovf_import/ovf_utils/ovf_utils.go
@@ -221,6 +221,7 @@ var ovfOSTypeToOSID = map[string]OsInfo{
 	"debian8_64Guest":       OsInfo{importerOSIDs: []string{"debian-8"}},
 	"debian9_64Guest":       OsInfo{importerOSIDs: []string{"debian-9"}},
 	"debian10_64Guest":      OsInfo{importerOSIDs: []string{"debian-10"}},
+	"debian11_64Guest":      OsInfo{importerOSIDs: []string{"debian-11"}},
 	"centos7_64Guest":       OsInfo{importerOSIDs: []string{"centos-7"}},
 	"centos8_64Guest":       OsInfo{importerOSIDs: []string{"centos-8"}},
 	"rhel6_64Guest":         OsInfo{importerOSIDs: []string{"rhel-6"}},

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -114,6 +114,10 @@ var basicCases = []*testCase{
 		source:   "projects/compute-image-tools-test/global/images/debian-10",
 		os:       "debian-10",
 	},
+	{
+		caseName: "debian-11",
+		source:   "projects/compute-image-tools-test/global/images/debian-11",
+	},
 
 	// Ubuntu
 	{

--- a/daisy_workflows/image_import/debian/translate.py
+++ b/daisy_workflows/image_import/debian/translate.py
@@ -90,8 +90,8 @@ def DistroSpecific(g):
       r'/GRUB_CMDLINE_LINUX/s#"$# console=ttyS0,38400n8"#',
       '/etc/default/grub'])
 
-  # Disable predictive network interface naming in Stretch and Buster.
-  if deb_release in ['stretch', 'buster']:
+  # Disable predictive network interface naming in 9+.
+  if deb_release != 'jessie':
     run(g,
         ['sed', '-i',
         r's#^\(GRUB_CMDLINE_LINUX=".*\)"$#\1 net.ifnames=0 biosdevname=0"#',

--- a/daisy_workflows/image_import/debian/translate_debian_11.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_11.wf.json
@@ -1,0 +1,72 @@
+{
+  "Name": "translate-debian-11",
+  "Vars": {
+    "source_disk": {
+      "Required": true,
+      "Description": "The Debian 11 GCE disk to translate."
+    },
+    "sysprep": {
+      "Value": "false",
+      "Description": "If enabled, run sysprep. This is a no-op for Linux."
+    },
+    "install_gce_packages": {
+      "Value": "true",
+      "Description": "Whether to install GCE packages."
+    },
+    "image_name": {
+      "Value": "debian-11-${ID}",
+      "Description": "The name of the translated Debian 11 image."
+    },
+    "family": {
+      "Value": "",
+      "Description": "Optional family to set for the translated image"
+    },
+    "description": {
+      "Value": "",
+      "Description": "Optional description to set for the translated image"
+    },
+    "import_network": {
+      "Value": "global/networks/default",
+      "Description": "Network to use for the import instance"
+    },
+    "import_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the import instance"
+    },
+    "compute_service_account": {
+      "Value": "default",
+      "Description": "Service account that will be used by the created worker instance"
+    }
+  },
+  "Steps": {
+    "translate-disk": {
+      "IncludeWorkflow": {
+        "Path": "./translate_debian.wf.json",
+        "Vars": {
+          "debian_release": "bullseye",
+          "install_gce_packages": "${install_gce_packages}",
+          "imported_disk": "${source_disk}",
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}",
+          "compute_service_account": "${compute_service_account}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "${image_name}",
+          "SourceDisk": "${source_disk}",
+          "Family": "${family}",
+          "Licenses": ["projects/debian-cloud/global/licenses/debian-11-bullseye"],
+          "Description": "${description}",
+          "ExactName": true,
+          "NoCleanup": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["translate-disk"]
+  }
+}


### PR DESCRIPTION
This adds support for importing Debian 11 to image and instance import. 

Testing
 - Passed an invalid `-os` to `gce_ovf_import` and `gce_vm_image_import` and confirmed that `debian-11` was in the list of suggested values.
 - Manually ran an import of Debian 11 without `--os` and confirmed that inspection chose the correct translation workflow.
 - Ran new and existing Debian import tests.