### PR TITLE
nginx for rhua health checks

### DIFF
--- a/daisy_workflows/build-publish/rhui/cds.wf.json
+++ b/daisy_workflows/build-publish/rhui/cds.wf.json
@@ -28,6 +28,7 @@
     "cds_artifacts": "./cds_artifacts",
     "cds_artifacts/rhui.crt": "${tls_cert_path}",
     "cds_artifacts/health_check.py": "./health_check.py",
+    "cds_artifacts/health_check.nginx.conf": "./health_check.nginx.conf",
     "install_cds.sh": "./install_cds.sh"
   },
   "Steps": {

--- a/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-health-check.service
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/rhui-health-check.service
@@ -5,7 +5,7 @@ Description=CDS health check
 Type=oneshot
 ExecStart=python3 /opt/google-rhui-infra/health_check.py \
     --node cds \
-    --result_file /var/log/google_rhui_health_check.txt \
+    --result_file /usr/share/nginx/html/google_rhui_health_check.txt \
     --nfs_mount /var/lib/rhui/remote_share
 
 [Install]

--- a/daisy_workflows/build-publish/rhui/health_check.nginx.conf
+++ b/daisy_workflows/build-publish/rhui/health_check.nginx.conf
@@ -1,0 +1,7 @@
+server {
+  listen       8080 default_server;
+  location / {
+    root   /usr/share/nginx/html;
+    index  google_rhui_health_check.txt;
+  }
+}

--- a/daisy_workflows/build-publish/rhui/install_cds.sh
+++ b/daisy_workflows/build-publish/rhui/install_cds.sh
@@ -95,6 +95,7 @@ for unit in rhui-health-check.{service,timer}; do
   install -m 664 -t /etc/systemd/system $tempdir/$unit
   systemctl enable $unit
 done
+install -m 664 -t /etc/nginx/conf.d $tempdir/health_check.nginx.conf
 
 # Delete installer resources.
 rm -rf $tempdir

--- a/daisy_workflows/build-publish/rhui/install_rhua.sh
+++ b/daisy_workflows/build-publish/rhui/install_rhua.sh
@@ -105,6 +105,7 @@ for unit in rhui-health-check.{service,timer}; do
   install -m 664 -t /etc/systemd/system $tempdir/$unit
   systemctl enable $unit
 done
+install -m 664 -t /etc/nginx/conf.d $tempdir/health_check.nginx.conf
 
 # Add NFS dependency to pulp units
 # We do this instead of patching the Ansible templates, as we need the

--- a/daisy_workflows/build-publish/rhui/rhua.wf.json
+++ b/daisy_workflows/build-publish/rhui/rhua.wf.json
@@ -23,6 +23,7 @@
   "Sources": {
     "rhua_artifacts": "./rhua_artifacts",
     "rhua_artifacts/health_check.py": "./health_check.py",
+    "rhua_artifacts/health_check.nginx.conf": "./health_check.nginx.conf",
     "install_rhua.sh": "./install_rhua.sh"
   },
   "Steps": {

--- a/daisy_workflows/build-publish/rhui/rhua_artifacts/rhua.patch
+++ b/daisy_workflows/build-publish/rhui/rhua_artifacts/rhua.patch
@@ -73,3 +73,14 @@ diff -Naur playbooks/rhua-provision.yml playbooks/rhua-provision.yml
  
      - name: Collect static browsable API and media files
        command: "{{ pulpcore_env }} pulpcore-manager collectstatic --noinput"
+
+--- templates/nginx-pulp.conf	2022-01-01 23:56:33.757374995 +0000
++++ templates/nginx-pulp.conf	2022-01-01 23:56:47.768584643 +0000
+@@ -10,6 +10,7 @@
+ }
+
+ http {
++    include /etc/nginx/conf.d/*.conf;
+     include mime.types;
+     # fallback in case we can't determine a type
+     default_type application/octet-stream;

--- a/daisy_workflows/build-publish/rhui/rhua_artifacts/rhui-health-check.service
+++ b/daisy_workflows/build-publish/rhui/rhua_artifacts/rhui-health-check.service
@@ -5,7 +5,7 @@ Description=RHUA health check
 Type=oneshot
 ExecStart=python3 /opt/google-rhui-infra/health_check.py \
     --node rhua \
-    --result_file /var/log/google_rhui_health_check.txt \
+    --result_file /usr/share/nginx/html/google_rhui_health_check.txt \
     --nfs_mount /var/lib/rhui/remote_share
 
 [Install]


### PR DESCRIPTION
- Health checks run on `8080`; RHUA listens on `80`, so I didn't want to interfere with anything that depends on that.
- nginx on the CDS node already includes `/etc/nginx/conf.d` drop-ins. RHUA required patching.
- I moved the results file from the health check to nginx's default HTML directory