### PR TITLE
follow staticcheck-S1012-and-ST1005 checks

### DIFF
--- a/cli_tools/common/disk/inspect.go
+++ b/cli_tools/common/disk/inspect.go
@@ -112,7 +112,7 @@ func (i *bootInspector) Inspect(reference string) (*pb.InspectionResults, error)
 		return i.assembleErrors(reference, results, pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS, err, startTime)
 	}
 
-	results.ElapsedTimeMs = time.Now().Sub(startTime).Milliseconds()
+	results.ElapsedTimeMs = time.Since(startTime).Milliseconds()
 	i.logger.Metric(&pb.OutputInfo{InspectionResults: results})
 	return results, nil
 }
@@ -126,7 +126,7 @@ func (i *bootInspector) assembleErrors(reference string, results *pb.InspectionR
 	} else {
 		err = fmt.Errorf("failed to inspect %v", reference)
 	}
-	results.ElapsedTimeMs = time.Now().Sub(startTime).Milliseconds()
+	results.ElapsedTimeMs = time.Since(startTime).Milliseconds()
 	return results, err
 }
 
@@ -137,33 +137,33 @@ func (i *bootInspector) validate(results *pb.InspectionResults) error {
 	if results.OsCount != 1 {
 		if results.OsRelease != nil {
 			return fmt.Errorf(
-				"Worker should not return OsRelease when NumOsFound != 1: NumOsFound=%d", results.OsCount)
+				"worker should not return OsRelease when NumOsFound != 1: NumOsFound=%d", results.OsCount)
 		}
 		return nil
 	}
 
 	if results.OsRelease == nil {
-		return errors.New("Worker should return OsRelease when OsCount == 1")
+		return errors.New("worker should return OsRelease when OsCount == 1")
 	}
 
 	if results.OsRelease.CliFormatted != "" {
-		return errors.New("Worker should not return CliFormatted")
+		return errors.New("worker should not return CliFormatted")
 	}
 
 	if results.OsRelease.Distro != "" {
-		return errors.New("Worker should not return Distro name, only DistroId")
+		return errors.New("worker should not return Distro name, only DistroId")
 	}
 
 	if results.OsRelease.MajorVersion == "" {
-		return errors.New("Missing MajorVersion")
+		return errors.New("missing MajorVersion")
 	}
 
 	if results.OsRelease.Architecture == pb.Architecture_ARCHITECTURE_UNKNOWN {
-		return errors.New("Missing Architecture")
+		return errors.New("missing Architecture")
 	}
 
 	if results.OsRelease.DistroId == pb.Distro_DISTRO_UNKNOWN {
-		return errors.New("Missing DistroId")
+		return errors.New("missing DistroId")
 	}
 
 	return nil

--- a/cli_tools/common/disk/inspect_test.go
+++ b/cli_tools/common/disk/inspect_test.go
@@ -125,7 +125,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 				ErrorWhen: pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS,
 				OsRelease: &pb.OsRelease{},
 			},
-			expectErrorToContain: "Worker should not return OsRelease when NumOsFound != 1",
+			expectErrorToContain: "worker should not return OsRelease when NumOsFound != 1",
 		},
 		{
 			caseName: "Fail when OsCount is one and OsRelease is nil",
@@ -136,7 +136,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 				OsCount:   1,
 				ErrorWhen: pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS,
 			},
-			expectErrorToContain: "Worker should return OsRelease when OsCount == 1",
+			expectErrorToContain: "worker should return OsRelease when OsCount == 1",
 		},
 		{
 			caseName: "Fail when OsCount > 1 and OsRelease non-nil",
@@ -149,7 +149,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 				ErrorWhen: pb.InspectionResults_INTERPRETING_INSPECTION_RESULTS,
 				OsRelease: &pb.OsRelease{},
 			},
-			expectErrorToContain: "Worker should not return OsRelease when NumOsFound != 1",
+			expectErrorToContain: "worker should not return OsRelease when NumOsFound != 1",
 		},
 		{
 			caseName: "Fail when CliFormatted is populated",
@@ -174,7 +174,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 					CliFormatted: "ubuntu-1804",
 				},
 			},
-			expectErrorToContain: "Worker should not return CliFormatted",
+			expectErrorToContain: "worker should not return CliFormatted",
 		}, {
 			caseName: "Fail when Distro name is populated",
 			responseFromInspection: &pb.InspectionResults{
@@ -196,7 +196,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 					Distro:       "ubuntu",
 				},
 			},
-			expectErrorToContain: "Worker should not return Distro name",
+			expectErrorToContain: "worker should not return Distro name",
 		}, {
 			caseName: "Fail when missing MajorVersion",
 			responseFromInspection: &pb.InspectionResults{
@@ -214,7 +214,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 					DistroId:     pb.Distro_UBUNTU,
 				},
 			},
-			expectErrorToContain: "Missing MajorVersion",
+			expectErrorToContain: "missing MajorVersion",
 		}, {
 			caseName: "Fail when missing Architecture",
 			responseFromInspection: &pb.InspectionResults{
@@ -232,7 +232,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 					MajorVersion: "10",
 				},
 			},
-			expectErrorToContain: "Missing Architecture",
+			expectErrorToContain: "missing Architecture",
 		}, {
 			caseName: "Fail when missing DistroId",
 			responseFromInspection: &pb.InspectionResults{
@@ -250,7 +250,7 @@ func TestBootInspector_Inspect_InvalidWorkerResponses(t *testing.T) {
 					MajorVersion: "10",
 				},
 			},
-			expectErrorToContain: "Missing DistroId",
+			expectErrorToContain: "missing DistroId",
 		},
 	} {
 		t.Run(tt.caseName, func(t *testing.T) {

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -418,7 +418,7 @@ func (t *testCase) run(ctx context.Context, junit *junitxml.TestCase, logger *lo
 			t.writeFailure(junit, "Failed post translate test: %v", err)
 		}
 	}
-	junit.Time = time.Now().Sub(start).Seconds()
+	junit.Time = time.Since(start).Seconds()
 }
 
 func (t *testCase) verifyImage(ctx context.Context, junit *junitxml.TestCase, logger *log.Logger, testProjectConfig *testconfig.Project) {


### PR DESCRIPTION
follow staticcheck-S1012-and-ST1005 checks by modifying capitalized strings and replacing time-now-sub by time since