### PR TITLE
pin rhui package versions

### DIFF
--- a/daisy_workflows/build-publish/rhui/install_cds.sh
+++ b/daisy_workflows/build-publish/rhui/install_cds.sh
@@ -69,7 +69,8 @@ subscription-manager repos --enable=rhui-4-for-rhel-8-x86_64-rpms
 # The patch skips actually mounting NFS (update fstab only), makes backups of
 # files from rhui-tools, and skips generating unique RHUI and CA certs, instead
 # copying our pre-generated certs.
-dnf install -y rhui-tools patch
+# TODO: temporarily pin version to match patch.
+dnf install -y rhui-tools-4.1.0.6-1.el8ui patch
 ( cd /usr/share/rhui-tools; patch -b -p1 < $tempdir/cds.patch; )
 
 build_status "Run Ansible playbook."

--- a/daisy_workflows/build-publish/rhui/install_rhua.sh
+++ b/daisy_workflows/build-publish/rhui/install_rhua.sh
@@ -76,7 +76,8 @@ subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rhui-rpms
 # Get rhui-installer and patch Ansible playbook
 # The patch skips actually mounting NFS (update fstab only), and skips
 # generating a unique RHUA cert, instead copying our pre-generated cert.
-dnf install -y rhui-installer patch
+# TODO: temporarily pin version to match patch.
+dnf install -y rhui-installer-4.1.0.4-1.el8ui patch
 ( cd /usr/share/rhui-installer; patch -b -p0 < $tempdir/rhua.patch; )
 
 # We don't use rhui-installer as it doesn't allow us to extend the answers file


### PR DESCRIPTION
The original design for RHUI node image builds was to install content from repo, but patch it before use. This has become unmaintainable because the content of the Ansible playbooks changes frequently. As a temporary measure, pin the version to the version corresponding to the patch file.