### PR TITLE
Fix getDeviceForMount call

### DIFF
--- a/cli_tools/common/mount/inspector.go
+++ b/cli_tools/common/mount/inspector.go
@@ -66,7 +66,7 @@ func (mi *defaultMountInspector) Inspect(dir string) (mountInfo InspectionResult
 
 // getDeviceForMount returns the path of the block device that is mounted for dir.
 func (mi *defaultMountInspector) getDeviceForMount(dir string) (string, error) {
-	stdout, err := mi.shellExecutor.Exec("getDeviceForMount", "--noheadings", "--output=SOURCE", dir)
+	stdout, err := mi.shellExecutor.Exec("findmnt", "--noheadings", "--output=SOURCE", dir)
 	if err != nil {
 		return "", err
 	}

--- a/cli_tools/common/mount/inspector_test.go
+++ b/cli_tools/common/mount/inspector_test.go
@@ -73,7 +73,7 @@ func TestMountInspector_Inspect_PropagatesErrorFromFindMnt(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockShell := mocks.NewMockShellExecutor(mockCtrl)
-	mockShell.EXPECT().Exec("getDeviceForMount", "--noheadings",
+	mockShell.EXPECT().Exec("findmnt", "--noheadings",
 		"--output=SOURCE", "/").Return("", errors.New("[getDeviceForMount] not executable"))
 
 	mountInspector := &defaultMountInspector{mockShell}
@@ -86,7 +86,7 @@ func TestMountInspector_Inspect_PropagatesErrorFromGettingDeviceType(t *testing.
 	defer mockCtrl.Finish()
 
 	mockShell := mocks.NewMockShellExecutor(mockCtrl)
-	mockShell.EXPECT().Exec("getDeviceForMount", "--noheadings",
+	mockShell.EXPECT().Exec("findmnt", "--noheadings",
 		"--output=SOURCE", "/").Return("/dev/mapper/vg-device", nil)
 	mockShell.EXPECT().Exec("lsblk", "--noheadings",
 		"--output=TYPE", "/dev/mapper/vg-device").Return("", errors.New("[lsblk] not executable"))
@@ -140,6 +140,6 @@ func setupPhysicalDisks(mockShell *mocks.MockShellExecutor, deviceMap map[string
 }
 
 func setupRootMount(mockShell *mocks.MockShellExecutor, mointPoint string, mointPointType string) {
-	mockShell.EXPECT().Exec("getDeviceForMount", "--noheadings", "--output=SOURCE", "/").Return(mointPoint, nil)
+	mockShell.EXPECT().Exec("findmnt", "--noheadings", "--output=SOURCE", "/").Return(mointPoint, nil)
 	mockShell.EXPECT().Exec("lsblk", "--noheadings", "--output=TYPE", mointPoint).Return(mointPointType, nil)
 }


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1743 we improved mount detection for the precheck tool; when doing so, we used the wrong CLI binary -- it should have been `findmnt`.

Found by @yswe, thanks!