### PR TITLE
Support RHEL 7.9 for SAP.

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.publish.json
@@ -1,0 +1,56 @@
+{{/*
+  Template to publish Red Hat Enterprise Linux for SAP images.
+  By default this template is setup to publish to the 'gce-image-builder'
+  project, the 'environment' variable can be used to publish to 'test', 'prod',
+  or 'staging'.
+  DeleteAfter is set to 180 days for all environments other than prod where no
+  time period is set.
+*/}}
+{
+  "Name": "rhel-7-9-sap",
+  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
+  {{$delete_after := `"24h*30*6"` -}}
+  {{if eq .environment "test" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "bct-prod-images",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- else if eq .environment "prod" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "rhel-sap-cloud",
+  "ComputeEndpoint": {{$endpoint}},
+  {{- else if eq .environment "oslogin-staging" -}}
+  "WorkProject": "oslogin-staging-project",
+  "PublishProject": "oslogin-staging-project",
+  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
+  "DeleteAfter": {{$delete_after}},
+  {{- else if eq .environment "staging" -}}
+  "WorkProject": "oslogin-staging-project",
+  "PublishProject": "gce-staging-images",
+  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
+  "DeleteAfter": {{$delete_after}},
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": {{$work_project}},
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- end}}
+  {{$guest_features := `["UEFI_COMPATIBLE"]` -}}
+  {{$time := trimPrefix .publish_version "v"}}
+  "Images": [
+    {
+      "Prefix": "rhel-7-9-sap",
+      "Family": "rhel-7-9-sap-ha",
+      "Description": "Red Hat, Red Hat Enterprise Linux for SAP with HA, 7.9, x86_64 built on {{$time}}, supports Shielded VM features",
+      "Licenses": [
+        {{if (or (eq .environment "staging") (eq .environment "oslogin-staging")) -}}
+        "projects/bct-staging-functional/global/licenses/rhel-7-server"
+        {{- else -}}
+        "projects/rhel-sap-cloud/global/licenses/rhel-7-sap"
+        {{- end}}
+      ],
+      "GuestOsFeatures": {{$guest_features}}
+    }
+  ]
+}

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.wf.json
@@ -1,0 +1,62 @@
+{
+  "Name": "rhel-7-9-sap",
+  "Project": "gce-image-builder",
+  "Zone": "us-central1-b",
+  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "Vars": {
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "gcs_url": {
+      "Required": true,
+      "Description": "The GCS path that image raw file exported to."
+    },
+    "installer_iso": {
+      "Required": true,
+      "Description": "The RHEL 7 installer ISO to build from."
+    }
+  },
+  "Steps": {
+    "build": {
+      "TimeOut": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/image_build/enterprise_linux/rhel_7_sap.wf.json",
+        "Vars": {
+          "build_date": "${build_date}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "install_disk": "disk-rhel-7",
+          "installer_iso": "${installer_iso}",
+          "rhel_release": "rhel-7-9"
+        }
+      }
+    },
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "source_disk": "disk-rhel-7"
+        }
+      }
+    },
+    "cleanup-image": {
+      "DeleteResources": {
+        "Images": ["rhel-7-9-sap-v${build_date}"]
+      }
+    }
+  },
+  "Dependencies": {
+    "export-image": ["build"],
+    "cleanup-image": ["build"]
+  }
+}

--- a/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
+++ b/daisy_workflows/image_build/enterprise_linux/ks_helpers.py
@@ -204,15 +204,16 @@ def BuildKsConfig(release, google_cloud_repo, byos, sap):
   if rhel:
     pkg = 'yum' if major == 7 else 'dnf'
 
-    # Why do we only do this for SAP? Does the ordering matter?
-    # Minor version post.
-    if sap and minor:
+    # Minor version post for SAP SKUs except 7.9
+    if (sap and minor) and not (major == 7 and minor == 9):
       templ = Template(FetchConfigPart('rhel-minor-post.cfg'))
       ks_post.append(templ.substitute(pkg=pkg, minor=minor, major=major))
 
     # RHEL common post.
     templ = Template(FetchConfigPart('rhel-post.cfg'))
     majors = f'{major}-sap' if sap else major
+    # RHEL 7.9 for SAP doesn't use E4S content and has a different config.
+    majors = 'rhel79-sap' if sap and major == 7 and minor == 9 else major
     ks_post.append(templ.substitute(pkg=pkg, major=majors))
 
     # SAP post.


### PR DESCRIPTION
RHEL 7.9 for SAP has its own unique configuration because it does not use E4S (Update Services) content and does not use the releasever yum variable to peg to a RHEL point release. Instead, it uses the regular `7Server` release but has a different set of content in the client configuration because it is an SAP SKU.