### PR TITLE
Revert the debian worker image for disk_export due to a potential race

### DIFF
--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -14,7 +14,7 @@
       "Description": "list of GCE licenses to record in the exported image"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-11-worker",
+      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {


### PR DESCRIPTION
in disk enumeration in Debian 11.