### PR TITLE
debian-11-arm64: fix boot issue

### DIFF
--- a/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
@@ -33,3 +33,8 @@ grub-efi-arm64
 # Use gce-disk-expand instead of cloud-init based scripts.
 PACKAGES remove
 cloud-initramfs-growroot
+
+# No secure boot on ARM, yet.
+PACKAGES remove ARM64
+grub-efi-arm64-signed
+shim-signed


### PR DESCRIPTION
With the current configuration debian-11-arm64 will fail to boot with efi loaders created grub with if grub-efi-arm64-signed & shim-signed modules are present.