### PR TITLE
Image import: Support release info changes in new versions of apt

### DIFF
--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -819,4 +819,18 @@ def install_apt_packages(g, *pkgs):
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def update_apt(g):
-  run(g, 'apt -y update')
+  """Runs apt update in a guest.
+
+  Starting at apt 1.5, release info changes must be confirmed
+  explicitly with `--allow-releaseinfo-change`. That flag,
+  however, is not supported prior to 1.5.
+
+  Args:
+    g: guestfs.GuestFS, mounted guest.
+
+  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931566
+  """
+  try:
+    run(g, 'apt update -y')
+  except RuntimeError:
+    run(g, 'apt update -y --allow-releaseinfo-change')


### PR DESCRIPTION
Debian 10 import tests are currently failing with the error:

```
Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
```

Solving this requires the flag `--allow-releaseinfo-change`, as discussed in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931566 . This flag, however, is only available in newer versions of apt, as seen in the revert #1732.

This PR first tries running apt without `--allow-releaseinfo-change`; if that fails, it tries again with that flag.

There's an alternative approach to sniff the version of apt, either directly by using `--version`, or indirectly through inference based on the distro and version. I opted against that approach since it seemed fragile (regex matches) and incurred higher maintenance for future developers (which version of apt is in which distro?).


Testing:
- Ran import e2e tests for Debian 8,9,10 and Ubuntu 14.04, 16.04, and 18.04. 