### PR TITLE
Do not overwrite windows sboms at the end

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -76,7 +76,7 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows_export.wf.json
+++ b/daisy_workflows/build-publish/windows/windows_export.wf.json
@@ -30,7 +30,7 @@
         "Vars": {
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
-          "existing_sbom_name": "${existing_sbom_file_name}",
+          "existing_sbom_file_name": "${existing_sbom_file_name}",
           "sbom_already_generated": "true"
         }
       }

--- a/daisy_workflows/build-publish/windows/windows_export.wf.json
+++ b/daisy_workflows/build-publish/windows/windows_export.wf.json
@@ -17,13 +17,9 @@
       "Value": "50m",
       "Description": "Disk export step time out. Default is 50m."
     },
-    "sbom_destination": {
+    "existing_sbom_file_name": {
       "Value": "${OUTSPATH}/export-image.sbom.json",
-      "Description": "The GCS url that the sbom file exported to."
-    },
-    "sbom_util_gcs_root": {
-      "Value": "",
-      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+      "Description": "The name of the existing sbom file, generated earlier in the windows workflow."
     }
   },
   "Steps": {
@@ -34,7 +30,8 @@
         "Vars": {
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
-          "sbom_destination": "${sbom_destination}"
+          "existing_sbom_name": "${existing_sbom_file_name}",
+          "sbom_already_generated": "true"
         }
       }
     }

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -44,6 +44,14 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "the root gcs path for the sbom-util executable, used to generate SBOM if provided"
+    },
+    "sbom_already_generated": {
+      "Value": "false",
+      "Description": "true if the sbom has already been generated earlier in the super-workflow"
+    },
+    "existing_sbom_file_name": {
+      "Value": "${OUTSPATH}/${NAME}.sbom.json",
+      "Description": "Name of the existing sbom file, should only be passed in from windows workflows"
     }
   },
   "Sources": {
@@ -73,7 +81,8 @@
             "sbom-path": "${OUTSPATH}/${NAME}.sbom.json",
             "startup-script": "${SOURCE:${NAME}_export_disk.sh}",
             "source-disk-name": "${source_disk}",
-            "sbom-util-gcs-root": "${sbom_util_gcs_root}"
+            "sbom-util-gcs-root": "${sbom_util_gcs_root}",
+            "sbom-already-generated": "${sbom_already_generated}"
           },
           "networkInterfaces": [
             {
@@ -120,7 +129,7 @@
     "copy-sbom-object": {
       "CopyGCSObjects": [
         {
-          "Source": "${OUTSPATH}/${NAME}.sbom.json",
+          "Source": "${existing_sbom_file_name}",
           "Destination": "${sbom_destination}"
         }
       ]

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -65,6 +65,8 @@ DESTINATION=$(curl -f -H Metadata-Flavor:Google ${URL}/destination)
 SBOM_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-path)
 # The gcs root for sbom-util. If empty, do not run sbom generation with sbom-util.
 SBOM_UTIL_GCS_ROOT=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-gcs-root)
+# Mostly used for windows workflows, set to true if the sbom is already generated and non-empty.
+SBOM_ALREADY_GENERATED=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-already-generated)
 
 # This function fetches the sbom-util executable from the gcs bucket.
 function fetch_sbomutil() {
@@ -113,8 +115,10 @@ function runSBOMGeneration() {
 }
 
 # Always create empty sbom file so workflow copying does not fail
-touch image.sbom.json
-gsutil cp image.sbom.json $SBOM_PATH
+if [ $SBOM_ALREADY_GENERATED != "true" ]; then
+  touch image.sbom.json
+  gsutil cp image.sbom.json $SBOM_PATH
+fi
 # If the sbom-util program location is passed in, generate the sbom.
 if [ $SBOM_UTIL_GCS_ROOT != "" ]; then
   runSBOMGeneration


### PR DESCRIPTION
The disk export workflow replaces sbom files with an empty file. However, windows workflows generate an sbom before this. To prevent the windows sbom file from being empty, this change is necessary.