### PR TITLE
Update licenses attached to staging images (Windows Enterprise)

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
       "Architecture": "X86_64",
       "Licenses": [
         {{if eq .environment "staging" -}}
-        "projects/windows-cloud/global/licenses/windows-10-x64-byol"
+        "projects/bct-staging-functional/global/licenses/windows-ent"
         {{- else if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
       "Architecture": "X86_64",
       "Licenses": [
         {{if eq .environment "staging" -}}
-        "projects/windows-cloud/global/licenses/windows-11-x64-byol"
+        "projects/bct-staging-functional/global/licenses/windows-ent"
         {{- else if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
       "Architecture": "X86_64",
       "Licenses": [
         {{if eq .environment "staging" -}}
-        "projects/windows-cloud/global/licenses/windows-81-x64-byol"
+        "projects/bct-staging-functional/global/licenses/windows-ent"
         {{- else if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}


### PR DESCRIPTION
Staging uses a different set of licenses than in other environments. This updates the licenses on Windows Enterprise publish workflows in Daisy to reflect this difference.