### PR TITLE
CLI Tools: Allow workflows to be re-run

### DIFF
--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -49,16 +49,20 @@ type Inspector interface {
 // A GCE instance runs the inspection; network and subnet are used
 // for its network interface.
 func NewInspector(env daisyutils.EnvironmentSettings, logger logging.Logger) (Inspector, error) {
-	wf, err := daisy.NewFromFile(path.Join(env.WorkflowDirectory, workflowFile))
-	if err != nil {
-		return nil, err
-	}
+	wfProvider := daisyutils.WorkflowProvider(func() (*daisy.Workflow, error) {
+		wf, err := daisy.NewFromFile(path.Join(env.WorkflowDirectory, workflowFile))
+		if err != nil {
+			return nil, err
+		}
 
-	if env.DaisyLogLinePrefix != "" {
-		env.DaisyLogLinePrefix += "-"
-	}
-	env.DaisyLogLinePrefix += "inspect"
-	return &bootInspector{daisyutils.NewDaisyWorker(wf, env, logger), logger}, nil
+		if env.DaisyLogLinePrefix != "" {
+			env.DaisyLogLinePrefix += "-"
+		}
+		env.DaisyLogLinePrefix += "inspect"
+		return wf, err
+	})
+
+	return &bootInspector{daisyutils.NewDaisyWorker(wfProvider, env, logger), logger}, nil
 }
 
 // bootInspector implements disk.Inspector using the Python boot-inspect package,

--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -203,8 +203,9 @@ func (inflater *apiInflater) calculateChecksum(diskURI string) (string, error) {
 		env.DaisyLogLinePrefix += "-"
 	}
 	env.DaisyLogLinePrefix += "shadow-disk-checksum"
-	worker := daisyutils.NewDaisyWorker(inflater.getCalculateChecksumWorkflow(diskURI),
-		env, inflater.logger)
+	worker := daisyutils.NewDaisyWorker(func() (*daisy.Workflow, error) {
+		return inflater.getCalculateChecksumWorkflow(diskURI), nil
+	}, env, inflater.logger)
 	return worker.RunAndReadSerialValue("disk-checksum", map[string]string{})
 }
 

--- a/cli_tools/common/image/importer/bootable_disk_processor.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor.go
@@ -50,7 +50,7 @@ func (b *bootableDiskProcessor) cancel(reason string) bool {
 	return true
 }
 
