### PR TITLE
Image Import: Use daisy worker

### DIFF
--- a/cli_tools/common/assert/assert.go
+++ b/cli_tools/common/assert/assert.go
@@ -16,9 +16,30 @@ package assert
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/files"
 )
+
+// NotEmpty asserts that obj is non-null and does not have a zero value.
+func NotEmpty(obj interface{}) {
+	if isEmpty(obj) {
+		panic("Expected non-empty value")
+	}
+}
+
+func isEmpty(obj interface{}) bool {
+	if obj == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(obj)
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	}
+	return v.IsZero()
+}
 
 // GreaterThanOrEqualTo asserts that value is greater than or equal to limit.
 func GreaterThanOrEqualTo(value int, limit int) {

--- a/cli_tools/common/assert/assert_test.go
+++ b/cli_tools/common/assert/assert_test.go
@@ -140,3 +140,81 @@ func TestDirectoryExists(t *testing.T) {
 		})
 	}
 }
+
+func TestNotEmpty(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         interface{}
+		expectPanic bool
+	}{
+		{
+			obj:  "s",
+			name: "pass when non-empty string",
+		},
+		{
+			obj:  struct{ s string }{s: "hi"},
+			name: "pass when non-default struct",
+		},
+		{
+			obj:  map[string]string{"hi": "there"},
+			name: "pass when non-empty map",
+		},
+		{
+			obj:  [1]string{"hi"},
+			name: "pass when non-empty array",
+		}, {
+			obj:  []string{"hi"},
+			name: "pass when non-empty slice",
+		},
+		{
+			obj:         nil,
+			name:        "panic when object is untypped nil",
+			expectPanic: true,
+		},
+		{
+			obj:         "",
+			name:        "pass when empty string",
+			expectPanic: true,
+		},
+		{
+			obj:         map[string]string{},
+			name:        "panic when object is empty map",
+			expectPanic: true,
+		},
+		{
+			obj:         map[string]map[string]string{},
+			name:        "panic when object is empty nested map",
+			expectPanic: true,
+		},
+		{
+			obj:         [0]string{},
+			name:        "panic when object is empty array",
+			expectPanic: true,
+		}, {
+			obj:         []string{},
+			name:        "panic when object is empty slice",
+			expectPanic: true,
+		},
+		{
+			obj:         [][]string{},
+			name:        "panic when object is empty nested slice",
+			expectPanic: true,
+		},
+		{
+			obj:         struct{ s string }{},
+			name:        "panic when default struct",
+			expectPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectPanic {
+				assert.PanicsWithValue(t, "Expected non-empty value", func() {
+					NotEmpty(tt.obj)
+				})
+			} else {
+				NotEmpty(tt.obj)
+			}
+		})
+	}
+}

--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -54,12 +54,10 @@ func NewInspector(env daisyutils.EnvironmentSettings, logger logging.Logger) (In
 		return nil, err
 	}
 
-	// Daisy uses the workflow name as the prefix for log lines.
-	logPrefix := env.DaisyLogLinePrefix
-	if logPrefix != "" {
-		logPrefix += "-"
+	if env.DaisyLogLinePrefix != "" {
+		env.DaisyLogLinePrefix += "-"
 	}
-	wf.Name = logPrefix + "inspect"
+	env.DaisyLogLinePrefix += "inspect"
 	return &bootInspector{daisyutils.NewDaisyWorker(wf, env, logger), logger}, nil
 }
 

--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -365,8 +365,8 @@ func createDaisyInflaterSafe(t *testing.T, request ImageImportRequest,
 		request.ExecutionID = "build-id"
 	}
 
-	if request.Tool.URISafeName == "" {
-		request.Tool.URISafeName = "image-import"
+	if request.Tool.ResourceLabelName == "" {
+		request.Tool.ResourceLabelName = "image-import"
 	}
 
 	request.WorkflowDir = "../../../../daisy_workflows"

--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -20,13 +20,61 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
+
+func TestDaisyInflater_Inflate_ReadsDiskStatsFromWorker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWorker := mocks.NewMockDaisyWorker(ctrl)
+	inflater := daisyInflater{
+		mockWorker, map[string]string{}, nil, "/disk/uri", logging.NewToolLogger("test"),
+	}
+	mockWorker.EXPECT().RunAndReadSerialValues(inflater.vars, targetSizeGBKey,
+		sourceSizeGBKey, importFileFormatKey, diskChecksumKey).Return(map[string]string{
+		targetSizeGBKey:     "100",
+		sourceSizeGBKey:     "200",
+		importFileFormatKey: "vhd",
+		diskChecksumKey:     "9abc",
+	}, nil)
+	pDisk, shadowFields, e := inflater.Inflate()
+	assert.Nil(t, e)
+	assert.Equal(t, persistentDisk{uri: "/disk/uri", sizeGb: 100, sourceGb: 200, sourceType: "vhd"}, pDisk)
+	shadowFields.inflationTime = 0
+	assert.Equal(t, shadowTestFields{checksum: "9abc", inflationType: "qemu"}, shadowFields)
+}
+
+func TestDaisyInflater_Inflate_IncludesDiskStatsOnError(t *testing.T) {
+	expectedError := errors.New("failure to inflate disk")
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWorker := mocks.NewMockDaisyWorker(ctrl)
+	inflater := daisyInflater{
+		mockWorker, map[string]string{}, nil, "/disk/uri", logging.NewToolLogger("test"),
+	}
+	mockWorker.EXPECT().RunAndReadSerialValues(inflater.vars, targetSizeGBKey,
+		sourceSizeGBKey, importFileFormatKey, diskChecksumKey).Return(map[string]string{
+		targetSizeGBKey:     "50",
+		sourceSizeGBKey:     "12",
+		importFileFormatKey: "qcow2",
+		diskChecksumKey:     "9abc",
+	}, expectedError)
+	pDisk, shadowFields, actualError := inflater.Inflate()
+	assert.Equal(t, expectedError, actualError)
+	assert.Equal(t, persistentDisk{uri: "/disk/uri", sizeGb: 50, sourceGb: 12, sourceType: "qcow2"}, pDisk)
+	shadowFields.inflationTime = 0
+	assert.Equal(t, shadowTestFields{checksum: "9abc", inflationType: "qemu"}, shadowFields)
+}
 
 // gcloud expects log lines to start with the substring "[import". Daisy
 // constructs the log prefix using the workflow's name.
