### PR TITLE
Updating windows builds to run on n2 for Windows 11 CPU support

### DIFF
--- a/daisy_workflows/image_build/windows/windows-build-uefi.wf.json
+++ b/daisy_workflows/image_build/windows/windows-build-uefi.wf.json
@@ -174,7 +174,7 @@
           "DisplayDevice": {
             "enableDisplay": true
           },
-          "MachineType": "e2-standard-4",
+          "MachineType": "n2-standard-4",
           "Scopes": [
             "https://www.googleapis.com/auth/devstorage.read_write"
           ],


### PR DESCRIPTION
Updating windows builds to run on n2 for Windows 11 CPU support