### PR TITLE
fix more typos in partner workflows

### DIFF
--- a/daisy_workflows/build-publish/partner/freebsd_11.publish.json
+++ b/daisy_workflows/build-publish/partner/freebsd_11.publish.json
@@ -14,8 +14,8 @@
     {
       "Prefix": "freebsd-11",
       "Family": "freebsd-11",
-      "Description": "FreeBSD 11.0"
       "Architecture": "X86_64",
+      "Description": "FreeBSD 11.0"
     }
   ]
 }

--- a/daisy_workflows/build-publish/partner/freebsd_12.publish.json
+++ b/daisy_workflows/build-publish/partner/freebsd_12.publish.json
@@ -14,8 +14,8 @@
     {
       "Prefix": "freebsd-12",
       "Family": "freebsd-12",
-      "Description": "FreeBSD 12.0"
       "Architecture": "X86_64",
+      "Description": "FreeBSD 12.0"
     }
   ]
 }

--- a/daisy_workflows/build-publish/partner/freebsd_13.publish.json
+++ b/daisy_workflows/build-publish/partner/freebsd_13.publish.json
@@ -14,8 +14,8 @@
     {
       "Prefix": "freebsd-13",
       "Family": "freebsd-13",
-      "Description": "FreeBSD 13.0"
       "Architecture": "X86_64",
+      "Description": "FreeBSD 13.0"
     }
   ]
 }

--- a/daisy_workflows/build-publish/partner/opensuse_leap_15.publish.json
+++ b/daisy_workflows/build-publish/partner/opensuse_leap_15.publish.json
@@ -14,8 +14,8 @@
     {
       "Prefix": "opensuse-leap-15",
       "Family": "opensuse-leap-15",
-      "Description": "openSUSE Leap 15"
       "Architecture": "X86_64",
+      "Description": "openSUSE Leap 15"
     }
   ]
 }

--- a/daisy_workflows/build-publish/partner/opensuse_leap_15_arm64.publish.json
+++ b/daisy_workflows/build-publish/partner/opensuse_leap_15_arm64.publish.json
@@ -14,8 +14,8 @@
     {
       "Prefix": "opensuse-leap-15-arm64",
       "Family": "opensuse-leap-15-arm64",
-      "Description": "openSUSE Leap 15",
       "Architecture": "ARM64",
+      "Description": "openSUSE Leap 15"
     }
   ]
 }


### PR DESCRIPTION
it was my fault for assuming these were already in working order. `gce_image_publish` is strict about json, so final elements must not end in a comma.