### PR TITLE
cds build: include security section

### DIFF
--- a/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-tools.conf
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-tools.conf
@@ -6,3 +6,8 @@ ssl_ca_cert: /etc/pki/rhui/certs/ca.crt
 artifact_dir: /var/lib/rhui/remote_share/pulp3/artifact
 log_level: INFO
 symlink_dir: /var/lib/rhui/remote_share/symlinks
+
+[security]
+# CA certificate that is used to sign and verify client entitlement certificates
+entitlement_ca: /etc/pki/rhui/certs/ca.crt
+entitlement_ca_key: /etc/pki/rhui/private/ca.key


### PR DESCRIPTION
checked by gunicorn-auth service; missing section crashes the service