### PR TITLE
Fix go.mod: each 'replace' needs a corresponding 'require latest'

### DIFF
--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -7,10 +7,10 @@ require (
 	cloud.google.com/go/logging v1.2.0
 	cloud.google.com/go/storage v1.14.0
 	cos.googlesource.com/cos/tools.git v0.0.0-20210104210903-4b3bc7d49b79 // indirect
-	github.com/GoogleCloudPlatform/compute-image-tools/common v0.0.0
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/common latest
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy latest
 	github.com/GoogleCloudPlatform/compute-image-tools/mocks v0.0.0-20200416045929-22b14b6b7c19
-	github.com/GoogleCloudPlatform/compute-image-tools/proto/go v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/proto/go latest
 	github.com/GoogleCloudPlatform/osconfig v0.0.0-20210202205636-8f5a30e8969f
 	github.com/aws/aws-sdk-go v1.37.5
 	github.com/cenkalti/backoff/v4 v4.1.0

--- a/cli_tools/go.mod
+++ b/cli_tools/go.mod
@@ -7,10 +7,10 @@ require (
 	cloud.google.com/go/logging v1.2.0
 	cloud.google.com/go/storage v1.14.0
 	cos.googlesource.com/cos/tools.git v0.0.0-20210104210903-4b3bc7d49b79 // indirect
-	github.com/GoogleCloudPlatform/compute-image-tools/common latest
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy latest
+	github.com/GoogleCloudPlatform/compute-image-tools/common v0.0.0-20220126184140-b288db61775e
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200406182414-bf9021434372
 	github.com/GoogleCloudPlatform/compute-image-tools/mocks v0.0.0-20200416045929-22b14b6b7c19
-	github.com/GoogleCloudPlatform/compute-image-tools/proto/go latest
+	github.com/GoogleCloudPlatform/compute-image-tools/proto/go v0.0.0-20220126184140-b288db61775e
 	github.com/GoogleCloudPlatform/osconfig v0.0.0-20210202205636-8f5a30e8969f
 	github.com/aws/aws-sdk-go v1.37.5
 	github.com/cenkalti/backoff/v4 v4.1.0

--- a/cli_tools_tests/go.mod
+++ b/cli_tools_tests/go.mod
@@ -4,11 +4,11 @@ go 1.13
 
 require (
 	cloud.google.com/go/storage v1.14.0
-	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools v0.0.0
-	github.com/GoogleCloudPlatform/compute-image-tools/common v0.0.0
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0
-	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0
-	github.com/GoogleCloudPlatform/compute-image-tools/proto/go v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools latest
+	github.com/GoogleCloudPlatform/compute-image-tools/common latest
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy latest
+	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils latest
+	github.com/GoogleCloudPlatform/compute-image-tools/proto/go latest
 	github.com/aws/aws-sdk-go v1.37.5
 	github.com/golang/protobuf v1.5.1
 	github.com/google/go-cmp v0.5.5

--- a/cli_tools_tests/go.mod
+++ b/cli_tools_tests/go.mod
@@ -4,11 +4,11 @@ go 1.13
 
 require (
 	cloud.google.com/go/storage v1.14.0
-	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools latest
-	github.com/GoogleCloudPlatform/compute-image-tools/common latest
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy latest
-	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils latest
-	github.com/GoogleCloudPlatform/compute-image-tools/proto/go latest
+	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/common v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/proto/go v0.0.0
 	github.com/aws/aws-sdk-go v1.37.5
 	github.com/golang/protobuf v1.5.1
 	github.com/google/go-cmp v0.5.5

--- a/common/go.mod
+++ b/common/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go/storage v1.10.0
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy latest
 	google.golang.org/api v0.31.0
 )
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go/storage v1.10.0
-	github.com/GoogleCloudPlatform/compute-image-tools/daisy latest
+	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200406182414-bf9021434372
 	google.golang.org/api v0.31.0
 )
 


### PR DESCRIPTION
Each 'replace' needs a corresponding 'require latest'. Without that, even though it works for our repositories, it blocked others to pull the module. It will fail with "unknown revision v0.0.0".

v0.0.0 is a pseudo version number and can't work when the module consumer doesn't have the same "replace".