@@ -35,7 +83,9 @@ func TestCreateDaisyInflater_SetsWorkflowNameToGcloudPrefix(t *testing.T) {
 		Source:             imageSource{uri: "projects/test/uri/image"},
 		DaisyLogLinePrefix: "disk-1",
 	})
-	assert.Equal(t, "disk-1-inflate", inflater.wf.Name)
+	daisyutils.CheckEnvironment(inflater.worker, func(env daisyutils.EnvironmentSettings) {
+		assert.Equal(t, "disk-1-inflate", env.DaisyLogLinePrefix)
+	})
 }
 
 func TestCreateDaisyInflater_Image_HappyCase(t *testing.T) {
@@ -46,10 +96,11 @@ func TestCreateDaisyInflater_Image_HappyCase(t *testing.T) {
 	})
 
 	assert.Equal(t, "zones/us-west1-b/disks/disk-1234", inflater.inflatedDiskURI)
-	assert.Equal(t, "projects/test/uri/image", inflater.wf.Vars["source_image"].Value)
-	inflatedDisk := getDisk(inflater.wf, 0)
-	assert.Contains(t, inflatedDisk.Licenses,
-		"projects/compute-image-tools/global/licenses/virtual-disk-import")
+	assert.Equal(t, "projects/test/uri/image", inflater.vars["source_image"])
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.Contains(t, getDisk(wf, 0).Licenses,
+			"projects/compute-image-tools/global/licenses/virtual-disk-import")
+	})
 }
 
 func TestCreateDaisyInflater_Image_Windows(t *testing.T) {
@@ -57,9 +108,10 @@ func TestCreateDaisyInflater_Image_Windows(t *testing.T) {
 		Source: imageSource{uri: "image/uri"},
 		OS:     "windows-2019",
 	})
-
-	assert.Contains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "WINDOWS",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.Contains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "WINDOWS",
+		})
 	})
 }
 
@@ -68,9 +120,10 @@ func TestCreateDaisyInflater_Image_NotWindows(t *testing.T) {
 		Source: imageSource{uri: "image/uri"},
 		OS:     "ubuntu-1804",
 	})
-
-	assert.NotContains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "WINDOWS",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.NotContains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "WINDOWS",
+		})
 	})
 }
 
@@ -80,9 +133,10 @@ func TestCreateDaisyInflater_Image_UEFI(t *testing.T) {
 		OS:             "ubuntu-1804",
 		UefiCompatible: true,
 	})
-
-	assert.Contains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "UEFI_COMPATIBLE",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.Contains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "UEFI_COMPATIBLE",
+		})
 	})
 }
 
@@ -92,9 +146,10 @@ func TestCreateDaisyInflater_Image_NotUEFI(t *testing.T) {
 		OS:             "ubuntu-1804",
 		UefiCompatible: false,
 	})
-
-	assert.NotContains(t, getDisk(inflater.wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "UEFI_COMPATIBLE",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.NotContains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "UEFI_COMPATIBLE",
+		})
 	})
 }
 
@@ -113,15 +168,16 @@ func TestCreateDaisyInflater_File_HappyCase(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.Equal(t, "zones/us-west1-c/disks/disk-1234", inflater.inflatedDiskURI)
+		assert.Equal(t, "gs://bucket/vmdk", wf.Vars["source_disk_file"].Value)
+		assert.Equal(t, "projects/subnet/subnet", wf.Vars["import_subnet"].Value)
+		assert.Equal(t, "projects/network/network", wf.Vars["import_network"].Value)
+		assert.Equal(t, "default", wf.Vars["compute_service_account"].Value)
 
-	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", inflater.inflatedDiskURI)
-	assert.Equal(t, "gs://bucket/vmdk", inflater.wf.Vars["source_disk_file"].Value)
-	assert.Equal(t, "projects/subnet/subnet", inflater.wf.Vars["import_subnet"].Value)
-	assert.Equal(t, "projects/network/network", inflater.wf.Vars["import_network"].Value)
-	assert.Equal(t, "default", inflater.wf.Vars["compute_service_account"].Value)
-
-	network := getWorkerNetwork(t, inflater.wf)
-	assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+		network := getWorkerNetwork(t, wf)
+		assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+	})
 }
 
 func TestCreateDaisyInflater_File_ComputeServiceAcount(t *testing.T) {
@@ -135,8 +191,9 @@ func TestCreateDaisyInflater_File_ComputeServiceAcount(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
-
-	assert.Equal(t, "csa", inflater.wf.Vars["compute_service_account"].Value)
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		assert.Equal(t, "csa", wf.Vars["compute_service_account"].Value)
+	})
 }
 
 func TestCreateDaisyInflater_File_NoExternalIP(t *testing.T) {
@@ -150,9 +207,9 @@ func TestCreateDaisyInflater_File_NoExternalIP(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
-
-	network := getWorkerNetwork(t, inflater.wf)
-	assert.NotNil(t, network.AccessConfigs, "To disable external IPs, AccessConfigs must be non-nil.")
+	daisyutils.CheckEnvironment(inflater.worker, func(env daisyutils.EnvironmentSettings) {
+		assert.True(t, env.NoExternalIP)
+	})
 }
 
 func TestCreateDaisyInflater_File_UsesFallbackSizes_WhenInspectionFails(t *testing.T) {
@@ -166,10 +223,11 @@ func TestCreateDaisyInflater_File_UsesFallbackSizes_WhenInspectionFails(t *testi
 		errorToReturn:     errors.New("inspection failed"),
 		metaToReturn:      imagefile.Metadata{},
 	})
-
-	// The 10GB defaults are hardcoded in inflate_file.wf.json.
-	assert.Equal(t, "10", inflater.wf.Vars["scratch_disk_size_gb"].Value)
-	assert.Equal(t, "10", inflater.wf.Vars["inflated_disk_size_gb"].Value)
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		// The 10GB defaults are hardcoded in inflate_file.wf.json.
+		assert.Equal(t, "10", wf.Vars["scratch_disk_size_gb"].Value)
+		assert.Equal(t, "10", wf.Vars["inflated_disk_size_gb"].Value)
+	})
 }
 
 func TestCreateDaisyInflater_File_SetsSizesFromInspectedFile(t *testing.T) {
@@ -211,9 +269,10 @@ func TestCreateDaisyInflater_File_SetsSizesFromInspectedFile(t *testing.T) {
 					PhysicalSizeGB: tt.physicalSize,
 				},
 			})
