### PR TITLE
Fix image export failing occasionally for large images by allocating buffer disk size to match raw image size

### DIFF
--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -29,6 +29,7 @@ import (
 const (
 	rfc1035LabelRegexpStr = "[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]"
 	imageNameStr          = "^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$"
+	diskSnapshotNameStr   = "^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$"
 
 	// projectID: "The unique, user-assigned ID of the Project. It must be 6 to 30
 	// lowercase letters,  digits, or hyphens. It must start with a letter.
@@ -38,10 +39,11 @@ const (
 )
 
 var (
-	rfc1035LabelRegexp = regexp.MustCompile(rfc1035LabelRegexpStr)
-	fqdnRegexp         = regexp.MustCompile(fmt.Sprintf("^((%v)\\.)+(%v)$", rfc1035LabelRegexpStr, rfc1035LabelRegexpStr))
-	imageNameRegexp    = regexp.MustCompile(imageNameStr)
-	projectIDRegexp    = regexp.MustCompile(projectIDStr)
+	rfc1035LabelRegexp     = regexp.MustCompile(rfc1035LabelRegexpStr)
+	fqdnRegexp             = regexp.MustCompile(fmt.Sprintf("^((%v)\\.)+(%v)$", rfc1035LabelRegexpStr, rfc1035LabelRegexpStr))
+	imageNameRegexp        = regexp.MustCompile(imageNameStr)
+	diskSnapshotNameRegexp = regexp.MustCompile(diskSnapshotNameStr)
+	projectIDRegexp        = regexp.MustCompile(projectIDStr)
 )
 
 // ValidateStringFlagNotEmpty returns error with error message stating field must be provided if
@@ -93,6 +95,15 @@ func ValidateRfc1035Label(value string) error {
 func ValidateImageName(value string) error {
 	if !imageNameRegexp.MatchString(value) {
 		return daisy.Errf("Image name `%v` must conform to https://cloud.google.com/compute/docs/reference/rest/v1/images", value)
+	}
+	return nil
+}
+
+// ValidateSnapshotName validates whether a string is a valid disk snapshot name, as defined by
+// <https://cloud.google.com/compute/docs/reference/rest/v1/snapshots>.
+func ValidateSnapshotName(value string) error {
+	if !diskSnapshotNameRegexp.MatchString(value) {
+		return daisy.Errf("Snapshot name `%v` must conform to https://cloud.google.com/compute/docs/reference/rest/v1/snapshots", value)
 	}
 	return nil
 }

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -106,7 +106,7 @@ func buildDaisyVars(destinationURI string, sourceImage string, sourceDiskSnapsho
 	}
 
 	if sourceDiskSnapshot != "" {
-		varMap["source_disk_snapshot"] = sourceDiskSnapshot //param.GetGlobalResourcePath(			"snapshots", sourceDiskSnapshot)
+		varMap["source_disk_snapshot"] = param.GetGlobalResourcePath("snapshots", sourceDiskSnapshot)
 	}
 
 	if bufferDiskSizeGb > 0 {

--- a/cli_tools/gce_vm_image_export/exporter/exporter_test.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter_test.go
@@ -142,7 +142,7 @@ func TestBuildDaisyVarsWithSimpleSnapshotName(t *testing.T) {
 	got := buildDaisyVars(
 		ws+destinationURI+ws,
 		ws+""+ws,
-		ws+"aSnapshot"+ws,
+		ws+"global/snapshots/aSnapshot"+ws,
 		0,
 		ws+format+ws,
 		ws+network+ws,

--- a/cli_tools/gce_vm_image_export/exporter/exporter_test.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	v1 "google.golang.org/api/compute/v1"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/common/utils/path"
 	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/mocks"
@@ -80,6 +81,7 @@ func TestBuildDaisyVarsWithoutFormatConversion(t *testing.T) {
 		ws+destinationURI+ws,
 		ws+sourceImage+ws,
 		ws+sourceDiskSnapshot+ws,
+		15,
 		ws+format+ws,
 		ws+network+ws,
 		ws+subnet+ws,
@@ -90,7 +92,8 @@ func TestBuildDaisyVarsWithoutFormatConversion(t *testing.T) {
 	assert.Equal(t, "gs://bucket/exported_image", got["destination"])
 	assert.Equal(t, "global/networks/aNetwork", got["export_network"])
 	assert.Equal(t, "regions/aRegion/subnetworks/aSubnet", got["export_subnet"])
-	assert.Equal(t, 4, len(got))
+	assert.Equal(t, "15", got["export_instance_disk_size"])
+	assert.Equal(t, 5, len(got))
 }
 
 func TestBuildDaisyVarsWithFormatConversion(t *testing.T) {
@@ -100,6 +103,7 @@ func TestBuildDaisyVarsWithFormatConversion(t *testing.T) {
 		ws+destinationURI+ws,
 		ws+sourceImage+ws,
 		ws+sourceDiskSnapshot+ws,
+		15,
 		ws+"vmdk"+ws,
 		ws+network+ws,
 		ws+subnet+ws,
@@ -111,7 +115,8 @@ func TestBuildDaisyVarsWithFormatConversion(t *testing.T) {
 	assert.Equal(t, "vmdk", got["format"])
 	assert.Equal(t, "global/networks/aNetwork", got["export_network"])
 	assert.Equal(t, "regions/aRegion/subnetworks/aSubnet", got["export_subnet"])
-	assert.Equal(t, 5, len(got))
+	assert.Equal(t, "15", got["export_instance_disk_size"])
+	assert.Equal(t, 6, len(got))
 }
 
 func TestBuildDaisyVarsWithSimpleImageName(t *testing.T) {
@@ -121,6 +126,7 @@ func TestBuildDaisyVarsWithSimpleImageName(t *testing.T) {
 		ws+destinationURI+ws,
 		ws+"anImage"+ws,
 		ws+""+ws,
+		0,
 		ws+format+ws,
 		ws+network+ws,
 		ws+subnet+ws,
@@ -137,6 +143,7 @@ func TestBuildDaisyVarsWithSimpleSnapshotName(t *testing.T) {
 		ws+destinationURI+ws,
 		ws+""+ws,
 		ws+"aSnapshot"+ws,
+		0,
 		ws+format+ws,
 		ws+network+ws,
 		ws+subnet+ws,
@@ -150,7 +157,7 @@ func TestBuildDaisyVarsWithComputeServiceAccount(t *testing.T) {
 	resetArgs()
 	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
 	got := buildDaisyVars(
-		"", "", "", "", "", "", "",
+		"", "", "", 0, "", "", "", "",
 		ws+"account1"+ws)
 
 	assert.Equal(t, "account1", got["compute_service_account"])
@@ -160,7 +167,7 @@ func TestBuildDaisyVarsWithoutComputeServiceAccount(t *testing.T) {
 	resetArgs()
 	ws := "\t \r\n\f\u0085\u00a0\u2000\u3000"
 	got := buildDaisyVars(
-		"", "", "", "", "", "", "",
+		"", "", "", 0, "", "", "", "",
 		ws)
 
 	_, hasVar := got["compute_service_account"]
@@ -171,17 +178,20 @@ func TestValidateImageExists_ReturnsNoError_WhenImageFound(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
-	mockComputeClient.EXPECT().GetImage("project", "image").Return(nil, nil)
-	assert.NoError(t, validateImageExists(mockComputeClient, "project", "image"))
+	mockComputeClient.EXPECT().GetImage("project", "image").Return(&v1.Image{DiskSizeGb: 21}, nil)
+	diskSize, err := validateImageExists(mockComputeClient, "project", "image")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(21), diskSize)
 }
 
-func TestValidateImageExists_SkipsValidation_WhenSourceImageIsURI(t *testing.T) {
+func TestValidateImageExists_SkipsValidation_WhenSourceImageIsValidURI(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
 	// No expectations on the mockComputeClient means the test fails if the mock detects calls.
-	assert.NoError(t, validateImageExists(mockComputeClient,
-		"project", "projects/project/global/image/image-name"))
+	diskSize, err := validateImageExists(mockComputeClient, "project", "projects/project/global/image/image-name")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), diskSize)
 }
 
 func TestValidateImageExists_ReturnsError_WhenImageNotFound(t *testing.T) {
@@ -189,8 +199,41 @@ func TestValidateImageExists_ReturnsError_WhenImageNotFound(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockComputeClient := mocks.NewMockClient(mockCtrl)
 	mockComputeClient.EXPECT().GetImage("project", "image").Return(nil, errors.New("image not found"))
-	assert.EqualError(t, validateImageExists(mockComputeClient, "project", "image"),
+	diskSize, err := validateImageExists(mockComputeClient, "project", "image")
+	assert.EqualError(t, err,
 		"Image \"image\" not found")
+	assert.Equal(t, int64(0), diskSize)
+}
+
+func TestValidateSnapshotExists_ReturnsNoError_WhenSnapshotFound(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().GetSnapshot("project", "snapshot").Return(&v1.Snapshot{DiskSizeGb: 21}, nil)
+	diskSize, err := validateSnapshotExists(mockComputeClient, "project", "snapshot")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(21), diskSize)
+}
+
+func TestValidateSnapshotExists_SkipsValidation_WhenSourceSnapshotIsValidURI(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	// No expectations on the mockComputeClient means the test fails if the mock detects calls.
+	diskSize, err := validateSnapshotExists(mockComputeClient, "project", "projects/project/global/snapshot/snapshot-name")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), diskSize)
+}
+
+func TestValidateSnapshotExists_ReturnsError_WhenSnapshotNotFound(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockComputeClient := mocks.NewMockClient(mockCtrl)
+	mockComputeClient.EXPECT().GetSnapshot("project", "snapshot").Return(nil, errors.New("snapshot not found"))
+	diskSize, err := validateSnapshotExists(mockComputeClient, "project", "snapshot")
+	assert.EqualError(t, err,
+		"Snapshot \"snapshot\" not found")
+	assert.Equal(t, int64(0), diskSize)
 }
 
 func resetArgs() {

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -47,7 +47,6 @@
         {
           "Name": "disk-${NAME}",
           "SourceImage": "${export_instance_disk_image}",
-          "SizeGb": "${export_instance_disk_size}",
           "Type": "${export_instance_disk_type}"
         }
       ]


### PR DESCRIPTION
Image export for non-raw files: fix the issue of temporary buffer disk failing to resize occasionally with a resize2fs error by creating buffer disk of the same size as the image raw size.

Additionally:
* Added disk snapshot name validation
* Fixed raw disk export instance having OS disk match the size of the exported image as this is unnecessary

TODOs:
* Have buffer disk match image size for VMDK/VHD export when image path is provided (instead of a name as for this PR)
* Ensure disk snapshot export works