### PR TITLE
Temporarily revert empty daisy variable

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
@@ -20,9 +20,6 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
-    "sbom_destination": {
-      "Description": "SBOM Destination"
-    },
     "installer_iso": {
       "Required": true,
       "Description": "The AlmaLinux 8 installer ISO to build from."
@@ -51,7 +48,6 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
-          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-almalinux-8",
           "syft_source": "${syft_source}"
         }


### PR DESCRIPTION
There was a mistake in passing in an empty variable, so this is to revert that mistake. A future change will hopefully fix this for all the sbom workflows. 