### PR TITLE
Validating image URI on image export and setting temporary disk to match the image size.

### DIFF
--- a/cli_tools/common/utils/validation/validation_utils.go
+++ b/cli_tools/common/utils/validation/validation_utils.go
@@ -42,7 +42,7 @@ var (
 	rfc1035LabelRegexp     = regexp.MustCompile(rfc1035LabelRegexpStr)
 	fqdnRegexp             = regexp.MustCompile(fmt.Sprintf("^((%v)\\.)+(%v)$", rfc1035LabelRegexpStr, rfc1035LabelRegexpStr))
 	imageNameRegexp        = regexp.MustCompile(fmt.Sprintf("^%v$", imageNameStr))
-	imageUriRegexp         = regexp.MustCompile(fmt.Sprintf("^projects/(%v)/global/images/(%v)$", projectIDStr, imageNameStr))
+	imageURIRegexp         = regexp.MustCompile(fmt.Sprintf("^projects/(%v)/global/images/(%v)$", projectIDStr, imageNameStr))
 	diskSnapshotNameRegexp = regexp.MustCompile(diskSnapshotNameStr)
 	projectIDRegexp        = regexp.MustCompile(fmt.Sprintf("^%v$", projectIDStr))
 )
@@ -100,14 +100,14 @@ func ValidateImageName(value string) error {
 	return nil
 }
 
-// ValidateImageUri validates whether a string is a valid image URI, as defined by
+// ValidateImageURI validates whether a string is a valid image URI, as defined by
 // <https://cloud.google.com/compute/docs/reference/rest/v1/images> and returns
 // image name and project ID if valid.
