### PR TITLE
Enable WinRM also on Windows Client Professional

### DIFF
--- a/daisy_workflows/image_build/windows/post_install.ps1
+++ b/daisy_workflows/image_build/windows/post_install.ps1
@@ -621,7 +621,7 @@ function Generate-NativeImage {
 }
 
 function Enable-WinRM {
-  if ($pn -like '*Enterprise') {
+  if ($pn -like '*Enterprise' -Or $pn -like '*Pro') {
     Write-Host 'Windows Client detected, enabling WinRM (including on Public networks).'
     & winrm quickconfig -quiet -force
   }


### PR DESCRIPTION
My customer is building a Windows 11 Professional image, by adapting the .wf.json file. The shared post_install.ps1 only enables WinRM on Windows Client Enterprise, not Professional. Per https://learn.microsoft.com/en-us/answers/questions/721139/programmatically-(powershell)-getting-windows-vers , in this case $pn ends with Pro.