### PR TITLE
Use disk export subworkflow in Debian 10

### DIFF
--- a/daisy_workflows/build-publish/debian/debian_10.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_10.wf.json
@@ -22,7 +22,7 @@
     },
     "syft_source": {
       "Value": "",
-      "Description": "Source url for the syft tar gz file, required only if generating SBOM."
+      "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
     }
   },
   "Steps": {

--- a/daisy_workflows/build-publish/debian/debian_10.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_10.wf.json
@@ -19,6 +19,10 @@
     "gcs_url": {
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
+    },
+    "syft_source": {
+      "Value": "",
+      "Description": "Source url for the syft tar gz file, required only if generating SBOM."
     }
   },
   "Steps": {
@@ -41,13 +45,16 @@
         }
       ]
     },
-    "copy-to-destination": {
-      "CopyGCSObjects": [
-        {
-          "Source": "${OUTSPATH}/root.tar.gz",
-          "Destination": "${gcs_url}"
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "source_disk": "disk-debian-10",
+          "syft_source": "${syft_source}"
         }
-      ]
+      }
     },
     "cleanup-image": {
       "DeleteResources": {
@@ -57,7 +64,7 @@
   },
   "Dependencies": {
     "create-disk": ["build"],
-    "copy-to-destination": ["build"],
-    "cleanup-image": ["create-disk"]
+    "export-image": ["create-disk"],
+    "cleanup-image": ["export-image"]
   }
 }

--- a/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
@@ -26,7 +26,7 @@
     },
     "syft_source": {
       "Value": "",
-      "Description": "Source url for the syft tar gz file."
+      "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
     }
   },
   "Steps": {


### PR DESCRIPTION
To enable SBOM generation for debian 10 and ensure debian workflow consistency with other workflows such as Enterprise Linux, debian 10 build-publish will use the disk export subworkflow.

It would be useful to have confirmation from someone more familiar with these workflows that replacing "CopyGCSObjects" with "disk_export.wf.json" maintains the same export behavior.