### PR TITLE
RHUI: Runner for health checks

### DIFF
--- a/daisy_workflows/build-publish/rhui/cds.wf.json
+++ b/daisy_workflows/build-publish/rhui/cds.wf.json
@@ -27,6 +27,7 @@
   "Sources": {
     "cds_artifacts": "./cds_artifacts",
     "cds_artifacts/rhui.crt": "${tls_cert_path}",
+    "cds_artifacts/health_check.py": "./health_check.py",
     "install_cds.sh": "./install_cds.sh"
   },
   "Steps": {

--- a/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-health-check.service
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-health-check.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=CDS health check
+
+[Service]
+Type=oneshot
+ExecStart=python3 /opt/google-rhui-infra/health_check.py \
+    --node cds \
+    --result_file /var/log/google_rhui_health_check.txt \
+    --nfs_mount /var/lib/rhui/remote_share
+
+[Install]
+WantedBy=multi-user.target

--- a/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-health-check.timer
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-health-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer for CDS health check
+Requires=rhui-health-check.service
+
+[Timer]
+Unit=rhui-health-check.service
+OnUnitActiveSec=1m
+
+[Install]
+WantedBy=timers.target

--- a/daisy_workflows/build-publish/rhui/health_check.py
+++ b/daisy_workflows/build-publish/rhui/health_check.py
@@ -1,0 +1,137 @@
+#  Copyright 2022 Google Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Health check for RHUI infrastructure nodes."""
+
+import argparse
+import logging
+import logging.handlers
+import os
+import sys
+import tempfile
+import typing
+
+
+class HealthChecks:
+  nfs_mount: str
+
+  def __init__(
+      self,
+      nfs_mount: str,
+  ) -> None:
+    self.nfs_mount = nfs_mount
+
+  def mount_uses_nfs(self, logger: logging.Logger):
+    logger.info("checking that %s is mounted as NFS", self.nfs_mount)
+    with open("/proc/mounts") as mounts:
+      for line in mounts:
+        parts = line.split()
+        mnt_point, mnt_type = parts[1], parts[2]
+        if mnt_point == self.nfs_mount:
+          if mnt_type == "nfs":
+            return
+          else:
+            raise EnvironmentError("Not mounted as nfs. mount: %s" % line)
+    raise EnvironmentError("%s not in /proc/mounts" % self.nfs_mount)
+
+  def mount_is_writable(self, logger: logging.Logger):
+    logger.info("checking that %s is writable", self.nfs_mount)
+    with tempfile.TemporaryFile(dir=self.nfs_mount) as f:
+      f.write(b"content")
+
+  def mount_is_readable(self, logger: logging.Logger):
+    logger.info("checking that %s is readable", self.nfs_mount)
+    os.listdir(self.nfs_mount)
+
+
+def main(node_type: str, result_file: typing.TextIO, nfs_mount: str):
+  """Executes health check for node_type, and writes the overall
+  result to result_file ('OK' if all checks pass, otherwise 'ERROR').
+  """
+  result_file.truncate()
+  health_checks = HealthChecks(nfs_mount=nfs_mount)
+  checks = [
+    health_checks.mount_is_readable,
+    health_checks.mount_uses_nfs,
+  ]
+  if node_type == "rhua":
+    checks += [
+      health_checks.mount_is_writable,
+    ]
+  success = True
+  for func in checks:
+    logger = logging.getLogger(func.__name__)
+    try:
+      func(logger=logger)
+      logger.info("success")
+    except Exception as e:
+      success = False
+      logger.error(e)
+  if success:
+    result_file.write("HEALTHY\n")
+  else:
+    result_file.write("ERROR\n")
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Run health checks.")
+  parser.add_argument(
+    "--node",
+    dest="node",
+    type=str,
+    nargs=1,
+    required=True,
+    choices=["cds", "rhua"],
+    help="type of node where check is running",
+  )
+  parser.add_argument(
+    "--result_file",
+    dest="result_file",
+    required=True,
+    type=argparse.FileType("w"),
+    help="file to write result",
+  )
+  parser.add_argument(
+    "--nfs_mount",
+    dest="nfs_mount",
+    type=str,
+    nargs=1,
+    required=True,
+    help="directory of NFS mount",
+  )
+  parser.add_argument(
+    "--log",
+    dest="log",
+    type=str,
+    nargs=1,
+    choices=["stdout", "syslog"],
+    default="syslog",
+    help="where to write logs",
+  )
+  args = parser.parse_args()
+  if args.log[0] == "stdout":
+    handler = logging.StreamHandler(sys.stdout)
+  else:
+    handler = logging.handlers.SysLogHandler(address="/dev/log")
+    # syslog parses on the colon to determine the tag for the message.
+    handler.ident = "rhui-health-check: "
+  logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(name)s - %(levelname)s - %(message)s",
+    handlers=[handler],
+  )
+  main(
+    node_type=args.node[0],
+    result_file=args.result_file,
+    nfs_mount=args.nfs_mount[0],
+  )