-func ValidateImageUri(value string) (project string, imageName string, err error) {
-	if !imageUriRegexp.MatchString(value) {
+func ValidateImageURI(value string) (project string, imageName string, err error) {
+	if !imageURIRegexp.MatchString(value) {
 		return imageName, project, daisy.Errf("Image URI `%v` must conform to https://cloud.google.com/compute/docs/reference/rest/v1/images", value)
 	}
-	match := imageUriRegexp.FindStringSubmatch(value)
+	match := imageURIRegexp.FindStringSubmatch(value)
 	return match[1], match[3], nil
 }
 

--- a/cli_tools/common/utils/validation/validation_utils_test.go
+++ b/cli_tools/common/utils/validation/validation_utils_test.go
@@ -109,6 +109,7 @@ func TestValidateImageName_ExpectInvalid(t *testing.T) {
 	} {
 		t.Run(imgName, func(t *testing.T) {
 			err := ValidateImageName(imgName)
+			assert.NotNil(t, err)
 			assert.Regexp(t, "Image name .* must conform to https://cloud.google.com/compute/docs/reference/rest/v1/images", err)
 			assert.Contains(t, err.Error(), imgName, "Raw error should include image's name")
 			realError := err.(daisy.DError)
@@ -120,6 +121,57 @@ func TestValidateImageName_ExpectInvalid(t *testing.T) {
 	}
 }
 
+func TestValidateImageUri_ExpectValid(t *testing.T) {
+	// Allowable name format: https://cloud.google.com/compute/docs/reference/rest/v1/images
+	for _, testCase := range [][]string{
+		{"projects/a-project/global/images/dashes-allowed-inside", "a-project", "dashes-allowed-inside"},
+		{"projects/google.com:google-project/global/images/a", "google.com:google-project", "a"},
+		{"projects/long-project-name-less-than-28/global/images/o-----equal-to-max-63-----------------------------------------o", "long-project-name-less-than-28", "o-----equal-to-max-63-----------------------------------------o"},
+	} {
+		t.Run(testCase[0], func(t *testing.T) {
+			project, imageName, err := ValidateImageUri(testCase[0])
+			assert.NoError(t, err)
+			assert.Equal(t, testCase[1], project)
+			assert.Equal(t, testCase[2], imageName)
+		})
+	}
+}
+
+func TestValidateImageUri_ExpectInvalid(t *testing.T) {
+	// Allowable name format: https://cloud.google.com/compute/docs/reference/rest/v1/images
+	for _, imageUri := range []string{
+		"not-a-uri",
+		"projects/a-project/global/images/-no-starting-dash",
+		"projects/a-project/global/images/no-ending-dash-",
+		"projects/a-project/global/images/dont/allow/slashes/in/image/name",
+		"projects/a-project/global/images/DontAllowCaps",
+		"projects/a-project/global/images/o-----longer-than-max-63---------------------------------------o",
+		"abcde/a-project/global/images/image", // shorter than min length of 6
+		"-no-leading-dash/a-project/global/images/image",
+		"no-ending-dash-/a-project/global/images/image",
+		"1-no-leading-numbers/a-project/global/images/image",
+		"DontAllowCaps/a-project/global/images/image",
+		"notgoogle.com:test-project/a-project/global/images/image",
+		"o-----longer-than-max-30------o/a-project/global/images/image",
+	} {
+		t.Run(imageUri, func(t *testing.T) {
+			imageName, project, err := ValidateImageUri(imageUri)
+
+			assert.Empty(t, imageName)
+			assert.Empty(t, project)
+
+			assert.NotNil(t, err)
+			assert.Regexp(t, "Image URI .* must conform to https://cloud.google.com/compute/docs/reference/rest/v1/images", err)
+			assert.Contains(t, err.Error(), imageUri, "Raw error should include image's URI")
+			realError := err.(daisy.DError)
+			for _, anonymizedErrs := range realError.AnonymizedErrs() {
+				assert.NotContains(t, anonymizedErrs, imageUri,
+					"Anonymized error should not contain image's name")
+			}
+
+		})
+	}
+}
 func TestValidateDiskSnapshotName_ExpectValid(t *testing.T) {
 	// Allowable name format: https://cloud.google.com/compute/docs/reference/rest/v1/snapshot
 	for _, snapshotName := range []string{
@@ -144,6 +196,7 @@ func TestValidateDiskSnapshotName_ExpectInvalid(t *testing.T) {
 	} {
 		t.Run(snapshotName, func(t *testing.T) {
 			err := ValidateSnapshotName(snapshotName)
+			assert.NotNil(t, err)
 			assert.Regexp(t, "Snapshot name .* must conform to https://cloud.google.com/compute/docs/reference/rest/v1/snapshots", err)
 			assert.Contains(t, err.Error(), snapshotName, "Raw error should include snapshot's name")
 			realError := err.(daisy.DError)
@@ -182,6 +235,7 @@ func TestValidateProjectID_ExpectInvalid(t *testing.T) {
 	} {
 		t.Run(projectID, func(t *testing.T) {
 			err := ValidateProjectID(projectID)
+			assert.NotNil(t, err)
 			assert.Regexp(t, "projectID .* must conform to https://cloud.google.com/resource-manager/reference/rest/v1/projects", err)
 			assert.Contains(t, err.Error(), projectID, "Raw error should include projectID")
 			realError := err.(daisy.DError)

--- a/cli_tools/common/utils/validation/validation_utils_test.go
+++ b/cli_tools/common/utils/validation/validation_utils_test.go
@@ -121,7 +121,7 @@ func TestValidateImageName_ExpectInvalid(t *testing.T) {
 	}
 }
 
-func TestValidateImageUri_ExpectValid(t *testing.T) {
+func TestValidateImageURI_ExpectValid(t *testing.T) {
 	// Allowable name format: https://cloud.google.com/compute/docs/reference/rest/v1/images
 	for _, testCase := range [][]string{
 		{"projects/a-project/global/images/dashes-allowed-inside", "a-project", "dashes-allowed-inside"},
@@ -129,7 +129,7 @@ func TestValidateImageUri_ExpectValid(t *testing.T) {
 		{"projects/long-project-name-less-than-28/global/images/o-----equal-to-max-63-----------------------------------------o", "long-project-name-less-than-28", "o-----equal-to-max-63-----------------------------------------o"},
 	} {
 		t.Run(testCase[0], func(t *testing.T) {
-			project, imageName, err := ValidateImageUri(testCase[0])
+			project, imageName, err := ValidateImageURI(testCase[0])
 			assert.NoError(t, err)
 			assert.Equal(t, testCase[1], project)
 			assert.Equal(t, testCase[2], imageName)
@@ -137,9 +137,9 @@ func TestValidateImageUri_ExpectValid(t *testing.T) {
 	}
 }
 
-func TestValidateImageUri_ExpectInvalid(t *testing.T) {
+func TestValidateImageURI_ExpectInvalid(t *testing.T) {
 	// Allowable name format: https://cloud.google.com/compute/docs/reference/rest/v1/images
-	for _, imageUri := range []string{
+	for _, imageURI := range []string{
 		"not-a-uri",
 		"projects/a-project/global/images/-no-starting-dash",
 		"projects/a-project/global/images/no-ending-dash-",
@@ -154,18 +154,18 @@ func TestValidateImageUri_ExpectInvalid(t *testing.T) {
 		"notgoogle.com:test-project/a-project/global/images/image",
 		"o-----longer-than-max-30------o/a-project/global/images/image",
 	} {
-		t.Run(imageUri, func(t *testing.T) {
-			imageName, project, err := ValidateImageUri(imageUri)
+		t.Run(imageURI, func(t *testing.T) {
+			imageName, project, err := ValidateImageURI(imageURI)
 
 			assert.Empty(t, imageName)
 			assert.Empty(t, project)
 
 			assert.NotNil(t, err)
 			assert.Regexp(t, "Image URI .* must conform to https://cloud.google.com/compute/docs/reference/rest/v1/images", err)
-			assert.Contains(t, err.Error(), imageUri, "Raw error should include image's URI")
+			assert.Contains(t, err.Error(), imageURI, "Raw error should include image's URI")
 			realError := err.(daisy.DError)
 			for _, anonymizedErrs := range realError.AnonymizedErrs() {
-				assert.NotContains(t, anonymizedErrs, imageUri,
+				assert.NotContains(t, anonymizedErrs, imageURI,
 					"Anonymized error should not contain image's name")
 			}
 

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -227,19 +227,23 @@ func Run(clientID string, destinationURI string, sourceImage string, sourceDiskS
 // interpreting the various permutations of specifying an image and project,
 // and we don't want to copy that here, since this is a convenience method to create
 // user-friendly messages.
-func validateImageExists(computeClient daisyCompute.Client, project string, imageName string) (diskSizeGb int64, err error) {
+func validateImageExists(computeClient daisyCompute.Client, project string, imageUri string) (diskSizeGb int64, err error) {
 	// try to get image even before validation in case it's a valid URL,
 	// in order to obtain its size
-
-	if err := validation.ValidateImageName(imageName); err != nil {
-		return diskSizeGb, nil
+	var imageName string
+	if err := validation.ValidateImageName(imageUri); err != nil {
+		if project, imageName, err = validation.ValidateImageUri(imageUri); err != nil {
+			return diskSizeGb, nil
+		}
+	} else {
+		imageName = imageUri
 	}
+	log.Printf("Fetghing image %q from project %q.", imageName, project)
 	image, err := computeClient.GetImage(project, imageName)
 	if err != nil {
-		log.Printf("Error when fetching image %q: %q.", imageName, err)
-		return diskSizeGb, daisy.Errf("Image %q not found", imageName)
+		log.Printf("Error when fetching image %q: %q.", imageUri, err)
+		return diskSizeGb, daisy.Errf("Image %q not found", imageUri)
 	}
-
 	return image.DiskSizeGb, nil
 }
 

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -227,22 +227,22 @@ func Run(clientID string, destinationURI string, sourceImage string, sourceDiskS
 // interpreting the various permutations of specifying an image and project,
 // and we don't want to copy that here, since this is a convenience method to create
 // user-friendly messages.
-func validateImageExists(computeClient daisyCompute.Client, project string, imageUri string) (diskSizeGb int64, err error) {
+func validateImageExists(computeClient daisyCompute.Client, project string, imageURI string) (diskSizeGb int64, err error) {
 	// try to get image even before validation in case it's a valid URL,
 	// in order to obtain its size
 	var imageName string
-	if err := validation.ValidateImageName(imageUri); err != nil {
-		if project, imageName, err = validation.ValidateImageUri(imageUri); err != nil {
+	if err := validation.ValidateImageName(imageURI); err != nil {
+		if project, imageName, err = validation.ValidateImageURI(imageURI); err != nil {
 			return diskSizeGb, nil
 		}
 	} else {
-		imageName = imageUri
+		imageName = imageURI
 	}
-	log.Printf("Fetghing image %q from project %q.", imageName, project)
+	log.Printf("Fetching image %q from project %q.", imageName, project)
 	image, err := computeClient.GetImage(project, imageName)
 	if err != nil {
-		log.Printf("Error when fetching image %q: %q.", imageUri, err)
-		return diskSizeGb, daisy.Errf("Image %q not found", imageUri)
+		log.Printf("Error when fetching image %q: %q.", imageURI, err)
+		return diskSizeGb, daisy.Errf("Image %q not found", imageURI)
 	}
 	return image.DiskSizeGb, nil
 }


### PR DESCRIPTION
This is a continuation of work from https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1821 to prevent large image exports from failing due to buffer disk resize errors. This PR adds the functionality added in 1821 but for images that are specificied as URIs. 