### PR TITLE
Windows Server 2025 image build workflows

### DIFF
--- a/daisy_workflows/image_build/windows/windows-server-2025-core-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-core-uefi-byol.wf.json
@@ -1,0 +1,127 @@
+{
+  "Name": "windows-2025-core-uefi-byol",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Core Preview, Server Core, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-standard-core-byol-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-core-byol-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERSTANDARDCORE",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025-byol",
+            "projects/windows-cloud/global/licenses/windows-server-core"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-core-uefi-payg.wf.json
@@ -93,7 +93,7 @@
           "Family": "${family}",
           "Description": "${description}",
           "Licenses": [
-            "projects/windows-cloud/global/licenses/windows-server-2025",
+            "projects/windows-cloud/global/licenses/windows-server-2022",
             "projects/windows-cloud/global/licenses/windows-server-core"
           ],
           "GuestOsFeatures": [

--- a/daisy_workflows/image_build/windows/windows-server-2025-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-core-uefi-payg.wf.json
@@ -1,0 +1,127 @@
+{
+  "Name": "windows-2025-core-uefi",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Core Preview, Server Core, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-standard-core-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-core-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERSTANDARDCORE",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025",
+            "projects/windows-cloud/global/licenses/windows-server-core"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-dc-core-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-dc-core-uefi-byol.wf.json
@@ -1,0 +1,127 @@
+{
+  "Name": "windows-2025-dc-core-uefi-byol",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Datacenter Core Preview, Server Core, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-core-byol-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-dc-core-byol-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERDATACENTERCORE",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025-byol",
+            "projects/windows-cloud/global/licenses/windows-server-core"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-dc-core-uefi-payg.wf.json
@@ -1,0 +1,127 @@
+{
+  "Name": "windows-2025-dc-core-uefi",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Datacenter Core Preview, Server Core, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-core-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-dc-core-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERDATACENTERCORE",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025-dc",
+            "projects/windows-cloud/global/licenses/windows-server-core"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-dc-core-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-dc-core-uefi-payg.wf.json
@@ -93,7 +93,7 @@
           "Family": "${family}",
           "Description": "${description}",
           "Licenses": [
-            "projects/windows-cloud/global/licenses/windows-server-2025-dc",
+            "projects/windows-cloud/global/licenses/windows-server-2022-dc",
             "projects/windows-cloud/global/licenses/windows-server-core"
           ],
           "GuestOsFeatures": [

--- a/daisy_workflows/image_build/windows/windows-server-2025-dc-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-dc-uefi-byol.wf.json
@@ -1,0 +1,126 @@
+{
+  "Name": "windows-2025-dc-uefi-byol",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Datacenter Preview, Server with Desktop Experience, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-byol-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-dc-byol-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERDATACENTER",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025-dc"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-dc-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-dc-uefi-payg.wf.json
@@ -1,0 +1,126 @@
+{
+  "Name": "windows-2025-dc-uefi",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Datacenter Preview, Server with Desktop Experience, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-dc-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERDATACENTER",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025-dc"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-dc-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-dc-uefi-payg.wf.json
@@ -93,7 +93,7 @@
           "Family": "${family}",
           "Description": "${description}",
           "Licenses": [
-            "projects/windows-cloud/global/licenses/windows-server-2025-dc"
+            "projects/windows-cloud/global/licenses/windows-server-2022-dc"
           ],
           "GuestOsFeatures": [
             {

--- a/daisy_workflows/image_build/windows/windows-server-2025-uefi-byol.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-uefi-byol.wf.json
@@ -1,0 +1,126 @@
+{
+  "Name": "windows-2025-uefi-byol",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Preview, Server with Desktop Experience, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-standard-byol-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-byol-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERSTANDARD",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}

--- a/daisy_workflows/image_build/windows/windows-server-2025-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-uefi-payg.wf.json
@@ -93,7 +93,7 @@
           "Family": "${family}",
           "Description": "${description}",
           "Licenses": [
-            "projects/windows-cloud/global/licenses/windows-server-2025"
+            "projects/windows-cloud/global/licenses/windows-server-2022"
           ],
           "GuestOsFeatures": [
             {

--- a/daisy_workflows/image_build/windows/windows-server-2025-uefi-payg.wf.json
+++ b/daisy_workflows/image_build/windows/windows-server-2025-uefi-payg.wf.json
@@ -1,0 +1,126 @@
+{
+  "Name": "windows-2025-uefi",
+  "Vars": {
+    "install_disk": "install-disk",
+    "media": {
+      "Required": true,
+      "Description": "GCS or local path to Windows Server ISO."
+    },
+    "pwsh": {
+      "Required": true,
+      "Description": "GCS or local path to PowerShell v7+ installer"
+    },
+    "dotnet48": {
+      "Required": true,
+      "Description": "GCS or local path to Microsoft .NET Framework 4.8 offline installer"
+    },
+    "cloudsdk": {
+      "Required": true,
+      "Description": "GCS or local path to Cloud SDK installer"
+    },
+    "description": {
+      "Value": "Microsoft, Windows Server, 2025 Preview, Server with Desktop Experience, x64 built on ${TIMESTAMP}"
+    },
+    "family": {
+      "Value": "windows-2025-standard-preview",
+      "Description": "Desired image family of the output image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "Google Cloud repo to retrieve packages from during the build."
+    },
+    "name": {
+      "Value": "windows-server-2025-preview-v${TIMESTAMP}",
+      "Description": "The name of the output image."
+    },
+    "project": {
+      "Value": "${PROJECT}",
+      "Description": "The GCP project to create and store the image in."
+    },
+    "updates": {
+      "Value": "",
+      "Description": "GCS or local filesystem location containing Windows update files."
+    },
+    "drivers_bucket": {
+      "Value": "gs://gce-windows-drivers-public/release/win6.3-signed-stornvme/",
+      "Description": "GCS location containing the GCP Windows driver files."
+    },
+    "install_disk_size": {
+      "Value": "50",
+      "Description": "The size of disk to provision for the image in GB."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "The GCS url that the sbom file exported to."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    }
+  },
+  "Steps": {
+    "windows-build": {
+      "Timeout": "4h",
+      "IncludeWorkflow": {
+        "Path": "./windows-build-uefi.wf.json",
+        "Vars": {
+          "install_disk": "${install_disk}",
+          "install_disk_size": "${install_disk_size}",
+          "updates": "${updates}",
+          "drivers_bucket": "${drivers_bucket}",
+          "dotnet48": "${dotnet48}",
+          "pwsh": "${pwsh}",
+          "edition": "Windows Server 2025 SERVERSTANDARD",
+          "media": "${media}",
+          "cloud_sdk": "${cloudsdk}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "workflow_root": "${workflow_root}",
+          "sbom_destination": "${sbom_destination}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Project": "${project}",
+          "SourceDisk": "${install_disk}",
+          "Name": "${name}",
+          "Family": "${family}",
+          "Description": "${description}",
+          "Licenses": [
+            "projects/windows-cloud/global/licenses/windows-server-2025"
+          ],
+          "GuestOsFeatures": [
+            {
+              "Type": "VIRTIO_SCSI_MULTIQUEUE"
+            },
+            {
+              "Type": "WINDOWS"
+            },
+            {
+              "Type": "MULTI_IP_SUBNET"
+            },
+            {
+              "Type": "UEFI_COMPATIBLE"
+            },
+            {
+              "Type": "GVNIC"
+            }
+          ],
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": [
+      "windows-build"
+    ]
+  }
+}


### PR DESCRIPTION
- Adding Server 2025 image build workflows
- Server 2022 payg licenses are being used so instance are charged/licensed for usage.