-
-			assert.Equal(t, tt.expectedInflated, inflater.wf.Vars["inflated_disk_size_gb"].Value)
-			assert.Equal(t, tt.expectedScratch, inflater.wf.Vars["scratch_disk_size_gb"].Value)
+			daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+				assert.Equal(t, tt.expectedInflated, wf.Vars["inflated_disk_size_gb"].Value)
+				assert.Equal(t, tt.expectedScratch, wf.Vars["scratch_disk_size_gb"].Value)
+			})
 		})
 	}
 }
@@ -229,10 +288,11 @@ func TestCreateDaisyInflater_File_Windows(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
-
-	inflatedDisk := getDisk(inflater.wf, 1)
-	assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "WINDOWS",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		inflatedDisk := getDisk(wf, 1)
+		assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "WINDOWS",
+		})
 	})
 }
 
@@ -248,9 +308,11 @@ func TestCreateDaisyInflater_File_NotWindows(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	})
 
-	inflatedDisk := getDisk(inflater.wf, 1)
-	assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "WINDOWS",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		inflatedDisk := getDisk(wf, 1)
+		assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "WINDOWS",
+		})
 	})
 }
 
@@ -267,9 +329,11 @@ func TestCreateDaisyInflater_File_UEFI(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	})
 
-	inflatedDisk := getDisk(inflater.wf, 1)
-	assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "UEFI_COMPATIBLE",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		inflatedDisk := getDisk(wf, 1)
+		assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "UEFI_COMPATIBLE",
+		})
 	})
 }
 
@@ -286,14 +350,25 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	})
 
