### PR TITLE
[safely Enable VMDK API] stage 2: enable API inflater

### DIFF
--- a/cli_tools/common/image/importer/daisy_inflater_test.go
+++ b/cli_tools/common/image/importer/daisy_inflater_test.go
@@ -42,7 +42,7 @@ func TestDaisyInflater_Inflate_ReadsDiskStatsFromWorker(t *testing.T) {
 	}
 	mockWorker.EXPECT().RunAndReadSerialValues(inflater.vars, targetSizeGBKey,
 		sourceSizeGBKey, importFileFormatKey, diskChecksumKey).DoAndReturn(
-		func (vars map[string]string, keys ...string) (map[string]string, error) {
+		func(vars map[string]string, keys ...string) (map[string]string, error) {
 			// Guarantee that the workflow executes for at least 1ms
 			time.Sleep(time.Millisecond)
 			return map[string]string{

--- a/cli_tools/common/image/importer/inflater.go
+++ b/cli_tools/common/image/importer/inflater.go
@@ -97,7 +97,7 @@ func newInflater(request ImageImportRequest, computeClient daisyCompute.Client, 
 
 func isShadowTestFormat(request ImageImportRequest) bool {
 	// TODO: process VHD/VPC differently
-	return true
+	return false
 }
 
 // inflaterFacade implements an inflater using other concrete implementations.

--- a/cli_tools/common/image/importer/inflater_test.go
+++ b/cli_tools/common/image/importer/inflater_test.go
@@ -37,11 +37,11 @@ func TestCreateFallbackInflater_File(t *testing.T) {
 	//and uses Daisy inflater as a fallback.
 
 	inflater, err := newInflater(ImageImportRequest{
-		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
-		Subnet:       "projects/subnet/subnet",
-		Network:      "projects/network/network",
-		Zone:         "us-west1-c",
-		ExecutionID:  "1234",
+		Source:      fileSource{gcsPath: "gs://bucket/vmdk"},
+		Subnet:      "projects/subnet/subnet",
+		Network:     "projects/network/network",
+		Zone:        "us-west1-c",
+		ExecutionID: "1234",
 		Tool: daisyutils.Tool{
 			ResourceLabelName: "image-import",
 		},

--- a/cli_tools/common/image/importer/inflater_test.go
+++ b/cli_tools/common/image/importer/inflater_test.go
@@ -35,8 +35,6 @@ import (
 func TestCreateFallbackInflater_File(t *testing.T) {
 	//Test the creation of a fallback inflater, which primarily uses API inflater
 	//and uses Daisy inflater as a fallback.
-	//TODO: remove SkipNow once inflater is switched to the fallback variant (not shadow)
-	t.SkipNow()
 
 	inflater, err := newInflater(ImageImportRequest{
 		Source:       fileSource{gcsPath: "gs://bucket/vmdk"},
@@ -44,6 +42,9 @@ func TestCreateFallbackInflater_File(t *testing.T) {
 		Network:      "projects/network/network",
 		Zone:         "us-west1-c",
 		ExecutionID:  "1234",
+		Tool: daisyutils.Tool{
+			ResourceLabelName: "image-import",
+		},
 		NoExternalIP: false,
 		WorkflowDir:  daisyWorkflows,
 	}, nil, &storage.Client{}, mockInspector{
@@ -79,6 +80,7 @@ func TestCreateShadowTestInflater_File(t *testing.T) {
 	//inflater while API inflater is used only to verify its output against Daisy
 	//inflater
 	//TODO: remove/disable this test once API inflater is the default (fallback mode)
+	t.SkipNow()
 
 	inflater, err := newInflater(ImageImportRequest{
 		Source:      fileSource{gcsPath: "gs://bucket/vmdk"},


### PR DESCRIPTION
Enable the API as main inflater.