### PR TITLE
Import_Precheck: Update_cloudbuild_pipeline_to_Add_binaries_for_32-bit Operating Systems

### DIFF
--- a/cli_tools/import_precheck/README.md
+++ b/cli_tools/import_precheck/README.md
@@ -8,9 +8,13 @@ for more information.
 Precheck must be run as root or Administrator on the running system you want to import.
 
 ## Binaries
-Windows: https://storage.googleapis.com/compute-image-tools/release/windows/import_precheck.exe
+Windows 64-bit: https://storage.googleapis.com/compute-image-tools/release/windows/import_precheck.exe
 
-Linux: https://storage.googleapis.com/compute-image-tools/release/linux/import_precheck
+Windows 32-bit: https://storage.googleapis.com/compute-image-tools/release/windows/import_precheck_32bit.exe
+
+Linux 64-bit: https://storage.googleapis.com/compute-image-tools/release/linux/import_precheck
+
+Linux 32-bit: https://storage.googleapis.com/compute-image-tools/release/linux/import_precheck_32bit
 
 ## Building from Source
 `go get -u github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/import_precheck`

--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -60,6 +60,18 @@ steps:
   dir: 'cli_tools/import_precheck'
   args: ['go', 'build', '-o=/workspace/windows/import_precheck.exe']
   env: ['GOOS=windows']
+- name: 'golang'
+  dir: 'cli_tools/import_precheck'
+  args: ['go', 'build', '-o=/workspace/linux/import_precheck_32bit']
+  env:
+  - CGO_ENABLED=0
+  - GOARCH=386
+- name: 'golang'
+  dir: 'cli_tools/import_precheck'
+  args: ['go', 'build', '-o=/workspace/windows/import_precheck_32bit.exe']
+  env:
+  - GOOS=windows
+  - GOARCH=386
 
 # Build gce_vm_image_import.
 - name: 'golang'


### PR DESCRIPTION
Import_Precheck tool: Update_cloudbuild_pipeline_to_Add_binaries_for_32-bit Operating Systems

/cc EricEdens
/cc yswe

/assign EricEdens
/assign yswe
