### PR TITLE
split ha repos from el9 rhui config

### DIFF
--- a/daisy_workflows/build-publish/rhui/rpms/google-rhui-client-rhel9-ha.repo
+++ b/daisy_workflows/build-publish/rhui/rpms/google-rhui-client-rhel9-ha.repo
@@ -1,0 +1,29 @@
+[rhui-rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name=Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify=1
+sslclientcert=/etc/pki/rhui/product/content.crt
+sslclientkey=/etc/pki/rhui/key.pem
+
+[rhui-rhel-9-for-$basearch-highavailability-rhui-rpms]
+name=Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify=1
+sslclientcert=/etc/pki/rhui/product/content.crt
+sslclientkey=/etc/pki/rhui/key.pem
+
+[rhui-rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name=Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify=1
+sslclientcert=/etc/pki/rhui/product/content.crt
+sslclientkey=/etc/pki/rhui/key.pem

--- a/daisy_workflows/build-publish/rhui/rpms/google-rhui-client-rhel9-ha.spec
+++ b/daisy_workflows/build-publish/rhui/rpms/google-rhui-client-rhel9-ha.spec
@@ -1,0 +1,47 @@
+Name:		google-rhui-client-rhel9-ha
+Version:	4.0
+Release:	1
+Summary:	RHUI config for GCE (HA repo)
+
+Group:		Applications/Internet
+License:	GPLv2
+URL:		  http://redhat.com
+Source0:	%{name}-%{version}.tar.gz
+BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildArch:	noarch
+Requires: yum
+Requires: google-rhui-client-rhel9
+
+%description
+Red Hat Update Infrastructure for Google Compute Engine instances
+High Availability repo only
+
+
+%prep
+%setup -q
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT
+
+# Repo file and mirrorlist
+mkdir -p $RPM_BUILD_ROOT/etc/yum.repos.d
+cp $RPM_BUILD_DIR/%{name}-%{version}/rh-cloud-ha.repo $RPM_BUILD_ROOT/etc/yum.repos.d/
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%defattr(-,root,root,-)
+%config  /etc/yum.repos.d/rh-cloud-ha.repo
+
+%changelog
+* Fri Jun 03 2022 Liam Hopkins <liamh@google.com>
+- Created new HA RPM

--- a/daisy_workflows/build-publish/rhui/rpms/google-rhui-client-rhel9.repo
+++ b/daisy_workflows/build-publish/rhui/rpms/google-rhui-client-rhel9.repo
@@ -88,36 +88,6 @@ sslverify=1
 sslclientcert=/etc/pki/rhui/product/content.crt
 sslclientkey=/etc/pki/rhui/key.pem
 
-[rhui-rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
-name=Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
-mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify=1
-sslclientcert=/etc/pki/rhui/product/content.crt
-sslclientkey=/etc/pki/rhui/key.pem
-
-[rhui-rhel-9-for-$basearch-highavailability-rhui-rpms]
-name=Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
-mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify=1
-sslclientcert=/etc/pki/rhui/product/content.crt
-sslclientkey=/etc/pki/rhui/key.pem
-
-[rhui-rhel-9-for-$basearch-highavailability-source-rhui-rpms]
-name=Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
-mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify=1
-sslclientcert=/etc/pki/rhui/product/content.crt
-sslclientkey=/etc/pki/rhui/key.pem
-
 [rhui-rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
 name=Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
 mirrorlist=https://rhui.googlecloud.com/pulp/mirror/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug


### PR DESCRIPTION
Making the el9 RHUI config multi-arch has one issue, which is that the HA repos are x86-only. After consulting with RH, we decided to split the HA repos out to their own package, and install it only on x86 images at image build time.