### PR TITLE
use  'go install' instead of 'go get'

### DIFF
--- a/test-infra/prowjobs/gocheck/Dockerfile
+++ b/test-infra/prowjobs/gocheck/Dockerfile
@@ -15,7 +15,7 @@ FROM gcr.io/$PROJECT_ID/wrapper:latest
 
 FROM golang
 
-RUN go get -u golang.org/x/lint/golint
+RUN go install golang.org/x/lint/golint@latest
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 ENV GO111MODULE on
 

--- a/test-infra/prowjobs/unittests/Dockerfile
+++ b/test-infra/prowjobs/unittests/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get -y install libssl-dev && \
     rm -rf /var/cache/apt/archives
 
 # Go test junit xml output
-RUN go get -u github.com/jstemmer/go-junit-report
+RUN go install github.com/jstemmer/go-junit-report@latest
 ENV GO111MODULE on
 
 COPY --from=0 /wrapper wrapper


### PR DESCRIPTION
'go get' is deprecated by new golang version.