### PR TITLE
Presubmit tests that sbom file is not empty

### DIFF
--- a/daisy_workflows/sbom_validation/test_sbom_export.sh
+++ b/daisy_workflows/sbom_validation/test_sbom_export.sh
@@ -4,35 +4,38 @@ URL="http://metadata/computeMetadata/v1/instance/attributes"
 OUTS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/outs-path)
 DISK_FILE_NAME=$(curl -f -H Metadata-Flavor:Google ${URL}/disk-file-name)
 
+# expected GCS path for the sbom file ending in .sbom.json
 GCS_PATH_SBOM=${OUTS_PATH}/*.sbom.json
 GCS_PATH_OUTDISK=${OUTS_PATH}/${DISK_FILE_NAME}
-# check if tar.gz file is there
-# check if sbom file is there
-# potentially run other script for sbom contents
-# to check, need a convention for the sbom json file name as well, input variable. 
 
-gsutil -q stat $GCS_PATH_SBOM
-status=$?
-
-if [[ $status == 0 ]]; then
-  echo "SBOM file successfully found"
+# Ensure that there are not multiple sbom files
+gsutil du $GCS_PATH_SBOM > sbom_file_info.txt
+num_sbom_files=$(wc -l < sbom_file_info.txt)
+if [[ $num_sbom_files -eq 1 ]]; then
+  echo "SBOMTesting: found exactly one SBOM file"
 else
-  echo "SBOMFailed: sbom file not found"
-  exit 1
+  echo "SBOMFailed: incorrect number of SBOM files found"
 fi
 
+# The disk export workflow creates an empty sbom file by default
+# so check that it has been overriden with a non-empty sbom
+read -r -n 1 sbom_file_size < sbom_file_info.txt
+if [[ $sbom_file_size -eq 0 ]]; then
+  echo "SBOMFailed: empty SBOM file found"
+else
+  echo "SBOMTesting: non-empty SBOM file found"
+fi
+
+# Check that the disk export succeeded
 gsutil -q stat $GCS_PATH_OUTDISK
 status=$?
-
-if [[ $status == 0 ]]; then
-  echo "Disk tar file successfully found"
+if [[ $status -eq 0 ]]; then
+  echo "SBOMTesting: Disk tar file successfully found"
 else
-  echo "SBOMFailed: disk tar gz failure"
+  echo "SBOMFailed: Disk tar file not found"
   exit 1
 fi
 
 echo "SBOMTesting: All tests passed"
 echo "SBOMSuccess"
 sync
-
-


### PR DESCRIPTION
From a previous change, export_disk.sh now creates an empty sbom file all the time. 

For the sbom file to be a success, it should not be empty. The presubmit now checks that the sbom file is not empty for enterprise linux. 