### PR TITLE
Add Windows 11 build/publish files

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -1,0 +1,46 @@
+{{/*
+  Template to publish Windows server UEFI images.
+  By default this template is setup to publish to the 'gce-image-builder'
+  project, the 'environment' variable can be used to publish to 'test', 'prod',
+  or 'staging'.
+  DeleteAfter is set to 180 days for all environments other than prod where no
+  time period is set.
+*/}}
+{
+  "Name": "windows-11-21h2-ent-x64-uefi",
+  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
+  {{$delete_after := `"24h*30*6"` -}}
+  {{if eq .environment "staging" -}}
+  "WorkProject": "bct-staging-images",
+  "PublishProject": "bct-staging-images",
+  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
+  "DeleteAfter": {{$delete_after}},
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "google.com:windows-internal",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- end}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
+  {{$time := trimPrefix .publish_version "v"}}
+  "Images": [
+    {
+      "Prefix": "windows-11-ent-x64",
+      "Family": "windows-11",
+      "Description": "Microsoft, Windows 11 Enterprise, 21h2 Update, x64 built on {{$time}}, supports Shielded VM features",
+      "Architecture": "X86_64",
+      "Licenses": [
+        {{if eq .environment "staging" -}}
+        "projects/windows-cloud/global/licenses/windows-11-x64-byol"
+        {{- else if eq .environment "internal" -}}
+        "projects/google.com:windows-internal/global/licenses/internal-windows"
+        {{- else -}}
+        "projects/windows-cloud/global/licenses/windows-11-x64-byol"
+        {{- end}}
+      ],
+      "GuestOsFeatures": {{$guest_features}}
+    }
+  ]
+}
+  

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -1,0 +1,78 @@
+{
+  "Name": "windows-11-21h2-ent-x64-uefi",
+  "Project": "gce-image-builder",
+  "Zone": "us-central1-b",
+  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "Vars": {
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "updates": {
+      "Required": true,
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "gcs_url": {
+      "Required": true,
+      "Description": "The GCS url that the image raw file exported to."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    }
+  },
+  "Steps": {
+    "build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json",
+        "Vars": {
+          "install_disk": "disk-install",
+          "updates": "${updates}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "media": "${media}",
+          "cloudsdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}"
+        }
+      }
+    },
+    "windows-export": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "./windows_export.wf.json",
+        "Vars": {
+          "build_date": "${build_date}",
+          "gcs_url": "${gcs_url}",
+          "workflow_root": "${workflow_root}"
+        }
+      }
+    }
+  },
+  "Dependencies": {
+    "windows-export": [
+      "build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -1,0 +1,113 @@
+{
+  "Name": "windows-11-21h2-ent-x64-uefi",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows 11 Enterprise 21h2, x64 built on ${TIMESTAMP}, supports Shielded VM features"
+    },
+    "family": {
+      "Value": "windows-11-21h2-ent-x64",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-11-21h2-ent-x64-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows 10 ENTERPRISE",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-11-x64-byol"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}


### PR DESCRIPTION
Adds support for building Windows 11 for internal/byol builds with Daisy. Not to be offered as official GCE image.