### PR TITLE
Add skeleton for sbom-util SBOM generation path

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
@@ -31,6 +31,10 @@
     "syft_source": {
       "Value": "",
       "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
+    },
+    "sbom_util_source": {
+      "Value": "",
+      "Description": "Source url for the sbomutil executable, if using sbomutil to generate the SBOM."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-almalinux-8",
-          "syft_source": "${syft_source}"
+          "syft_source": "${syft_source}",
+          "sbom_util_source": "${sbom_util_source}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
@@ -32,9 +32,9 @@
       "Value": "",
       "Description": "Source url for the syft tar gz file, if generating SBOM. If empty no SBOM is generated."
     },
-    "sbom_util_source": {
+    "sbom_util_gcs_root": {
       "Value": "",
-      "Description": "Source url for the sbomutil executable, if using sbomutil to generate the SBOM."
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
     }
   },
   "Steps": {
@@ -59,7 +59,7 @@
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-almalinux-8",
           "syft_source": "${syft_source}",
-          "sbom_util_source": "${sbom_util_source}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     },

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -44,6 +44,10 @@
     "syft_source": {
       "Value": "",
       "Description": "the source url for syft"
+    },
+    "sbom_util_source": {
+      "Value": "",
+      "Description": "the source url for the sbom-util executable, takes priority over syft_source"
     }
   },
   "Sources": {
@@ -75,7 +79,8 @@
             "startup-script": "${SOURCE:${NAME}_export_disk.sh}",
             "source-disk-name": "${source_disk}",
             "syft-tar-file": "${SOURCESPATH}/syft.tar.gz",
-            "syft-source": "${syft_source}"
+            "syft-source": "${syft_source}",
+            "sbom-util-source": "${sbom_util_source}"
           },
           "networkInterfaces": [
             {

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -52,7 +52,8 @@
   },
   "Sources": {
     "${NAME}_export_disk.sh": "./export_disk.sh",
-    "syft.tar.gz": "${syft_source}"
+    "syft.tar.gz": "${syft_source}",
+    "sbom_util": "${sbom_util_source}"
   },
   "Steps": {
     "setup-disks": {
@@ -80,7 +81,8 @@
             "source-disk-name": "${source_disk}",
             "syft-tar-file": "${SOURCESPATH}/syft.tar.gz",
             "syft-source": "${syft_source}",
-            "sbom-util-source": "${sbom_util_source}"
+            "sbom-util-source": "${sbom_util_source}",
+            "sbom-util-executable": "${SOURCESPATH}/sbom_util"
           },
           "networkInterfaces": [
             {

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -45,15 +45,14 @@
       "Value": "",
       "Description": "the source url for syft"
     },
-    "sbom_util_source": {
+    "sbom_util_gcs_root": {
       "Value": "",
-      "Description": "the source url for the sbom-util executable, takes priority over syft_source"
+      "Description": "the root gcs path for the sbom-util executable, takes priority over syft_source"
     }
   },
   "Sources": {
     "${NAME}_export_disk.sh": "./export_disk.sh",
-    "syft.tar.gz": "${syft_source}",
-    "sbom_util": "${sbom_util_source}"
+    "syft.tar.gz": "${syft_source}"
   },
   "Steps": {
     "setup-disks": {
@@ -81,8 +80,7 @@
             "source-disk-name": "${source_disk}",
             "syft-tar-file": "${SOURCESPATH}/syft.tar.gz",
             "syft-source": "${syft_source}",
-            "sbom-util-source": "${sbom_util_source}",
-            "sbom-util-executable": "${SOURCESPATH}/sbom_util"
+            "sbom-util-gcs-root": "${sbom_util_gcs_root}"
           },
           "networkInterfaces": [
             {

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -67,6 +67,7 @@ SBOM_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-path)
 SBOM_UTIL_EXECUTABLE=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-executable)
 # User passed in value for sbom-util source. If empty, do not run sbom generation.
 SBOM_UTIL_SOURCE=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-source)
+echo "GCEExport: SBOM Util Values are ${SBOM_UTIL_EXECUTABLE} ${SBOM_UTIL_SOURCE}"
 
 # References the tar-gz for syft, if SBOM generation will run. 
 SYFT_TAR_FILE=$(curl -f -H Metadata-Flavor:Google ${URL}/syft-tar-file)
@@ -85,7 +86,9 @@ function runSBOMGeneration() {
   EXECUTION_MODE=$1
   if [ $EXECUTION_MODE == $SBOM_UTIL_EXECUTION_MODE ]; then
     gsutil cp $SBOM_UTIL_EXECUTABLE sbomutil
+    chmod +x sbomutil
     ./sbomutil --archetype=linux-image --comp_name=$SOURCE_DISK_NAME --output=./image.sbom.json
+    echo "GCEExport: Used SBOM Util Source"
   elif [ $EXECUTION_MODE == $SYFT_EXECUTION_MODE ]; then
     gsutil cp $SYFT_TAR_FILE syft.tar.gz
     tar -xf syft.tar.gz

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -67,7 +67,6 @@ SBOM_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-path)
 SBOM_UTIL_EXECUTABLE=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-executable)
 # User passed in value for sbom-util source. If empty, do not run sbom generation.
 SBOM_UTIL_SOURCE=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-source)
-echo "GCEExport: SBOM Util Values are ${SBOM_UTIL_EXECUTABLE} ${SBOM_UTIL_SOURCE}"
 
 # References the tar-gz for syft, if SBOM generation will run. 
 SYFT_TAR_FILE=$(curl -f -H Metadata-Flavor:Google ${URL}/syft-tar-file)
@@ -88,7 +87,6 @@ function runSBOMGeneration() {
     gsutil cp $SBOM_UTIL_EXECUTABLE sbomutil
     chmod +x sbomutil
     ./sbomutil --archetype=linux-image --comp_name=$SOURCE_DISK_NAME --output=./image.sbom.json
-    echo "GCEExport: Used SBOM Util Source"
   elif [ $EXECUTION_MODE == $SYFT_EXECUTION_MODE ]; then
     gsutil cp $SYFT_TAR_FILE syft.tar.gz
     tar -xf syft.tar.gz

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -63,8 +63,11 @@ serialOutputPrefixedKeyValue "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
 DESTINATION=$(curl -f -H Metadata-Flavor:Google ${URL}/destination)
 # Local sbom outspath
 SBOM_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-path)
+# References the executable file for sbom_util in the sources path.
+SBOM_UTIL_EXECUTABLE=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-executable)
 # User passed in value for sbom-util source. If empty, do not run sbom generation.
 SBOM_UTIL_SOURCE=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-source)
