### PR TITLE
Update windows client publish workflows

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
   "Images": [
     {
       "Prefix": "windows-10-21h2-ent-x64",
-      "Family": "windows-10",
+      "Family": "windows-10-21h2-x64",
       "Description": "Microsoft, Windows 10 Enterprise, 21h2 Update, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [

--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
@@ -16,9 +16,14 @@
   "PublishProject": "bct-staging-images",
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
-  {{- else -}}
+  {{if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "bct-prod-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
   "Images": [
     {
       "Prefix": "windows-11-ent-x64",
-      "Family": "windows-11-x64",
+      "Family": "windows-11-21h2-x64",
       "Description": "Microsoft, Windows 11 Enterprise, 21h2 Update, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
   "Images": [
     {
       "Prefix": "windows-11-ent-x64",
-      "Family": "windows-11",
+      "Family": "windows-11-x64",
       "Description": "Microsoft, Windows 11 Enterprise, 21h2 Update, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -16,9 +16,14 @@
   "PublishProject": "bct-staging-images",
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
-  {{- else -}}
+  {{if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "bct-prod-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
@@ -16,9 +16,14 @@
   "PublishProject": "bct-staging-images",
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
-  {{- else -}}
+  {{if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "bct-prod-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
@@ -32,7 +32,7 @@
   "Images": [
     {
       "Prefix": "windows-81-ent-x64",
-      "Family": "windows-81",
+      "Family": "windows-8-1-x64",
       "Description": "Microsoft, Windows 8.1 Enterprise, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [


### PR DESCRIPTION
Reworks the logic in the publish workflow to add the testing environment, allowing for publishing to bct-prod, which was missing in the original push adding the workflows. This is needed for integration tests; also matches the logic of other publish files. Also updates image families to match those of previous iterations for consistency.