### PR TITLE
Add image publish workflow for centos-7-predictable-nic

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/centos_7_predictable_nic.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7_predictable_nic.publish.json
@@ -1,0 +1,31 @@
+{{/*
+  Template to publish UEFI-enabled CentOS images.
+  By default this template is setup to publish to the 'gce-image-builder'
+  project, the 'environment' variable can be used to publish to 'test', 'prod'
+  DeleteAfter is set to 180 days for all environments other than prod where no
+  time period is set.
+*/}}
+{
+  "Name": "centos-7",
+  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
+  {{$delete_after := `"24h*30*6"` -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "bct-prod-images",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$time := trimPrefix .publish_version "v"}}
+  "Images": [
+    {
+      "Family": "centos-7",
+      "Prefix": "centos-7",
+      "Description": "CentOS, CentOS, 7, x86_64 built on {{$time}}",
+      "Architecture": "X86_64",
+      "Licenses": [
+        "projects/centos-cloud/global/licenses/centos-7"
+      ],
+      "GuestOsFeatures": {{$guest_features}}
+    }
+  ]
+}

--- a/daisy_workflows/build-publish/enterprise_linux/centos_7_predictable_nic.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7_predictable_nic.wf.json
@@ -37,7 +37,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/centos_7.wf.json",
+        "Path": "${workflow_root}/image_build/enterprise_linux/centos_7_predictable_nic.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "google_cloud_repo": "${google_cloud_repo}",

--- a/daisy_workflows/build-publish/enterprise_linux/centos_7_predictable_nic.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7_predictable_nic.wf.json
@@ -1,0 +1,70 @@
+{
+  "Name": "centos-7-predictable-nic",
+  "Project": "gce-image-builder",
+  "Zone": "us-central1-b",
+  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "Vars": {
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "gcs_url": {
+      "Required": true,
+      "Description": "The GCS path that image raw file exported to."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
+    "installer_iso": {
+      "Required": true,
+      "Description": "The CentOS 7 installer ISO to build from."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "build": {
+      "TimeOut": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/image_build/enterprise_linux/centos_7.wf.json",
+        "Vars": {
+          "build_date": "${build_date}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "installer_iso": "${installer_iso}"
+        }
+      }
+    },
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
+          "source_disk": "el-install-disk",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "cleanup-image": {
+      "DeleteResources": {
+        "Images": ["centos-7-predictable-nic-v${build_date}"]
+      }
+    }
+  },
+  "Dependencies": {
+    "export-image": ["build"],
+    "cleanup-image": ["export-image"]
+  }
+}


### PR DESCRIPTION
Publish template is still missing so it can't successfully push to ARLE, forgot I need this workflow.