-func newBootableDiskProcessor(request ImageImportRequest, wfPath string, logger logging.Logger, detectedOs distro.Release) (processor, error) {
+func newBootableDiskProcessor(request ImageImportRequest, wfPath string, logger logging.Logger, detectedOs distro.Release) processor {
 	vars := map[string]string{
 		"image_name":           request.ImageName,
 		"install_gce_packages": strconv.FormatBool(!request.NoGuestEnvironment),
@@ -83,7 +83,7 @@ func newBootableDiskProcessor(request ImageImportRequest, wfPath string, logger 
 		detectedOs: detectedOs,
 		vars:       vars,
 	}
-	return diskProcessor, nil
+	return diskProcessor
 }
 
 func createResourceLabeler(request ImageImportRequest) *daisyutils.ResourceLabeler {

--- a/cli_tools/common/image/importer/bootable_disk_processor_test.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor_test.go
@@ -92,9 +92,8 @@ func TestBootableDiskProcessor_SupportsNoExternalIPForWorker(t *testing.T) {
 func TestBootableDiskProcessor_SetsWorkflowNameToGcloudPrefix(t *testing.T) {
 	args := defaultImportArgs()
 	args.DaisyLogLinePrefix = "disk-1"
-	processor, e := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()),
+	processor := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()),
 		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
-	assert.NoError(t, e)
 
 	daisyutils.CheckEnvironment((processor.(*bootableDiskProcessor)).worker, func(env daisyutils.EnvironmentSettings) {
 		assert.Equal(t, "disk-1-translate", env.DaisyLogLinePrefix)
@@ -236,9 +235,8 @@ func TestBootableDiskProcessor_PermitsUnsetStorageLocation(t *testing.T) {
 
 func TestBootableDiskProcessor_SupportsCancel(t *testing.T) {
 	args := defaultImportArgs()
-	processor, e := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()),
+	processor := newBootableDiskProcessor(args, opensuse15workflow, logging.NewToolLogger(t.Name()),
 		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
-	assert.NoError(t, e)
 
 	realProcessor := processor.(*bootableDiskProcessor)
 	realProcessor.cancel("timed-out")
@@ -247,10 +245,9 @@ func TestBootableDiskProcessor_SupportsCancel(t *testing.T) {
 }
 
 func createProcessor(t *testing.T, request ImageImportRequest) *bootableDiskProcessor {
-	translator, e := newBootableDiskProcessor(request, opensuse15workflow, logging.NewToolLogger(t.Name()),
+	processor := newBootableDiskProcessor(request, opensuse15workflow, logging.NewToolLogger(t.Name()),
 		distro.FromGcloudOSArgumentMustParse("windows-2008r2"))
-	assert.NoError(t, e)
-	realTranslator := translator.(*bootableDiskProcessor)
+	realTranslator := processor.(*bootableDiskProcessor)
 	// A concrete logger is required since the import/export logging framework writes a log entry
 	// when the workflow starts. Without this there's a panic.
 	return realTranslator

--- a/cli_tools/common/image/importer/bootable_disk_processor_test.go
+++ b/cli_tools/common/image/importer/bootable_disk_processor_test.go
@@ -112,7 +112,7 @@ func TestBootableDiskProcessor_PopulatesWorkflowVarsUsingArgs(t *testing.T) {
 	imageSpec.SysprepWindows = true
 	imageSpec.ComputeServiceAccount = "csa@email.com"
 	diskProcessor := createProcessor(t, imageSpec)
-	daisyutils.CheckWorkflow(diskProcessor.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(diskProcessor.worker, func(wf *daisy.Workflow, err error) {
 		actual := asMap(wf.Vars)
 		assert.Equal(t, map[string]string{
 			"source_disk":             "", // source_disk is written in process, since a previous processor may create a new disk
@@ -130,7 +130,7 @@ func TestBootableDiskProcessor_PopulatesWorkflowVarsUsingArgs(t *testing.T) {
 
 func TestBootableDiskProcessor_SupportsWorkflowDefaultVars(t *testing.T) {
 	diskProcessor := createProcessor(t, defaultImportArgs())
-	daisyutils.CheckWorkflow(diskProcessor.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(diskProcessor.worker, func(wf *daisy.Workflow, err error) {
 		actual := asMap(wf.Vars)
 		assert.Equal(t, map[string]string{
 			"source_disk":             "",
@@ -155,7 +155,7 @@ func TestBootableDiskProcessor_SetsWorkerDiskTrackingValues(t *testing.T) {
 	actual := createProcessor(t, imageSpec)
 
 	var wf *daisy.Workflow
-	daisyutils.CheckWorkflow(actual.worker, func(w *daisy.Workflow) {
+	daisyutils.CheckWorkflow(actual.worker, func(w *daisy.Workflow, err error) {
 		wf = w
 	})
 	daisyutils.CheckResourceLabeler(actual.worker, func(rl *daisyutils.ResourceLabeler) {
@@ -179,7 +179,7 @@ func TestBootableDiskProcessor_SetsWorkerTrackingValues(t *testing.T) {
 	actual := createProcessor(t, imageSpec)
 
 	var wf *daisy.Workflow
-	daisyutils.CheckWorkflow(actual.worker, func(w *daisy.Workflow) {
+	daisyutils.CheckWorkflow(actual.worker, func(w *daisy.Workflow, err error) {
 		wf = w
 	})
 	daisyutils.CheckResourceLabeler(actual.worker, func(rl *daisyutils.ResourceLabeler) {
@@ -203,7 +203,7 @@ func TestBootableDiskProcessor_SetsImageTrackingValues(t *testing.T) {
 	actual := createProcessor(t, imageSpec)
 
 	var wf *daisy.Workflow
-	daisyutils.CheckWorkflow(actual.worker, func(w *daisy.Workflow) {
+	daisyutils.CheckWorkflow(actual.worker, func(w *daisy.Workflow, err error) {
 		wf = w
 	})
 	daisyutils.CheckResourceLabeler(actual.worker, func(rl *daisyutils.ResourceLabeler) {
@@ -228,7 +228,7 @@ func TestBootableDiskProcessor_SupportsStorageLocation(t *testing.T) {
 
 func TestBootableDiskProcessor_PermitsUnsetStorageLocation(t *testing.T) {
 	actual := createProcessor(t, defaultImportArgs())
-	daisyutils.CheckWorkflow(actual.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(actual.worker, func(wf *daisy.Workflow, err error) {
 		image := getImage(t, wf)
 		assert.Empty(t, image.StorageLocations)
 	})
@@ -242,10 +242,8 @@ func TestBootableDiskProcessor_SupportsCancel(t *testing.T) {
 
 	realProcessor := processor.(*bootableDiskProcessor)
 	realProcessor.cancel("timed-out")
-	daisyutils.CheckWorkflow(realProcessor.worker, func(wf *daisy.Workflow) {
-		_, channelOpen := <-wf.Cancel
-		assert.False(t, channelOpen, "realProcessor.workflow.Cancel should be closed on timeout")
-	})
+	err := realProcessor.worker.Run(map[string]string{})
+	assert.EqualError(t, err, "workflow canceled: timed-out")
 }
 
 func createProcessor(t *testing.T, request ImageImportRequest) *bootableDiskProcessor {

--- a/cli_tools/common/image/importer/daisy_inflater.go
+++ b/cli_tools/common/image/importer/daisy_inflater.go
@@ -109,9 +109,6 @@ func newDaisyInflater(request ImageImportRequest, fileInspector imagefile.Inspec
 		if err != nil {
 			return nil, err
 		}
-		// If there's a failure during inflation, remove the PD that would otherwise
-		// be left for translation.
-		wf.ForceCleanupOnError = true
 		if request.UefiCompatible {
 			addFeatureToDisk(wf, "UEFI_COMPATIBLE", inflationDiskIndex)
 		}

--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -97,7 +97,7 @@ func TestCreateDaisyInflater_Image_HappyCase(t *testing.T) {
 
 	assert.Equal(t, "zones/us-west1-b/disks/disk-1234", inflater.inflatedDiskURI)
 	assert.Equal(t, "projects/test/uri/image", inflater.vars["source_image"])
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Contains(t, getDisk(wf, 0).Licenses,
 			"projects/compute-image-tools/global/licenses/virtual-disk-import")
 	})
@@ -108,7 +108,7 @@ func TestCreateDaisyInflater_Image_Windows(t *testing.T) {
 		Source: imageSource{uri: "image/uri"},
 		OS:     "windows-2019",
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Contains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "WINDOWS",
 		})
@@ -120,7 +120,7 @@ func TestCreateDaisyInflater_Image_NotWindows(t *testing.T) {
 		Source: imageSource{uri: "image/uri"},
 		OS:     "ubuntu-1804",
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.NotContains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "WINDOWS",
 		})
@@ -133,7 +133,7 @@ func TestCreateDaisyInflater_Image_UEFI(t *testing.T) {
 		OS:             "ubuntu-1804",
 		UefiCompatible: true,
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Contains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "UEFI_COMPATIBLE",
 		})
@@ -146,7 +146,7 @@ func TestCreateDaisyInflater_Image_NotUEFI(t *testing.T) {
 		OS:             "ubuntu-1804",
 		UefiCompatible: false,
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.NotContains(t, getDisk(wf, 0).GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "UEFI_COMPATIBLE",
 		})
@@ -168,7 +168,7 @@ func TestCreateDaisyInflater_File_HappyCase(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Equal(t, "zones/us-west1-c/disks/disk-1234", inflater.inflatedDiskURI)
 		assert.Equal(t, "gs://bucket/vmdk", wf.Vars["source_disk_file"].Value)
 		assert.Equal(t, "projects/subnet/subnet", wf.Vars["import_subnet"].Value)
@@ -191,7 +191,7 @@ func TestCreateDaisyInflater_File_ComputeServiceAcount(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Equal(t, "csa", wf.Vars["compute_service_account"].Value)
 	})
 }
@@ -223,7 +223,7 @@ func TestCreateDaisyInflater_File_UsesFallbackSizes_WhenInspectionFails(t *testi
 		errorToReturn:     errors.New("inspection failed"),
 		metaToReturn:      imagefile.Metadata{},
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		// The 10GB defaults are hardcoded in inflate_file.wf.json.
 		assert.Equal(t, "10", wf.Vars["scratch_disk_size_gb"].Value)
 		assert.Equal(t, "10", wf.Vars["inflated_disk_size_gb"].Value)
@@ -269,7 +269,7 @@ func TestCreateDaisyInflater_File_SetsSizesFromInspectedFile(t *testing.T) {
 					PhysicalSizeGB: tt.physicalSize,
 				},
 			})
-			daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+			daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 				assert.Equal(t, tt.expectedInflated, wf.Vars["inflated_disk_size_gb"].Value)
 				assert.Equal(t, tt.expectedScratch, wf.Vars["scratch_disk_size_gb"].Value)
 			})
@@ -288,7 +288,7 @@ func TestCreateDaisyInflater_File_Windows(t *testing.T) {
 		errorToReturn:     nil,
 		metaToReturn:      imagefile.Metadata{},
 	})
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		inflatedDisk := getDisk(wf, 1)
 		assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "WINDOWS",
@@ -308,7 +308,7 @@ func TestCreateDaisyInflater_File_NotWindows(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	})
 
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		inflatedDisk := getDisk(wf, 1)
 		assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "WINDOWS",
@@ -329,7 +329,7 @@ func TestCreateDaisyInflater_File_UEFI(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	})
 
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		inflatedDisk := getDisk(wf, 1)
 		assert.Contains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "UEFI_COMPATIBLE",
@@ -350,7 +350,7 @@ func TestCreateDaisyInflater_File_NotUEFI(t *testing.T) {
 		metaToReturn:      imagefile.Metadata{},
 	})
 
-	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(inflater.worker, func(wf *daisy.Workflow, err error) {
 		inflatedDisk := getDisk(wf, 1)
 		assert.NotContains(t, inflatedDisk.GuestOsFeatures, &compute.GuestOsFeature{
 			Type: "UEFI_COMPATIBLE",

--- a/cli_tools/common/image/importer/inflater_test.go
+++ b/cli_tools/common/image/importer/inflater_test.go
@@ -55,7 +55,7 @@ func TestCreateFallbackInflater_File(t *testing.T) {
 	daisyInflater, ok := facade.daisyInflater.(*daisyInflater)
 	assert.True(t, ok)
 	assert.Equal(t, "zones/us-west1-c/disks/disk-1234", daisyInflater.inflatedDiskURI)
-	daisyutils.CheckWorkflow(daisyInflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(daisyInflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Equal(t, "gs://bucket/vmdk", wf.Vars["source_disk_file"].Value)
 		assert.Equal(t, "projects/subnet/subnet", wf.Vars["import_subnet"].Value)
 		assert.Equal(t, "projects/network/network", wf.Vars["import_network"].Value)
@@ -99,7 +99,7 @@ func TestCreateShadowTestInflater_File(t *testing.T) {
 
 	daisyInflater, ok := facade.mainInflater.(*daisyInflater)
 	assert.True(t, ok)
-	daisyutils.CheckWorkflow(daisyInflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(daisyInflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Equal(t, "zones/us-west1-c/disks/disk-1234", daisyInflater.inflatedDiskURI)
 		assert.Equal(t, "gs://bucket/vmdk", wf.Vars["source_disk_file"].Value)
 		assert.Equal(t, "projects/subnet/subnet", wf.Vars["import_subnet"].Value)
@@ -128,7 +128,7 @@ func TestCreateInflater_Image(t *testing.T) {
 	assert.NoError(t, err)
 	realInflater, ok := inflater.(*daisyInflater)
 	assert.True(t, ok)
-	daisyutils.CheckWorkflow(realInflater.worker, func(wf *daisy.Workflow) {
+	daisyutils.CheckWorkflow(realInflater.worker, func(wf *daisy.Workflow, err error) {
 		assert.Equal(t, "zones/us-west1-b/disks/disk-1234", realInflater.inflatedDiskURI)
 		assert.Equal(t, "projects/test/uri/image", wf.Vars["source_image"].Value)
 		inflatedDisk := getDisk(wf, 0)

--- a/cli_tools/common/image/importer/processor.go
+++ b/cli_tools/common/image/importer/processor.go
@@ -64,7 +64,7 @@ func (d defaultProcessorProvider) provide(pd persistentDisk) ([]processor, error
 		processors = append(processors, p)
 	}
 
-	bootableDiskProcessor, err := newBootableDiskProcessor(d.ImageImportRequest, plan.translationWorkflowPath, d.logger, plan.detectedOs)
+	bootableDiskProcessor := newBootableDiskProcessor(d.ImageImportRequest, plan.translationWorkflowPath, d.logger, plan.detectedOs)
 	if err != nil {
 		return nil, err
 	}

--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -366,6 +366,8 @@ func RunWorkflowWithCancelSignal(w *daisy.Workflow, cancel <-chan string) error 
 		case reason := <-cancel:
 			if reason != "" {
 				w.CancelWithReason(reason)
+			} else {
+				w.CancelWorkflow()
 			}
 			break
 		case <-c:
@@ -375,6 +377,9 @@ func RunWorkflowWithCancelSignal(w *daisy.Workflow, cancel <-chan string) error 
 		case <-w.Cancel:
 		}
 	}(w)
+	// Daisy doesn't support cancellation through context; if the context that's passed in
+	// is cancelled, then all of its clients die, causing confusing errors and resources
+	// being left that should have been cleaned up.
 	return w.Run(context.Background())
 }
 

--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -355,19 +355,27 @@ func PostProcessDErrorForNetworkFlag(action string, err error, network string, w
 	}
 }
 
-// RunWorkflowWithCancelSignal runs Daisy workflow with accepting Ctrl-C signal
-func RunWorkflowWithCancelSignal(ctx context.Context, w *daisy.Workflow) error {
+// RunWorkflowWithCancelSignal runs a Daisy workflow, and allows for cancellation from two sources:
+//   1. The user types Ctrl-C on their keyboard.
+//   2. The caller sends a cancellation reason on the cancel channel (or closes it).
+func RunWorkflowWithCancelSignal(w *daisy.Workflow, cancel <-chan string) error {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func(w *daisy.Workflow) {
 		select {
+		case reason := <-cancel:
+			if reason != "" {
+				w.CancelWithReason(reason)
+			}
+			break
 		case <-c:
 			w.LogWorkflowInfo("\nCtrl-C caught, sending cancel signal to %q...\n", w.Name)
 			w.CancelWorkflow()
+			break
 		case <-w.Cancel:
 		}
 	}(w)
-	return w.Run(ctx)
+	return w.Run(context.Background())
 }
 
 // NewStep creates a new step for the workflow along with dependencies.

--- a/cli_tools/common/utils/daisyutils/daisy_worker_testing.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker_testing.go
@@ -20,8 +20,8 @@ import (
 
 // CheckWorkflow allows a test to check the fields on the daisy workflow associated with a DaisyWorker.
 func CheckWorkflow(worker DaisyWorker, check func(wf *daisy.Workflow, workflowCreationError error)) {
-	if worker.(*defaultDaisyWorker).finished != nil {
-		check(worker.(*defaultDaisyWorker).finished, nil)
+	if worker.(*defaultDaisyWorker).finishedWf != nil {
+		check(worker.(*defaultDaisyWorker).finishedWf, nil)
 	} else {
 		wf, err := worker.(*defaultDaisyWorker).workflowProvider()
 		check(wf, err)

--- a/cli_tools/common/utils/daisyutils/daisy_worker_testing.go
+++ b/cli_tools/common/utils/daisyutils/daisy_worker_testing.go
@@ -19,8 +19,13 @@ import (
 )
 
 // CheckWorkflow allows a test to check the fields on the daisy workflow associated with a DaisyWorker.
-func CheckWorkflow(worker DaisyWorker, check func(wf *daisy.Workflow)) {
-	check(worker.(*defaultDaisyWorker).wf)
+func CheckWorkflow(worker DaisyWorker, check func(wf *daisy.Workflow, workflowCreationError error)) {
+	if worker.(*defaultDaisyWorker).finished != nil {
+		check(worker.(*defaultDaisyWorker).finished, nil)
+	} else {
+		wf, err := worker.(*defaultDaisyWorker).workflowProvider()
+		check(wf, err)
+	}
 }
 
 // CheckEnvironment allows a test to check the fields on the EnvironmentSettings associated with a DaisyWorker.

--- a/cli_tools/gce_ovf_export/exporter/instance_export_cleaner.go
+++ b/cli_tools/gce_ovf_export/exporter/instance_export_cleaner.go
@@ -115,13 +115,17 @@ func (iec *instanceExportCleanerImpl) Clean(instance *compute.Instance, params *
 			iec.wfPreRunCallback(attachDiskWf)
 		}
 		// ignore errors as these will be due to instance being already started or disks already attached
-		_ = daisyutils.NewDaisyWorker(attachDiskWf, params.EnvironmentSettings(attachDiskWf.Name), iec.logger).Run(map[string]string{})
+		_ = daisyutils.NewDaisyWorker(func() (*daisy.Workflow, error) {
+			return attachDiskWf, nil
+		}, params.EnvironmentSettings(attachDiskWf.Name), iec.logger).Run(map[string]string{})
 	}
 	if iec.startInstanceWf != nil {
 		if iec.wfPreRunCallback != nil {
 			iec.wfPreRunCallback(iec.startInstanceWf)
 		}
-		_ = daisyutils.NewDaisyWorker(iec.startInstanceWf, params.EnvironmentSettings(iec.startInstanceWf.Name), iec.logger).Run(map[string]string{})
+		_ = daisyutils.NewDaisyWorker(func() (*daisy.Workflow, error) {
+			return iec.startInstanceWf, nil
+		}, params.EnvironmentSettings(iec.startInstanceWf.Name), iec.logger).Run(map[string]string{})
 	}
 	return err
 }

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -171,11 +171,8 @@ func Run(clientID string, destinationURI string, sourceImage string, sourceDiskS
 	}
 	varMap := buildDaisyVars(destinationURI, sourceImage, sourceDiskSnapshot, format, network, subnet, *region, computeServiceAccount)
 
-	var w *daisy.Workflow
-
-	w, err = daisy.NewFromFile(getWorkflowPath(format, currentExecutablePath))
-	if err != nil {
-		return err
+	workflowProvider := func() (*daisy.Workflow, error) {
+		return daisy.NewFromFile(getWorkflowPath(format, currentExecutablePath))
 	}
 
 	env := daisyutils.EnvironmentSettings{
@@ -202,7 +199,7 @@ func Run(clientID string, destinationURI string, sourceImage string, sourceDiskS
 	if env.ExecutionID == "" {
 		env.ExecutionID = path.RandString(5)
 	}
-	values, err := daisyutils.NewDaisyWorker(w, env, logger).RunAndReadSerialValues(
+	values, err := daisyutils.NewDaisyWorker(workflowProvider, env, logger).RunAndReadSerialValues(
 		varMap, targetSizeGBKey, sourceSizeGBKey)
 	logger.Metric(&pb.OutputInfo{
 		SourcesSizeGb: []int64{stringutils.SafeStringToInt(values[sourceSizeGBKey])},

--- a/cli_tools/gce_windows_upgrade/upgrader/upgrader.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/upgrader.go
@@ -102,12 +102,12 @@ type upgrader struct {
 	initFn                    func() error
 	printIntroHelpTextFn      func() error
 	validateAndDeriveParamsFn func() error
-	prepareFn                 func() (*daisy.Workflow, error)
-	upgradeFn                 func() (*daisy.Workflow, error)
-	retryUpgradeFn            func() (*daisy.Workflow, error)
-	rebootFn                  func() (*daisy.Workflow, error)
-	cleanupFn                 func() (*daisy.Workflow, error)
-	rollbackFn                func() (*daisy.Workflow, error)
+	prepareFn                 func() (daisyutils.DaisyWorker, error)
+	upgradeFn                 func() (daisyutils.DaisyWorker, error)
+	retryUpgradeFn            func() (daisyutils.DaisyWorker, error)
+	rebootFn                  func() (daisyutils.DaisyWorker, error)
+	cleanupFn                 func() (daisyutils.DaisyWorker, error)
+	rollbackFn                func() (daisyutils.DaisyWorker, error)
 
 	logger logging.Logger
 }
@@ -171,7 +171,7 @@ func (u *upgrader) printIntroHelpText() error {
 	return nil
 }
 
-func (u *upgrader) runUpgradeWorkflow() (*daisy.Workflow, error) {
+func (u *upgrader) runUpgradeWorkflow() (daisyutils.DaisyWorker, error) {
 	var err error
 
 	// If upgrade failed, run cleanup or rollback before exiting.

--- a/cli_tools/gce_windows_upgrade/upgrader/upgrader_test.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/upgrader_test.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/daisyutils"
 
-	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -62,10 +62,10 @@ func TestUpgraderRunFailedOnPrintUpgradeGuide(t *testing.T) {
 
 func TestUpgraderRunFailedOnPrepare(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.prepareFn = func() (*daisy.Workflow, error) {
+	tu.prepareFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("failed")
 	}
-	tu.cleanupFn = func() (*daisy.Workflow, error) {
+	tu.cleanupFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
 
@@ -75,10 +75,10 @@ func TestUpgraderRunFailedOnPrepare(t *testing.T) {
 
 func TestUpgraderRunFailedOnUpgrade(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.upgradeFn = func() (*daisy.Workflow, error) {
+	tu.upgradeFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("failed")
 	}
-	tu.cleanupFn = func() (*daisy.Workflow, error) {
+	tu.cleanupFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
 
@@ -88,13 +88,13 @@ func TestUpgraderRunFailedOnUpgrade(t *testing.T) {
 
 func TestUpgraderRunFailedOnReboot(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.upgradeFn = func() (*daisy.Workflow, error) {
+	tu.upgradeFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("Windows needs to be restarted")
 	}
-	tu.rebootFn = func() (*daisy.Workflow, error) {
+	tu.rebootFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("failed")
 	}
-	tu.cleanupFn = func() (*daisy.Workflow, error) {
+	tu.cleanupFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
 
@@ -104,16 +104,16 @@ func TestUpgraderRunFailedOnReboot(t *testing.T) {
 
 func TestUpgraderRunFailedOnRetryUpgrade(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.upgradeFn = func() (*daisy.Workflow, error) {
+	tu.upgradeFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("Windows needs to be restarted")
 	}
-	tu.rebootFn = func() (*daisy.Workflow, error) {
+	tu.rebootFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
-	tu.retryUpgradeFn = func() (*daisy.Workflow, error) {
+	tu.retryUpgradeFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("failed")
 	}
-	tu.cleanupFn = func() (*daisy.Workflow, error) {
+	tu.cleanupFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
 
@@ -130,13 +130,13 @@ func TestUpgraderRunSuccessWithoutReboot(t *testing.T) {
 
 func TestUpgraderRunSuccessWithReboot(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.upgradeFn = func() (*daisy.Workflow, error) {
+	tu.upgradeFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("Windows needs to be restarted")
 	}
-	tu.rebootFn = func() (*daisy.Workflow, error) {
+	tu.rebootFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
-	tu.retryUpgradeFn = func() (*daisy.Workflow, error) {
+	tu.retryUpgradeFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, nil
 	}
 
@@ -146,7 +146,7 @@ func TestUpgraderRunSuccessWithReboot(t *testing.T) {
 
 func TestUpgraderRunFailedWithAutoRollback(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.prepareFn = func() (*daisy.Workflow, error) {
+	tu.prepareFn = func() (daisyutils.DaisyWorker, error) {
 		// Test workaround: let newOSDiskName to be the same as current disk name
 		// in order to trigger auto rollback.
 		tu.newOSDiskName = testDisk
@@ -154,11 +154,11 @@ func TestUpgraderRunFailedWithAutoRollback(t *testing.T) {
 	}
 	tu.AutoRollback = true
 	rollbackExecuted := false
-	tu.rollbackFn = func() (*daisy.Workflow, error) {
+	tu.rollbackFn = func() (daisyutils.DaisyWorker, error) {
 		rollbackExecuted = true
 		return nil, nil
 	}
-	tu.cleanupFn = func() (*daisy.Workflow, error) {
+	tu.cleanupFn = func() (daisyutils.DaisyWorker, error) {
 		t.Errorf("Unexpected cleanup.")
 		return nil, nil
 	}
@@ -170,7 +170,7 @@ func TestUpgraderRunFailedWithAutoRollback(t *testing.T) {
 
 func TestUpgraderRunFailedWithAutoRollbackFailed(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.prepareFn = func() (*daisy.Workflow, error) {
+	tu.prepareFn = func() (daisyutils.DaisyWorker, error) {
 		// Test workaround: let newOSDiskName to be the same as current disk name
 		// in order to trigger auto rollback.
 		tu.newOSDiskName = testDisk
@@ -178,7 +178,7 @@ func TestUpgraderRunFailedWithAutoRollbackFailed(t *testing.T) {
 	}
 	tu.AutoRollback = true
 	rollbackExecuted := false
-	tu.rollbackFn = func() (*daisy.Workflow, error) {
+	tu.rollbackFn = func() (daisyutils.DaisyWorker, error) {
 		rollbackExecuted = true
 		return nil, fmt.Errorf("failed2")
 	}
@@ -190,12 +190,12 @@ func TestUpgraderRunFailedWithAutoRollbackFailed(t *testing.T) {
 
 func TestUpgraderRunFailedWithAutoRollbackWithoutNewOSDiskAttached(t *testing.T) {
 	tu := initTestUpgrader(t)
-	tu.prepareFn = func() (*daisy.Workflow, error) {
+	tu.prepareFn = func() (daisyutils.DaisyWorker, error) {
 		return nil, fmt.Errorf("failed1")
 	}
 	tu.AutoRollback = true
 	cleanupExecuted := false
-	tu.cleanupFn = func() (*daisy.Workflow, error) {
+	tu.cleanupFn = func() (daisyutils.DaisyWorker, error) {
 		cleanupExecuted = true
 		return nil, fmt.Errorf("failed2")
 	}
@@ -210,28 +210,28 @@ func initTestUpgrader(t *testing.T) *TestUpgrader {
 		computeClient = newTestGCEClient()
 		return nil
 	}
-	tu.prepareFn = func() (workflow *daisy.Workflow, e error) {
+	tu.prepareFn = func() (worker daisyutils.DaisyWorker, e error) {
 		// Test workaround: let newOSDiskName to be the same as current disk name
 		// in order to pretend the enw OS disk has been attached.
 		tu.newOSDiskName = testDisk
 		return nil, nil
 	}
-	tu.upgradeFn = func() (workflow *daisy.Workflow, e error) {
+	tu.upgradeFn = func() (worker daisyutils.DaisyWorker, e error) {
 		return nil, nil
 	}
-	tu.rebootFn = func() (workflow *daisy.Workflow, e error) {
+	tu.rebootFn = func() (worker daisyutils.DaisyWorker, e error) {
 		t.Errorf("Unexpected reboot.")
 		return nil, nil
 	}
-	tu.retryUpgradeFn = func() (workflow *daisy.Workflow, e error) {
+	tu.retryUpgradeFn = func() (worker daisyutils.DaisyWorker, e error) {
 		t.Errorf("Unexpected retryUpgrade.")
 		return nil, nil
 	}
-	tu.cleanupFn = func() (workflow *daisy.Workflow, e error) {
+	tu.cleanupFn = func() (worker daisyutils.DaisyWorker, e error) {
 		t.Errorf("Unexpected cleanup.")
 		return nil, nil
 	}
-	tu.rollbackFn = func() (workflow *daisy.Workflow, e error) {
+	tu.rollbackFn = func() (worker daisyutils.DaisyWorker, e error) {
 		t.Errorf("Unexpected rollback.")
 		return nil, nil
 	}

--- a/cli_tools/gce_windows_upgrade/upgrader/workflows.go
+++ b/cli_tools/gce_windows_upgrade/upgrader/workflows.go
@@ -502,9 +502,13 @@ func (u *upgrader) getOriginalStartupScriptURL() string {
 }
 
 func (u *upgrader) runWorkflowWithSteps(workflowName string, timeout string, populateStepsFunc func(*upgrader, *daisy.Workflow) error) (*daisy.Workflow, error) {
-	w, err := u.generateWorkflowWithSteps(workflowName, timeout, populateStepsFunc)
-	if err != nil {
-		return w, err
+
+	var wf *daisy.Workflow
+
+	workflowProvider := func() (*daisy.Workflow, error) {
+		var err error
+		wf, err = u.generateWorkflowWithSteps(workflowName, timeout, populateStepsFunc)
+		return wf, err
 	}
 
 	env := daisyutils.EnvironmentSettings{
@@ -524,7 +528,8 @@ func (u *upgrader) runWorkflowWithSteps(workflowName string, timeout string, pop
 		},
 	}
 
-	return w, daisyutils.NewDaisyWorker(w, env, u.logger).Run(map[string]string{})
+	err := daisyutils.NewDaisyWorker(workflowProvider, env, u.logger).Run(map[string]string{})
+	return wf, err
 }
 
 func (u *upgrader) generateWorkflowWithSteps(workflowName string, timeout string, populateStepsFunc func(*upgrader, *daisy.Workflow) error) (*daisy.Workflow, error) {


### PR DESCRIPTION
This PR updates DaisyWorker to allow workflows to be retried. To achieve this, clients of DaisyWorker supply a closure that *generates* a workflow. On the first invocation, and any retries, this factory is used to create a new workflow. This is required since daisy workflows aren't designed to be run multiple times.

This PR is the first half of removing the fallback-to-PD-standard feature from daisy. The second PR adds a hook that implements the fallback-to-PD-standard behavior.

Testing
* Ran a subset of the OVF and image import e2e tests locally.