### PR TITLE
export-metadata: regex and case sensitive match Version Source

### DIFF
--- a/daisy_workflows/export_metadata/export-metadata.ps1
+++ b/daisy_workflows/export_metadata/export-metadata.ps1
@@ -51,10 +51,10 @@ function Export-ImageMetadata {
             # Get Package Info for each package
             $info = & 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' 'installed' '-info' $name
             foreach ($line in $info) {
-                if ($line -match "Version") {
+                if ($line -cmatch "^Version") {
                     $version = $line.Split(":")[1].Trim()
                 }
-                if ($line -match "Source") {
+                if ($line -cmatch "^Source") {
                     $source = $line.Split(":")
                     $source = [String]::Concat($source[1..$source.length]).Trim()
                 }


### PR DESCRIPTION
Turns out that for some cases where the change log contains the keywords we'll end up parsing the wrong lines and using wong strings.