### PR TITLE
Fix empty sbom bug

### DIFF
--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -110,7 +110,7 @@ function runSBOMGeneration() {
   EXECUTION_MODE=$1
   if [ $EXECUTION_MODE == $SBOM_UTIL_EXECUTION_MODE ]; then
     fetch_sbomutil
-    ./sbomutil --archetype=linux-image --comp_name=$SOURCE_DISK_NAME --output=./image.sbom.json
+    ./sbomutil --archetype=linux-image --comp_name=$SOURCE_DISK_NAME --output=image.sbom.json
   elif [ $EXECUTION_MODE == $SYFT_EXECUTION_MODE ]; then
     gsutil cp $SYFT_TAR_FILE syft.tar.gz
     tar -xf syft.tar.gz


### PR DESCRIPTION
Currently concourse is writing an empty sbom file to the output bucket, investigate whether the reason is the "./" in front of the output file path.