### PR TITLE
Exclude KB5034439 from Server 2022 builds

### DIFF
--- a/daisy_workflows/image_build/windows/post_install.ps1
+++ b/daisy_workflows/image_build/windows/post_install.ps1
@@ -195,6 +195,19 @@ function Install-WindowsUpdates {
     }
   }
 
+  # As of Jan 2024, Server 2022 may get stuck installing KB5034439.
+  # Temporarily work around this to let the build continue.
+  if ($updates.Count -eq 1) {
+    if([Environment]::OSVersion.Version.Major -eq 10 -and [Environment]::OSVersion.Version.Minor -eq 0 -and [Environment]::OSVersion.Version.Build -eq 20348) {
+      foreach ($update in $updates) {
+        if ($update.Title -like '*KB5034439*') {
+          Write-Host 'Install-WindowsUpdates: KB5034439 detected as a single update remaining. Skipping known issue KB.'
+          return $false
+        }
+      }
+    }
+  }
+
   foreach ($update in $updates) {
     if (-not ($update.EulaAccepted)) {
       Write-Host 'The following update required a EULA to be accepted:'


### PR DESCRIPTION
Likely a temporary exception to allow the build to complete.

Looking at Windows Update logs for a failed test VM it appears the KB is never actually attempted by the Windows Update service, yet the build log shows it repeatedly trying and Succeeding with Errors.