### PR TITLE
Tag images that contain kernel commit 43955a1a2 with SEV_LIVE_MIGRATABLE_V2

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8.wf.json
@@ -41,7 +41,7 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8, x86_64 built on ${build_date}",
           "Family": "rhel-8",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_byos.wf.json
@@ -45,7 +45,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9.wf.json
@@ -41,7 +41,7 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9, x86_64 built on ${build_date}",
           "Family": "rhel-9",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_byos.wf.json
@@ -45,7 +45,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_8.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_8.wf.json
@@ -44,7 +44,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_LIVE_MIGRATABLE_V2"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9.wf.json
@@ -44,7 +44,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"]
         }
       ]
     }


### PR DESCRIPTION
Ping me on corp if you need context. I updated the image-build stuff too because CIT is starting to rely on guest os feature tags more so it would be good to keep things in sync everywhere.

rhel 8 and 9 byos did not previous have the v1 tags but it's still rhel and they have the backports so I added it, if there's something I'm missing LMK.

/cc @zmarano @elicriffield 