--- a/daisy_workflows/build-publish/rhui/install_cds.sh
+++ b/daisy_workflows/build-publish/rhui/install_cds.sh
@@ -89,6 +89,13 @@ cat $tempdir/rhui-tools.conf > /etc/rhui/rhui-tools.conf
 # Remove enrollment cert and repos from final image.
 subscription-manager remove --all
 
+# Install health checks.
+install -D -t /opt/google-rhui-infra $tempdir/health_check.py
+for unit in rhui-health-check.{service,timer}; do
+  install -m 664 -t /etc/systemd/system $tempdir/$unit
+  systemctl enable $unit
+done
+
 # Delete installer resources.
 rm -rf $tempdir
 

--- a/daisy_workflows/build-publish/rhui/install_rhua.sh
+++ b/daisy_workflows/build-publish/rhui/install_rhua.sh
@@ -99,6 +99,13 @@ rhui-manager --noninteractive --user admin --password "$password" cert upload \
 rhui-manager --noninteractive --user admin --password "$password" repo \
   add_by_repo --repo_ids $(paste -sd "," "${tempdir}/reponames.txt")
 
+# Install health checks.
+install -D -t /opt/google-rhui-infra $tempdir/health_check.py
+for unit in rhui-health-check.{service,timer}; do
+  install -m 664 -t /etc/systemd/system $tempdir/$unit
+  systemctl enable $unit
+done
+
 # Add NFS dependency to pulp units
 # We do this instead of patching the Ansible templates, as we need the
 # services up to run the above rhui-manager commands and the modification

--- a/daisy_workflows/build-publish/rhui/rhua.wf.json
+++ b/daisy_workflows/build-publish/rhui/rhua.wf.json
@@ -22,6 +22,7 @@
   },
   "Sources": {
     "rhua_artifacts": "./rhua_artifacts",
+    "rhua_artifacts/health_check.py": "./health_check.py",
     "install_rhua.sh": "./install_rhua.sh"
   },
   "Steps": {

--- a/daisy_workflows/build-publish/rhui/rhua_artifacts/rhui-health-check.service
+++ b/daisy_workflows/build-publish/rhui/rhua_artifacts/rhui-health-check.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=RHUA health check
+
+[Service]
+Type=oneshot
+ExecStart=python3 /opt/google-rhui-infra/health_check.py \
+    --node rhua \
+    --result_file /var/log/google_rhui_health_check.txt \
+    --nfs_mount /var/lib/rhui/remote_share
+
+[Install]
+WantedBy=multi-user.target

--- a/daisy_workflows/build-publish/rhui/rhua_artifacts/rhui-health-check.timer
+++ b/daisy_workflows/build-publish/rhui/rhua_artifacts/rhui-health-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer for RHUA health check
+Requires=rhui-health-check.service
+
+[Timer]
+Unit=rhui-health-check.service
+OnUnitActiveSec=1m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
A first pass at health checks for RHUI; for now, it includes a single check. The goal is to validate the overall approach prior to adding more checks.

To facilitate deployment, the script currently exposes the following flags:

```
`health_check.py \`
    --node {cds,rhua}  \
    --result_file RESULT_FILE \
    --nfs_mount NFS_MOUNT_POINT
```


Key points:
- The health checker runs on a timer, and writes the result (`{OK|ERROR}`) to a sentinel file that's read by nginx's health check handler
- Logs are written to stdout, allowing them to be queried with `journalctl`