### PR TITLE
CLI Tools: Ensure network is cleared when only subnet is specified

### DIFF
--- a/cli_tools/common/utils/daisyutils/workflow_hook_workflow_vars.go
+++ b/cli_tools/common/utils/daisyutils/workflow_hook_workflow_vars.go
@@ -24,9 +24,9 @@ var (
 	// These patterns match a key of "Vars" in a daisy workflow. All CLI tools use these variables.
 	//
 	// For network and subnet, some workflows use the prefix `import_`.
-	networkPattern               = regexp.MustCompile("^(import_)?network$")
-	subnetPattern                = regexp.MustCompile("^(import_)?subnet$")
-	computeServiceAccountPattern = regexp.MustCompile("compute_service_account")
+	networkVarPattern               = regexp.MustCompile("^(import_)?network$")
+	subnetVarPattern                = regexp.MustCompile("^(import_)?subnet$")
+	computeServiceAccountVarPattern = regexp.MustCompile("compute_service_account")
 )
 
 // ApplyAndValidateVars is a WorkflowHook that applies vars to a daisy workflow.
@@ -41,7 +41,7 @@ type ApplyAndValidateVars struct {
 func (t *ApplyAndValidateVars) PreRunHook(wf *daisy.Workflow) error {
 	t.updateNetworkAndSubnet(wf)
 	if t.env.ComputeServiceAccount != "" {
-		t.backfillVar(computeServiceAccountPattern, t.env.ComputeServiceAccount, wf)
+		t.backfillVar(computeServiceAccountVarPattern, t.env.ComputeServiceAccount, wf)
 	}
 Loop:
 	for k, v := range t.vars {
@@ -67,13 +67,13 @@ Loop:
 //   https://cloud.google.com/compute/docs/reference/rest/v1/instances
 func (t *ApplyAndValidateVars) updateNetworkAndSubnet(wf *daisy.Workflow) {
 	if t.env.Subnet != "" {
-		t.backfillVar(subnetPattern, t.env.Subnet, wf)
+		t.backfillVar(subnetVarPattern, t.env.Subnet, wf)
 		if t.env.Network == "" {
-			t.backfillVar(networkPattern, "", wf)
+			t.backfillVar(networkVarPattern, "", wf)
 		}
 	}
 	if t.env.Network != "" {
-		t.backfillVar(networkPattern, t.env.Network, wf)
+		t.backfillVar(networkVarPattern, t.env.Network, wf)
 	}
 }
 

--- a/cli_tools/common/utils/daisyutils/workflow_hook_workflow_vars_test.go
+++ b/cli_tools/common/utils/daisyutils/workflow_hook_workflow_vars_test.go
@@ -92,6 +92,21 @@ func Test_ApplyEnvToWorkers_SetsNetworkAndAccounts(t *testing.T) {
 			},
 		},
 		{
+			name: "clear default network from workflow when " +
+				"only subnet is specified. This ensures GCE " +
+				"API infers the network from the subnet.",
+			declaredDaisyVars: []string{"network", "subnet"},
+			env: EnvironmentSettings{
+				Network: "",
+				Subnet:  "path/to/subnet",
+			},
+			originalVars: map[string]string{},
+			expectedVars: map[string]string{
+				"network": "",
+				"subnet":  "path/to/subnet",
+			},
+		},
+		{
 			name:              "support `import_network` and `import_subnet` naming",
 			declaredDaisyVars: []string{"import_network", "import_subnet"},
 			env: EnvironmentSettings{
@@ -118,7 +133,7 @@ func Test_ApplyEnvToWorkers_SetsNetworkAndAccounts(t *testing.T) {
 			},
 		},
 		{
-			name:              "apply non-env variables to workfly",
+			name:              "apply non-env variables to workflow",
 			declaredDaisyVars: []string{"var1", "var2"},
 			env: EnvironmentSettings{
 				Network: "a",


### PR DESCRIPTION
While working on adding the module tests to presubmit hooks, I found that the DaisyWorker doesn't implement the logic from #1378 that ensures the network is inferred when the user only specifies the subnet. Prior to this PR, when using the DaisyWorker, the workflow would attempt to use the default value that's declared in the daisy workflow, which in the case of inspection is "global/networks/default"

Testing:
 - Ensured that this test is passing now: https://github.com/GoogleCloudPlatform/compute-image-tools/blob/bc0c805f462ddeb9d9b7c15e146602a1da5e4c93/cli_tools_tests/module/diskinspect/disk_inspect_test.go#L430 