### PR TITLE
package install: use dpkg for debian rather than apt-get

### DIFF
--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -63,7 +63,7 @@ def main():
 
   distribution = get_distro_from_image(image)
   if distribution == 'debian':
-    install_cmd = 'apt-get install -y --ignore-missing'
+    install_cmd = 'dpkg --force-all -i'
   elif distribution == 'enterprise_linux':
     install_cmd = 'rpm --nodeps -Uvh'
   else:


### PR DESCRIPTION
That way we don't deal with dependencies for build testing derived images.