### PR TITLE
Update windows client publish file environment logic

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
@@ -16,7 +16,7 @@
   "PublishProject": "bct-staging-images",
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
-  {{if eq .environment "internal" -}}
+  {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
   "ComputeEndpoint": {{$endpoint}},

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -16,7 +16,7 @@
   "PublishProject": "bct-staging-images",
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
-  {{if eq .environment "internal" -}}
+  {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
   "ComputeEndpoint": {{$endpoint}},

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
@@ -16,7 +16,7 @@
   "PublishProject": "bct-staging-images",
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
-  {{if eq .environment "internal" -}}
+  {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
   "ComputeEndpoint": {{$endpoint}},


### PR DESCRIPTION
Fixes missing "- else" from client publish files that would result in unexpected EOF issues in publish process.