### PR TITLE
EL6 import: Enable rsyslog and add e2e test

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -261,6 +261,10 @@ var basicCases = []*testCase{
 		source:   "projects/compute-image-tools-test/global/images/centos-8-3",
 		os:       "centos-8",
 	}, {
+		caseName: "el-rhel-6-10",
+		source:   "projects/compute-image-tools-test/global/images/rhel-6-10",
+		os:       "rhel-6",
+	}, {
 		caseName:  "el-rhel-7-uefi",
 		source:    "projects/compute-image-tools-test/global/images/linux-uefi-no-guestosfeature-rhel7",
 		os:        "rhel-7",

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -258,6 +258,8 @@ def DistroSpecific(spec: TranslateSpec):
             binary_path
         g.write(new_bin_path, bin_str)
         g.chmod(0o755, new_bin_path)
+        logging.info('Enabling rsyslog')
+        run(g, 'chkconfig rsyslog on')
     else:
       g.write_append(
           '/etc/yum.repos.d/google-cloud.repo', repo_sdk % el_release)


### PR DESCRIPTION
This was prompted by a user's report of a failed RHEL 6 import, where the guest agent was crashing due to `rsyslog` not being enabled. This PR:

1. Enables the rsyslog service during translate for RHEL6. rsyslog is an [explicit dependency](https://github.com/GoogleCloudPlatform/guest-configs/blob/master/packaging/google-compute-engine.spec) for RHEL6, and while in RHEL 7+ it's [required to be running](https://github.com/GoogleCloudPlatform/guest-agent/blob/main/google-guest-agent.service#L10), in RHEL6, however, the init conf [doesn't assert that rsyslog is running](https://github.com/GoogleCloudPlatform/guest-agent/blob/main/google-guest-agent.conf). 
3. Added an e2e test.