### PR TITLE
Update image family for Windows 11 21h2

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -31,7 +31,7 @@
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {
-      "Prefix": "windows-11-ent-x64",
+      "Prefix": "windows-11-21h2-ent-x64",
       "Family": "windows-11-21h2-x64",
       "Description": "Microsoft, Windows 11 Enterprise, 21h2 Update, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",


### PR DESCRIPTION
This will make the naming less confusing for future iterations of Win11.