### PR TITLE
Remove backslash on windows path

### DIFF
--- a/daisy_workflows/image_build/windows/bootstrap_install.ps1
+++ b/daisy_workflows/image_build/windows/bootstrap_install.ps1
@@ -87,14 +87,15 @@ function Download-Sbomutil {
   }
 
   $gs_path = "${gs_path}/windows"
-  $latest = gsutil ls "${gs_path}" | Select -Last 1
+  $latest = gsutil ls "${gs_path}" | Select-Object -Last 1
   if (!$latest) {
     Write-Output "Could not determine sbomutil's latest release, skipping sbomutil download."
     return
   }
 
+  # The variable $latest already has a backslash at the end, as a result of gsutil ls.
   Write-Output "Downloading sbomutil from $gs_path."
-  & 'gsutil' -m cp "${latest}/sbomutil" $script:components_dir
+  & 'gsutil' -m cp "${latest}sbomutil" $script:components_dir
   Write-Output 'Components download complete.'
 }
 

--- a/daisy_workflows/image_build/windows/bootstrap_install.ps1
+++ b/daisy_workflows/image_build/windows/bootstrap_install.ps1
@@ -87,7 +87,7 @@ function Download-Sbomutil {
   }
 
   $gs_path = "${gs_path}/windows"
-  $latest = gsutil ls "${gs_path}" | Select-Object -Last 1
+  $latest = gsutil ls "${gs_path}" | Select -Last 1
   if (!$latest) {
     Write-Output "Could not determine sbomutil's latest release, skipping sbomutil download."
     return


### PR DESCRIPTION
gsutil ls adds a slash at the end of the path, so when copying sbomutil, do not add an extra slash twice.