+
 # References the tar-gz for syft, if SBOM generation will run. 
 SYFT_TAR_FILE=$(curl -f -H Metadata-Flavor:Google ${URL}/syft-tar-file)
 # User passed in value for syft source, if empty then do not run SBOM generation.
@@ -81,7 +84,8 @@ function runSBOMGeneration() {
   mount -o bind,ro /dev /mnt/dev
   EXECUTION_MODE=$1
   if [ $EXECUTION_MODE == $SBOM_UTIL_EXECUTION_MODE ]; then
-    echo "ExportFailed: sbom-util sbom generation not yet implemented" 
+    gsutil cp $SBOM_UTIL_EXECUTABLE sbomutil
+    ./sbomutil --archetype=linux-image --comp_name=$SOURCE_DISK_NAME --output=./image.sbom.json
   elif [ $EXECUTION_MODE == $SYFT_EXECUTION_MODE ]; then
     gsutil cp $SYFT_TAR_FILE syft.tar.gz
     tar -xf syft.tar.gz

--- a/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
+++ b/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
@@ -10,9 +10,9 @@
       "Value": "",
       "Description": "the source url for syft for sbom generation, will soon be deprecated for this test."
     },
-    "sbom_util_source": {
+    "sbom_util_gcs_root": {
       "Value": "",
-      "Description": "Source url for the sbomutil executable, if using this option for sbom generation."
+      "Description": "root gcs bucket for sbom-util, if using this option for sbom generation."
     },
     "disk_outs_tar_file": {
       "Value": "export-image.tar.gz",
@@ -40,7 +40,7 @@
           "destination": "${OUTSPATH}/${disk_outs_tar_file}",
           "source_disk": "disk-export",
           "syft_source": "${syft_source}",
-          "sbom_util_source": "${sbom_util_source}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     },

--- a/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
+++ b/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
@@ -7,8 +7,12 @@
       "Description": "Root of workflows, should be set to parent of the export directory."
     },
     "syft_source": {
-      "Required": true,
-      "Description": "the source url for syft, required because this is a test for sbom generation"
+      "Value": "",
+      "Description": "the source url for syft for sbom generation, will soon be deprecated for this test."
+    },
+    "sbom_util_source": {
+      "Value": "",
+      "Description": "Source url for the sbomutil executable, if using this option for sbom generation."
     },
     "disk_outs_tar_file": {
       "Value": "export-image.tar.gz",
@@ -35,7 +39,8 @@
         "Vars": {
           "destination": "${OUTSPATH}/${disk_outs_tar_file}",
           "source_disk": "disk-export",
-          "syft_source": "${syft_source}"
+          "syft_source": "${syft_source}",
+          "sbom_util_source": "${sbom_util_source}"
         }
       }
     },


### PR DESCRIPTION
Add the daisy config variables so sbom-util can be used to generate the sbom, instead of a fixed gcs location where syft is stored.