### PR TITLE
Kernel Commit Query: extend time out to 40m

### DIFF
--- a/daisy_workflows/kernel_commit_query/kernel_commit_query.wf.json
+++ b/daisy_workflows/kernel_commit_query/kernel_commit_query.wf.json
@@ -1,6 +1,6 @@
 {
   "Name": "kernel-commit-query",
-  "DefaultTimeout": "30m",
+  "DefaultTimeout": "40m",
   "Vars": {
     "result_dest": {
       "Required": true,
@@ -81,7 +81,7 @@
       "WaitForInstancesSignal": [
         {
           "Name": "inst",
-          "Timeout": "15m",
+          "Timeout": "40m",
           "SerialOutput": {
             "Port": 1,
             "FailureMatch": "ExportFailed:",


### PR DESCRIPTION
Due to network connectivity we may take longer than 30m so extending it for now while we work on optimizations.