### PR TITLE
Add read_write permissions to the boostrap instance

### DIFF
--- a/daisy_workflows/image_build/windows/windows-build-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-build-uefi.wf.json
@@ -123,6 +123,9 @@
             }
           ],
           "MachineType": "e2-standard-4",
+          "Scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_write"
+          ],
           "Metadata": {
             "components-path": "${SOURCESPATH}/components",
             "drivers-path": "${SOURCESPATH}/drivers",


### PR DESCRIPTION
Previously, the boostrap instance did not need to upload to gcs. Now it needs it for the sbom upload.