### PR TITLE
Increase disk size for W11 build

### DIFF
--- a/daisy_workflows/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -46,7 +46,7 @@
       "Description": "GCS location containing the GCP Windows driver files."
     },
     "install_disk_size": {
-      "Value": "50",
+      "Value": "70",
       "Description": "The size of disk to provision for the image in GB."
     },
     "workflow_root": {


### PR DESCRIPTION
Windows 11 requires a minimum 64GB, so increasing to the nearest multiple of 10 rounded up.