### PR TITLE
Import e2e tests: Look for image in project where import occurred

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/cli_tests.go
@@ -350,7 +350,7 @@ func runImageImportWithSubnetWithoutNetworkSpecified(ctx context.Context, testCa
 		},
 	}
 
-	runImportTest(ctx, argsMap[testType], testType, testProjectConfig.TestProjectID, destinationImage, logger, testCase)
+	runImportTest(ctx, argsMap[testType], testType, project, destinationImage, logger, testCase)
 }
 
 func runImageImportShadowDiskCleanedUpWhenMainInflaterFails(ctx context.Context, testCase *junitxml.TestCase,


### PR DESCRIPTION
The `Import with subnet but without network` tests are currently failing with the error:

>  Image 'e2e-test-image-import-subnet-xjryl' doesn't exist after import: googleapi: Error 404: The resource 'projects/compute-image-test-pool-001/global/images/e2e-test-image-import-subnet-xjryl' was not found, notFound

This is occurring since the e2e tests confirm that the imported image is present. In #1781 I changed the project where this tests runs, but did not update the project that is used to assert the image exists.

https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-images-import-export-cli-e2e-tests/1460137697052987392