### PR TITLE
Remove staging environment from publish files

### DIFF
--- a/daisy_workflows/build-publish/sqlserver/sql-2012-enterprise-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2012-enterprise-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2012-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2012-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2012-standard-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2012-standard-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2012 Standard, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2012-standard",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2012-standard",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2012-web-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2012-web-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2012 Web, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2012-web",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2012-web",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2014 Enterprise, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2014-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2014-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2014 Enterprise, on Windows Server 2016 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2014-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2014-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2016-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2014 Standard, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2014-standard",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2014-standard",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2014 Web, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2014-web",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2014-web",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2016 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2016-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2019 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2019-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-standard",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-standard",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-standard",
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-standard",
         "projects/windows-cloud/global/licenses/windows-server-2016-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2019 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-standard",
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-standard",
         "projects/windows-cloud/global/licenses/windows-server-2019-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2012 R2 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-web",
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-web",
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2016 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-web",
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-web",
         "projects/windows-cloud/global/licenses/windows-server-2016-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2019 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2016-web",
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2016-web",
         "projects/windows-cloud/global/licenses/windows-server-2019-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2016 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2017-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2017-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2016-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019-dc-uefi.publish.json
@@ -21,11 +21,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-sql-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": {{$work_project}},
@@ -41,13 +36,8 @@
       "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2019 Datacenter, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/sql-server-2017-enterprise",
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc"
-        {{- else -}}
         "projects/windows-sql-cloud/global/licenses/sql-server-2017-enterprise",
         "projects/windows-cloud/global/licenses/windows-server-2019-dc"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2004-dc-core-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2004-dc-core-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "bct-prod-images",
@@ -35,13 +30,8 @@
       "Description": "Microsoft, Windows Server, version 2004 Datacenter Core, Server Core, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2004-dc",
-        "projects/bct-staging-functional/global/licenses/windows-server-core"
-        {{- else -}}
         "projects/windows-cloud/global/licenses/windows-server-2004-dc",
         "projects/windows-cloud/global/licenses/windows-server-core"
-        {{- end}}
       ],
       "GuestOsFeatures": {{$guest_features}}
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,10 +35,7 @@
       "Description": "Microsoft, Windows Server, 2012 R2 Datacenter Core, Server Core, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc",
-        "projects/bct-staging-functional/global/licenses/windows-server-core"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows",
         "projects/windows-cloud/global/licenses/windows-server-core"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,9 +35,7 @@
       "Description": "Microsoft, Windows Server, 2012 R2 Datacenter, Server with Desktop Experience, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2012-r2-dc"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}
         "projects/windows-cloud/global/licenses/windows-server-2012-r2-dc"

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,10 +35,7 @@
       "Description": "Microsoft, Windows Server, 2016 Datacenter Core, Server Core, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc",
-        "projects/bct-staging-functional/global/licenses/windows-server-core"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows",
         "projects/windows-cloud/global/licenses/windows-server-core"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,9 +35,7 @@
       "Description": "Microsoft, Windows Server, 2016 Datacenter, Server with Desktop Experience, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2016-dc"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}
         "projects/windows-cloud/global/licenses/windows-server-2016-dc"

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,10 +35,7 @@
       "Description": "Microsoft, Windows Server, 2019 Datacenter Core, Server Core, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc",
-        "projects/bct-staging-functional/global/licenses/windows-server-core"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows",
         "projects/windows-cloud/global/licenses/windows-server-core"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,9 +35,7 @@
       "Description": "Microsoft, Windows Server, 2019 Datacenter, Server with Desktop Experience, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}
         "projects/windows-cloud/global/licenses/windows-server-2019-dc"

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,10 +35,7 @@
       "Description": "Microsoft, Windows Server, 2022 Datacenter Core, Server Core, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2022-dc",
-        "projects/bct-staging-functional/global/licenses/windows-server-core"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows",
         "projects/windows-cloud/global/licenses/windows-server-core"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,9 +35,7 @@
       "Description": "Microsoft, Windows Server, 2022 Datacenter, Server with Desktop Experience, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-2022-dc"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}
         "projects/windows-cloud/global/licenses/windows-server-2022-dc"

--- a/daisy_workflows/build-publish/windows/windows-server-20h2-dc-core-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-server-20h2-dc-core-uefi.publish.json
@@ -15,11 +15,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "oslogin-staging-project",
-  "PublishProject": "gce-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -40,10 +35,7 @@
       "Description": "Microsoft, Windows Server, version 20H2 Datacenter Core, Server Core, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-server-20h2-dc",
-        "projects/bct-staging-functional/global/licenses/windows-server-core"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows",
         "projects/windows-cloud/global/licenses/windows-server-core"
         {{- else -}}

--- a/daisy_workflows/build-publish/windows_container/windows-server-2019-dc-for-containers-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows_container/windows-server-2019-dc-for-containers-uefi.publish.json
@@ -18,11 +18,6 @@
   "WorkProject": {{$work_project}},
   "PublishProject": "windows-cloud",
   "ComputeEndpoint": {{$endpoint}},
-  {{- else if eq .environment "staging" -}}
-  "WorkProject": "bct-staging-images",
-  "PublishProject": "bct-staging-images",
-  "ComputeEndpoint": "https://www.googleapis.com/compute/staging_alpha/projects/",
-  "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "internal" -}}
   "WorkProject": {{$work_project}},
   "PublishProject": "google.com:windows-internal",
@@ -43,10 +38,7 @@
       "Description": "Microsoft, Windows Server, 2019 Datacenter for Containers, x64 built on {{$time}}, supports Shielded VM features",
       "Architecture": "X86_64",
       "Licenses": [
-        {{if eq .environment "staging" -}}
-        "projects/bct-staging-functional/global/licenses/windows-for-containers",
-        "projects/bct-staging-functional/global/licenses/windows-server-2019-dc"
-        {{- else if eq .environment "internal" -}}
+        {{if eq .environment "internal" -}}
         "projects/google.com:windows-internal/global/licenses/internal-windows"
         {{- else -}}
         "projects/windows-cloud/global/licenses/windows-for-containers",


### PR DESCRIPTION
Reflecting changes to the pipeline where staging environment is no longer used. client builds are handled in a different PR adding some functionality, so they were left out here.