### PR TITLE
SBOM and disk export changes to debian 11

### DIFF
--- a/daisy_workflows/build-publish/debian/debian_11.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_11.wf.json
@@ -19,6 +19,10 @@
     "gcs_url": {
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
+    },
+    "syft_source": {
+      "Value": "",
+      "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
     }
   },
   "Steps": {
@@ -41,13 +45,16 @@
         }
       ]
     },
-    "copy-to-destination": {
-      "CopyGCSObjects": [
-        {
-          "Source": "${OUTSPATH}/root.tar.gz",
-          "Destination": "${gcs_url}"
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "source_disk": "disk-debian-11",
+          "syft_source": "${syft_source}"
         }
-      ]
+      }
     },
     "cleanup-image": {
       "DeleteResources": {
@@ -57,7 +64,7 @@
   },
   "Dependencies": {
     "create-disk": ["build"],
-    "copy-to-destination": ["build"],
-    "cleanup-image": ["create-disk"]
+    "export-image": ["create-disk"],
+    "cleanup-image": ["export-image"]
   }
 }

--- a/daisy_workflows/build-publish/debian/debian_11_arm64.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_11_arm64.wf.json
@@ -18,6 +18,10 @@
     "gcs_url": {
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
+    },
+    "syft_source": {
+      "Value": "",
+      "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
     }
   },
   "Steps": {
@@ -40,13 +44,16 @@
         }
       ]
     },
-    "copy-to-destination": {
-      "CopyGCSObjects": [
-        {
-          "Source": "${OUTSPATH}/root.tar.gz",
-          "Destination": "${gcs_url}"
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "source_disk": "disk-debian-11",
+          "syft_source": "${syft_source}"
         }
-      ]
+      }
     },
     "cleanup-image": {
       "DeleteResources": {
@@ -56,7 +63,7 @@
   },
   "Dependencies": {
     "create-disk": ["build"],
-    "copy-to-destination": ["build"],
-    "cleanup-image": ["create-disk"]
+    "export-image": ["create-disk"],
+    "cleanup-image": ["export-image"]
   }
 }


### PR DESCRIPTION
Use disk export in debian 11, and add SBOM generation support. 

Identical changes to #2046 but for the other build-publish debian workflows. 