### PR TITLE
Add daisy workflows for SQL Server 2022 release versions

### DIFF
--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019-dc.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-enterprise-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-enterprise-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-enterprise-windows-2019-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-enterprise-windows-2019-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2019-standard",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022-dc.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-enterprise-windows-2022-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-enterprise-windows-2022-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2022",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-enterprise-windows-2022-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-enterprise-windows-2022-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-enterprise"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2022-standard",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2019",
+          "Family": "sql-std-2022-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-standard-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-standard-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-standard-windows-2019-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-standard-windows-2019-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2019-standard",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2019-standard",
+          "Family": "sql-std-2022-win-2019-standard",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022",
+          "Family": "sql-std-2022-win-2022",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-standard-windows-2022-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-standard-windows-2022-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2022",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-standard-windows-2022-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-standard-windows-2022-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-standard"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2022-standard",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022-standard",
+          "Family": "sql-std-2022-win-2022-standard",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019-dc.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-web-windows-2019-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-web-windows-2019-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-web"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2019",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019-dc.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2019",
+          "Family": "sql-web-2022-win-2019",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-web-windows-2019-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-web-windows-2019-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-web"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2019-standard",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2019-standard",
+          "Family": "sql-web-2022-win-2019-standard",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022-dc.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022",
+          "Family": "sql-web-2022-win-2022",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022-dc.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-web-windows-2022-dc-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-web-windows-2022-dc-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-web"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2022",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022.wf.json
@@ -46,7 +46,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022-standard",
+          "Family": "sql-web-2022-win-2022-standard",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022.wf.json
@@ -1,0 +1,60 @@
+{
+  "Name": "sql-2022-web-windows-2022-image-build",
+  "Vars": {
+    "build_date": "${TIMESTAMP}",
+    "install_disk": "disk-install",
+    "publish_project": "${PROJECT}",
+    "sql_server_media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows installer media"
+    },
+    "source_image_project": {
+      "Value": "windows-cloud",
+      "Description": "Project to source base image from."
+    },
+    "ssms_exe": {
+      "Required": true,
+      "Description": "GCS or local path to SSMS installer"
+    },
+    "timeout": {
+      "Value": "2h",
+      "Description": "The timeout to set for the image build."
+    }
+  },
+  "Steps": {
+    "build-sql-image": {
+      "TimeOut": "${timeout}",
+      "IncludeWorkflow": {
+        "Path": "./sqlserver.wf.json",
+        "Vars": {
+          "sql_server_config": "./configs/sql_server_2022.ini",
+          "sql_server_media": "${sql_server_media}",
+          "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
+          "install_disk": "${install_disk}",
+          "ssms_exe": "${ssms_exe}",
+          "timeout": "${timeout}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "sql-2022-web-windows-2022-v${build_date}",
+          "SourceDisk": "${install_disk}",
+          "Licenses": [
+            "projects/windows-sql-cloud/global/licenses/sql-server-2022-web"
+          ],
+          "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
+          "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
+          "Family": "sql-ent-2022-win-2022-standard",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-sql-image"]
+  }
+}


### PR DESCRIPTION
Including 2022 and 2019 Windows Server builds. Evaluating 2016 in future PR. Leverages existing workflows used for preview builds, adjusted for actual release candidate versions.