### PR TITLE
Add skeleton variables for sbom generation on windows export

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -42,6 +42,10 @@
     "workflow_root": {
       "Value": "/workflows",
       "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
     }
   },
   "Steps": {
@@ -68,7 +72,9 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows_export.wf.json
+++ b/daisy_workflows/build-publish/windows/windows_export.wf.json
@@ -16,6 +16,13 @@
     "disk_export_time_out": {
       "Value": "50m",
       "Description": "Disk export step time out. Default is 50m."
+    },
+    "sbom_destination": {
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
     }
   },
   "Steps": {
@@ -25,7 +32,9 @@
         "Path": "${workflow_root}/export/disk_export.wf.json",
         "Vars": {
           "source_disk": "${install_disk}",
-          "destination": "${gcs_url}"
+          "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }


### PR DESCRIPTION
Add sbom destination and sbom util gcs root for windows export.

A follow up PR will add these variables to other windows build publish workflows.