### PR TITLE
Windows upgrade: Use daisy worker

### DIFF
--- a/cli_tools/common/mount/inspector_test.go
+++ b/cli_tools/common/mount/inspector_test.go
@@ -16,6 +16,7 @@ package mount
 
 import (
 	"errors"
+	"sort"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -59,6 +60,7 @@ func TestMountInspector_Inspect_HappyCase_Virtual(t *testing.T) {
 	mountInspector := &defaultMountInspector{mockShell}
 	mountInfo, err := mountInspector.Inspect("/")
 	assert.NoError(t, err)
+	sort.Strings(mountInfo.UnderlyingBlockDevices)
 	assert.Equal(t, InspectionResults{
 		BlockDevicePath:        "/dev/mapper/vg-device",
 		BlockDeviceIsVirtual:   true,

--- a/cli_tools/gce_windows_upgrade/upgrader/test_common_test.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/test_common_test.go
@@ -76,6 +76,9 @@ func newTestUpgrader() *TestUpgrader {
 			CloudLogsDisabled:    false,
 			StdoutLogsDisabled:   false,
 		},
+		derivedVars: &derivedVars{
+			executionID: "execid",
+		},
 		ctx: context.Background(),
 	}
 	return &TestUpgrader{upgrader: u}

--- a/cli_tools/gce_windows_upgrade/upgrader/utils.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/utils.go
@@ -158,17 +158,3 @@ func needReboot(err error) bool {
 	// restarting is required
 	return strings.Contains(err.Error(), "Windows needs to be restarted")
 }
-
-func setWorkflowAttributes(w *daisy.Workflow, u *upgrader) {
-	daisyutils.EnvironmentSettings{
-		Project:           u.instanceProject,
-		Zone:              u.instanceZone,
-		GCSPath:           u.ScratchBucketGcsPath,
-		OAuth:             u.Oauth,
-		Timeout:           u.Timeout,
-		ComputeEndpoint:   u.Ce,
-		DisableGCSLogs:    u.GcsLogsDisabled,
-		DisableCloudLogs:  u.CloudLogsDisabled,
-		DisableStdoutLogs: u.StdoutLogsDisabled,
-	}.ApplyToWorkflow(w)
-}

--- a/cli_tools/gce_windows_upgrade/upgrader/workflows.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/workflows.go
@@ -507,10 +507,24 @@ func (u *upgrader) runWorkflowWithSteps(workflowName string, timeout string, pop
 		return w, err
 	}
 
-	w.SetLogProcessHook(daisyutils.RemovePrivacyLogTag)
-	setWorkflowAttributes(w, u)
-	err = daisyutils.RunWorkflowWithCancelSignal(u.ctx, w)
-	return w, err
+	env := daisyutils.EnvironmentSettings{
+		Project:           u.instanceProject,
+		Zone:              u.instanceZone,
+		GCSPath:           u.ScratchBucketGcsPath,
+		OAuth:             u.Oauth,
+		Timeout:           u.Timeout,
+		ComputeEndpoint:   u.Ce,
+		DisableGCSLogs:    u.GcsLogsDisabled,
+		DisableCloudLogs:  u.CloudLogsDisabled,
+		DisableStdoutLogs: u.StdoutLogsDisabled,
+		ExecutionID:       u.executionID,
+		Tool: daisyutils.Tool{
+			HumanReadableName: "windows upgrade",
+			ResourceLabelName: "windows-upgrade",
+		},
+	}
+
+	return w, daisyutils.NewDaisyWorker(w, env, u.logger).Run(map[string]string{})
 }
 
 func (u *upgrader) generateWorkflowWithSteps(workflowName string, timeout string, populateStepsFunc func(*upgrader, *daisy.Workflow) error) (*daisy.Workflow, error) {


### PR DESCRIPTION
This changes windows upgrade to use the `DaisyWorker` facade. For testing, I ran the the tests in gce_windows_upgrade.Dockerfile.