### PR TITLE
gce_image_publish test fix

### DIFF
--- a/cli_tools/gce_image_publish/publish/publish_test.go
+++ b/cli_tools/gce_image_publish/publish/publish_test.go
@@ -787,7 +787,7 @@ func TestCreatePublishWithTemplate(t *testing.T) {
 		template string
 		wantErr  bool
 	}{
-		{"pass template", "{}", false},
+		{"pass template", `{"WorkProject": "blah"}`, false},
 		{"pass with invalid template", "{", true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This test only passes on GCE VMs coincidentally; update it to work with local invocation.

Before this PR:
```
+>>> go test -v -run TestCreatePublishWithTemplate
=== RUN   TestCreatePublishWithTemplate
=== RUN   TestCreatePublishWithTemplate/pass_template
    publish_test.go:797: CreatePublishWithTemplate() called with template {}: got error {}
        WorkProject unspecified
=== RUN   TestCreatePublishWithTemplate/pass_with_invalid_template
--- FAIL: TestCreatePublishWithTemplate (0.06s)
    --- FAIL: TestCreatePublishWithTemplate/pass_template (0.06s)
    --- PASS: TestCreatePublishWithTemplate/pass_with_invalid_template (0.00s)
FAIL
exit status 1
FAIL	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_image_publish/publish	0.202s
```

After this PR:
```
+>>> go test -v -run TestCreatePublishWithTemplate
=== RUN   TestCreatePublishWithTemplate
=== RUN   TestCreatePublishWithTemplate/pass_template
[""] Created a publish object successfully from {"WorkProject": "blah"}
=== RUN   TestCreatePublishWithTemplate/pass_with_invalid_template
--- PASS: TestCreatePublishWithTemplate (0.00s)
    --- PASS: TestCreatePublishWithTemplate/pass_template (0.00s)
    --- PASS: TestCreatePublishWithTemplate/pass_with_invalid_template (0.00s)
PASS
ok  	github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_image_publish/publish	0.141s
```