### PR TITLE
kcq: don't export upstream kernel patches for Changelog analysis

### DIFF
--- a/daisy_workflows/kernel_commit_query/kcq.py
+++ b/daisy_workflows/kernel_commit_query/kcq.py
@@ -171,16 +171,11 @@ class CommitQuery(object):
 
         catalog = self.__readCatalog()
         data = self.__getPatchesData(catalog)
-        upstream_chain = self.__exportPatches(write_patch=False)
 
         for curr_hash in data:
             curr_found = False
             curr = data[curr_hash]
             test_attrs = ['hash', 'subject', 'abbrev_hash']
-
-            if curr_hash in upstream_chain:
-                found.append(curr_hash)
-                continue
 
             for attr in test_attrs:
                 res = run(['grep', curr[attr], changelog_file], check=False,


### PR DESCRIPTION
Don't use the upstream exported patches for checking distribution's changelog and rely only on the git log's data.