### PR TITLE
[import] respect custom network/subnet in shadow test workflow

### DIFF
--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -247,6 +247,8 @@ func (inflater *apiInflater) getCalculateChecksumWorkflow(diskURI string) *daisy
 							NetworkInterfaces: []*compute.NetworkInterface{
 								{
 									AccessConfigs: []*compute.AccessConfig{},
+									Network: inflater.request.Network,
+									Subnetwork: inflater.request.Subnet,
 								},
 							},
 							ServiceAccounts: []*compute.ServiceAccount{

--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -247,8 +247,8 @@ func (inflater *apiInflater) getCalculateChecksumWorkflow(diskURI string) *daisy
 							NetworkInterfaces: []*compute.NetworkInterface{
 								{
 									AccessConfigs: []*compute.AccessConfig{},
-									Network: inflater.request.Network,
-									Subnetwork: inflater.request.Subnet,
+									Network:       inflater.request.Network,
+									Subnetwork:    inflater.request.Subnet,
 								},
 							},
 							ServiceAccounts: []*compute.ServiceAccount{


### PR DESCRIPTION
Now network/subnet in shadow test workflow is not respected.

Impact: some imports failed to run shadow test.

It's not urgent since:
1. It won't break any import result.
2. It just lost a very small portion of shadow test result, so it won't impact the shadow test conclusion.

Fix: populate the value from the request.

Manually tested on my own test project. It's not worth adding new e2e test due to the above reason, and also due that its testing requires default network to be deleted, which will impacts the existing test set.