### PR TITLE
Update RHUI health checks

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - dntczdx
   - zmarano
   - bkatyl
+  - linskeyd
 reviewers:
   - adjackura
   - hopkiw
@@ -15,3 +16,4 @@ reviewers:
   - dntczdx
   - zmarano
   - bkatyl
+  - linskeyd

--- a/daisy_workflows/build-publish/rhui/health_check.py
+++ b/daisy_workflows/build-publish/rhui/health_check.py
@@ -20,7 +20,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import typing
 
 NFS_MOUNT = "/var/lib/rhui/remote_share"
 
@@ -71,25 +70,24 @@ class MountIsReadable(HealthCheck):
 class ServicesAreActive(HealthCheck):
 
   cds_services = ["gunicorn-auth",
-		 "gunicorn-mirror",
-		 "gunicorn-content_manager",
-		 "nginx"]
+                  "gunicorn-mirror",
+                  "gunicorn-content_manager",
+                  "nginx"]
 
   rhua_services = ["postgresql",
-		  "redis",
-		  "pulpcore-api",
-		  "pulpcore-content",
-		  "pulpcore-resource-manager",
-		  "pulpcore-worker@1",
-		  "pulpcore-worker@2",
-		  "pulpcore-worker@3",
-		  "pulpcore-worker@4",
-                  "heck",
-		  "pulpcore-worker@5",
-		  "pulpcore-worker@6",
-		  "pulpcore-worker@7",
-		  "pulpcore-worker@8",
-		  "nginx"]
+                   "redis",
+                   "pulpcore-api",
+                   "pulpcore-content",
+                   "pulpcore-resource-manager",
+                   "pulpcore-worker@1",
+                   "pulpcore-worker@2",
+                   "pulpcore-worker@3",
+                   "pulpcore-worker@4",
+                   "pulpcore-worker@5",
+                   "pulpcore-worker@6",
+                   "pulpcore-worker@7",
+                   "pulpcore-worker@8",
+                   "nginx"]
 
   def _run(self, node: str):
     self.logger.info("checking that %s services are active", node)

--- a/daisy_workflows/build-publish/rhui/health_check.py
+++ b/daisy_workflows/build-publish/rhui/health_check.py
@@ -25,55 +25,78 @@ import typing
 NFS_MOUNT = "/var/lib/rhui/remote_share"
 
 
-class HealthChecks:
-  nfs_mount: str
+class HealthCheck:
 
-  def __init__(
-      self,
-      nfs_mount: str,
-  ) -> None:
-    self.nfs_mount = nfs_mount
+  # Node types the health check supports; defaults to both types.
+  nodes = ["cds", "rhua"]
 
-  def mount_uses_nfs(self, logger: logging.Logger):
-    logger.info("checking that %s is mounted as NFS", self.nfs_mount)
+  def __init__(self):
+    self.logger = logging.getLogger(self.__class__.__name__)
+
+  def run(self, node: str):
+    if node in self.nodes:
+      self._run(node)
+
+
+class MountIsNFS(HealthCheck):
+
+  mount = NFS_MOUNT
+
+  def _run(self, node: str):
+    self.logger.info("checking that %s is mounted as NFS", self.mount)
     with open("/proc/mounts") as mounts:
-        if "/var/lib/rhui/remote_share nfs rw" not in mounts:
-            raise EnvironmentError("%s not mounted")
+      if f"{self.mount} nfs rw" not in mounts.read():
+        raise EnvironmentError("%s is not NFS or not mounted" % self.mount)
 
-  def mount_is_writable(self, logger: logging.Logger):
-    logger.info("checking that %s is writable", self.nfs_mount)
-    with tempfile.TemporaryFile(dir=self.nfs_mount) as f:
+
+class MountIsWritable(HealthCheck):
+
+  mount = NFS_MOUNT
+
+  def _run(self, node: str):
+    self.logger.info("checking that %s is writable", self.mount)
+    with tempfile.TemporaryFile(dir=self.mount) as f:
       f.write(b"content")
 
-  def mount_is_readable(self, logger: logging.Logger):
-    logger.info("checking that %s is readable", self.nfs_mount)
-    os.listdir(self.nfs_mount)
 
-  def cds_services_are_active(self, logger: logging.Logger):
-    logger.info("checking that services are active")
-    self._check_services(["gunicorn-auth",
-                          "gunicorn-mirror",
-                          "gunicorn-content_manager",
-                          "nginx"])
+class MountIsReadable(HealthCheck):
 
