### PR TITLE
2016/2019 Upgrade script fixes.

### DIFF
--- a/daisy_workflows/image_build/windows/windows_install_media/components/2016_64Bit/upgrade.ps1
+++ b/daisy_workflows/image_build/windows/windows_install_media/components/2016_64Bit/upgrade.ps1
@@ -22,16 +22,18 @@
 function Find-ImageIndex {
     param (
         [parameter(Mandatory=$true)]
-        [string]$image_name
+        [string[]]$image_names
     )
 
     $images = Get-WindowsImage -ImagePath ./sources/install.wim
     foreach ($image in $images) {
-        if ($image.ImageName -eq $image_name) {
-            return $image.ImageIndex
+        foreach ($image_name in $image_names) {
+            if ($image.ImageName -eq $image_name) {
+                return $image.ImageIndex
+            }
         }
     }
-    $msg = 'No image is found from the installation media: '+$image_name
+    $msg = 'No image is found from the installation media: '+$image_names[0]
     throw $msg
 }
 

--- a/daisy_workflows/image_build/windows/windows_install_media/components/2019_64Bit/upgrade.ps1
+++ b/daisy_workflows/image_build/windows/windows_install_media/components/2019_64Bit/upgrade.ps1
@@ -22,16 +22,18 @@
 function Find-ImageIndex {
     param (
         [parameter(Mandatory=$true)]
-        [string]$image_name
+        [string[]]$image_names
     )
 
     $images = Get-WindowsImage -ImagePath ./sources/install.wim
     foreach ($image in $images) {
-        if ($image.ImageName -eq $image_name) {
-            return $image.ImageIndex
+        foreach ($image_name in $image_names) {
+            if ($image.ImageName -eq $image_name) {
+                return $image.ImageIndex
+            }
         }
     }
-    $msg = 'No image is found from the installation media: '+$image_name
+    $msg = 'No image is found from the installation media: '+$image_names[0]
     throw $msg
 }
 


### PR DESCRIPTION
A few of the 2022 differences were missed in the previous PR. I have successfully upgraded a 2012r2 instance to 2019 using the fixed version of this script.