### PR TITLE
Image Import: Send InspectionResults in OutputInfo

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -289,21 +289,10 @@ type OutputInfo struct {
 	IsUEFICompatibleImage bool `json:"is_uefi_compatible_image,omitempty"`
 	// Indicates whether the image is auto-detected to be UEFI compatible
 	IsUEFIDetected bool `json:"is_uefi_detected,omitempty"`
+	// Inspection results. Ref to the def of `InspectionResults` for details
+	InspectionResults *pb.InspectionResults `json:"inspection_results,omitempty"`
 	// Inflation fallback reason
 	InflationFallbackReason string `json:"inflation_fallback_reason,omitempty"`
-}
-
-// InspectionResults contains metadata determined using automated inspection
-type InspectionResults struct {
-	// BIOSBootable indicates whether the disk is bootable with BIOS.
-	BIOSBootable bool `json:"bios_bootable,omitempty"`
-
-	// UEFIBootable indicates whether the disk is bootable with UEFI.
-	UEFIBootable bool `json:"uefi_bootable,omitempty"`
-
-	// RootFS indicates the file system type of the partition containing
-	// the root directory ("/").
-	RootFS string `json:"root_fs,omitempty"`
 }
 
 func (l *Logger) updateParams(projectPointer *string) {

--- a/cli_tools/common/utils/logging/service/logger.go
+++ b/cli_tools/common/utils/logging/service/logger.go
@@ -202,10 +202,12 @@ func (l *Logger) getOutputInfo(loggable Loggable, err error) *OutputInfo {
 		o.IsUEFIDetected = loggable.GetValueAsBool(isUEFIDetected)
 		o.InflationFallbackReason = loggable.GetValue(inflationFallbackReason)
 
-		// TODO: ideally we suppose to set o.InspectionResults. Will modify after proto is adjusted.
+		// TODO: ideally we suppose to set only o.InspectionResults. Remove after
+		// the dependency is eliminated.
 		if l.Params.ImageImportParams != nil {
 			l.Params.ImageImportParams.InspectionResults = loggable.GetInspectionResults()
 		}
+		o.InspectionResults = loggable.GetInspectionResults()
 	}
 
 	if err != nil {


### PR DESCRIPTION
OutputInfo already contains the definition for InspectionResults. As the
protos are adjusted, we can safely populate this field in logs.

The field InspectionResults is left in ImageImportParams for backward
compatibility and will be removed in the future.

A manually defined struct InspectionResults in log_entry.go is not used
anywhere and can be safely removed.