### PR TITLE
Change worker to debian 11

### DIFF
--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -14,7 +14,7 @@
       "Description": "list of GCE licenses to record in the exported image"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-tools/global/images/family/debian-11-worker",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {


### PR DESCRIPTION
As a follow up to the symlink change, use a debian 11 worker instead of debian 10. 

Even if the disks /dev/sda and /dev/sdb are flipped, the symlinks should export the correct disk. 