### PR TITLE
Windows import: Don't fail when EMS is on COM1

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -329,6 +329,11 @@ var basicCases = []*testCase{
 
 	// Windows
 	{
+		caseName:                "windows-2016-azure",
+		source:                  "projects/compute-image-tools-test/global/images/windows-server-2016-azure",
+		expectLicense:           "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2016-dc",
+		requiredGuestOsFeatures: []string{"WINDOWS"},
+	}, {
 		caseName:                "windows-2019-uefi",
 		source:                  "projects/compute-image-tools-test/global/images/windows-2019-uefi-nodrivers",
 		expectLicense:           "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2019-dc",

--- a/daisy_workflows/image_import/windows/translate_bootstrap.ps1
+++ b/daisy_workflows/image_import/windows/translate_bootstrap.ps1
@@ -235,6 +235,20 @@ try {
   Start-Sleep -s 5
   Run-Command reg unload 'HKLM\MountedSoftware'
 
+  # Disable EMS for the first boot of translation.
+  #
+  # Azure and AWS use COM1 for EMS:
+  #   https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/troubleshooting-sac.html
+  #   https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/serial-console-windows
+  #
+  # The translation scripts that run after bootstrap write to COM1. Translation fails if
+  # the EMS is listening to that port.
+  #
+  # Disabling EMS here is fine, since we re-enable it with in translate.ps1 using COM2, which is
+  # the port used by GCP:
+  #   https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
+  Run-Command bcdedit /store "${bcd_drive}\boot\bcd" /ems "{default}" off
+
   Write-Output 'TranslateBootstrap: Rewriting boot files.'
   Write-Output 'Translate bootstrap complete.'
 }


### PR DESCRIPTION
We had  a report of Windows Server 2016 failing to import when the original instance was exported from Azure. The translation instance (which runs the user's VM) rebooted every five minutes.

This occurred since [Azure uses COM1 for their EMS server](https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/serial-console-windows). Daisy (and these translation scripts) use COM1. My theory is that the first pipe fails [here](https://github.com/GoogleCloudPlatform/compute-image-tools/blob/c66dc9accdb83fc50fe0e825b861321a937f01a7/daisy_workflows/image_import/windows/run_startup_scripts.cmd#L55), and causes the script to die. This is consistent with the reboots that we see every five minutes; those reboots are scheduled by run_startup_script.cmd, and intended to be cleared by translate.ps1. translate.ps1 (under this scenario) is never executed since the pipe write failed.

This change disables EMS prior to translation, and allows translation to set the EMS server with GCP's default settings. 

## Testing

- Added an e2e test that failed prior to this change, but passes afterward.