### PR TITLE
Stop creation of cloud logging client when cloud logging is disabled

### DIFF
--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -414,7 +414,7 @@ func (w *Workflow) PopulateClients(ctx context.Context, options ...option.Client
 		}
 	}
 
-	if w.externalLogging && w.cloudLoggingClient == nil {
+	if w.externalLogging && !w.cloudLoggingDisabled && w.cloudLoggingClient == nil {
 		w.cloudLoggingClient, err = logging.NewClient(ctx, w.Project, loggingOptions...)
 		if err != nil {
 			return err

--- a/daisy/workflow_test.go
+++ b/daisy/workflow_test.go
@@ -1137,6 +1137,13 @@ func TestPopulateClients(t *testing.T) {
 		t.Errorf("Did not populate Cloud Logging client.")
 	}
 
+	w.cloudLoggingClient = nil
+	w.DisableCloudLogging()
+	tryPopulateClients(t, w)
+	if w.cloudLoggingClient != nil {
+		t.Errorf("Cloud Logging client populated when Cloud Logging is disabled.")
+	}
+
 	w.ComputeClient = nil
 	tryPopulateClients(t, w, option.WithEndpoint("test.com"))
 	if w.ComputeClient.BasePath() != "test.com" {


### PR DESCRIPTION
Before if `DisableCloudLogging` was called, the `cloudLoggingClient` would still be created despite cloud logging explicitly not being enabled.

Added a condition to fix this behavior.