### PR TITLE
Placeholder sbom destination var, unused currently

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."

--- a/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
@@ -33,7 +33,7 @@
       "Description": "The GCS url that the image raw file exported to."
     },
     "sbom_destination": {
-      "Description": "Eventual url for the final sbom export destination, not yet in use"
+      "Description": "The GCS url that the sbom file exported to."
     },
     "google_cloud_repo": {
       "Value": "stable",

--- a/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
@@ -32,6 +32,9 @@
       "Required": true,
       "Description": "The GCS url that the image raw file exported to."
     },
+    "sbom_destination": {
+      "Description": "Eventual url for the final sbom export destination, not yet in use"
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."


### PR DESCRIPTION
This change adds the placeholder variable for sbom final export destination in windows workflows. 

This variable is necessary for specific automated builds to compile in daisy while providing an input for "sbom_destination."