-  def rhua_services_are_active(self, logger: logging.Logger):
-    logger.info("checking that services are active")
-    self._check_services(["postgresql",
-                          "redis",
-                          "pulpcore-api",
-                          "pulpcore-content",
-                          "pulpcore-resource-manager",
-                          "pulpcore-worker@1",
-                          "pulpcore-worker@2",
-                          "pulpcore-worker@3",
-                          "pulpcore-worker@4",
-                          "pulpcore-worker@5",
-                          "pulpcore-worker@6",
-                          "pulpcore-worker@7",
-                          "pulpcore-worker@8",
-                          "nginx"])
+  mount = NFS_MOUNT
 
-  def _check_services(self, services):
+  def _run(self, node: str):
+    self.logger.info("checking that %s is readable", self.mount)
+    os.listdir(self.mount)
+
+
+class ServicesAreActive(HealthCheck):
+
+  cds_services = ["gunicorn-auth",
+		 "gunicorn-mirror",
+		 "gunicorn-content_manager",
+		 "nginx"]
+
+  rhua_services = ["postgresql",
+		  "redis",
+		  "pulpcore-api",
+		  "pulpcore-content",
+		  "pulpcore-resource-manager",
+		  "pulpcore-worker@1",
+		  "pulpcore-worker@2",
+		  "pulpcore-worker@3",
+		  "pulpcore-worker@4",
+                  "heck",
+		  "pulpcore-worker@5",
+		  "pulpcore-worker@6",
+		  "pulpcore-worker@7",
+		  "pulpcore-worker@8",
+		  "nginx"]
+
+  def _run(self, node: str):
+    self.logger.info("checking that %s services are active", node)
+    if node == "cds":
+      services = self.cds_services
+    if node == "rhua":
+      services = self.rhua_services
     for service in services:
       subprocess.run(["systemctl", "is-active", service],
                      stdout=subprocess.PIPE,
@@ -81,41 +104,28 @@ class HealthChecks:
                      check=True)
 
 
-def main(node_type: str, result_file: typing.TextIO, nfs_mount: str):
-  """Executes health check for node_type, and writes the overall
-  result to result_file ('OK' if all checks pass, otherwise 'ERROR').
-  """
-  result_file.truncate()
-  health_checks = HealthChecks(nfs_mount=nfs_mount)
-  checks = [
-    health_checks.mount_is_readable,
-    health_checks.mount_uses_nfs,
-  ]
-  if node_type == "rhua":
-    checks += [
-      health_checks.mount_is_writable,
-      health_checks.rhua_services_are_active,
-    ]
-  if node_type == "cds":
-    checks += [
-      health_checks.cds_services_are_active,
-    ]
-  success = True
-  for func in checks:
-    logger = logging.getLogger(func.__name__)
-    try:
-      func(logger=logger)
-      logger.info("success")
-    except Exception as e:
-      success = False
-      logger.error(e)
-  if success:
-    result_file.write("HEALTHY\n")
-  else:
-    result_file.write("ERROR\n")
+class HealthCheckSuite:
+
+  checks = MountIsNFS, MountIsWritable, MountIsReadable, ServicesAreActive
+
+  def __init__(self, node: str):
+    """Executes health checks for node"""
+    self.run(node)
+
+  def run(self, node: str):
+    for check_type in self.checks:
+      check = check_type()
+      try:
+        check.run(node)
+        check.logger.info("success")
+      except Exception as e:
+        check.logger.error(e)
+        return False
+
+    return True
 
 
-if __name__ == "__main__":
+def main():
   parser = argparse.ArgumentParser(description="Run health checks.")
   parser.add_argument(
     "--node",
@@ -141,4 +151,12 @@ if __name__ == "__main__":
     handlers=[handler],
   )
 
-  main(args.node, args.result_file, NFS_MOUNT)
+  args.result_file.truncate()
+  if HealthCheckSuite(args.node):
+    args.result_file.write("HEALTHY\n")
+  else:
+    args.result_file.write("ERROR\n")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
* add cds and rhua service checks
* move nfs mount path to constant
* always log to stdout (systemd will get it to syslog for us)
* always run read & write checks on all node types (mount options aren't different across types)
* simplify nfs mount type check for readability

the final commit refactors the plugin architecture to use classes, but this is just an idea i had. feel free to review excluding that commit. output format is maintained (added fake service name to the check in this example to force a failure):
```
MountIsNFS - INFO - checking that /var/lib/rhui/remote_share is mounted as NFS
MountIsNFS - INFO - success
MountIsWritable - INFO - checking that /var/lib/rhui/remote_share is writable
MountIsWritable - INFO - success
MountIsReadable - INFO - checking that /var/lib/rhui/remote_share is readable
MountIsReadable - INFO - success
ServicesAreActive - INFO - checking that rhua services are active
ServicesAreActive - ERROR - Command '['systemctl', 'is-active', 'fakeservice']' returned non-zero exit status 3.
```