### PR TITLE
CDS: Collect nginx metrics and logs

### DIFF
--- a/daisy_workflows/build-publish/rhui/cds.wf.json
+++ b/daisy_workflows/build-publish/rhui/cds.wf.json
@@ -29,6 +29,7 @@
     "cds_artifacts/rhui.crt": "${tls_cert_path}",
     "cds_artifacts/health_check.py": "./health_check.py",
     "cds_artifacts/health_check.nginx.conf": "./health_check.nginx.conf",
+    "cds_artifacts/status.nginx.conf": "./status.nginx.conf",
     "install_cds.sh": "./install_cds.sh"
   },
   "Steps": {

--- a/daisy_workflows/build-publish/rhui/cds_artifacts/config.opsagent.yaml
+++ b/daisy_workflows/build-publish/rhui/cds_artifacts/config.opsagent.yaml
@@ -1,0 +1,26 @@
+# Config for Google Ops Agent to collect nginx logs and metrics.
+# https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+logging:
+  receivers:
+    nginx_access:
+      type: nginx_access
+      include_paths:
+      - /var/log/nginx/ssl-access.log
+    nginx_error:
+      type: nginx_error
+  service:
+    pipelines:
+      nginx:
+        receivers:
+        - nginx_access
+        - nginx_error
+metrics:
+  receivers:
+    nginx:
+      type: nginx
+      stub_status_url: http://127.0.0.1:80/status
+  service:
+    pipelines:
+      nginx:
+        receivers:
+        - nginx

--- a/daisy_workflows/build-publish/rhui/health_check.nginx.conf
+++ b/daisy_workflows/build-publish/rhui/health_check.nginx.conf
@@ -3,5 +3,6 @@ server {
   location / {
     root   /usr/share/nginx/html;
     index  google_rhui_health_check.txt;
+    access_log off;
   }
 }

--- a/daisy_workflows/build-publish/rhui/install_cds.sh
+++ b/daisy_workflows/build-publish/rhui/install_cds.sh
@@ -100,6 +100,9 @@ cd $tempdir
 curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
 bash ./add-google-cloud-ops-agent-repo.sh --also-install --remove-repo
 cd /
+install -m 664 -T $tempdir/config.opsagent.yaml /etc/google-cloud-ops-agent/config.yaml
+# Status handler is used by the ops agent to collect nginx metrics.
+install -m 664 -t /etc/nginx/conf.d $tempdir/status.nginx.conf
 
 # Delete installer resources.
 rm -rf $tempdir

--- a/daisy_workflows/build-publish/rhui/install_rhua.sh
+++ b/daisy_workflows/build-publish/rhui/install_rhua.sh
@@ -123,6 +123,9 @@ curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
 bash ./add-google-cloud-ops-agent-repo.sh --also-install --remove-repo
 yum clean all
 cd /
+install -m 664 -T $tempdir/config.opsagent.yaml /etc/google-cloud-ops-agent/config.yaml
+# Status handler is used by the ops agent to collect nginx metrics.
+install -m 664 -t /etc/nginx/conf.d $tempdir/status.nginx.conf
 
 # Delete installer resources.
 cp $tempdir/answers.yaml /root/.rhui/answers.yaml  # Expected to be found here.

--- a/daisy_workflows/build-publish/rhui/rhua.wf.json
+++ b/daisy_workflows/build-publish/rhui/rhua.wf.json
@@ -24,6 +24,7 @@
     "rhua_artifacts": "./rhua_artifacts",
     "rhua_artifacts/health_check.py": "./health_check.py",
     "rhua_artifacts/health_check.nginx.conf": "./health_check.nginx.conf",
+    "rhua_artifacts/status.nginx.conf": "./status.nginx.conf",
     "install_rhua.sh": "./install_rhua.sh"
   },
   "Steps": {

--- a/daisy_workflows/build-publish/rhui/rhua_artifacts/config.opsagent.yaml
+++ b/daisy_workflows/build-publish/rhui/rhua_artifacts/config.opsagent.yaml
@@ -1,0 +1,49 @@
+# Config for Google Ops Agent to collect nginx logs and metrics.
+# https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+#
+# Log file locations from:
+#   https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-config-files-status-codes-log-files
+logging:
+  receivers:
+    nginx_access:
+      type: nginx_access
+    nginx_error:
+      type: nginx_error
+    rhui_manager:
+      type: files
+      include_paths:
+      - /root/.rhui/rhui.log*
+    rhui_sync:
+      type: files
+      include_paths:
+      - /var/log/rhui-subscription-sync.log
+  processors:
+    # Extracts the timestamp to a structured field. Example message:
+    # 2022-06-10 17:30:01,964 - Successfully connected to [http://localhost:24817].
+    parse_rhui_log:
+      type: parse_regex
+      regex: "^(?<time>.*?) - (?<message>.*)$"
+      time_key: time
+      time_format: "%Y-%m-%d %H:%M:%S,%L"
+  service:
+    pipelines:
+      nginx:
+        receivers:
+        - nginx_access
+        - nginx_error
+      rhui:
+        receivers:
+        - rhui_manager
+        - rhui_sync
+        processors:
+        - parse_rhui_log
+metrics:
+  receivers:
+    nginx:
+      type: nginx
+      stub_status_url: http://127.0.0.1:80/status
+  service:
+    pipelines:
+      nginx:
+        receivers:
+        - nginx

--- a/daisy_workflows/build-publish/rhui/status.nginx.conf
+++ b/daisy_workflows/build-publish/rhui/status.nginx.conf
@@ -1,0 +1,13 @@
+# A status handler; used by Ops Agent.
+# https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/nginx
+
+server {
+   listen 80;
+   server_name 127.0.0.1;
+   allow 127.0.0.1;
+   deny all;
+   location /status {
+       stub_status on;
+       access_log off;
+   }
+}


### PR DESCRIPTION
This updates the RHUA and CDS images to include Cloud Ops configurations to collect the following logs:
1. nginx logs (CDS and RHUA)
2. rhui-manager logs (RHUA)
3. rhui-sync logs (RHUA)

For (2) and (3), it adds a processor that splits the log into structured fields.

## Testing

- Ran the configs on the CDS and RHUA nodes, and confirmed that the logs and metrics were sent to Cloud Ops. 
- Looked at the merge config from `journalctl`, and verified that the syslogs were still being collected (and verified in the Cloud Ops UI):

```
2022/06/10 17:43:12 Merged config:
logging:
  receivers:
    nginx_access:
      type: nginx_access
    nginx_error:
      type: nginx_error
    rhui_manager:
      type: files
      include_paths:
      - /root/.rhui/rhui.log*
    rhui_sync:
      type: files
      include_paths:
      - /var/log/rhui-subscription-sync.log
    syslog:
      type: files
      include_paths:
      - /var/log/messages
      - /var/log/syslog
  processors:
    parse_rhui_log:
      type: parse_regex
      time_key: time
      time_format: "%Y-%m-%d %H:%M:%S,%L"
      regex: ^(?<time>.*?) - (?<message>.*)$
  service:
    pipelines:
      default_pipeline:
        receivers: [syslog]
      nginx:
        receivers: [nginx_access, nginx_error]
      rhui:
        receivers: [rhui_manager, rhui_sync]
        processors: [parse_rhui_log]
metrics:
  receivers:
    hostmetrics:
      type: hostmetrics
      collection_interval: 60s
    nginx:
      type: nginx
      collection_interval: ""
      stub_status_url: http://127.0.0.1:80/status
  processors:
    metrics_filter:
      type: exclude_metrics
      metrics_pattern: []
  service:
    pipelines:
      default_pipeline:
        receivers: [hostmetrics]
        processors: [metrics_filter]
      nginx:
        receivers: [nginx]
        processors: []
```