### PR TITLE
Set default windows workflow root for presubmits

### DIFF
--- a/daisy_workflows/sbom_validation/windows_sbom_validation.wf.json
+++ b/daisy_workflows/sbom_validation/windows_sbom_validation.wf.json
@@ -36,7 +36,7 @@
       "Description": "The size of disk to provision for the image in GB."
     },
     "workflow_root": {
-      "Value": "/workflows",
+      "Value": "../../daisy_workflows",
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "sbom_destination": {


### PR DESCRIPTION
When running the presubmit, we do not want to have to pass in a workflow_root, and instead want the default workflow_root to work.

This sets the default value correctly.