### PR TITLE
Rename sbomcontents to sbomcomponents for consistency with windows

### DIFF
--- a/daisy_workflows/image_build/sqlserver/sql_install.ps1
+++ b/daisy_workflows/image_build/sqlserver/sql_install.ps1
@@ -338,7 +338,7 @@ try {
 
   if (!(Test-Path 'D:\')) {
     # Any file which should be included in the sbom is stored in the sbom directory.
-    $script:sbom_dir = "D:\sbomcontents"
+    $script:sbom_dir = "D:\sbomcomponents"
     $sysprep = 'c:\Windows\System32\Sysprep'
     Remove-Item "${sysprep}\Panther\*" -Recurse -Force -ErrorAction Continue
     Remove-Item "${sysprep}\Sysprep_succeeded.tag" -Recurse -Force -ErrorAction Continue


### PR DESCRIPTION
Keep the sbom folder names the same for windows and sql images, so documentation is not confusing.