### PR TITLE
Avoid race conditions due to using shortnames in enterprise linux builds

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/build_installer.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer.py
@@ -32,6 +32,7 @@ def main():
   # Get Parameters
   release = utils.GetMetadataAttribute('el_release', raise_on_not_found=True)
   savelogs = utils.GetMetadataAttribute('el_savelogs') == 'true'
+  install_disk = 'scsi-0Google_PersistentDisk_' + utils.GetMetadataAttribute('install_disk', raise_on_not_found=True)
 
   logging.info('EL Release: %s' % release)
   logging.info('Build working directory: %s' % os.getcwd())
@@ -108,6 +109,15 @@ def main():
         oldcfg.splitlines(1),
         cfg.splitlines(1))
     logging.info('Modified grub.cfg:\n%s' % '\n'.join(diff))
+
+    f.seek(0)
+    f.write(cfg)
+    f.truncate()
+
+  # Modify kickstart config
+  with open('installer/ks.cfg', 'r+') as f:
+    oldcfg = f.read()
+    cfg = re.sub(r'sub-install-disk-id', install_disk, oldcfg)
 
     f.seek(0)
     f.write(cfg)

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux.wf.json
@@ -85,7 +85,8 @@
             "el_savelogs": "${el_savelogs}",
             "google_cloud_repo": "${google_cloud_repo}",
             "rhel_byos": "${rhel_byos}",
-            "rhel_sap": "${rhel_sap}"
+            "rhel_sap": "${rhel_sap}",
+            "install_disk": "${install_disk}"
           },
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],
           "StartupScript": "installerprep_startup_script"

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/almalinux_8.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/almalinux_8.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/almalinux_9.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/almalinux_9.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_7.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_7.cfg
@@ -11,12 +11,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_8.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_8.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_8.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_8.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_9.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_9.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_4_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_4_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_6_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_6_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_7_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_7_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_9_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_9_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_7_byos.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_1_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_1_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_2_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_2_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_4_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_4_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_6_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_6_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_8_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_8_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_byos.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_0_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_0_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_2_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_2_sap.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_byos.cfg
@@ -10,12 +10,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp.cfg
@@ -13,12 +13,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9.cfg
@@ -12,12 +12,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp.cfg
@@ -13,12 +13,12 @@ poweroff
 network --bootproto=dhcp --device=link
 
 ### Disk configuration.
-# The bootloader must be set to sdb since sda is the installer.
-bootloader --boot-drive=sdb --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# build_installer.py should replace with the id of the install disk referenced by id to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/sub-install-disk-id --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
 # EFI partitioning, creates a GPT partitioned disk.
-clearpart --drives=sdb --all
-part /boot/efi --size=200 --fstype=efi --ondrive=sdb
-part / --size=100 --grow --ondrive=sdb --label=root --fstype=xfs
+clearpart --drives=/dev/disk/by-id/sub-install-disk-id --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/sub-install-disk-id
+part / --size=100 --grow --ondrive=/dev/disk/by-id/sub-install-disk-id --label=root --fstype=xfs
 
 ### Installed system configuration.
 firewall --enabled


### PR DESCRIPTION
* Pass the name of the gce disk to be installed to the bootstrap stage through metadata

* Modify the kickstart config to reference this disk directly through the /dev/disk/by-id subsystem instead of hoping it appears second on /dev/sdb