### PR TITLE
[e2e test] add qemu/gcsfuse for test docker images

### DIFF
--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -28,7 +28,6 @@ RUN chmod +x /gce_onestep_image_import
 
 # Build test container
 FROM gcr.io/compute-image-tools-test/wrapper-with-gcloud:latest
-RUN gcsfuse
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_image_import_export_test_runner gce_image_import_export_test_runner

--- a/gce_image_import_export_tests.Dockerfile
+++ b/gce_image_import_export_tests.Dockerfile
@@ -28,6 +28,7 @@ RUN chmod +x /gce_onestep_image_import
 
 # Build test container
 FROM gcr.io/compute-image-tools-test/wrapper-with-gcloud:latest
+RUN gcsfuse
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /gce_image_import_export_test_runner gce_image_import_export_test_runner

--- a/test-infra/prowjobs/wrapper/withgcloud.Dockerfile
+++ b/test-infra/prowjobs/wrapper/withgcloud.Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#FROM gcr.io/$PROJECT_ID/wrapper:latest
+FROM gcr.io/$PROJECT_ID/wrapper:latest
 
 FROM google/cloud-sdk:slim
 

--- a/test-infra/prowjobs/wrapper/withgcloud.Dockerfile
+++ b/test-infra/prowjobs/wrapper/withgcloud.Dockerfile
@@ -11,9 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/$PROJECT_ID/wrapper:latest
+#FROM gcr.io/$PROJECT_ID/wrapper:latest
 
-FROM google/cloud-sdk:alpine
+FROM google/cloud-sdk:slim
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg ca-certificates
+RUN echo "deb http://packages.cloud.google.com/apt gcsfuse-stretch main" > /etc/apt/sources.list.d/gcsfuse.list
+# gcsfuse, installed using instructions from:
+#  https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/installing.md
+COPY gcsfuse-apt-key.gpg .
+RUN apt-key add gcsfuse-apt-key.gpg
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y gcsfuse
 
 COPY --from=0 wrapper wrapper
 RUN gcloud components install beta --quiet


### PR DESCRIPTION
For those e2e test which directly running local binary, we need gcsfuse/qemu-img on local as well to enable file inspection.