### PR TITLE
Update W10 21H2 build timeout

### DIFF
--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -51,7 +51,7 @@
   },
   "Steps": {
     "build": {
-      "Timeout": "4h",
+      "Timeout": "5h",
       "IncludeWorkflow": {
         "Path": "${workflow_root}/image_build/windows/windows-10-21h2-ent-x64-uefi.wf.json",
         "Vars": {

--- a/daisy_workflows/image_build/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -64,7 +64,7 @@
   },
   "Steps": {
     "windows-build": {
-      "Timeout": "4h",
+      "Timeout": "5h",
       "IncludeWorkflow": {
         "Path": "./windows-build-uefi.wf.json",
         "Vars": {


### PR DESCRIPTION
Missed a timeout reference in the last PR. Updating the other build file to match the new timeout.