### PR TITLE
Adding the appropriate GuestOsFeatures for Windows builds

### DIFF
--- a/daisy_workflows/image_build/windows/windows-build-bios.wf.json
+++ b/daisy_workflows/image_build/windows/windows-build-bios.wf.json
@@ -100,7 +100,13 @@
           "Name": "${install_disk}",
           "SourceImage": "${install_source_image}",
           "SizeGb": "${install_disk_size}",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "GuestOsFeatures": [
+            { "type": "MULTI_IP_SUBNET" },
+            { "type": "VIRTIO_SCSI_MULTIQUEUE" },
+            { "type": "GVNIC" },
+            { "type": "WINDOWS" }
+          ]
         }
       ]
     },

--- a/daisy_workflows/image_build/windows/windows-build-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-build-uefi.wf.json
@@ -99,9 +99,11 @@
           "SizeGb": "${install_disk_size}",
           "Type": "pd-ssd",
           "GuestOsFeatures": [
-            {
-              "type": "UEFI_COMPATIBLE"
-            }
+            { "type": "UEFI_COMPATIBLE" },
+            { "type": "MULTI_IP_SUBNET" },
+            { "type": "VIRTIO_SCSI_MULTIQUEUE" },
+            { "type": "GVNIC" },
+            { "type": "WINDOWS" }
           ]
         }
       ]


### PR DESCRIPTION
This is so on the first boot in the build process the installation disk has the correct set of Guest OS Features.