### PR TITLE
pass variables into sql img build for sbom generation

### DIFF
--- a/daisy_workflows/image_build/sqlserver/sql-2012-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-enterprise-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2012-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2012-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2012-enterprise-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-enterprise-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2012-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2012-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2012-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-standard-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2012-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Standard, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2012-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2012-standard-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-standard-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2012-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Standard, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2012-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2012-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-web-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2012-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2012-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2012-web-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2012-web-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2012-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2012-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2014-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2014-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2012-r2.wf.json
@@ -27,6 +27,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2014-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -42,7 +46,8 @@
           "ssms_exe": "${ssms_exe}",
           "timeout": "${timeout}",
           "sbom_destination": "${sbom_destination}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -56,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2014-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2014-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2014-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-enterprise-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2014-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}"
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2012 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2014-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-standard-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2014-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2014 Standard, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2014-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-standard-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-standard-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2014-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2014 Standard, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2014-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-web-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2014-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2014 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2014-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2014-web-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2014-web-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2014-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2014 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2014-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2016-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2016-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2016-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2016-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2016-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2016-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2016-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2016-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2016-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2016-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-enterprise-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2016-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2016-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2016-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2016-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2016-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2016-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2016-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2016-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2016-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2019, x64 built on ${build_date}",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2016-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-standard-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2016-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Standard, on Windows Server 2019, x64 built on ${build_date}",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2016-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2016-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2016-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2016-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2016-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2016-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2016-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2016-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2016-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2016-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2016-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2016-web-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2016-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2016 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2016-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2017-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2017-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2017-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2017-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2017-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2017-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2017-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2017-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2017-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2017-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-enterprise-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2017-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2017-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2012-r2-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-exp-2017-win-2012-r2",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-exp-2017-win-2012-r2",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2012-r2.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2012-r2.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-exp-2017-win-2012-r2-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2012-r2-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2012 R2, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-exp-2017-win-2012-r2-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-exp-2017-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-exp-2017-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-exp-2017-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-exp-2017-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-exp-2017-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-exp-2017-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-express-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-exp-2017-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Express, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-exp-2017-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2017-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2017-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2017-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2017-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2017-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2017-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2017-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2017-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2017-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2017-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-standard-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2017-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2017-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2016-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2016-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2017-win-2016",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2017-win-2016",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2016.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2016.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2017-win-2016-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2016-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2016, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2017-win-2016-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2017-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2017-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2017-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2017-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2017-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2017-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2017-web-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2017-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2017 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-web-2017-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2019-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2019-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2019-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-ent-2019-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2019-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2019-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-enterprise-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2019-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-ent-2019-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2019-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2019-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2019-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-std-2019-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2019-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2019-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-standard-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2019-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-std-2019-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2019-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2019-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2019-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-web-2019-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2019-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2019-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2019-web-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2019-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2019 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS"],
-          "Family": "sql-web-2019-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2022-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2022-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2022-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-enterprise-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2022-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Enterprise, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-preview-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-preview-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2022-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Preview, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-preview-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-preview-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-ent-2022-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Preview, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-ent-2022-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2022-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2022-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2022-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2022-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2022-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2022-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-standard-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-std-2022-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Standard, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-std-2022-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2022-win-2019",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2022-win-2019",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2019.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2022-win-2019-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2019-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2019, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2022-win-2019-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022-dc.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2022-win-2022",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2022-win-2022",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022.wf.json
+++ b/daisy_workflows/image_build/sqlserver/sql-2022-web-windows-2022.wf.json
@@ -19,6 +19,18 @@
     "timeout": {
       "Value": "2h",
       "Description": "The timeout to set for the image build."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "img_family": {
+      "Value": "sql-web-2022-win-2022-standard",
+      "Description": "The image family and component name for the sbom."
     }
   },
   "Steps": {
@@ -32,7 +44,10 @@
           "source_image": "projects/${source_image_project}/global/images/family/windows-2022-standard",
           "install_disk": "${install_disk}",
           "ssms_exe": "${ssms_exe}",
-          "timeout": "${timeout}"
+          "timeout": "${timeout}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "img_family": "${img_family}
         }
       }
     },
@@ -46,7 +61,7 @@
           ],
           "Description": "Microsoft, SQL Server 2022 Web, on Windows Server 2022, x64 built on ${build_date}, supports Shielded VM features",
           "GuestOsFeatures": ["MULTI_IP_SUBNET", "UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "WINDOWS", "GVNIC"],
-          "Family": "sql-web-2022-win-2022-standard",
+          "Family": "${img_family}",
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true


### PR DESCRIPTION
With this change, sbom generation on sql server workflows would not yet happen. However, it would allow us to add sbom variables to the build_publish workflows, and then sbom generation would happen.