-	inflatedDisk := getDisk(inflater.wf, 1)
-	assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
-		Type: "UEFI_COMPATIBLE",
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+		inflatedDisk := getDisk(wf, 1)
+		assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "UEFI_COMPATIBLE",
+		})
 	})
 }
 
 func createDaisyInflaterSafe(t *testing.T, request ImageImportRequest,
 	inspector imagefile.Inspector) *daisyInflater {
+
+	if request.ExecutionID == "" {
+		request.ExecutionID = "build-id"
+	}
+
+	if request.Tool.URISafeName == "" {
+		request.Tool.URISafeName = "image-import"
+	}
+
 	request.WorkflowDir = "../../../../daisy_workflows"
 	daisyInflater, err := newDaisyInflater(request, inspector, logging.NewToolLogger("test"))
 	assert.NoError(t, err)

--- a/cli_tools/common/image/importer/inflater_test.go
+++ b/cli_tools/common/image/importer/inflater_test.go
@@ -83,7 +83,7 @@ func TestCreateShadowTestInflater_File(t *testing.T) {
 		Zone:        "us-west1-c",
 		ExecutionID: "1234",
 		Tool: daisyutils.Tool{
-			URISafeName: "image-import",
+			ResourceLabelName: "image-import",
 		},
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
@@ -122,7 +122,7 @@ func TestCreateInflater_Image(t *testing.T) {
 		ExecutionID: "1234",
 		WorkflowDir: daisyWorkflows,
 		Tool: daisyutils.Tool{
-			URISafeName: "image-import",
+			ResourceLabelName: "image-import",
 		},
 	}, nil, &storage.Client{}, nil, nil)
 	assert.NoError(t, err)

--- a/cli_tools/common/image/importer/inflater_test.go
+++ b/cli_tools/common/image/importer/inflater_test.go
@@ -18,11 +18,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/imagefile"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/storage"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
 
 func TestCreateFallbackInflater_File(t *testing.T) {
@@ -52,12 +55,14 @@ func TestCreateFallbackInflater_File(t *testing.T) {
 	daisyInflater, ok := facade.daisyInflater.(*daisyInflater)
 	assert.True(t, ok)
 	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", daisyInflater.inflatedDiskURI)
-	assert.Equal(t, "gs://bucket/vmdk", daisyInflater.wf.Vars["source_disk_file"].Value)
-	assert.Equal(t, "projects/subnet/subnet", daisyInflater.wf.Vars["import_subnet"].Value)
-	assert.Equal(t, "projects/network/network", daisyInflater.wf.Vars["import_network"].Value)
+	daisyutils.CheckWorkflow(daisyInflater.worker, func(wf *daisy.Workflow) {
+		assert.Equal(t, "gs://bucket/vmdk", wf.Vars["source_disk_file"].Value)
+		assert.Equal(t, "projects/subnet/subnet", wf.Vars["import_subnet"].Value)
+		assert.Equal(t, "projects/network/network", wf.Vars["import_network"].Value)
 
-	network := getWorkerNetwork(t, daisyInflater.wf)
-	assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+		network := getWorkerNetwork(t, wf)
+		assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+	})
 
 	apiInflater, ok := facade.apiInflater.(*apiInflater)
 	assert.True(t, ok)
@@ -72,11 +77,14 @@ func TestCreateShadowTestInflater_File(t *testing.T) {
 	//TODO: remove/disable this test once API inflater is the default (fallback mode)
 
 	inflater, err := newInflater(ImageImportRequest{
-		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
-		Subnet:       "projects/subnet/subnet",
-		Network:      "projects/network/network",
-		Zone:         "us-west1-c",
-		ExecutionID:  "1234",
+		Source:      fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:      "projects/subnet/subnet",
+		Network:     "projects/network/network",
+		Zone:        "us-west1-c",
+		ExecutionID: "1234",
+		Tool: daisyutils.Tool{
+			URISafeName: "image-import",
+		},
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
 	}, nil, &storage.Client{}, mockInspector{
@@ -91,13 +99,15 @@ func TestCreateShadowTestInflater_File(t *testing.T) {
 
 	daisyInflater, ok := facade.mainInflater.(*daisyInflater)
 	assert.True(t, ok)
-	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", daisyInflater.inflatedDiskURI)
-	assert.Equal(t, "gs://bucket/vmdk", daisyInflater.wf.Vars["source_disk_file"].Value)
-	assert.Equal(t, "projects/subnet/subnet", daisyInflater.wf.Vars["import_subnet"].Value)
-	assert.Equal(t, "projects/network/network", daisyInflater.wf.Vars["import_network"].Value)
+	daisyutils.CheckWorkflow(daisyInflater.worker, func(wf *daisy.Workflow) {
+		assert.Equal(t, "zones/us-west1-c/disks/disk-1234", daisyInflater.inflatedDiskURI)
+		assert.Equal(t, "gs://bucket/vmdk", wf.Vars["source_disk_file"].Value)
+		assert.Equal(t, "projects/subnet/subnet", wf.Vars["import_subnet"].Value)
+		assert.Equal(t, "projects/network/network", wf.Vars["import_network"].Value)
 
-	network := getWorkerNetwork(t, daisyInflater.wf)
-	assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+		network := getWorkerNetwork(t, wf)
+		assert.Nil(t, network.AccessConfigs, "AccessConfigs must be nil to allow ExternalIP to be allocated.")
+	})
 
 	apiInflater, ok := facade.shadowInflater.(*apiInflater)
 	assert.True(t, ok)
@@ -111,15 +121,21 @@ func TestCreateInflater_Image(t *testing.T) {
 		Zone:        "us-west1-b",
 		ExecutionID: "1234",
 		WorkflowDir: daisyWorkflows,
+		Tool: daisyutils.Tool{
+			URISafeName: "image-import",
+		},
 	}, nil, &storage.Client{}, nil, nil)
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)
-	assert.Equal(t, "zones/us-west1-b/disks/disk-1234", realInflater.inflatedDiskURI)
-	assert.Equal(t, "projects/test/uri/image", realInflater.wf.Vars["source_image"].Value)
-	inflatedDisk := getDisk(realInflater.wf, 0)
-	assert.Contains(t, inflatedDisk.Licenses,
-		"projects/compute-image-tools/global/licenses/virtual-disk-import")
+	daisyutils.CheckWorkflow(realInflater.worker, func(wf *daisy.Workflow) {
+		assert.Equal(t, "zones/us-west1-b/disks/disk-1234", realInflater.inflatedDiskURI)
+		assert.Equal(t, "projects/test/uri/image", wf.Vars["source_image"].Value)
+		inflatedDisk := getDisk(wf, 0)
+		assert.Contains(t, inflatedDisk.Licenses,
+			"projects/compute-image-tools/global/licenses/virtual-disk-import")
+	})
+
 }
 
 func TestInflaterFacade_SuccessOnApiInflater(t *testing.T) {

--- a/cli_tools/common/image/importer/request.go
+++ b/cli_tools/common/image/importer/request.go
@@ -99,7 +99,8 @@ type ImageImportRequest struct {
 	StorageLocation       string
 	Subnet                string
 	SysprepWindows        bool
-	Timeout               time.Duration `name:"timeout" validate:"required"`
+	Tool                  daisyutils.Tool `name:"tool" validate:"required"`
+	Timeout               time.Duration   `name:"timeout" validate:"required"`
 	UefiCompatible        bool
 	Zone                  string `name:"zone" validate:"required"`
 }
@@ -142,5 +143,6 @@ func (args ImageImportRequest) EnvironmentSettings() daisyutils.EnvironmentSetti
 		Labels:                args.Labels,
 		ExecutionID:           args.ExecutionID,
 		StorageLocation:       args.StorageLocation,
+		Tool:                  args.Tool,
 	}
 }

--- a/cli_tools/common/imagefile/qemu_img_test.go
+++ b/cli_tools/common/imagefile/qemu_img_test.go
@@ -118,7 +118,7 @@ func TestGetInfo_PropagateQemuImgError(t *testing.T) {
 	client := NewInfoClient()
 	_, err := client.GetInfo(context.Background(), "/tmp")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "qemu-img: Could not open '/tmp': A regular file")
+	assert.Contains(t, err.Error(), "qemu-img: Could not open '/tmp'")
 }
 
 func TestGetInfo_PropagateContextCancellation(t *testing.T) {

--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -438,6 +438,15 @@ Loop:
 	return w, nil
 }
 
+// Tool is used to communicate the tool's name ot the user.
+type Tool struct {
+
+	// HumanReadableName is used for error messages, for example: "image import".
+	HumanReadableName string
+	// URISafeName is used programmatically, eg: "image-import"
+	URISafeName string
+}
+
 // EnvironmentSettings controls the resources that are used during tool execution.
 type EnvironmentSettings struct {
 	// Location of workflows
@@ -461,6 +470,7 @@ type EnvironmentSettings struct {
 	Labels                map[string]string
 	ExecutionID           string
 	StorageLocation       string
+	Tool                  Tool
 }
 
 // ApplyToWorkflow sets fields on daisy.Workflow from the environment settings.

--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -443,8 +443,8 @@ type Tool struct {
 
 	// HumanReadableName is used for error messages, for example: "image import".
 	HumanReadableName string
-	// URISafeName is used programmatically, eg: "image-import"
-	URISafeName string
+	// ResourceLabelName is used when labeling temporary resources, for example: "image-import"
+	ResourceLabelName string
 }
 
 // EnvironmentSettings controls the resources that are used during tool execution.

--- a/cli_tools/common/utils/daisyutils/daisy_worker.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker.go
@@ -55,10 +55,10 @@ func createResourceLabelerIfMissing(env EnvironmentSettings, modifiers []Workflo
 			return modifiers
 		}
 	}
-	assert.NotEmpty(env.Tool.URISafeName)
+	assert.NotEmpty(env.Tool.ResourceLabelName)
 	assert.NotEmpty(env.ExecutionID)
 	return append(modifiers, NewResourceLabeler(
-		env.Tool.URISafeName, env.ExecutionID, env.Labels, env.StorageLocation))
+		env.Tool.ResourceLabelName, env.ExecutionID, env.Labels, env.StorageLocation))
 }
 
 type defaultDaisyWorker struct {

--- a/cli_tools/common/utils/daisyutils/daisy_worker.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker.go
@@ -17,6 +17,7 @@ package daisyutils
 import (
 	"context"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/assert"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/logging"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 )
@@ -28,18 +29,36 @@ import (
 type DaisyWorker interface {
 	Run(vars map[string]string) error
 	RunAndReadSerialValue(key string, vars map[string]string) (string, error)
+	RunAndReadSerialValues(vars map[string]string, keys ...string) (map[string]string, error)
 	Cancel(reason string) bool
 }
 
 // NewDaisyWorker returns an implementation of DaisyWorker. The returned value is
-// designed to be run once and discarded. In other words, don't run RunAndReadSerialValue
-// twice on the same instance.
-func NewDaisyWorker(wf *daisy.Workflow, env EnvironmentSettings, logger logging.Logger, modifiers ...WorkflowModifier) DaisyWorker {
+// designed to be run once and discarded. In other words, don't run the same instance twice.
+//
+// If modifiers doesn't include a resource labeler, one will be created.
+func NewDaisyWorker(wf *daisy.Workflow, env EnvironmentSettings,
+	logger logging.Logger, modifiers ...WorkflowModifier) DaisyWorker {
 	modifiers = append(modifiers, &ApplyEnvToWorkflow{env}, &ConfigureDaisyLogging{env})
 	if env.NoExternalIP {
 		modifiers = append(modifiers, &RemoveExternalIPModifier{})
 	}
-	return &defaultDaisyWorker{wf: wf, env: env, logger: logger, modifiers: modifiers}
+	return &defaultDaisyWorker{wf: wf, env: env, logger: logger, modifiers: createResourceLabelerIfMissing(env, modifiers)}
+}
+
+// createResourceLabelerIfMissing checks whether there is a resource labeler in modifiers.
+// If not, then it creates a new one.
+func createResourceLabelerIfMissing(env EnvironmentSettings, modifiers []WorkflowModifier) []WorkflowModifier {
+	for _, modifier := range modifiers {
+		switch modifier.(type) {
+		case *ResourceLabeler:
+			return modifiers
+		}
+	}
+	assert.NotEmpty(env.Tool.URISafeName)
+	assert.NotEmpty(env.ExecutionID)
+	return append(modifiers, NewResourceLabeler(
+		env.Tool.URISafeName, env.ExecutionID, env.Labels, env.StorageLocation))
 }
 
 type defaultDaisyWorker struct {
@@ -59,11 +78,14 @@ func (w *defaultDaisyWorker) Run(vars map[string]string) error {
 			return err
 		}
 	}
-	err := w.wf.Run(context.Background())
+	err := RunWorkflowWithCancelSignal(context.Background(), w.wf)
 	if w.wf.Logger != nil {
 		for _, trace := range w.wf.Logger.ReadSerialPortLogs() {
 			w.logger.Trace(trace)
 		}
+	}
+	if err != nil {
+		PostProcessDErrorForNetworkFlag(w.env.Tool.HumanReadableName, err, w.env.Network, w.wf)
 	}
 	return err
 }
@@ -71,11 +93,19 @@ func (w *defaultDaisyWorker) Run(vars map[string]string) error {
 // RunAndReadSerialValue runs the daisy workflow with the supplied vars, and returns the serial
 // output value associated with the supplied key.
 func (w *defaultDaisyWorker) RunAndReadSerialValue(key string, vars map[string]string) (string, error) {
+	m, err := w.RunAndReadSerialValues(vars, key)
+	return m[key], err
+}
+
+// RunAndReadSerialValues runs the daisy workflow with the supplied vars, and returns the serial
+// output values associated with the supplied keys.
+func (w *defaultDaisyWorker) RunAndReadSerialValues(vars map[string]string, keys ...string) (map[string]string, error) {
 	err := w.Run(vars)
-	if err != nil {
-		return "", err
+	m := map[string]string{}
+	for _, key := range keys {
+		m[key] = w.wf.GetSerialConsoleOutputValue(key)
 	}
-	return w.wf.GetSerialConsoleOutputValue(key), nil
+	return m, err
 }
 
 func (w *defaultDaisyWorker) Cancel(reason string) bool {

--- a/cli_tools/common/utils/daisyutils/daisy_worker_test.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker_test.go
@@ -30,24 +30,50 @@ import (
 
 func Test_NewDaisyWorker_IncludesStandardModifiers(t *testing.T) {
 	wf := daisy.New()
-	env := EnvironmentSettings{}
+	env := EnvironmentSettings{
+		Labels:             map[string]string{"env": "prod"},
+		StorageLocation:    "us-east",
+		DaisyLogLinePrefix: "import-image",
+		ExecutionID:        "b1234",
+		Tool:               Tool{URISafeName: "unit-test"},
+	}
 	worker := NewDaisyWorker(wf, env, logging.NewToolLogger("test"))
 	assert.Equal(t, appliedModifiers{
 		applyEnvToWorkflow:       true,
 		configureDaisyLogging:    true,
 		removeExternalIPModifier: false,
+		resourceLabeler:          true,
 	}, findWhichModifiersApplied(worker))
+	rl := getResourceLabeler(t, worker)
+	assert.Equal(t, env.Labels, rl.UserLabels)
+	assert.Equal(t, env.StorageLocation, rl.ImageLocation)
+	assert.Contains(t, rl.BuildIDLabelKey, env.Tool.URISafeName)
+	assert.Equal(t, env.ExecutionID, rl.BuildID)
 }
 
 func Test_NewDaisyWorker_IncludesNoExternalIPModifier_WhenRequestedByUser(t *testing.T) {
 	wf := daisy.New()
-	env := EnvironmentSettings{NoExternalIP: true}
+	env := EnvironmentSettings{NoExternalIP: true,
+		ExecutionID: "b1234",
+		Tool:        Tool{URISafeName: "unit-test"},
+	}
 	worker := NewDaisyWorker(wf, env, logging.NewToolLogger("test"))
 	assert.Equal(t, appliedModifiers{
 		applyEnvToWorkflow:       true,
 		configureDaisyLogging:    true,
 		removeExternalIPModifier: true,
+		resourceLabeler:          true,
 	}, findWhichModifiersApplied(worker))
+}
+
+func Test_NewDaisyWorker_KeepsResourceLabelerIfSpecified(t *testing.T) {
+	wf := daisy.New()
+	env := EnvironmentSettings{NoExternalIP: true, ExecutionID: "b1234",
+		Tool: Tool{URISafeName: "unit-test"}}
+	rl := NewResourceLabeler("tool", "buildid", map[string]string{}, "location")
+	worker := NewDaisyWorker(wf, env, logging.NewToolLogger("test"), rl)
+	actualResourceLabeler := getResourceLabeler(t, worker)
+	assert.Equal(t, rl, actualResourceLabeler)
 }
 
 func Test_DaisyWorkerRun_RunsCustomModifiers(t *testing.T) {
@@ -66,6 +92,8 @@ func Test_DaisyWorkerRun_RunsCustomModifiers(t *testing.T) {
 		GCSPath:            "gs://test",
 		Timeout:            "60s",
 		DaisyLogLinePrefix: "import-image",
+		ExecutionID:        "b1234",
+		Tool:               Tool{URISafeName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -90,6 +118,8 @@ func Test_DaisyWorkerRun_CapturesDaisyLogs(t *testing.T) {
 		GCSPath:            "gs://test",
 		Timeout:            "60s",
 		DaisyLogLinePrefix: "import-image",
+		ExecutionID:        "b1234",
+		Tool:               Tool{URISafeName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -107,13 +137,19 @@ func Test_DaisyWorkerRun_FailsIfModifierFails(t *testing.T) {
 	modifier := mocks.NewMockWorkflowModifier(mockCtrl)
 	modifier.EXPECT().Modify(wf).Return(errors.New("modifier failed"))
 
-	worker := NewDaisyWorker(wf, EnvironmentSettings{}, logging.NewToolLogger("test"), modifier)
+	worker := NewDaisyWorker(wf, EnvironmentSettings{
+		ExecutionID: "b1234",
+		Tool:        Tool{URISafeName: "unit-test"},
+	}, logging.NewToolLogger("test"), modifier)
 	assert.EqualError(t, worker.Run(map[string]string{}), "modifier failed")
 }
 
 func Test_DaisyWorkerRun_FailsIfWorkflowFails(t *testing.T) {
 	wf := daisy.New()
-	worker := NewDaisyWorker(wf, EnvironmentSettings{}, logging.NewToolLogger("test"))
+	worker := NewDaisyWorker(wf, EnvironmentSettings{
+		ExecutionID: "b1234",
+		Tool:        Tool{URISafeName: "unit-test"},
+	}, logging.NewToolLogger("test"))
 	assert.EqualError(t, worker.Run(map[string]string{}),
 		"error validating workflow: must provide workflow field 'Name'")
 }
@@ -136,6 +172,8 @@ func Test_DaisyWorkerRun_AppliesEnvToWorkflow(t *testing.T) {
 		Timeout:            "60s",
 		ComputeEndpoint:    "new-endpoint",
 		DaisyLogLinePrefix: "import-image",
+		ExecutionID:        "b1234",
+		Tool:               Tool{URISafeName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -167,6 +205,8 @@ func Test_DaisyWorkerRun_AppliesVariables(t *testing.T) {
 		Timeout:            "60s",
 		ComputeEndpoint:    "new-endpoint",
 		DaisyLogLinePrefix: "import-image",
+		ExecutionID:        "b1234",
+		Tool:               Tool{URISafeName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -187,6 +227,8 @@ func Test_DaisyWorkerRunAndReadSerialValue_HappyCase(t *testing.T) {
 		Timeout:            "60s",
 		ComputeEndpoint:    "new-endpoint",
 		DaisyLogLinePrefix: "import-image",
+		ExecutionID:        "b1234",
+		Tool:               Tool{URISafeName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -197,7 +239,7 @@ func Test_DaisyWorkerRunAndReadSerialValue_HappyCase(t *testing.T) {
 }
 
 type appliedModifiers struct {
-	applyEnvToWorkflow, configureDaisyLogging, removeExternalIPModifier bool
+	applyEnvToWorkflow, configureDaisyLogging, removeExternalIPModifier, resourceLabeler bool
 }
 
 func findWhichModifiersApplied(worker DaisyWorker) (t appliedModifiers) {
@@ -212,8 +254,26 @@ func findWhichModifiersApplied(worker DaisyWorker) (t appliedModifiers) {
 		if _, ok := modifier.(*RemoveExternalIPModifier); ok {
 			t.removeExternalIPModifier = true
 		}
+		if _, ok := modifier.(*ResourceLabeler); ok {
+			t.resourceLabeler = true
+		}
 	}
 	return t
+}
+
+func getResourceLabeler(t *testing.T, worker DaisyWorker) *ResourceLabeler {
+	var actualResourceLabeler *ResourceLabeler
+	realWorker := worker.(*defaultDaisyWorker)
+	for _, modifier := range realWorker.modifiers {
+		switch modifier.(type) {
+		case *ResourceLabeler:
+			if actualResourceLabeler != nil {
+				assert.Fail(t, "Found more than one resource labeler in modifiers")
+			}
+			actualResourceLabeler = modifier.(*ResourceLabeler)
+		}
+	}
+	return actualResourceLabeler
 }
 
 // configWorkflowForUnitTesting adds a minimal number of steps and mocks so that the workflow can run without errors.

--- a/cli_tools/common/utils/daisyutils/daisy_worker_test.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker_test.go
@@ -35,7 +35,7 @@ func Test_NewDaisyWorker_IncludesStandardModifiers(t *testing.T) {
 		StorageLocation:    "us-east",
 		DaisyLogLinePrefix: "import-image",
 		ExecutionID:        "b1234",
-		Tool:               Tool{URISafeName: "unit-test"},
+		Tool:               Tool{ResourceLabelName: "unit-test"},
 	}
 	worker := NewDaisyWorker(wf, env, logging.NewToolLogger("test"))
 	assert.Equal(t, appliedModifiers{
@@ -47,7 +47,7 @@ func Test_NewDaisyWorker_IncludesStandardModifiers(t *testing.T) {
 	rl := getResourceLabeler(t, worker)
 	assert.Equal(t, env.Labels, rl.UserLabels)
 	assert.Equal(t, env.StorageLocation, rl.ImageLocation)
-	assert.Contains(t, rl.BuildIDLabelKey, env.Tool.URISafeName)
+	assert.Contains(t, rl.BuildIDLabelKey, env.Tool.ResourceLabelName)
 	assert.Equal(t, env.ExecutionID, rl.BuildID)
 }
 
@@ -55,7 +55,7 @@ func Test_NewDaisyWorker_IncludesNoExternalIPModifier_WhenRequestedByUser(t *tes
 	wf := daisy.New()
 	env := EnvironmentSettings{NoExternalIP: true,
 		ExecutionID: "b1234",
-		Tool:        Tool{URISafeName: "unit-test"},
+		Tool:        Tool{ResourceLabelName: "unit-test"},
 	}
 	worker := NewDaisyWorker(wf, env, logging.NewToolLogger("test"))
 	assert.Equal(t, appliedModifiers{
@@ -69,7 +69,7 @@ func Test_NewDaisyWorker_IncludesNoExternalIPModifier_WhenRequestedByUser(t *tes
 func Test_NewDaisyWorker_KeepsResourceLabelerIfSpecified(t *testing.T) {
 	wf := daisy.New()
 	env := EnvironmentSettings{NoExternalIP: true, ExecutionID: "b1234",
-		Tool: Tool{URISafeName: "unit-test"}}
+		Tool: Tool{ResourceLabelName: "unit-test"}}
 	rl := NewResourceLabeler("tool", "buildid", map[string]string{}, "location")
 	worker := NewDaisyWorker(wf, env, logging.NewToolLogger("test"), rl)
 	actualResourceLabeler := getResourceLabeler(t, worker)
@@ -93,7 +93,7 @@ func Test_DaisyWorkerRun_RunsCustomModifiers(t *testing.T) {
 		Timeout:            "60s",
 		DaisyLogLinePrefix: "import-image",
 		ExecutionID:        "b1234",
-		Tool:               Tool{URISafeName: "unit-test"},
+		Tool:               Tool{ResourceLabelName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -119,7 +119,7 @@ func Test_DaisyWorkerRun_CapturesDaisyLogs(t *testing.T) {
 		Timeout:            "60s",
 		DaisyLogLinePrefix: "import-image",
 		ExecutionID:        "b1234",
-		Tool:               Tool{URISafeName: "unit-test"},
+		Tool:               Tool{ResourceLabelName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -139,7 +139,7 @@ func Test_DaisyWorkerRun_FailsIfModifierFails(t *testing.T) {
 
 	worker := NewDaisyWorker(wf, EnvironmentSettings{
 		ExecutionID: "b1234",
-		Tool:        Tool{URISafeName: "unit-test"},
+		Tool:        Tool{ResourceLabelName: "unit-test"},
 	}, logging.NewToolLogger("test"), modifier)
 	assert.EqualError(t, worker.Run(map[string]string{}), "modifier failed")
 }
@@ -148,7 +148,7 @@ func Test_DaisyWorkerRun_FailsIfWorkflowFails(t *testing.T) {
 	wf := daisy.New()
 	worker := NewDaisyWorker(wf, EnvironmentSettings{
 		ExecutionID: "b1234",
-		Tool:        Tool{URISafeName: "unit-test"},
+		Tool:        Tool{ResourceLabelName: "unit-test"},
 	}, logging.NewToolLogger("test"))
 	assert.EqualError(t, worker.Run(map[string]string{}),
 		"error validating workflow: must provide workflow field 'Name'")
@@ -173,7 +173,7 @@ func Test_DaisyWorkerRun_AppliesEnvToWorkflow(t *testing.T) {
 		ComputeEndpoint:    "new-endpoint",
 		DaisyLogLinePrefix: "import-image",
 		ExecutionID:        "b1234",
-		Tool:               Tool{URISafeName: "unit-test"},
+		Tool:               Tool{ResourceLabelName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -206,7 +206,7 @@ func Test_DaisyWorkerRun_AppliesVariables(t *testing.T) {
 		ComputeEndpoint:    "new-endpoint",
 		DaisyLogLinePrefix: "import-image",
 		ExecutionID:        "b1234",
-		Tool:               Tool{URISafeName: "unit-test"},
+		Tool:               Tool{ResourceLabelName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 
@@ -228,7 +228,7 @@ func Test_DaisyWorkerRunAndReadSerialValue_HappyCase(t *testing.T) {
 		ComputeEndpoint:    "new-endpoint",
 		DaisyLogLinePrefix: "import-image",
 		ExecutionID:        "b1234",
-		Tool:               Tool{URISafeName: "unit-test"},
+		Tool:               Tool{ResourceLabelName: "unit-test"},
 	}
 	configWorkflowForUnitTesting(t, wf, mockCtrl, env)
 

--- a/cli_tools/common/utils/daisyutils/daisy_worker_testing.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker_testing.go
@@ -1,0 +1,41 @@
+//  Copyright 2021 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisyutils
+
+import (
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+// CheckWorkflow allows a test to check the fields on the daisy workflow associated with a DaisyWorker.
+func CheckWorkflow(worker DaisyWorker, check func(wf *daisy.Workflow)) {
+	check(worker.(*defaultDaisyWorker).wf)
+}
+
+// CheckEnvironment allows a test to check the fields on the EnvironmentSettings associated with a DaisyWorker.
+func CheckEnvironment(worker DaisyWorker, check func(env EnvironmentSettings)) {
+	check(worker.(*defaultDaisyWorker).env)
+}
+
+// CheckResourceLabeler allows a test to check the fields on the resource labeler associated with a DaisyWorker.
+func CheckResourceLabeler(worker DaisyWorker, check func(rl *ResourceLabeler)) {
+	for _, modifier := range worker.(*defaultDaisyWorker).modifiers {
+		switch modifier.(type) {
+		case *ResourceLabeler:
+			check(modifier.(*ResourceLabeler))
+			return
+		}
+	}
+	panic("Didn't find resource labeler")
+}

--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -17,10 +17,9 @@ package domain
 import (
 	"fmt"
 	"time"
-
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
-
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
 )
 
@@ -119,4 +118,18 @@ func (oip *OVFImportParams) IsInstanceImport() bool {
 // a machine image import. False otherwise.
 func (oip *OVFImportParams) IsMachineImageImport() bool {
 	return !oip.IsInstanceImport()
+}
+
+// GetTool returns a description of the tool being run that can be used for logging and messaging.
+func (oip *OVFImportParams) GetTool() daisyutils.Tool {
+	if oip.IsInstanceImport() {
+		return daisyutils.Tool{
+			HumanReadableName: "instance import",
+			URISafeName:       "instance-import",
+		}
+	}
+	return daisyutils.Tool{
+		HumanReadableName: "machine image import",
+		URISafeName:       "machine-image-import",
+	}
 }

--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -17,9 +17,11 @@ package domain
 import (
 	"fmt"
 	"time"
-	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
+
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
 )
 
@@ -125,11 +127,11 @@ func (oip *OVFImportParams) GetTool() daisyutils.Tool {
 	if oip.IsInstanceImport() {
 		return daisyutils.Tool{
 			HumanReadableName: "instance import",
-			URISafeName:       "instance-import",
+			ResourceLabelName: "instance-import",
 		}
 	}
 	return daisyutils.Tool{
 		HumanReadableName: "machine image import",
-		URISafeName:       "machine-image-import",
+		ResourceLabelName: "machine-image-import",
 	}
 }

--- a/cli_tools/gce_ovf_import/domain/ovf_import_params_test.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params_test.go
@@ -1,0 +1,23 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
+)
+
+func TestOVFImportParams_GetTool_InstanceImport(t *testing.T) {
+	assert.Equal(t, daisyutils.Tool{
+		HumanReadableName: "instance import",
+		URISafeName:       "instance-import",
+	}, (&OVFImportParams{InstanceNames: "instance"}).GetTool())
+}
+
+func TestOVFImportParams_GetTool_MachineImageImport(t *testing.T) {
+	assert.Equal(t, daisyutils.Tool{
+		HumanReadableName: "machine image import",
+		URISafeName:       "machine-image-import",
+	}, (&OVFImportParams{}).GetTool())
+}

--- a/cli_tools/gce_ovf_import/domain/ovf_import_params_test.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params_test.go
@@ -11,13 +11,13 @@ import (
 func TestOVFImportParams_GetTool_InstanceImport(t *testing.T) {
 	assert.Equal(t, daisyutils.Tool{
 		HumanReadableName: "instance import",
-		URISafeName:       "instance-import",
+		ResourceLabelName: "instance-import",
 	}, (&OVFImportParams{InstanceNames: "instance"}).GetTool())
 }
 
 func TestOVFImportParams_GetTool_MachineImageImport(t *testing.T) {
 	assert.Equal(t, daisyutils.Tool{
 		HumanReadableName: "machine image import",
-		URISafeName:       "machine-image-import",
+		ResourceLabelName: "machine-image-import",
 	}, (&OVFImportParams{}).GetTool())
 }

--- a/cli_tools/gce_ovf_import/multi_image_importer/request_builder.go
+++ b/cli_tools/gce_ovf_import/multi_image_importer/request_builder.go
@@ -56,6 +56,7 @@ func (r *requestBuilder) buildRequests(params *ovfdomain.OVFImportParams, fileUR
 			StdoutLogsDisabled:    params.StdoutLogsDisabled,
 			Subnet:                params.Subnet,
 			Timeout:               params.Deadline.Sub(time.Now()),
+			Tool:                  params.GetTool(),
 			UefiCompatible:        params.UefiCompatible,
 			Zone:                  params.Zone,
 		}

--- a/cli_tools/gce_vm_image_import/cli/args.go
+++ b/cli_tools/gce_vm_image_import/cli/args.go
@@ -67,6 +67,10 @@ func (args *imageImportArgs) populateAndValidate(populator param.Populator,
 	}
 
 	importer.FixBYOLAndOSArguments(&args.OS, &args.BYOL)
+	args.Tool = daisyutils.Tool{
+		HumanReadableName: "image import",
+		URISafeName:       "image-import",
+	}
 	args.Source, err = sourceFactory.Init(args.SourceFile, args.SourceImage)
 	if err != nil {
 		return err

--- a/cli_tools/gce_vm_image_import/cli/args.go
+++ b/cli_tools/gce_vm_image_import/cli/args.go
@@ -69,7 +69,7 @@ func (args *imageImportArgs) populateAndValidate(populator param.Populator,
 	importer.FixBYOLAndOSArguments(&args.OS, &args.BYOL)
 	args.Tool = daisyutils.Tool{
 		HumanReadableName: "image import",
-		URISafeName:       "image-import",
+		ResourceLabelName: "image-import",
 	}
 	args.Source, err = sourceFactory.Init(args.SourceFile, args.SourceImage)
 	if err != nil {

--- a/cli_tools/mocks/mock_daisy_worker.go
+++ b/cli_tools/mocks/mock_daisy_worker.go
@@ -75,3 +75,23 @@ func (mr *MockDaisyWorkerMockRecorder) RunAndReadSerialValue(key, vars interface
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAndReadSerialValue", reflect.TypeOf((*MockDaisyWorker)(nil).RunAndReadSerialValue), key, vars)
 }
+
+// RunAndReadSerialValues mocks base method.
+func (m *MockDaisyWorker) RunAndReadSerialValues(vars map[string]string, keys ...string) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{vars}
+	for _, a := range keys {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunAndReadSerialValues", varargs...)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunAndReadSerialValues indicates an expected call of RunAndReadSerialValues.
+func (mr *MockDaisyWorkerMockRecorder) RunAndReadSerialValues(vars interface{}, keys ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{vars}, keys...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAndReadSerialValues", reflect.TypeOf((*MockDaisyWorker)(nil).RunAndReadSerialValues), varargs...)
+}


### PR DESCRIPTION
This updates image import (and therefore a portion of OVF import) to use the DaisyWorker facade. Specifically:

1. Inflating the disk using qemu-img
2. Calculating the checksum of the API-inflated disk
3. Translating the disk

Disk inspection was already using the DaisyWorker facade.