### PR TITLE
OVF import: Fix PD-fallback

### DIFF
--- a/cli_tools/common/utils/daisyutils/workflow_hook_fallback_pd.go
+++ b/cli_tools/common/utils/daisyutils/workflow_hook_fallback_pd.go
@@ -56,5 +56,14 @@ func useStandardDisks(workflow *daisy.Workflow) {
 				disk.Disk.Type = "pd-standard"
 			}
 		}
+		if step.CreateInstances != nil {
+			for _, instance := range (*step.CreateInstances).Instances {
+				for _, disk := range instance.Disks {
+					if disk.InitializeParams != nil {
+						disk.InitializeParams.DiskType = "pd-standard"
+					}
+				}
+			}
+		}
 	})
 }

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_import_e2e_common.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_import_e2e_common.go
@@ -40,6 +40,7 @@ type OvfImportTestProperties struct {
 	ExpectedStartupOutput     string
 	FailureMatches            []string
 	VerificationStartupScript string
+	AllowFallbackToPDStandard bool
 	Zone                      string
 	SourceURI                 string
 	Os                        string
@@ -185,9 +186,9 @@ func VerifyInstance(instance *gcp.InstanceBeta, client daisyCompute.Client,
 
 		// Verify disk type (SSD vs Standard)
 		expectedDiskType := "pd-ssd"
-		if !strings.Contains(disk.Type, expectedDiskType) {
+		if !strings.Contains(disk.Type, expectedDiskType) && !props.AllowFallbackToPDStandard {
 			e2e.Failure(testCase, logger, fmt.Sprintf(
-				"Disk should be of `%v` type, but is `%v`", expectedDiskType, attachedDisk.Type))
+				"Disk should be of `%v` type, but is `%v`", expectedDiskType, disk.Type))
 			return
 		}
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_instance_import/ovf_instance_import_test_suite.go
@@ -164,12 +164,13 @@ func fallbackWhenSSDQuotaExhausted(ctx context.Context, testCase *junitxml.TestC
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
 			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
 				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
-			Zone:                  zone,
-			ExpectedStartupOutput: "All tests passed!",
-			FailureMatches:        []string{"FAILED:", "TestFailed:"},
-			SourceURI:             fmt.Sprintf("gs://%v/ova/ubuntu-1604-1000GB-disk", ovaBucket),
-			Os:                    "ubuntu-1604",
-			MachineType:           "n1-standard-4",
+			Zone:                      zone,
+			ExpectedStartupOutput:     "All tests passed!",
+			FailureMatches:            []string{"FAILED:", "TestFailed:"},
+			SourceURI:                 fmt.Sprintf("gs://%v/ova/debian-11-600GB-disk", ovaBucket),
+			Os:                        "debian-11",
+			MachineType:               "n1-standard-1",
+			AllowFallbackToPDStandard: true,
 		}}
 
 	runOVFInstanceImportTest(ctx, buildTestArgs(props, testProjectConfig)[testType], testType, testProjectConfig, logger, testCase, props)


### PR DESCRIPTION
This fixes the failure that we're seeing in the "Allow import to work when SSD quota is exhausted" e2e test.

https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/ci-ovf-import-e2e-tests-daily/1460869781400850432

Two changes:
1. Implement pd-standard fallback for attached disks
2. Decouple disk import from final instance creation

## More info


The test is failing with an error "Intermediate image ovf-w1207zz123-1 already exists. Re-run import." This happened since the SSD quota was insufficient to create the imported instance; prior to this PR, OVF import would re-run *everything*, and find that the disks had already been imported to images.

This PR splits OVF import into two phases:
1. Import disks to images.
2. Create an instance from the images.

While working on this, I noticed an existing bug: If creation of the final instance (or GMI fails), the intermediate disk images will be left. I created an internal bug to track this, and will submit a follow-up PR for that.