### PR TITLE
Install python38 on rocky 8 optimized gcp arm64

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
@@ -55,6 +55,7 @@ dnf-automatic
 net-tools
 openssh-server
 python3
+python38
 rng-tools
 tar
 vim
@@ -97,6 +98,7 @@ vim
 %end
 
 %post
+dnf mark remove python38 || exit 1 # workaround for gcloud broken on el8 arm64
 tee -a /etc/yum.repos.d/google-cloud.repo << EOM
 [google-compute-engine]
 name=Google Compute Engine


### PR DESCRIPTION
/cc @elicriffield @zmarano 
/hold

This would make gcloud work for now by installing a version of python3 that works and allow us to release rocky 8 arm this month.

The downside of removing the python38 mark is that gcloud will break when the user does `dnf upgrade`, but even the current image `rocky-linux-8-optimized-gcp-arm64-v20231010` has this problem. The upside is that we don't leave python38 installed permanently for a temporary workaround.