### PR TITLE
install-package: skip dependency resolver

### DIFF
--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -63,14 +63,14 @@ def main():
 
   distribution = get_distro_from_image(image)
   if distribution == 'debian':
-    util = 'apt-get'
+    install_cmd = 'apt-get install -y --ignore-missing'
   elif distribution == 'enterprise_linux':
-    util = 'yum'
+    install_cmd = 'rpm --nodeps -Uvh'
   else:
     raise Exception('Unknown Linux distribution.')
 
   logging.info('Installing package %s', package_name)
-  run(f'chroot /mnt {util} install -y /tmp/{package_name}')
+  run(f'chroot /mnt {install_cmd} /tmp/{package_name}')
   if distribution == 'enterprise_linux':
     run('chroot /mnt /sbin/setfiles -v -F '
         '/etc/selinux/targeted/contexts/files/file_contexts /')


### PR DESCRIPTION
We are introducing a explicit guest-agent -> guest-oslogin dependency chain to format enforcement. With that in the build pipe line when creating testing derived images we won't have yet available the target guest-oslogin dependency, this change makes sure we are not breaking due to missing dependencies in the tests stage.