### PR TITLE
Ubuntu import: When possible, don't install cloud-init 21.3-1

### DIFF
--- a/daisy_workflows/image_import/ubuntu/translate.py
+++ b/daisy_workflows/image_import/ubuntu/translate.py
@@ -212,7 +212,11 @@ def setup_cloud_init(g: guestfs.GuestFS):
   a = Apt(run)
   curr_version = a.get_package_version(g, 'cloud-init')
   available_versions = a.list_available_versions(g, 'cloud-init')
-  # Don't install 21.3-1, which conflicts which the guest agent.
+  # Try to avoid installing 21.3-1, which conflicts which the guest agent.
+  # On first boot, systemd reaches a deadlock deadlock and doest start
+  # its unit. If a version other than 21.3-1 isn't explicitly found, *and*
+  # cloud-init isn't currently installed, then this allows apt to pick the
+  # version to install.
   version_to_install = Apt.determine_version_to_install(
     curr_version, available_versions, {'21.3-1'})
   pkg_to_install = ''

--- a/daisy_workflows/linux_common/tests/test_apt.py
+++ b/daisy_workflows/linux_common/tests/test_apt.py
@@ -1,0 +1,139 @@
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from textwrap import dedent
+
+from utils.apt import Apt
+from utils.guestfsprocess import CompletedProcess
+
+
+class TestVersionToInstall:
+
+  def test_return_greatest_match(self):
+    assert Apt.determine_version_to_install(
+      '1', {'3', '2', '1'}, {}) == '3'
+
+  def test_allow_current_version_empty(self):
+    assert Apt.determine_version_to_install(
+      '', {'3', '2', '1'}, {}) == '3'
+
+  def test_dont_return_blocked(self):
+    assert Apt.determine_version_to_install(
+      '1', {'3', '2', '1'}, {'3'}) == '2'
+
+  def test_blocklist_uses_prefix_matching(self):
+    assert Apt.determine_version_to_install(
+      '1', {'2.1', '2.2'}, {'2'}) == ''
+
+  def test_return_empty_when_nothing_newer(self):
+    assert Apt.determine_version_to_install(
+      '2', {'1.1'}, set()) == ''
+
+
+class TestGetPackageVersion:
+
+  def test_return_true_when_package_installed(self):
+    stdout = dedent("""
+    Package: python3
+    Status: install ok installed
+    Priority: optional
+    Section: python
+    Installed-Size: 89
+    Maintainer: Matthias Klose <doko@debian.org>
+    Architecture: amd64
+    Multi-Arch: allowed
+    Source: python3-defaults
+    Version: 3.9.2-3
+    Replaces: python3-minimal (<< 3.1.2-2)
+    Provides: python3-profiler
+    Depends: python3.9 (>= 3.9.2-0~), libpython3-stdlib (= 3.9.2-3)
+    Pre-Depends: python3-minimal (= 3.9.2-3)
+    Suggests: python3-doc (>= 3.9.2-3), python3-tk (>= 3.9.2-0~),
+    Description: interactive high-level object-oriented languag
+     Python, the high-level, interactive object oriented language,
+     includes an extensive class library with lots of goodies for
+     network programming, system administration, sounds and graphics.
+     .
+     This package is a dependency package, which depends on Debian's default
+     Python 3 version (currently v3.9).
+    Homepage: https://www.python.org/
+    Cnf-Extra-Commands: python
+    Cnf-Priority-Bonus: 5""").strip()
+    g = None
+    a = Apt(_mock_run(['dpkg', '-s', 'python3'],
+                      CompletedProcess(stdout, 'stderr', 0, 'cmd')))
+    assert a.get_package_version(g, 'python3') == '3.9.2-3'
+
+  def test_return_empty_string_when_version_not_detected(self):
+    stdout = dedent("""
+    Package: python3
+    Cnf-Priority-Bonus: 5""").strip()
+    g = None
+    a = Apt(_mock_run(['dpkg', '-s', 'python3'],
+                      CompletedProcess(stdout, 'stderr', 0, 'cmd')))
+    assert a.get_package_version(g, 'python3') == ''
+
+  def test_return_empty_string_when_package_not_installed(self):
+    g = None
+    a = Apt(_mock_run(['dpkg', '-s', 'cloud-init'],
+                      CompletedProcess('stdout', 'stderr', 1, 'cmd')))
+    assert a.get_package_version(g, 'cloud-init') == ''
+
+
+class TestListAvailableVersions:
+  g = None
+
+  def test_return_versions_if_available(self):
+    g = None
+    stdout = '\n'.join([
+      'cloud-init | 21.3-1-g6803368d-0ubuntu1~20.04.3 | repo',
+      'cloud-init | 20.1-10-g71af48df-0ubuntu5 | repo',
+      'cloud-init | 0.7.5-0ubuntu1.23 | repo',
+    ])
+
+    a = Apt(_mock_run(['apt-cache', 'madison', 'cloud-init'],
+                      CompletedProcess(stdout, '', 0, 'cmd')))
+    assert a.list_available_versions(g, 'cloud-init') == {
+      '21.3-1-g6803368d-0ubuntu1~20.04.3',
+      '20.1-10-g71af48df-0ubuntu5',
+      '0.7.5-0ubuntu1.23'}
+
+  def test_return_empty_list_if_package_not_available(self):
+    g = None
+    a = Apt(_mock_run(
+      ['apt-cache', 'madison', 'cloud-init'],
+      CompletedProcess(
+        'N: Unable to locate package cloud-init', '', 1, 'cmd')))
+    assert a.list_available_versions(g, 'cloud-init') == set()
+
+  def test_skip_lines_from_madison_with_unexpected_syntax(self):
+    g = None
+    stdout = '\n'.join([
+      'cloud-init | 21.3-1-g6803368d-0ubuntu1~20.04.3 | repo',
+      'cloud-init | extra bar | repo | not-recognized',
+      'cloud-init | missing bar',
+      'no bar',
+    ])
+
+    a = Apt(_mock_run(['apt-cache', 'madison', 'cloud-init'],
+                      CompletedProcess(stdout, '', 0, 'cmd')))
+    assert a.list_available_versions(g, 'cloud-init') == {
+      '21.3-1-g6803368d-0ubuntu1~20.04.3'}
+
+
+def _mock_run(expected_args, return_value):
+  def run(g, args, raiseOnError=False):
+    assert args == expected_args
+    return return_value
+
+  return run

