### PR TITLE
Update Windows Client workflow names

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.publish.json
@@ -7,7 +7,7 @@
   time period is set.
 */}}
 {
-  "Name": "windows-10-21h2-ent-x64-uefi-byol",
+  "Name": "windows-10-21h2-ent-x64-uefi",
   {{$work_project := printf "%q" "gce-image-builder" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*6"` -}}

--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-10-21h2-ent-x64-uefi-byol",
+  "Name": "windows-10-21h2-ent-x64-uefi",
   "Project": "gce-image-builder",
   "Zone": "us-central1-b",
   "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
@@ -45,7 +45,7 @@
     "build": {
       "Timeout": "4h",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/windows/windows-10-21h2-ent-x64-uefi-byol.wf.json",
+        "Path": "${workflow_root}/image_build/windows/windows-10-21h2-ent-x64-uefi.wf.json",
         "Vars": {
           "install_disk": "disk-install",
           "updates": "${updates}",

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.publish.json
@@ -7,7 +7,7 @@
   time period is set.
 */}}
 {
-  "Name": "windows-11-21h2-ent-x64-uefi-byol",
+  "Name": "windows-11-21h2-ent-x64-uefi",
   {{$work_project := printf "%q" "gce-image-builder" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*6"` -}}

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-11-21h2-ent-x64-uefi-byol",
+  "Name": "windows-11-21h2-ent-x64-uefi",
   "Project": "gce-image-builder",
   "Zone": "us-central1-b",
   "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
@@ -45,7 +45,7 @@
     "build": {
       "Timeout": "5h",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/windows/windows-11-21h2-ent-x64-uefi-byol.wf.json",
+        "Path": "${workflow_root}/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json",
         "Vars": {
           "install_disk": "disk-install",
           "updates": "${updates}",

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.publish.json
@@ -7,7 +7,7 @@
   time period is set.
 */}}
 {
-  "Name": "windows-81-ent-x64-uefi-byol",
+  "Name": "windows-81-ent-x64-uefi",
   {{$work_project := printf "%q" "gce-image-builder" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*6"` -}}

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-81-ent-x64-uefi-byol",
+  "Name": "windows-81-ent-x64-uefi",
   "Project": "gce-image-builder",
   "Zone": "us-central1-b",
   "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
@@ -45,7 +45,7 @@
     "build": {
       "Timeout": "4h",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/windows/windows-81-ent-x64-uefi-byol.wf.json",
+        "Path": "${workflow_root}/image_build/windows/windows-81-ent-x64-uefi.wf.json",
         "Vars": {
           "install_disk": "disk-install",
           "updates": "${updates}",

--- a/daisy_workflows/image_build/windows/windows-10-20h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-20h2-ent-x64-uefi.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-10-20h2-ent-x64-uefi-byol",
+  "Name": "windows-10-20h2-ent-x64-uefi",
   "Vars": {
     "install_disk": "install-disk",
     "media": {

--- a/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-20h2-ent-x86-bios.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-10-20h2-ent-x86-bios-byol",
+  "Name": "windows-10-20h2-ent-x86-bios",
   "Vars": {
     "install_disk": "install-disk",
     "media": {

--- a/daisy_workflows/image_build/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-10-21h2-ent-x64-uefi-byol",
+  "Name": "windows-10-21h2-ent-x64-uefi",
   "Vars": {
     "install_disk": "install-disk",
     "media": {

--- a/daisy_workflows/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-11-21h2-ent-x64-uefi-byol",
+  "Name": "windows-11-21h2-ent-x64-uefi",
   "Vars": {
     "install_disk": "install-disk",
     "media": {

--- a/daisy_workflows/image_build/windows/windows-81-ent-x64-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-81-ent-x64-uefi-byol.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "windows-windows-81-ent-x64-uefi-byol",
+  "Name": "windows-windows-81-ent-x64-uefi",
   "Vars": {
     "install_disk": "install-disk",
     "media": {


### PR DESCRIPTION
Reflecting the removal of byol to the names in the previous PR. BYOL is still included in the license string and is intended.