### PR TITLE
Kernel Commit Query: fix kcq.py invocation from debian wrapper

### DIFF
--- a/daisy_workflows/kernel_commit_query/debian.sh
+++ b/daisy_workflows/kernel_commit_query/debian.sh
@@ -28,4 +28,4 @@ popd
 kernel_pkg=$(dpkg -S /boot/vmlinuz-`uname -r` | sed 's/:.*$//g')
 apt-get changelog $kernel_pkg > /files/kernel.changelog
 
-python3 kcq.py
+python3 /files/kcq.py


### PR DESCRIPTION
Given the wrapping around cloud build init_script environment the kcq.py script is not found in the same pwd.