### PR TITLE
Update image name in Windows 10 21h2 publish file

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
@@ -26,7 +26,7 @@
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {
-      "Prefix": "windows-10-ent-x64",
+      "Prefix": "windows-10-21h2-ent-x64",
       "Family": "windows-10",
       "Description": "Microsoft, Windows 10 Enterprise, 21h2 Update, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",


### PR DESCRIPTION
Fixes a reference to an older image name used in testing that was changed later. This will resolve an error being seen in the publish stage where the image name differs from what is expected.