### PR TITLE
Update post_install.ps1 to skip KB5007651

### DIFF
--- a/daisy_workflows/image_build/windows/post_install.ps1
+++ b/daisy_workflows/image_build/windows/post_install.ps1
@@ -182,6 +182,18 @@ function Install-WindowsUpdates {
     }
   }
 
+  # Windows 11 may get stuck installing KB5007651. $pn for Windows 11 reports as Win 10 Enterprise.
+  # This is an intended behavior by Microsoft for backwards compatibility.
+  # As such we skip the KB here instead of trying to target by $pn.
+  if ($updates.Count -eq 1) {
+    foreach ($update in $updates) {
+      if ($update.Title -like '*KB5007651*') {
+        Write-Host 'Install-WindowsUpdates: KB5007651 detected as a single update remaining. Skipping known issue KB.'
+        return $false
+      }
+    }
+  }      
+
   foreach ($update in $updates) {
     if (-not ($update.EulaAccepted)) {
       Write-Host 'The following update required a EULA to be accepted:'

--- a/daisy_workflows/image_build/windows/post_install.ps1
+++ b/daisy_workflows/image_build/windows/post_install.ps1
@@ -189,11 +189,12 @@ function Install-WindowsUpdates {
     $productMajorVersion = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentMajorVersionNumber).CurrentMajorVersionNumber
     $productMinorVersion = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentMinorVersionNumber).CurrentMinorVersionNumber
     $productBuildNumber = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentBuildNumber).CurrentBuildNumber
-    if($productMajorVersion -eq 10 -and $productMinorVersion -eq 0 -and $productBuildNumber -ge 22000)
-    foreach ($update in $updates) {
-      if ($update.Title -like '*KB5007651*') {
-        Write-Host 'Install-WindowsUpdates: KB5007651 detected as a single update remaining. Skipping known issue KB.'
-        return $false
+    if($productMajorVersion -eq 10 -and $productMinorVersion -eq 0 -and $productBuildNumber -ge 22000) {
+      foreach ($update in $updates) {
+        if ($update.Title -like '*KB5007651*') {
+          Write-Host 'Install-WindowsUpdates: KB5007651 detected as a single update remaining. Skipping known issue KB.'
+          return $false
+        }
       }
     }
   }      

--- a/daisy_workflows/image_build/windows/post_install.ps1
+++ b/daisy_workflows/image_build/windows/post_install.ps1
@@ -186,6 +186,10 @@ function Install-WindowsUpdates {
   # This is an intended behavior by Microsoft for backwards compatibility.
   # As such we skip the KB here instead of trying to target by $pn.
   if ($updates.Count -eq 1) {
+    $productMajorVersion = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentMajorVersionNumber).CurrentMajorVersionNumber
+    $productMinorVersion = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentMinorVersionNumber).CurrentMinorVersionNumber
+    $productBuildNumber = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentBuildNumber).CurrentBuildNumber
+    if($productMajorVersion -eq 10 -and $productMinorVersion -eq 0 -and $productBuildNumber -ge 22000)
     foreach ($update in $updates) {
       if ($update.Title -like '*KB5007651*') {
         Write-Host 'Install-WindowsUpdates: KB5007651 detected as a single update remaining. Skipping known issue KB.'


### PR DESCRIPTION
This update has appeared in the past and hangs up the build on an update loop. Updated Install-WindowsUpdates to skip it.