### PR TITLE
correct RHUI publish prefix

### DIFF
--- a/daisy_workflows/build-publish/rhui/cds.publish.json
+++ b/daisy_workflows/build-publish/rhui/cds.publish.json
@@ -16,12 +16,11 @@
   "Images": [
     {
       {{if eq .environment "test" -}}
-      "Family": "cds-testing",
       "Prefix": "cds-testing",
       {{- else -}}
       "Family": "cds",
-      "Prefix": "cds",
       {{- end}}
+      "Prefix": "cds",
       "Description": "Content Delivery Server node image, built {{$time}}",
       "Architecture": "X86_64",
       "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"]

--- a/daisy_workflows/build-publish/rhui/rhua.publish.json
+++ b/daisy_workflows/build-publish/rhui/rhua.publish.json
@@ -17,11 +17,10 @@
     {
       {{- if eq .environment "test" -}}
       "Family": "rhua-testing",
-      "Prefix": "rhua-testing",
       {{- else -}}
       "Family": "rhua",
-      "Prefix": "rhua",
       {{- end}}
+      "Prefix": "rhua",
       "Description": "RedHat Update Appliance node image, built {{$time}}",
       "Architecture": "X86_64",
       "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"]


### PR DESCRIPTION
Restore prefix fields. Had set prefix to differ to avoid any race conditions with publishing, but realized this parameter serves a double purpose in specifying the GCS path. 