### PR TITLE
fix `/etc/netplan` clean up issue for Ubuntu 18+ which interrupts the import process

### DIFF
--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -220,7 +220,7 @@ def DistroSpecific(g):
   elif ubuntu_release == 'xenial':
     g.write('/etc/network/interfaces', network_xenial)
   elif g.is_dir('/etc/netplan'):
-    run(g, 'rm -f /etc/netplan/*')
+    run(g, 'rm -f /etc/netplan/*.yaml')
     g.write('/etc/netplan/config.yaml', network_netplan)
     run(g, 'netplan apply')
 


### PR DESCRIPTION
This PR will fix issue #1747.

The solution could be one of `rm -f /etc/netplan/*.yaml` or `rm -rf /etc/netplan/*` but I would like to use the first approach to preserve everything on the image if they do not prevent making an image.