### PR TITLE
Also import the Cloud SIG GPG key.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp.cfg
@@ -129,6 +129,7 @@ userdel -r gce
 # Import all RPM GPG keys.
 curl -o /etc/pki/rpm-gpg/google-rpm-package-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 curl -o /etc/pki/rpm-gpg/google-key.gpg https://packages.cloud.google.com/yum/doc/yum-key.gpg
+curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-8-SIG-Cloud https://dl.rockylinux.org/pub/sig/8/cloud/x86_64/RPM-GPG-KEY-Rocky-8-SIG-Cloud
 rpm --import /etc/pki/rpm-gpg/*
 
 # Configure the network for GCE.


### PR DESCRIPTION
This prevents dnf from asking you if you want to import the key when pulling a package the first time.