### PR TITLE
Refresh docs to reflect current tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,70 @@
-# Compute Engine Image Tools
+# Compute Image Tools
 
-This repository contains various tools for managing disk images on Google
-Compute Engine.
+Tools for building, testing, releasing, and upgrading
+[Google Compute Engine images](https://cloud.google.com/compute/docs/images).
 
-## Docs
+## [GCE Export](cli_tools/gce_export)
 
-The main documentation for the tools in this repository can be found on our
-[GitHub.io page](https://googlecloudplatform.github.io/compute-image-tools/).
+Streams an attached Google Compute Engine disk to an image file in a Google
+Cloud Storage bucket.
 
-## [Daisy](daisy)
+**Docker**
 
-Daisy is a solution for running multi-step workflows on GCE.
+- Latest: `gcr.io/compute-image-tools/gce_export:latest`
+- Release: `gcr.io/compute-image-tools/gce_export:release`
 
-### [Daisy Workflows](daisy_workflows)
+**Linux x64**
 
-Full featured Daisy workflow examples, image builds, and image import
-workflows. A [user guide](daisy_workflows/import_userguide.md) for VM imports is
-also provided here.
+- [Latest](https://storage.googleapis.com/compute-image-tools/latest/linux/gce_export)
+- [Release](https://storage.googleapis.com/compute-image-tools/release/linux/gce_export)
 
-### [Daisy Tutorials](daisy_tutorials)
+**Windows x64**
 
-Basic workflow examples and tutorials for getting started with Daisy.
+- [Latest](https://storage.googleapis.com/compute-image-tools/latest/windows/gce_export.exe)
+- [Release](https://storage.googleapis.com/compute-image-tools/release/windows/gce_export.exe)
 
-## [GCE Export tool](cli_tools/gce_export)
+## [Windows Upgrade](cli_tools/gce_windows_upgrade)
 
-The gce_export tool streams a local disk to a Google Compute Engine
-image file in a Google Cloud Storage bucket.
+Performs in-place OS upgrades. The tool can be invoked
+with [`gcloud beta compute os-config os-upgrade`](https://cloud.google.com/sdk/gcloud/reference/beta/compute/os-config/os-upgrade).
 
-### Prebuilt binaries
-Prebuilt binaries are available for Windows, and Linux.
 
-Built from the latest GitHub release (all 64bit):
+**Docker**
 
-+ [Windows](https://storage.googleapis.com/compute-image-tools/release/windows/gce_export.exe)
-+ [Linux](https://storage.googleapis.com/compute-image-tools/release/linux/gce_export)
+- Latest: `gcr.io/compute-image-tools/gce_windows_upgrade:latest`
+- Release: `gcr.io/compute-image-tools/gce_windows_upgrade:release`
 
-Built from the latest commit to the master branch (all 64bit):
+**Linux x64**
 
-+ [Windows](https://storage.googleapis.com/compute-image-tools/latest/windows/gce_export.exe)
-+ [Linux](https://storage.googleapis.com/compute-image-tools/latest/linux/gce_export)
+- [Latest](https://storage.googleapis.com/compute-image-tools/latest/linux/gce_windows_upgrade)
+- [Release](https://storage.googleapis.com/compute-image-tools/release/linux/gce_windows_upgrade)
+
+
+## [Image Publish](cli_tools/gce_image_publish)
+
+Creates Google Compute Engine images from raw disk files.
+
+**Docker**
+
+- Latest: `gcr.io/compute-image-tools/gce_image_publish:latest`
+- Release: `gcr.io/compute-image-tools/gce_image_publish:release`
+
+**Linux x64**
+
+- [Latest](https://storage.googleapis.com/compute-image-tools/latest/linux/gce_image_publish)
+- [Release](https://storage.googleapis.com/compute-image-tools/release/linux/gce_image_publish)
+
+**Windows x64**
+
+- [Latest](https://storage.googleapis.com/compute-image-tools/latest/windows/gce_image_publish.exe)
+- [Release](https://storage.googleapis.com/compute-image-tools/release/windows/gce_image_publish.exe)
+
+**OSX x64**
+
+- [Latest](https://storage.googleapis.com/compute-image-tools/latest/darwin/gce_image_publish)
+- [Release](https://storage.googleapis.com/compute-image-tools/release/darwin/gce_image_publish)
+
+
 
 ## Contributing
 

--- a/cli_tools_tests/e2e/README.md
+++ b/cli_tools_tests/e2e/README.md
@@ -2,57 +2,45 @@ e2e tests: Invoke gcloud and the wrapper binaries using their public APIs.
 
 ## Overview
 
-Each directory adjacent to this README is a test suite. At the time of writing, there are four test suites:
+Each directory adjacent to this README is a test suite.
+At the time of writing, there is one test suite:
 
 ```
-gce_image_import_export
-gce_ovf_export
-gce_ovf_import
 gce_windows_upgrade
 ```
 
-We build, deploy, and invoke the e2e tests using Docker images, with one image per test suite. The Docker image
-contains:
+We build, deploy, and invoke the e2e tests using Docker images,
+with one image per test suite. The Docker image contains:
 
 1. Tests, as a compiled go binary
 2. One or more wrappers, as a compiled go binary.
 3. gcloud
 
-The Dockerfiles that generate these images are in the root of this repository. At the time of writing, they are:
+The Dockerfiles that generate these images are in the root of this repository.
+At the time of writing, there is one Dockerfile:
 
 ```
-gce_image_import_export_tests.Dockerfile
-gce_ovf_export_tests.Dockerfile
-gce_ovf_import_tests.Dockerfile
 gce_windows_upgrade_tests.Dockerfile
 ```
 
 ## Quick Run
 
-To run e2e tests, we recommend using the script `run_e2e.sh` from the root of this repository.
-The header of that file contains usage information.
+To run e2e tests, we recommend using the script `run_e2e.sh` from the
+root of this repository. The header of that file contains usage information.
 
 ## Details about building
 
 Build e2e Dockerfiles using `docker build -f <docker file name>`.
 
-This example builds the tests associated with `gce_image_import_export_tests.Dockerfile`, and stores the image in a
-tag `gce_image_import_export_tests`.
+This example builds the tests associated with
+`gce_windows_upgrade_tests.Dockerfile`, and stores the image in a tag
+`gce_windows_upgrade_tests`.
 
 From the root of this repository, execute:
 
 ```shell
-gcloud auth login
-gcloud auth configure-docker
-docker build -f gce_image_import_export_tests.Dockerfile . -t gce_image_import_export_tests
+docker build -f gce_windows_upgrade_tests.Dockerfile . -t gce_windows_upgrade_tests
 ```
-
-Notes:
-
-1. The first two gcloud commands ensure that your local docker installation can read
-   the `gcr.io/compute-image-tools-test/wrapper-with-gcloud:latest` image.
-
-Use the same syntax to build other e2e Dockerfiles.
 
 ## Details about running
 
@@ -66,11 +54,11 @@ gcloud auth application-default login
 docker run --env GOOGLE_APPLICATION_CREDENTIALS= \
            --env CLOUDSDK_CONFIG=/root/.config/gcloud \
            -v $HOME/.config/gcloud:/root/.config/gcloud \
-           gce_image_import_export_tests \
+           gce_windows_upgrade_tests \
            -test_project_id $PROJECT \
            -test_zone us-central1-a \
-           -test_suite_filter=^ImageImport$ \
-           -test_case_filter=ubuntu
+           -test_suite_filter=^WindowsUpgradeTests$ \
+           -test_case_filter=BYOL
 ```
 
 Notes:

--- a/daisy_workflows/README.md
+++ b/daisy_workflows/README.md
@@ -2,16 +2,3 @@
 These are workflows used by the GCE team to automate common tasks associated
 with building images as well as workflows used to actually build GCE base
 images. There are also example workflows.
-
-# Import Userguide
-The [import
-userguide](https://googlecloudplatform.github.io/compute-image-tools/image-import.html)
-provides examples for running import workflows using Google Compute Engine tools
-and VM's.
-
-# Styleguide
-The
-[styleguide](https://googlecloudplatform.github.io/compute-image-tools/daisy-styleguide.html)
-provides guidance for workflow symantics. When writing, modifying, or using
-workflows following common practices will make your life much easier.
-

--- a/daisy_workflows/import_userguide.md
+++ b/daisy_workflows/import_userguide.md
@@ -1,4 +1,0 @@
-# Importing Virtual Disks into Google Compute Engine (GCE)
-
-This page has moved to
-https://googlecloudplatform.github.io/compute-image-tools/image-import.html


### PR DESCRIPTION
Updates docs to reflect the tools that didn't move to https://github.com/GoogleCloudPlatform/compute-image-import.