### PR TITLE
OVF Export: Use Daisy worker

### DIFF
--- a/cli_tools/gce_ovf_export/domain/args.go
+++ b/cli_tools/gce_ovf_export/domain/args.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/assert"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/flags"
 )
@@ -151,7 +152,8 @@ func toWorkingDir(currentDir, workflowDir string) string {
 
 // EnvironmentSettings creates an EnvironmentSettings instance from the fields
 // in this struct.
-func (args *OVFExportArgs) EnvironmentSettings() daisyutils.EnvironmentSettings {
+func (args *OVFExportArgs) EnvironmentSettings(daisyLogLinePrefix string) daisyutils.EnvironmentSettings {
+	assert.NotEmpty(daisyLogLinePrefix)
 	return daisyutils.EnvironmentSettings{
 		Project:               args.Project,
 		Zone:                  args.Zone,
@@ -172,9 +174,9 @@ func (args *OVFExportArgs) EnvironmentSettings() daisyutils.EnvironmentSettings 
 		StorageLocation:       "",
 		Tool: daisyutils.Tool{
 			HumanReadableName: "ovf export",
-			ResourceLabelName: "ovf-export",
+			ResourceLabelName: "gce-ovf-export",
 		},
-		DaisyLogLinePrefix: "ovf-export",
+		DaisyLogLinePrefix: daisyLogLinePrefix,
 	}
 }
 

--- a/cli_tools/gce_ovf_export/domain/args_test.go
+++ b/cli_tools/gce_ovf_export/domain/args_test.go
@@ -51,8 +51,9 @@ func TestDaisyAttrs(t *testing.T) {
 			Subnet:                params.Subnet,
 			ComputeServiceAccount: params.ComputeServiceAccount,
 			Labels:                map[string]string{},
-			Tool:                  daisyutils.Tool{HumanReadableName: "ovf export", ResourceLabelName: "ovf-export"},
+			ExecutionID:           params.BuildID,
+			Tool:                  daisyutils.Tool{HumanReadableName: "ovf export", ResourceLabelName: "gce-ovf-export"},
 			DaisyLogLinePrefix:    "ovf-export",
 		},
-		params.EnvironmentSettings())
+		params.EnvironmentSettings("ovf-export"))
 }

--- a/cli_tools/gce_ovf_export/domain/test_data.go
+++ b/cli_tools/gce_ovf_export/domain/test_data.go
@@ -40,6 +40,7 @@ func GetAllInstanceExportArgs() *OVFExportArgs {
 	return &OVFExportArgs{
 		InstanceName:         "instance1",
 		ClientID:             "aClient",
+		BuildID:              "aBuildID",
 		DestinationURI:       "gs://ovfbucket/OVFpath/some-instance-ovf.ovf",
 		DestinationDirectory: "gs://ovfbucket/OVFpath/",
 		OvfName:              "ovfinst",

--- a/cli_tools/gce_ovf_export/exporter/exporter.go
+++ b/cli_tools/gce_ovf_export/exporter/exporter.go
@@ -86,7 +86,7 @@ func NewOVFExporter(params *ovfexportdomain.OVFExportArgs, logger logging.ToolLo
 	if err := validateAndPopulateParams(params, paramValidator, paramPopulator); err != nil {
 		return nil, err
 	}
-	inspector, err := commondisk.NewInspector(params.EnvironmentSettings(), logger)
+	inspector, err := commondisk.NewInspector(params.EnvironmentSettings("ovf-export-disk-inspect"), logger)
 	if err != nil {
 		return nil, daisy.Errf("Error creating disk inspector: %v", err)
 	}

--- a/cli_tools/gce_ovf_export/exporter/steps.go
+++ b/cli_tools/gce_ovf_export/exporter/steps.go
@@ -103,37 +103,12 @@ func (oe *OVFExporter) cleanup(instance *compute.Instance, exportError error) er
 	return nil
 }
 
-func generateWorkflowWithSteps(workflowName, timeout string, populateStepsFunc populateStepsFunc,
-	params *ovfexportdomain.OVFExportArgs) (*daisy.Workflow, error) {
-
+func generateWorkflowWithSteps(workflowName, timeout string, populateStepsFunc populateStepsFunc) (*daisy.Workflow, error) {
 	w := daisy.New()
 	w.Name = workflowName
 	w.DefaultTimeout = timeout
 	w.ForceCleanupOnError = true
-	w.SetLogProcessHook(daisyutils.RemovePrivacyLogTag)
-
-	if err := populateStepsFunc(w); err != nil {
-		return w, err
-	}
-
-	params.EnvironmentSettings().ApplyToWorkflow(w)
-	return w, nil
-}
-
-func labelResources(w *daisy.Workflow, params *ovfexportdomain.OVFExportArgs) {
-	rl := &daisyutils.ResourceLabeler{
-		BuildID:         params.BuildID,
-		BuildIDLabelKey: "gce-ovf-export-build-id",
-		InstanceLabelKeyRetriever: func(instanceName string) string {
-			return "gce-ovf-export-tmp"
-		},
-		DiskLabelKeyRetriever: func(disk *daisy.Disk) string {
-			return "gce-ovf-export-tmp"
-		},
-		ImageLabelKeyRetriever: func(imageName string) string {
-			return "gce-ovf-export-tmp"
-		}}
-	rl.LabelResources(w)
+	return w, populateStepsFunc(w)
 }
 
 //TODO: consolidate with gce_vm_image_import.runStep()


### PR DESCRIPTION
This updates `gce_ovf_export` to use the DaisyWorker facade, rather than making calls directly to `daisy.Worker.Run`.

For testing, I created a GCE instance with three disks, exported it before and after this PR and compared:
 - The log output lines had the same prefixes
 - Worker instances had the same label format
 - The resulting exported OVFs were the same.