### PR TITLE
remove run_sbom_bool, avoid sbom generation on EL9 until debian worke…

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_9.wf.json
@@ -23,14 +23,6 @@
     "installer_iso": {
       "Required": true,
       "Description": "The AlmaLinux 9 installer ISO to build from."
-    },
-    "run_sbom_bool": {
-      "Value": "false",
-      "Description": "Determines if the SBOM for the image will be generated."
-    },
-    "syft_source": {
-      "Value": "",
-      "Description": "Source url for the syft tar gz file, required if run_sbom_bool=true."
     }
   },
   "Steps": {
@@ -52,9 +44,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
-          "source_disk": "disk-almalinux-9",
-          "run_sbom_bool": "${run_sbom_bool}",
-          "syft_source": "${syft_source}"
+          "source_disk": "disk-almalinux-9"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
@@ -23,6 +23,10 @@
     "installer_iso": {
       "Required": true,
       "Description": "The CentOS 7 installer ISO to build from."
+    },
+    "syft_source": {
+      "Value": "",
+      "Description": "Source url for the syft tar gz file."
     }
   },
   "Steps": {
@@ -44,7 +48,8 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
-          "source_disk": "disk-centos-7"
+          "source_disk": "disk-centos-7",
+          "syft_source": "${syft_source}"
         }
       }
     },

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -37,13 +37,9 @@
       "Value": "default",
       "Description": "Service account that will be used by the created worker instance"
     },
-    "run_sbom_bool": {
-      "Value": "false",
-      "Description": "Flag for whether or not to run sbom generation, false by default"
-    },
     "syft_source": {
       "Value": "",
-      "Description": "the source url for syft, required if run_sbom_bool=true"
+      "Description": "the source url for syft"
     }
   },
   "Sources": {
@@ -73,9 +69,9 @@
             "licenses": "${licenses}",
             "sbom-path": "${OUTSPATH}/sbom.json",
             "startup-script": "${SOURCE:${NAME}_export_disk.sh}",
-            "run_sbom_bool": "${run_sbom_bool}",
             "sbom-script": "${SOURCESPATH}/sbom-script.sh",
-            "syft-source": "${SOURCESPATH}/syft.tar.gz"
+            "syft-tar-file": "${SOURCESPATH}/syft.tar.gz",
+            "syft-source": "${syft_source}"
           },
           "networkInterfaces": [
             {

--- a/image_test/sbom/enterprise_sbom_test.wf.json
+++ b/image_test/sbom/enterprise_sbom_test.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "export-almalinux-9",
+  "Name": "export-centos-7-test",
   "Zone": "us-central1-b",
   "Vars": {
     "workflow_root": {
@@ -7,7 +7,7 @@
       "Description": "Root of workflows, should be set to parent of the export directory."
     },
     "syft_source": {
-      "Value": ".",
+      "Required": true,
       "Description": "the source url for syft, required because this is a test for sbom generation"
     }
   },
@@ -19,7 +19,7 @@
       "CreateDisks": [
         {
           "Name": "disk-export",
-          "SourceImage": "projects/almalinux-cloud/global/images/family/almalinux-9",
+          "SourceImage": "projects/centos-cloud/global/images/family/centos-7",
           "Type": "pd-ssd"
         }
       ]
@@ -30,7 +30,6 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${OUTSPATH}/disk_export.tar.gz",
-          "run_sbom_bool": "true",
           "source_disk": "disk-export",
           "syft_source": "${syft_source}"
         }
@@ -40,7 +39,7 @@
       "CreateDisks": [
         {
           "Name": "disk-test",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
           "Type": "pd-ssd"
         }
       ]


### PR DESCRIPTION
Due to an issue in the worker, Almalinux 9 SBOM generation will not be supported for the time being. Centos 7 will instead be used for provisional SBOM generation changes.

Also, the daisy workflow variable "run_sbom_bool" will be removed so that providing a syft source url is enough to generate an SBOM. 
