### PR TITLE
Debian build fixes for Bookworm

### DIFF
--- a/daisy_workflows/image_build/debian/build_fai.py
+++ b/daisy_workflows/image_build/debian/build_fai.py
@@ -53,7 +53,7 @@ def main():
   # Get Parameters.
   build_date = utils.GetMetadataAttribute(
       'build_date', raise_on_not_found=True)
-  debian_cloud_images_version = '695ae0c8660d5bbfdb4e01f4a5cc2bacbc06783b'
+  debian_cloud_images_version = 'dc1efc3d60666560042ea1ef4069a8984525e5b9'
   debian_version = utils.GetMetadataAttribute(
       'debian_version', raise_on_not_found=True)
   outs_path = utils.GetMetadataAttribute('daisy-outs-path',
@@ -88,9 +88,6 @@ def main():
 
   # Remove upstream test cases that won't work here.
   os.remove(config_space + 'hooks/tests.BASE')
-
-  # Remove static hostname file
-  os.remove(config_space + 'files/etc/hostname/CLOUD')
 
   # Copy our classes to the FAI config space
   mycopytree('/files/fai_config', config_space)

--- a/daisy_workflows/image_build/debian/build_fai.py
+++ b/daisy_workflows/image_build/debian/build_fai.py
@@ -89,6 +89,10 @@ def main():
   # Remove upstream test cases that won't work here.
   os.remove(config_space + 'hooks/tests.BASE')
 
+  # Remove upstream netplan config until we can use it.
+  if debian_version == 'bookworm':
+    os.remove(config_space + 'files/etc/netplan/90-default.yaml/GCE')
+
   # Copy our classes to the FAI config space
   mycopytree('/files/fai_config', config_space)
 

--- a/daisy_workflows/image_build/debian/fai_config/files/etc/hostname/BOOKWORM
+++ b/daisy_workflows/image_build/debian/fai_config/files/etc/hostname/BOOKWORM
@@ -1,1 +1,0 @@
-# Do not set a static hostname.

--- a/daisy_workflows/image_build/debian/fai_config/files/etc/netplan/90-default.yaml/BOOKWORM
+++ b/daisy_workflows/image_build/debian/fai_config/files/etc/netplan/90-default.yaml/BOOKWORM
@@ -1,0 +1,21 @@
+network:
+    version: 2
+    ethernets:
+        all-en:
+            match:
+                name: en*
+            dhcp4: true
+            dhcp4-overrides:
+                use-domains: true
+            dhcp6: true
+            dhcp6-overrides:
+                use-domains: true
+        all-eth:
+            match:
+                name: eth*
+            dhcp4: true
+            dhcp4-overrides:
+                use-domains: true
+            dhcp6: true
+            dhcp6-overrides:
+                use-domains: true

--- a/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
@@ -1,7 +1,3 @@
-PACKAGES install BOOKWORM
-# Needed for systemd-networkd to set hostnames
-polkitd
-
 PACKAGES install
 # To avoid entropy issues when intances boot.
 haveged

--- a/daisy_workflows/image_build/debian/fai_config/scripts/BOOKWORM/10-clean
+++ b/daisy_workflows/image_build/debian/fai_config/scripts/BOOKWORM/10-clean
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f $target/etc/hostname

--- a/daisy_workflows/image_build/debian/fai_config/scripts/GCE_CLEAN/10-gce-clean
+++ b/daisy_workflows/image_build/debian/fai_config/scripts/GCE_CLEAN/10-gce-clean
@@ -12,10 +12,10 @@ chroot $target apt-get clean
 chroot $target apt-get update
 
 # Cleanup logs and caches
-rm -f $target/etc/resolv.conf \
-      $target/etc/mailname \
+rm -f $target/etc/mailname \
       $target/etc/machine-id \
-      $target/usr/bin/qemu-* \
+      $target/etc/resolv.conf \
+      $target/etc/apt/sources.list.d/localdebs.list \
       $target/var/lib/dbus/machine-id \
       $target/var/log/alternatives.log \
       $target/var/log/apt/* \
@@ -24,7 +24,8 @@ rm -f $target/etc/resolv.conf \
       $target/var/log/install_packages.list
 
 # Empty file needed for on-boot generation.
-> $target/etc/machine-id
+touch $target/etc/machine-id
+touch $target/var/lib/dpkg/available
 
 rm -rf $target/var/log/fai
 


### PR DESCRIPTION
- Use the now upstream changes for hostname configuration.
- We still use our own clean file because we aren't using the other parts of the upstream one. Rectify our clean script with upstream.
- Replace the default netplan config so that we can use DNS search domains from DHCP (revert when https://salsa.debian.org/cloud-team/debian-cloud-images/-/merge_requests/357 is merged).