### PR TITLE
Revert "Do not replace windows sbom with empty sbom"

### DIFF
--- a/daisy_workflows/build-publish/windows/windows_export.wf.json
+++ b/daisy_workflows/build-publish/windows/windows_export.wf.json
@@ -34,7 +34,7 @@
         "Vars": {
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
-          "sbom_already_generated": "true"
+          "sbom_destination": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -44,10 +44,6 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "the root gcs path for the sbom-util executable, used to generate SBOM if provided"
-    },
-    "sbom_already_generated": {
-      "Value": "false",
-      "Description": "true if the sbom has already been generated earlier in the super-workflow"
     }
   },
   "Sources": {
@@ -77,8 +73,7 @@
             "sbom-path": "${OUTSPATH}/${NAME}.sbom.json",
             "startup-script": "${SOURCE:${NAME}_export_disk.sh}",
             "source-disk-name": "${source_disk}",
-            "sbom-util-gcs-root": "${sbom_util_gcs_root}",
-            "sbom-already-generated": "${sbom_already_generated}"
+            "sbom-util-gcs-root": "${sbom_util_gcs_root}"
           },
           "networkInterfaces": [
             {

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -65,8 +65,6 @@ DESTINATION=$(curl -f -H Metadata-Flavor:Google ${URL}/destination)
 SBOM_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-path)
 # The gcs root for sbom-util. If empty, do not run sbom generation with sbom-util.
 SBOM_UTIL_GCS_ROOT=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-gcs-root)
-# Mostly used for windows workflows, set to true if the sbom is already generated and non-empty.
-SBOM_ALREADY_GENERATED=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-already-generated)
 
 # This function fetches the sbom-util executable from the gcs bucket.
 function fetch_sbomutil() {
@@ -114,11 +112,9 @@ function runSBOMGeneration() {
   echo "GCEExport: SBOM export success"
 }
 
-# Always create empty sbom file so workflow copying does not fail, if the sbom is not already generated.
-if [ $SBOM_ALREADY_GENERATED != "true" ]; then
-  touch image.sbom.json
-  gsutil cp image.sbom.json $SBOM_PATH
-fi
+# Always create empty sbom file so workflow copying does not fail
+touch image.sbom.json
+gsutil cp image.sbom.json $SBOM_PATH
 # If the sbom-util program location is passed in, generate the sbom.
 if [ $SBOM_UTIL_GCS_ROOT != "" ]; then
   runSBOMGeneration


### PR DESCRIPTION
Reverts GoogleCloudPlatform/compute-image-tools#2176

There is a name conflict between the windows and linux default sbom names. A future change will be made to avoid this conflict.