### PR TITLE
SBOM export to final destination, copy in place by default

### DIFF
--- a/daisy_workflows/build-publish/debian/debian_10.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_10.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "syft_source": {
       "Value": "",
       "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
@@ -51,6 +55,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-10",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/debian/debian_11.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_11.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "syft_source": {
       "Value": "",
       "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
@@ -51,6 +55,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-11",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/debian/debian_11_arm64.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_11_arm64.wf.json
@@ -19,6 +19,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "syft_source": {
       "Value": "",
       "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
@@ -50,6 +54,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-11",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The AlmaLinux 8 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-almalinux-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_9.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The AlmaLinux 9 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-almalinux-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The CentOS 7 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-centos-7",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/centos_stream_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_stream_8.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The CentOS Stream 8 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-centos-stream-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/centos_stream_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_stream_9.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The CentOS Stream 9 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-centos-stream-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 7 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-7",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_6_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_6_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 7 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-7",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_7_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_7_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 7 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-7",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 7 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-7",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_byos.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 7 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-7-byos",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 8 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_1_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_1_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The CentOS 7 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_2_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_2_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 8 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_4_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_4_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 8 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_6_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_6_sap.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 8 installer ISO to build from."
@@ -49,6 +53,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 8 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-8-byos",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 9 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_arm64.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 9 installer ISO to build from."
@@ -47,6 +51,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The RHEL 9 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rhel-9-byos",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 8 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 8 installer ISO to build from."
@@ -47,6 +51,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 8 installer ISO to build from."
@@ -47,6 +51,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-8",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 9 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_arm64.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 9 installer ISO to build from."
@@ -48,6 +52,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 9 installer ISO to build from."
@@ -47,6 +51,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-9",
           "syft_source": "${syft_source}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -20,6 +20,10 @@
       "Required": true,
       "Description": "The GCS path that image raw file exported to."
     },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
     "installer_iso": {
       "Required": true,
       "Description": "The Rocky Linux 9 installer ISO to build from."
@@ -47,6 +51,7 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-rocky-linux-9",
           "syft_source": "${syft_source}"
         }


### PR DESCRIPTION
Add the ability to export the SBOM to the final destination, similar to the disk tar gz file. By default this copies the sbom file in place, if no sbom_destination is passed in.

Currently, it is assumed that the name of the sbom file is "export-image.sbom.json" in the disk export workflow. 

Once other builds have been updated, sbom_destination may become a required variable, similar to gcs_url. 