### PR TITLE
Daisy: Eagerly record serial logs.

### DIFF
--- a/cli_tools/mocks/mock_daisy_logger.go
+++ b/cli_tools/mocks/mock_daisy_logger.go
@@ -19,10 +19,8 @@
 package mocks
 
 import (
-	bytes "bytes"
 	reflect "reflect"
 
-	logging "cloud.google.com/go/logging"
 	gomock "github.com/golang/mock/gomock"
 
 	daisy "github.com/GoogleCloudPlatform/compute-image-tools/daisy"
@@ -49,6 +47,30 @@ func NewMockDaisyLogger(ctrl *gomock.Controller) *MockDaisyLogger {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDaisyLogger) EXPECT() *MockDaisyLoggerMockRecorder {
 	return m.recorder
+}
+
+// AppendSerialPortLogs mocks base method.
+func (m *MockDaisyLogger) AppendSerialPortLogs(arg0 *daisy.Workflow, arg1, arg2 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AppendSerialPortLogs", arg0, arg1, arg2)
+}
+
+// AppendSerialPortLogs indicates an expected call of AppendSerialPortLogs.
+func (mr *MockDaisyLoggerMockRecorder) AppendSerialPortLogs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendSerialPortLogs", reflect.TypeOf((*MockDaisyLogger)(nil).AppendSerialPortLogs), arg0, arg1, arg2)
+}
+
+// WriteSerialPortLogsToCloudLogging mocks base method.
+func (m *MockDaisyLogger) WriteSerialPortLogsToCloudLogging(arg0 *daisy.Workflow, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "WriteSerialPortLogsToCloudLogging", arg0, arg1)
+}
+
+// WriteSerialPortLogsToCloudLogging indicates an expected call of WriteSerialPortLogsToCloudLogging.
+func (mr *MockDaisyLoggerMockRecorder) WriteSerialPortLogsToCloudLogging(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteSerialPortLogsToCloudLogging", reflect.TypeOf((*MockDaisyLogger)(nil).WriteSerialPortLogsToCloudLogging), arg0, arg1)
 }
 
 // Flush mocks base method.
@@ -78,74 +100,13 @@ func (mr *MockDaisyLoggerMockRecorder) ReadSerialPortLogs() *gomock.Call {
 }
 
 // WriteLogEntry mocks base method.
-func (m *MockDaisyLogger) WriteLogEntry(e *daisy.LogEntry) {
+func (m *MockDaisyLogger) WriteLogEntry(arg0 *daisy.LogEntry) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WriteLogEntry", e)
+	m.ctrl.Call(m, "WriteLogEntry", arg0)
 }
 
 // WriteLogEntry indicates an expected call of WriteLogEntry.
-func (mr *MockDaisyLoggerMockRecorder) WriteLogEntry(e interface{}) *gomock.Call {
+func (mr *MockDaisyLoggerMockRecorder) WriteLogEntry(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLogEntry", reflect.TypeOf((*MockDaisyLogger)(nil).WriteLogEntry), e)
-}
-
-// WriteSerialPortLogs mocks base method.
-func (m *MockDaisyLogger) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WriteSerialPortLogs", w, instance, buf)
-}
-
-// WriteSerialPortLogs indicates an expected call of WriteSerialPortLogs.
-func (mr *MockDaisyLoggerMockRecorder) WriteSerialPortLogs(w, instance, buf interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteSerialPortLogs", reflect.TypeOf((*MockDaisyLogger)(nil).WriteSerialPortLogs), w, instance, buf)
-}
-
-// MockcloudLogWriter is a mock of cloudLogWriter interface.
-type MockcloudLogWriter struct {
-	ctrl     *gomock.Controller
-	recorder *MockcloudLogWriterMockRecorder
-}
-
-// MockcloudLogWriterMockRecorder is the mock recorder for MockcloudLogWriter.
-type MockcloudLogWriterMockRecorder struct {
-	mock *MockcloudLogWriter
-}
-
-// NewMockcloudLogWriter creates a new mock instance.
-func NewMockcloudLogWriter(ctrl *gomock.Controller) *MockcloudLogWriter {
-	mock := &MockcloudLogWriter{ctrl: ctrl}
-	mock.recorder = &MockcloudLogWriterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockcloudLogWriter) EXPECT() *MockcloudLogWriterMockRecorder {
-	return m.recorder
-}
-
-// Flush mocks base method.
-func (m *MockcloudLogWriter) Flush() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Flush")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Flush indicates an expected call of Flush.
-func (mr *MockcloudLogWriterMockRecorder) Flush() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockcloudLogWriter)(nil).Flush))
-}
-
-// Log mocks base method.
-func (m *MockcloudLogWriter) Log(e logging.Entry) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Log", e)
-}
-
-// Log indicates an expected call of Log.
-func (mr *MockcloudLogWriterMockRecorder) Log(e interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockcloudLogWriter)(nil).Log), e)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLogEntry", reflect.TypeOf((*MockDaisyLogger)(nil).WriteLogEntry), arg0)
 }

