### PR TITLE
kernel commit query: changelog check: improve execution time

### DIFF
--- a/daisy_workflows/kernel_commit_query/debian.sh
+++ b/daisy_workflows/kernel_commit_query/debian.sh
@@ -15,7 +15,7 @@
 
 set -xeu
 
-apt-get update -y && apt-get upgrade -y && apt-get install -y git linux-source
+apt-get update -y && apt-get install -y git linux-source
 
 rm -rf /files/distro_kernel && mkdir -p /files/distro_kernel
 tar --strip-components=1 -xvf $(ls /usr/src/linux-source*.tar.xz) \


### PR DESCRIPTION
Remove the upstream kernel cloning step and instead uses upstream cgit api to query and parse a commit, additionally this change removes the apt-get upgrade step since we are interested on the images content and not transitioned stated between release and now.