### PR TITLE
Update sql2022 install parameters

### DIFF
--- a/daisy_workflows/image_build/sqlserver/configs/sql_server_2022.ini
+++ b/daisy_workflows/image_build/sqlserver/configs/sql_server_2022.ini
@@ -55,7 +55,7 @@ UpdateSource="MU"
 
 ; Specifies features to install, uninstall, or upgrade. The list of top-level features include SQL, AS, IS, MDS, and Tools. The SQL feature will install the Database Engine, Replication, Full-Text, and Data Quality Services (DQS) server. The Tools feature will install shared components. 
 
-FEATURES=SQLENGINE,REPLICATION,DQ,AS,IS,SNAC_SDK,Tools
+FEATURES=SQLENGINE,REPLICATION,DQ,AS,IS,Tools
 
 ; Displays the command line parameters usage. 
 


### PR DESCRIPTION
SNAC_SDK became an invalid feature option in the latest RC, blocking install. Removing it to allow installs to continue.