### PR TITLE
Revert "Install python38 on rocky 8 optimized gcp arm64 (#2258)"

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
@@ -55,7 +55,6 @@ dnf-automatic
 net-tools
 openssh-server
 python3
-python38
 rng-tools
 tar
 vim
@@ -98,7 +97,6 @@ vim
 %end
 
 %post
-dnf mark remove python38 || exit 1 # workaround for gcloud broken on el8 arm64
 tee -a /etc/yum.repos.d/google-cloud.repo << EOM
 [google-compute-engine]
 name=Google Compute Engine


### PR DESCRIPTION
This reverts commit 08601f6f19d8afd701fbec68c9ca5dcdc8472e08.

gcloud preamble changes are rolled out, I built an image from this and it passes CIT

/cc @zmarano @elicriffield 