### PR TITLE
Sbom export

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
@@ -20,6 +20,9 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "SBOM Destination"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The AlmaLinux 8 installer ISO to build from."
@@ -48,6 +51,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-almalinux-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -10,6 +10,10 @@
       "Required": true,
       "Description": "GCS path to export image to"
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/${NAME}.sbom.json",
+      "Description": "GCS path to export sbom to, does nothing by default"
+    },
     "licenses": {
       "Description": "list of GCE licenses to record in the exported image"
     },
@@ -114,12 +118,21 @@
           "Destination": "${destination}"
         }
       ]
+    },
+    "copy-sbom-object": {
+      "CopyGCSObjects": [
+        {
+          "Source": "${OUTSPATH}/${NAME}.sbom.json",
+          "Destination": "${sbom_destination}"
+        }
+      ]
     }
   },
   "Dependencies": {
     "run-${NAME}": ["setup-disks"],
     "wait-for-inst-${NAME}": ["run-${NAME}"],
     "delete-inst": ["wait-for-inst-${NAME}"],
-    "copy-image-object": ["wait-for-inst-${NAME}"]
+    "copy-image-object": ["wait-for-inst-${NAME}"],
+    "copy-sbom-object": ["copy-image-object"]
   }
 }

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -77,12 +77,14 @@ function runSBOMGeneration() {
   tar -xf syft.tar.gz
   ./syft /mnt -o spdx-json > image.sbom.json
   gsutil cp image.sbom.json $SBOM_PATH
-  gsutil cp $SBOM_PATH $DESTINATION
   umount /mnt/dev
   umount /mnt
   echo "GCEExport: SBOM export success"
 }
 
+# Always create empty sbom file so workflow copying does not fail
+touch image.sbom.json
+gsutil cp image.sbom.json $SBOM_PATH
 # If no source for syft was passed in, do not run SBOM generation. 
 if [ $SYFT_SOURCE != "" ]; then
   runSBOMGeneration

--- a/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
+++ b/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
@@ -57,7 +57,6 @@
           "Metadata": {
             "outs-path": "${OUTSPATH}",
             "startup-script": "${SOURCE:test-sbom-export}",
-            "sbom-file-name": "sbom.json",
             "disk-file-name": "${disk_outs_tar_file}"
           },
           "ServiceAccounts": [


### PR DESCRIPTION
Add input variable for copying the sbom file to the final location, similar to the disk file. 

In the caller workflow, such as almalinux_8.wf.json, the "sbom_destination" variable is explicitly not set by default. This ensures that if an SBOM should not be generated, an empty SBOM file is output but it is not copied anywhere. 