### PR TITLE
Include dhclient in the Debian builds.

### DIFF
--- a/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
@@ -8,6 +8,9 @@ net-tools
 # Google Cloud package keyring
 google-cloud-packages-archive-keyring
 
+# ISC DHCP client until the agent can create systemd-networkd configs
+isc-dhcp-client
+
 # GCE guest software
 google-compute-engine
 


### PR DESCRIPTION
Until we can change the agent's mutil-nic behavior we need to include dhclient.