### PR TITLE
Disable VCS stamping of binaries

### DIFF
--- a/gce_windows_upgrade_tests.Dockerfile
+++ b/gce_windows_upgrade_tests.Dockerfile
@@ -16,11 +16,11 @@ FROM golang
 
 # Build test runner
 COPY / /kaniko/build
-RUN CGO_ENABLED=0 go build -C /kaniko/build/cli_tools_tests/e2e/gce_windows_upgrade -o /gce_windows_upgrade_test_runner
+RUN CGO_ENABLED=0 go build -C /kaniko/build/cli_tools_tests/e2e/gce_windows_upgrade -buildvcs=false -o /gce_windows_upgrade_test_runner
 RUN chmod +x /gce_windows_upgrade_test_runner
 
 # Build binaries to test
-RUN CGO_ENABLED=0 go build -C /kaniko/build/cli_tools/gce_windows_upgrade -o /gce_windows_upgrade
+RUN CGO_ENABLED=0 go build -C /kaniko/build/cli_tools/gce_windows_upgrade -buildvcs=false -o /gce_windows_upgrade
 RUN chmod +x /gce_windows_upgrade
 
 # Build test container


### PR DESCRIPTION
Kaniko is not handling this well outside of the cloudbuild context. The commit hash will still be preserved as a tag when we push the image through concourse