### PR TITLE
Correctly reference driver directory

### DIFF
--- a/daisy_workflows/image_build/windows/bootstrap_install.ps1
+++ b/daisy_workflows/image_build/windows/bootstrap_install.ps1
@@ -119,7 +119,7 @@ function Generate-Sbom {
   $comp_name = Get-MetadataValue -key 'edition'
 
   Write-Output "Generating sbom."
-  & "${script:components_dir}\sbomutil.exe" -archetype=windows-image -googet_path 'D:\ProgramData\GooGet' -extra_content="${script:components_dir}\windows.iso","${script:$script:driver_dir}\","${script:components_dir}\SetupComplete.cmd" -comp_name="${comp_name}" -output image.sbom.json
+  & "${script:components_dir}\sbomutil.exe" -archetype=windows-image -googet_path 'D:\ProgramData\GooGet' -extra_content="${script:components_dir}\windows.iso","${script:driver_dir}\","${script:components_dir}\SetupComplete.cmd" -comp_name="${comp_name}" -output image.sbom.json
   & 'gsutil' cp image.sbom.json $gs_path
   Write-Output "Sbom file uploaded to $gs_path."
 }


### PR DESCRIPTION
Before this change, the driver directory was incorrectly referenced, leading to a scan of the entire \ directory.