### PR TITLE
EL8 import: gcloud requires python

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -263,7 +263,9 @@ def DistroSpecific(spec: TranslateSpec):
     else:
       g.write_append(
           '/etc/yum.repos.d/google-cloud.repo', repo_sdk % el_release)
-      yum_install(g, 'google-cloud-sdk')
+      # google-cloud-sdk stopped declaring Python as a dependency
+      # in their RPM starting with version 301.
+      yum_install(g, 'google-cloud-sdk', 'python3')
     yum_install(g, 'google-compute-engine', 'google-osconfig-agent')
 
   logging.info('Updating initramfs')


### PR DESCRIPTION
# In draft while running tests

The EL8 e2e tests are failing, stating that gcloud and gsutil cannot be found. This was caused by a regression in `google-cloud-sdk` where Python is no longer declared as an RPM dependency. This adds `python3` as an explicit dependency when installing `google-cloud-sdk`.

https://k8s-testgrid.appspot.com/google-gce-compute-image-tools#ci-images-import-export-cli-e2e-tests

## Testing
- Ran el-centos-8-3 e2e test locally