### PR TITLE
Tag rocky 8/9 optimized with SEV_LIVE_MIGRATABLE_V2

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {


### PR DESCRIPTION
/cc @zmarano @elicriffield 
```
[acrate_google_com@rocky8optimized ~]$ uname -r && sudo dnf install -y kernel-devel >/dev/null && casr/src/kernels/$(uname -r )/arch/x86/include/asm/mem_encrypt.h | grep 'early_set_mem_enc_dec_hypercall(unsigned long vaddr, unsigned long size, bool enc) {}' && echo "Kernel contains ac3f9c9f1b37edaa7d1a9b908bc79d843955a1a2"
4.18.0-513.9.1.el8_9.cloud.0.1.x86_64
early_set_mem_enc_dec_hypercall(unsigned long vaddr, unsigned long size, bool enc) {}
Kernel contains ac3f9c9f1b37edaa7d1a9b908bc79d843955a1a2
[acrate_google_com@rocky8optimized ~]$
```
```
[acrate_google_com@rocky9optimized ~]$ uname -r && sudo dnf install -y kernel-devel >/dev/null && cat /usr/src/kernels/$(uname -r )/arch/x86/include/asm/mem_encrypt.h | grep 'early_set_mem_enc_dec_hypercall(unsigned long vaddr, unsigned long size, bool enc) {}' && echo "Kernel contains ac3f9c9f1b37edaa7d1a9b908bc79d843955a1a2"
5.14.0-362.13.1.el9_3.cloud.0.3.x86_64
early_set_mem_enc_dec_hypercall(unsigned long vaddr, unsigned long size, bool enc) {}
Kernel contains ac3f9c9f1b37edaa7d1a9b908bc79d843955a1a2
[acrate_google_com@rocky9optimized ~]$
```