### PR TITLE
fix cleanerupper deletion of OS policy assignments

### DIFF
--- a/test-infra/prowjobs/cleanerupper/main.go
+++ b/test-infra/prowjobs/cleanerupper/main.go
@@ -383,7 +383,7 @@ func cleanOSPolicyAssignments(ctx context.Context, computeClient daisyCompute.Cl
 				fmt.Printf("Error calling ListOSPolicyAssignments in project %q: %v\n", project, err)
 				return
 			}
-			if !shouldDelete(ospa.GetName(), nil, ospa.GetDescription(), ospa.GetRevisionCreateTime().GetSeconds()) {
+			if !shouldDelete(ospa.GetName(), nil, "", ospa.GetRevisionCreateTime().GetSeconds()) {
 				continue
 			}
 			if *dryRun {


### PR DESCRIPTION
The third argument to `shouldDelete` should be a timestamp string.

Error without fix: `Error parsing create time "OS policy assignment API prober": parsing time "OS policy assignment API prober" as "2006-01-02T15:04:05Z07:00": cannot parse "OS policy assignment API prober" as "2006"`

/woof