### PR TITLE
Change builder folder name to sbomcomponents

### DIFF
--- a/daisy_workflows/image_build/windows/bootstrap_install.ps1
+++ b/daisy_workflows/image_build/windows/bootstrap_install.ps1
@@ -294,11 +294,12 @@ function Bootstrap-InstallDisk {
 }
 
 try {
-  # Setup directories to store files which are added to the sbom.
+  # Setup directories to store files which are added to the sbom, by storing files in sbom_dir. 
+  # Changing this path requires changing the path in image_build/windows/components/SetupComplete.cmd as well.
   $script:sbom_dir = 'C:\sbomcomponents'
   $script:components_dir = "$script:sbom_dir\components"
   $script:updates_dir = "$script:components_dir\updates"
-  $script:driver_dir = "$script:sbom_dir\drivers"
+  $script:driver_dir = "$script:components_dir\drivers"
   New-Item $script:sbom_dir -Type directory
   New-Item $script:updates_dir -Type directory
   New-Item $script:driver_dir -Type directory

--- a/daisy_workflows/image_build/windows/components/SetupComplete.cmd
+++ b/daisy_workflows/image_build/windows/components/SetupComplete.cmd
@@ -20,9 +20,9 @@ REM Check for .NET 4.8
 REM https://support.microsoft.com/en-us/help/4503548/microsoft-net-framework-4-8-offline-installer-for-windows
 reg query "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" /f 4.8
 if NOT %ERRORLEVEL%==0 (
-  if exist D:\builder\components\dotnet48-offline-installer.exe (
+  if exist D:\sbomcomponents\components\dotnet48-offline-installer.exe (
     echo Installing .NET 4.8. > COM1:
-    D:\builder\components\dotnet48-offline-installer.exe /quiet /norestart > COM1:
+    D:\sbomcomponents\components\dotnet48-offline-installer.exe /quiet /norestart > COM1:
     echo .NET install exited with code %ERRORLEVEL%. > COM1:
     echo Exiting for reboot. > COM1:
     shutdown /r /t 00
@@ -36,14 +36,14 @@ if NOT %ERRORLEVEL%==0 (
 REM Check for PowerShell 5.1 on 2008R2/7
 reg query "HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine" /f 5.1
 if NOT %ERRORLEVEL%==0 (
-  if exist D:\builder\components\Win7AndW2K8R2-KB3191566-x64.msu (
+  if exist D:\sbomcomponents\components\Win7AndW2K8R2-KB3191566-x64.msu (
     REM 2008R2/7 networking require manually setting DNS servers to the default gateway
     for /f "tokens=2 delims=:" %%a in (
       'ipconfig ^| find "Gateway"'
     ) do netsh interface ipv4 set dnsservers "Local Area Connection" static address=%%a primary
 
     echo Installing WMF 5.1. > COM1:
-    D:\builder\components\Win7AndW2K8R2-KB3191566-x64.msu /quiet
+    D:\sbomcomponents\components\Win7AndW2K8R2-KB3191566-x64.msu /quiet
     echo WMF install exited with code %ERRORLEVEL%. > COM1:
     echo Exiting for reboot. > COM1:
     shutdown /r /t 00
@@ -52,14 +52,14 @@ if NOT %ERRORLEVEL%==0 (
     echo Windows x64 build failed: WMF 5.1 not installed and no installer found. > COM1:
     exit /b 1
   )
-  if exist D:\builder\components\Win7-KB3191566-x86.msu (
+  if exist D:\sbomcomponents\components\Win7-KB3191566-x86.msu (
     REM 2008R2/7 networking require manually setting DNS servers to the default gateway
     for /f "tokens=2 delims=:" %%a in (
       'ipconfig ^| find "Gateway"'
     ) do netsh interface ipv4 set dnsservers "Local Area Connection" static address=%%a primary
 
     echo Installing WMF 5.1. > COM1:
-    D:\builder\components\Win7-KB3191566-x86.msu /quiet > COM1:
+    D:\sbomcomponents\components\Win7-KB3191566-x86.msu /quiet > COM1:
     echo WMF install exited with code %ERRORLEVEL%. > COM1:
     echo Exiting for reboot. > COM1:
     shutdown /r /t 00
@@ -87,7 +87,7 @@ REM ping packages.cloud.google.com -n 10 > COM1:
 
 REM Set the Googet install path based on the architecture.
 set GOOGETSOURCEPATH="D:\ProgramData\GooGet\googet.exe"
-if %PROCESSOR_ARCHITECTURE%==x86 (set GOOGETSOURCEPATH="D:\builder\components\googet.exe")
+if %PROCESSOR_ARCHITECTURE%==x86 (set GOOGETSOURCEPATH="D:\sbomcomponents\components\googet.exe")
 
 echo Installing GooGet and GooGet packages. > COM1:
 %GOOGETSOURCEPATH% -root C:\ProgramData\GooGet -noconfirm install googet > COM1: 2>&1
@@ -102,22 +102,22 @@ if %PROCESSOR_ARCHITECTURE%==x86 (
   copy /B %GOOGETSOURCEPATH% C:\ProgramData\GooGet\ > COM1: 2>&1
 
   echo GooGet x86 GCE Windows Agent > COM1:
-  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\builder\components\google-compute-engine-windows-x86.x86_32.4.6.0@1.goo > COM1: 2>&1
+  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\sbomcomponents\components\google-compute-engine-windows-x86.x86_32.4.6.0@1.goo > COM1: 2>&1
 
   echo GooGet x86 PowerShell module > COM1:
-  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\builder\components\google-compute-engine-powershell.noarch.1.1.1@4.goo > COM1: 2>&1
+  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\sbomcomponents\components\google-compute-engine-powershell.noarch.1.1.1@4.goo > COM1: 2>&1
 
   echo GooGet x86 certificate generator > COM1:
-  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\builder\components\certgen-x86.x86_32.1.0.0@2.goo > COM1: 2>&1
+  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\sbomcomponents\components\certgen-x86.x86_32.1.0.0@2.goo > COM1: 2>&1
 
   echo GooGet x86 GCE Metadata Script runner > COM1:
-  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\builder\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: 2>&1
+  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\sbomcomponents\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo > COM1: 2>&1
 
   echo GooGet x86 GCE Sysprep > COM1:
-  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\builder\components\google-compute-engine-sysprep.noarch.3.10.1@1.goo > COM1: 2>&1
+  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\sbomcomponents\components\google-compute-engine-sysprep.noarch.3.10.1@1.goo > COM1: 2>&1
 
   echo GooGet x86 > COM1:
-  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\builder\components\googet-x86.x86_32.2.16.3@1.goo > COM1: 2>&1
+  C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install D:\sbomcomponents\components\googet-x86.x86_32.2.16.3@1.goo > COM1: 2>&1
 )
 
 if NOT %PROCESSOR_ARCHITECTURE%==x86 (
@@ -125,11 +125,11 @@ if NOT %PROCESSOR_ARCHITECTURE%==x86 (
 )
 
 echo Installing Google Cloud SDK. > COM1:
-D:\builder\components\GoogleCloudSDKInstaller.exe /S /allusers > COM1: 2>&1
+D:\sbomcomponents\components\GoogleCloudSDKInstaller.exe /S /allusers > COM1: 2>&1
 if NOT %ERRORLEVEL%==0 (
   echo Google Cloud SDK exited with error level %ERRORLEVEL%, retrying... > COM1:
   timeout /t 10
-  D:\builder\components\GoogleCloudSDKInstaller.exe /S /allusers > COM1: 2>&1
+  D:\sbomcomponents\components\GoogleCloudSDKInstaller.exe /S /allusers > COM1: 2>&1
   if NOT %ERRORLEVEL%==0 (
     echo Windows build failed: Google Cloud SDK exited with error level %ERRORLEVEL% > COM1:
     exit 1

--- a/daisy_workflows/image_build/windows/post_install.ps1
+++ b/daisy_workflows/image_build/windows/post_install.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = 'Stop'
 
 $script:gce_install_dir = 'C:\Program Files\Google\Compute Engine'
 $script:hosts_file = "$env:windir\system32\drivers\etc\hosts"
-$script:components_path = 'D:\builder\components'
+$script:components_path = 'D:\sbomcomponents\components'
 
 # Windows Updates Registry Key Paths
 $windows_update_path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate'


### PR DESCRIPTION
After SBOM generatino was added, bootstrap files such as the Cloud SDK installer are stored in sbomcomponents instead of builder. This updates the cmd file to reflect this.