### PR TITLE
google-cloud-cli -> google-cloud-sdk in rhel sap byos images

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_2_sap_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_2_sap_byos.cfg
@@ -203,7 +203,7 @@ EOL
 dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.
-dnf install -y google-cloud-cli
+dnf install -y google-cloud-sdk
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_4_sap_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_4_sap_byos.cfg
@@ -203,7 +203,7 @@ EOL
 dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.
-dnf install -y google-cloud-cli
+dnf install -y google-cloud-sdk
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_6_sap_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_6_sap_byos.cfg
@@ -203,7 +203,7 @@ EOL
 dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.
-dnf install -y google-cloud-cli
+dnf install -y google-cloud-sdk
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_8_sap_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_8_sap_byos.cfg
@@ -203,7 +203,7 @@ EOL
 dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.
-dnf install -y google-cloud-cli
+dnf install -y google-cloud-sdk
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg


### PR DESCRIPTION
rhel sap byos uses a different gcloud package than the rest of enterprise linux, which throws a wrench in our package [testing](http://localhost:8080/teams/guestos/pipelines/linux-image-build/jobs/publish-to-testing-rhel-8-4-sap-byos/builds/58). If there's a preference for one or the other we can switch to either but we should make it consistent to make our testing easier.

/assign @zmarano 