### PR TITLE
el: fix rsync errors with -boot iso variant

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/build_installer.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer.py
@@ -67,7 +67,8 @@ def main():
   utils.Execute(['mount', '-o', 'ro,loop', '-t', 'iso9660', iso_file, 'iso'])
   utils.Execute(['mount', '-t', 'vfat', '/dev/sdb1', 'boot'])
   utils.Execute(['mount', '-t', 'ext2', '/dev/sdb2', 'installer'])
-  utils.Execute(['rsync', '-Pav', 'iso/EFI', 'iso/images', 'boot/'])
+  utils.Execute(['rsync', '-Pav', '--chown=root:root', 'iso/EFI',
+                 'iso/images', 'boot/'])
   utils.Execute(['cp', iso_file, 'installer/'])
   utils.Execute(['cp', ks_cfg, 'installer/'])
 


### PR DESCRIPTION
The distinction between -boot and -dvd1 isos for what concerns /EFI and /images directory is the content ownership, in the -boot some files will be 'nobody' owned, whereas in the dvd1 image all files are 'root' owned, rsync will try to sync the content attributes but fail for 'nobody' since the group and user are not yet available.

This change makes it consistent both -boot and -dvd1 use cases where the resulting/installed content will always be owned by root.