--- a/daisy_workflows/linux_common/utils/apt.py
+++ b/daisy_workflows/linux_common/utils/apt.py
@@ -37,6 +37,7 @@ class Apt:
       for b in blocked_versions:
         if v.startswith(b):
           blocked = True
+          break
       if not blocked:
         non_blocked_versions.add(v)
     candidate = ''

--- a/daisy_workflows/linux_common/utils/apt.py
+++ b/daisy_workflows/linux_common/utils/apt.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright 2021 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import typing
+
+
+class Apt:
+  """Facade for operating with apt to faciliate testing."""
+
+  def __init__(self, run):
+    """
+    Args:
+      run: a function that matches the signature of guestfsprocess.run
+    """
+    self._run = run
+
+  @staticmethod
+  def determine_version_to_install(current_version: str,
+                                   available_versions: typing.Set[str],
+                                   blocked_versions: typing.Set[str]) -> str:
+    non_blocked_versions = set()
+    for v in available_versions:
+      blocked = False
+      for b in blocked_versions:
+        if v.startswith(b):
+          blocked = True
+      if not blocked:
+        non_blocked_versions.add(v)
+    candidate = ''
+    for v in non_blocked_versions:
+      if v > current_version and v > candidate:
+        candidate = v
+    logging.debug({
+      'available_versions': available_versions,
+      'non_blocked_versions': non_blocked_versions,
+      'blocked_versions': blocked_versions,
+      'candidate': candidate,
+    })
+    return candidate
+
+  def get_package_version(self, g, package_name: str) -> str:
+    """Returns the package version if it is installed, or an empty
+    string if not.
+
+    Args:
+      g: A mounted GuestFS instance
+      package_name: The package to check
+    """
+    p = self._run(g, ['dpkg', '-s', package_name],
+                  raiseOnError=False)
+    if p.code != 0:
+      return ''
+    for line in p.stdout.splitlines():
+      if line.startswith('Version: '):
+        parts = line.split(':')
+        if len(parts) == 2:
+          return parts[1].strip()
+    logging.debug('could not find version. dpkg output={}'.format(p))
+    return ''
+
+  def list_available_versions(self, g, package_name) -> typing.Set[str]:
+    """Returns the versions of package_name that are available to install.
+
+    Args:
+      g: A mounted GuestFS instance
+      package_name: The package to check
+    """
+    p = self._run(g, ['apt-cache', 'madison', package_name],
+                  raiseOnError=False)
+    if p.code != 0:
+      return set()
+    logging.debug(p)
+    versions = set()
+    for line in p.stdout.splitlines():
+      parts = [s.strip() for s in line.split('|')]
+      if len(parts) == 3:
+        versions.add(parts[1])
+      else:
+        logging.debug('skipping line; expected format '
+                      '"pkg | version | repo" not found. Line={}'.format(line))
+    return versions


### PR DESCRIPTION
This updates Ubuntu translate to avoid installing cloud-init 21.3-1, which blocks systemd from starting the guest agent on first boot. 

It achieves this by querying `apt` to find the available package versions, and picking a version such that 21.3-1 is avoided if possible. If a version other than 21.3-1 is found, this falls back to the previous behavior of allowing apt to choose which version to install. In this case, the guest agent will start after the first boot, which is the current behavior.

Testing:
- Ran Ubuntu e2e tests. 