### PR TITLE
Pass in existing file name for robust sbom naming

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
@@ -75,7 +75,8 @@
         "Vars": {
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
-          "workflow_root": "${workflow_root}"
+          "workflow_root": "${workflow_root}",
+          "existing_sbom_file_name": "${sbom_destination}"
         }
       }
     }


### PR DESCRIPTION
Ensure that the windows sbom name is passed in, because it is different from the linux sbom name used in disk_export.wf.json.