### PR TITLE
Renaming SSMS variable in SQL 22 publish file

### DIFF
--- a/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022-dc.wf.json
@@ -26,7 +26,7 @@
       "Value": "windows-cloud",
       "Description": "Project to source base image from."
     },
-    "ssms_exe": {
+    "ssms22_exe": {
       "Required": true,
       "Description": "GCS or local path to SSMS installer"
     },
@@ -46,7 +46,7 @@
           "publish_project": "${publish_project}",
           "sql_server_media": "${sql_server_media}",
           "source_image_project": "${source_image_project}",
-          "ssms_exe": "${ssms_exe}",
+          "ssms22_exe": "${ssms22_exe}",
           "timeout": "${timeout}"
         }
       }


### PR DESCRIPTION
Microsoft is moving away from a universal installer, so each version going forward may have their own SSMS installer version. We're going to have to start naming these to account for pulling/using the correct secrets in Concourse.

This change is a precondition for upcoming changes to the Concourse pipeline; nonbreaking as this currently is not used.