### PR TITLE
[onestep-import] install gcsfuse and qemu for onestep-import

### DIFF
--- a/gce_onestep_image_import.Dockerfile
+++ b/gce_onestep_image_import.Dockerfile
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/base
+FROM launcher.gcr.io/google/debian9
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg ca-certificates
+RUN echo "deb http://packages.cloud.google.com/apt gcsfuse-stretch main" > /etc/apt/sources.list.d/gcsfuse.list
+# gcsfuse, installed using instructions from:
+#  https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/installing.md
+COPY gcsfuse-apt-key.gpg .
+RUN apt-key add gcsfuse-apt-key.gpg
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y gcsfuse
 
 COPY linux/gce_onestep_image_import /gce_onestep_image_import
 COPY linux/gce_vm_image_import /gce_vm_image_import


### PR DESCRIPTION
onestep-import docker image should have the same config as the regular import docker image. gcsfuse and qemu is required for inspection.