### PR TITLE
Add gvnic support to SQL Server Images

### DIFF
--- a/daisy_workflows/build-publish/sqlserver/sql-2012-enterprise-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2012-enterprise-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2012-standard-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2012-standard-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2012-web-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2012-web-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2022-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2012-r2-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2022-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2016-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2022-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2022-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2022-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2019-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2022-dc-uefi.publish.json
@@ -32,7 +32,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022-dc-uefi.publish.json
@@ -23,7 +23,7 @@
   "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","WINDOWS"]` -}}
+  {{$guest_features := `["MULTI_IP_SUBNET","UEFI_COMPATIBLE","VIRTIO_SCSI_MULTIQUEUE","GVNIC","WINDOWS"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {


### PR DESCRIPTION
Turns out they were never tagged for it, so let's fix that. gvnic is supported on all Server OSes running SQL Server, so this shouldn't be a problem.