--- a/common/logging/logging.go
+++ b/common/logging/logging.go
@@ -38,12 +38,16 @@ type goLogToDaisyLog struct {
 	logger *log.Logger
 }
 
-func (l goLogToDaisyLog) WriteLogEntry(e *daisy.LogEntry) {
-	l.logger.Printf(e.Message)
+func (l goLogToDaisyLog) AppendSerialPortLogs(w *daisy.Workflow, instance string, logs string) {
+	// no-op
 }
 
-func (l goLogToDaisyLog) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {
+func (l goLogToDaisyLog) WriteSerialPortLogsToCloudLogging(w *daisy.Workflow, instance string) {
 	// no-op
+}
+
+func (l goLogToDaisyLog) WriteLogEntry(e *daisy.LogEntry) {
+	l.logger.Printf(e.Message)
 }
 
 func (l goLogToDaisyLog) ReadSerialPortLogs() []string {

--- a/daisy/daisy_test_runner/main.go
+++ b/daisy/daisy_test_runner/main.go
@@ -140,14 +140,18 @@ type logger struct {
 	mx  sync.Mutex
 }
 
+func (l *logger) AppendSerialPortLogs(w *daisy.Workflow, instance string, logs string) {
+	// no-op
+}
+
+func (l *logger) WriteSerialPortLogsToCloudLogging(w *daisy.Workflow, instance string) {
+	// no-op
+}
+
 func (l *logger) WriteLogEntry(e *daisy.LogEntry) {
 	l.mx.Lock()
 	defer l.mx.Unlock()
 	l.buf.WriteString(e.String())
-}
-
-func (l *logger) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {
-	return
 }
 
 func (l *logger) ReadSerialPortLogs() []string {

--- a/daisy/logger.go
+++ b/daisy/logger.go
@@ -132,7 +132,6 @@ func (w *Workflow) logEntry(e *LogEntry) {
 	w.Logger.WriteLogEntry(e)
 }
 
-
 // AppendSerialPortLogs collects a segment of serial port logs for an instance.
 func (l *daisyLog) AppendSerialPortLogs(w *Workflow, instance string, logs string) {
 	// Only collect serial port logs if the user has opted-in to cloud logging.

--- a/daisy/step_create_instances.go
+++ b/daisy/step_create_instances.go
@@ -96,6 +96,7 @@ Loop:
 			numErr = 0
 			start = resp.Next
 			buf.WriteString(resp.Contents)
+			w.Logger.AppendSerialPortLogs(w, ii.getName(), resp.Contents)
 			wc := w.StorageClient.Bucket(w.bucket).Object(logsObj).NewWriter(ctx)
 			wc.ContentType = "text/plain"
 			if _, err := wc.Write(buf.Bytes()); err != nil && !gcsErr {
@@ -117,7 +118,7 @@ Loop:
 		}
 	}
 
-	w.Logger.WriteSerialPortLogs(w, ii.getName(), buf)
+	w.Logger.WriteSerialPortLogsToCloudLogging(w, ii.getName())
 }
 
 // populate preprocesses fields: Name, Project, Zone, Description, MachineType, NetworkInterfaces, Scopes, ServiceAccounts, and daisyName.


### PR DESCRIPTION
While debugging failed imports, I've noticed that a subset of logs don't include serial logs. This occurred since there's a race condition between reading serial port logs, and daisy declaring that the workflow is finished. The go routine that collects serial port logs continues after daisy makes that declaration, to ensure that all of the instances logs get sent to Cloud Logging in a single batch.

This PR ensures that serial port logs are eagerly collected, so that when a workflow finishes, `ReadSerialPortLogs` returns all of the instance's serial port logs. It achieves this by accumulating each portion of serial port logs as they're available, and enforces an explicit call to write to cloud logging. This allows a client of `daisy.Workflow` to call `ReadSerialPortLogs` at any point and retrieve the full view of serial port logs.

An alternative approach would have been to write each portion of logs to `WriteSerialPortLogs` and accumulate the logs there. That approach doesn't work, however, since it would send spam to Cloud Logging every three seconds, resulting in the serial port logs getting split across dozens of Cloud Logging entries.

## Testing
 - Ran this test, which asserts that serial logs are available through `ReadSerialPortLogs`: https://github.com/GoogleCloudPlatform/compute-image-tools/blob/df208b7437289a35aff067d9f8539c670d4af9e2/cli_tools_tests/module/import/logs_test.go#L66
 - Ran three workflows and verified that Cloud Logging received the serial port logs.
