### PR TITLE
CDS: Collect nginx metrics and logs

### DIFF
--- a/daisy_workflows/build-publish/rhui/cds_artifacts/config.opsagent.yaml
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/config.opsagent.yaml
@@ -1,0 +1,26 @@
+# Config for Google Ops Agent to collect nginx logs and metrics.
+# https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+logging:
+  receivers:
+    nginx_access:
+      type: nginx_access
+      include_paths:
+      - /var/log/nginx/ssl-access.log
+    nginx_error:
+      type: nginx_error
+  service:
+    pipelines:
+      nginx:
+        receivers:
+        - nginx_access
+        - nginx_error
+metrics:
+  receivers:
+    nginx:
+      type: nginx
+      stub_status_url: http://127.0.0.1:80/status
+  service:
+    pipelines:
+      nginx:
+        receivers:
+        - nginx

--- a/daisy_workflows/build-publish/rhui/cds_artifacts/status.nginx.conf
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/status.nginx.conf
@@ -1,0 +1,13 @@
+# A status handler; used by Ops Agent.
+# https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+
+server {
+   listen 80;
+   server_name 127.0.0.1;
+   allow 127.0.0.1;
+   deny all;
+   location /status {
+       stub_status on;
+       access_log off;
+   }
+}

--- a/daisy_workflows/build-publish/rhui/health_check.nginx.conf
+++ b/daisy_workflows/build-publish/rhui/health_check.nginx.conf
@@ -3,5 +3,6 @@ server {
   location / {
     root   /usr/share/nginx/html;
     index  google_rhui_health_check.txt;
+    access_log off;
   }
 }

--- a/daisy_workflows/build-publish/rhui/install_cds.sh
+++ b/daisy_workflows/build-publish/rhui/install_cds.sh
@@ -100,6 +100,9 @@ cd $tempdir
 curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
 bash ./add-google-cloud-ops-agent-repo.sh --also-install --remove-repo
 cd /
+install -m 664 -T $tempdir/config.opsagent.yaml /etc/google-cloud-ops-agent/config.yaml
+# Status handler is used by the ops agent to collect nginx metrics.
+install -m 664 -t /etc/nginx/conf.d $tempdir/status.nginx.conf
 
 # Delete installer resources.
 rm -rf $tempdir


### PR DESCRIPTION
This configures the Ops Agent to collect logs and metrics from nginx on the CDS node. I followed the [ops agent onboarding guide for nginx](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx), with a couple of changes:

1. The access logs for client traffic are stored in  `/var/log/nginx/ssl-access.log`
2. I disabled all access to port `80`, except when the connection is from localhost.

## Testing

Manually applied these changes to a CDS image in my testing project, and confirmed that the access logs, error logs, and metrics were propagated to cloud ops.