### PR TITLE
Import e2e: OS config is not supported for Windows 10

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -334,9 +334,10 @@ var basicCases = []*testCase{
 		expectLicense:           "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2019-dc",
 		requiredGuestOsFeatures: []string{"WINDOWS"},
 	}, {
-		caseName: "windows-10-x86-byol",
-		source:   "projects/compute-image-tools-test/global/images/windows-10-1909-ent-x86-nodrivers",
-		os:       "windows-10-x86-byol",
+		caseName:             "windows-10-x86-byol",
+		source:               "projects/compute-image-tools-test/global/images/windows-10-1909-ent-x86-nodrivers",
+		os:                   "windows-10-x86-byol",
+		osConfigNotSupported: true,
 	},
 }
 


### PR DESCRIPTION
This fixes the `windows-10-x86-byol` test on testgrid, which is failing since the OS Config agent cannot be found:

```
2022/01/25 18:59:27 windows-startup-script-url: Exception caught in script:
2022/01/25 18:59:27 windows-startup-script-url: At C:\WINDOWS\TEMP\metadata-scripts463353643\windows-startup-script-url.ps1:85 char:5
2022/01/25 18:59:27 windows-startup-script-url: +     Get-Service google_osconfig_agent
2022/01/25 18:59:27 windows-startup-script-url: +     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2022/01/25 18:59:27 windows-startup-script-url: Test Failed: Cannot find any service with service name 'google_osconfig_agent'.
2022/01/25 18:59:27 windows-startup-script-url: 
2022/01/25 18:59:27 windows-startup-script-url: 
```

VMM doesn't support OS config agent on non-server Windows: https://cloud.google.com/compute/docs/images/os-details#windows_client