### PR TITLE
OVF Export: Provide tool name

### DIFF
--- a/cli_tools/gce_ovf_export/domain/args.go
+++ b/cli_tools/gce_ovf_export/domain/args.go
@@ -170,6 +170,11 @@ func (args *OVFExportArgs) EnvironmentSettings() daisyutils.EnvironmentSettings 
 		Labels:                map[string]string{},
 		ExecutionID:           args.BuildID,
 		StorageLocation:       "",
+		Tool: daisyutils.Tool{
+			HumanReadableName: "ovf export",
+			ResourceLabelName: "ovf-export",
+		},
+		DaisyLogLinePrefix: "ovf-export",
 	}
 }
 


### PR DESCRIPTION
This fixes a regression caused by #1754, which broke OVF export at runtime: 

```

goroutine 1 [running]:
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/assert.NotEmpty(...)
	/build/cli_tools/common/assert/assert.go:27
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils.createResourceLabelerIfMissing({{0xc000556210, 0x10}, {0x7fff4a8a4b8f, 0x1b}, {0x7fff4a8a4c3c, 0xd}, {0xc0004b8060, 0x5c}, {0x0, 0x0}, ...}, ...)
	/build/cli_tools/common/utils/daisyutils/daisy_worker.go:58 +0x398
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils.NewDaisyWorker(_, {{0xc000556210, 0x10}, {0x7fff4a8a4b8f, 0x1b}, {0x7fff4a8a4c3c, 0xd}, {0xc0004b8060, 0x5c}, {0x0, ...}, ...}, ...)
	/build/cli_tools/common/utils/daisyutils/daisy_worker.go:46 +0x2e5
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/disk.NewInspector({{0xc000556210, 0x10}, {0x7fff4a8a4b8f, 0x1b}, {0x7fff4a8a4c3c, 0xd}, {0xc0004b8060, 0x5c}, {0x0, 0x0}, ...}, ...)
	/build/cli_tools/common/disk/inspect.go:61 +0x178
github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_ovf_export/exporter.NewOVFExporter(0xc000146480, {0x20ab9d8, 0xc00008c090})
	/build/cli_tools/gce_ovf_export/exporter/exporter.go:89 +0x545
main.runExport({0xc000030090, 0x7, 0x7})
	/build/cli_tools/gce_ovf_export/main.go:104 +0x1e5
main.main()
	/build/cli_tools/gce_ovf_export/main.go:121 +0x54
```


https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-ovf-export-e2e-tests-daily/1442422344105594880

This PR provides the tool name. To test, I ran an export using `gce_ovf_export`