### PR TITLE
test image build: move global volumes to local

### DIFF
--- a/prowjobs_cloudbuild.yaml
+++ b/prowjobs_cloudbuild.yaml
@@ -4,15 +4,15 @@ options:
   env:
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
+
+steps:
+- id: gce-windows-upgrade-tests
+  name: 'gcr.io/kaniko-project/executor:v0.22.0'
   volumes:
   - name: go-pkg
     path: /go/pkg
   - name: go-src
     path: /go/src
-
-steps:
-- id: gce-windows-upgrade-tests
-  name: 'gcr.io/kaniko-project/executor:v0.22.0'
   args:
   - --destination=gcr.io/$PROJECT_ID/gce-windows-upgrade-tests:latest
   - --destination=gcr.io/$PROJECT_ID/gce-windows-upgrade-tests:$COMMIT_SHA


### PR DESCRIPTION
global volume is not allowed when count of steps < 2