### PR TITLE
Import: Add suport for SLES 15SP3

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -228,6 +228,12 @@ var basicCases = []*testCase{
 		osConfigNotSupported: true,
 		tip:                  slesOnDemandTip,
 	}, {
+		caseName:             "sles-15-3-on-demand",
+		source:               "projects/compute-image-tools-test/global/images/sles-15-3-unregistered",
+		os:                   "sles-15",
+		osConfigNotSupported: true,
+		tip:                  slesOnDemandTip,
+	}, {
 		caseName:             "sles-sap-15-0-on-demand",
 		source:               "projects/compute-image-tools-test/global/images/sles-sap-15-0-unregistered",
 		os:                   "sles-sap-15",

--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -113,7 +113,7 @@ _releases = [
     _SuseRelease(
         product='sles',
         major='15',
-        minor='1|2',
+        minor='1|2|3',
         cloud_product='sle-module-public-cloud/{major}.{minor}/x86_64',
         on_demand_rpms=_Tarball(
             _on_demand_rpm_pattern.format(major=15, timestamp=1599058662),


### PR DESCRIPTION
This adds support for importing SLES 15SP3 -- the existing import logic worked, so it was just a config update to allow 15SP3. 

## Testing

- Added e2e test for 15SP3.