### PR TITLE
OVF Import: Use daisy worker

### DIFF
--- a/cli_tools/gce_ovf_import/domain/ovf_import_params.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params.go
@@ -135,3 +135,30 @@ func (oip *OVFImportParams) GetTool() daisyutils.Tool {
 		ResourceLabelName: "machine-image-import",
 	}
 }
+
+// EnvironmentSettings creates an EnvironmentSettings instance from the fields
+// in this struct.
+func (oip *OVFImportParams) EnvironmentSettings() daisyutils.EnvironmentSettings {
+	tool := oip.GetTool()
+	return daisyutils.EnvironmentSettings{
+		Project:               *oip.Project,
+		Zone:                  oip.Zone,
+		GCSPath:               oip.ScratchBucketGcsPath,
+		OAuth:                 oip.Oauth,
+		Timeout:               oip.Deadline.Sub(time.Now()).String(),
+		ComputeEndpoint:       oip.Ce,
+		DisableGCSLogs:        oip.GcsLogsDisabled,
+		DisableCloudLogs:      oip.CloudLogsDisabled,
+		DisableStdoutLogs:     oip.StdoutLogsDisabled,
+		NoExternalIP:          oip.NoExternalIP,
+		WorkflowDirectory:     oip.WorkflowDir,
+		Network:               oip.Network,
+		Subnet:                oip.Subnet,
+		ComputeServiceAccount: oip.ComputeServiceAccount,
+		Labels:                oip.UserLabels,
+		ExecutionID:           oip.BuildID,
+		StorageLocation:       oip.Region,
+		Tool:                  tool,
+		DaisyLogLinePrefix:    tool.ResourceLabelName,
+	}
+}

--- a/cli_tools/gce_ovf_import/domain/ovf_import_params_test.go
+++ b/cli_tools/gce_ovf_import/domain/ovf_import_params_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -20,4 +21,80 @@ func TestOVFImportParams_GetTool_MachineImageImport(t *testing.T) {
 		HumanReadableName: "machine image import",
 		ResourceLabelName: "machine-image-import",
 	}, (&OVFImportParams{}).GetTool())
+}
+
+func TestEnvironmentSettings_InstanceImport(t *testing.T) {
+	checkEnvironmentSettings(t, func(params *OVFImportParams) {
+		params.InstanceNames = "new-instance"
+	}, func(settings *daisyutils.EnvironmentSettings) {
+		settings.Tool = daisyutils.Tool{HumanReadableName: "instance import", ResourceLabelName: "instance-import"}
+		settings.DaisyLogLinePrefix = "instance-import"
+	})
+}
+
+func TestEnvironmentSettings_MachineImageImport(t *testing.T) {
+	checkEnvironmentSettings(t, func(params *OVFImportParams) {
+		params.MachineImageName = "machine-image-name"
+	}, func(settings *daisyutils.EnvironmentSettings) {
+		settings.Tool = daisyutils.Tool{HumanReadableName: "machine image import", ResourceLabelName: "machine-image-import"}
+		settings.DaisyLogLinePrefix = "machine-image-import"
+	})
+}
+
+func checkEnvironmentSettings(t *testing.T,
+	paramModifier func(*OVFImportParams),
+	expectedEnvModifier func(settings *daisyutils.EnvironmentSettings)) {
+
+	timeout, err := time.ParseDuration("3h")
+	assert.NoError(t, err)
+	project := "project"
+	params := &OVFImportParams{
+		Project:               &project,
+		Zone:                  "zone",
+		ScratchBucketGcsPath:  "gs://bucket",
+		Oauth:                 "auth-key",
+		Timeout:               timeout.String(),
+		Deadline:              time.Now().Add(timeout),
+		Ce:                    "https://endpoint.com",
+		GcsLogsDisabled:       true,
+		CloudLogsDisabled:     true,
+		NoExternalIP:          true,
+		WorkflowDir:           "~/workflows",
+		Network:               "non-default-network",
+		Subnet:                "non-default-subnet",
+		ComputeServiceAccount: "user@domain.com",
+		UserLabels:            map[string]string{"k": "v"},
+		BuildID:               "a123",
+		Region:                "us-west2",
+	}
+	expectedEnv := daisyutils.EnvironmentSettings{
+		Project:               *params.Project,
+		Zone:                  params.Zone,
+		GCSPath:               params.ScratchBucketGcsPath,
+		OAuth:                 params.Oauth,
+		ComputeEndpoint:       params.Ce,
+		WorkflowDirectory:     params.WorkflowDir,
+		DisableGCSLogs:        params.GcsLogsDisabled,
+		DisableCloudLogs:      params.CloudLogsDisabled,
+		DisableStdoutLogs:     params.StdoutLogsDisabled,
+		NoExternalIP:          params.NoExternalIP,
+		Network:               params.Network,
+		Subnet:                params.Subnet,
+		ComputeServiceAccount: params.ComputeServiceAccount,
+		Labels:                params.UserLabels,
+		ExecutionID:           params.BuildID,
+		StorageLocation:       params.Region,
+	}
+	paramModifier(params)
+	expectedEnvModifier(&expectedEnv)
+
+	actualEnv := params.EnvironmentSettings()
+
+	// The timeout is calculated dynamically using deadline and the current time.
+	// As long as the unit test runs within an hour this check will pass.
+	assert.Regexp(t, "[2|3]h.*", actualEnv.Timeout)
+	actualEnv.Timeout = ""
+	assert.Equal(t,
+		expectedEnv,
+		actualEnv)
 }

--- a/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
+++ b/cli_tools/gce_ovf_import/ovf_importer/ovf_param_validator_test.go
@@ -619,6 +619,7 @@ func getAllInstanceImportParams() *domain.OVFImportParams {
 		DeletionProtection:          true,
 		Description:                 "aDescription",
 		Labels:                      "userkey1=uservalue1,userkey2=uservalue2",
+		UserLabels:                  map[string]string{"userkey1": "uservalue1", "userkey2": "uservalue2"},
 		MachineType:                 "n1-standard-2",
 		Network:                     "aNetwork",
 		Subnet:                      "aSubnet",


### PR DESCRIPTION
This updates OVF import to use the daisy worker. (I'd recommend hiding whitespace for the review, since much of the changes are indents).

A notable change: For timeout handling, this change allows Daisy to handle the timeout, rather than having a goroutine handle it in `ovf_importer`.

Testing:
* Ran the "Ubuntu 3 disks" e2e test for OVF import