### PR TITLE
Allow the preloading script to create a preloaded COS image in different projects

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
@@ -49,9 +49,9 @@ steps:
 - name: '${_COS_CUSTOMIZER}'
   args: ['finish-image-build',
          '-zone=us-west1-b',
-         '-project=${PROJECT_ID}',
+         '-project=${_DEST_PROJECT}',
          '-image-name=${_NEW_IMAGE}',
          '-image-family=${_NEW_IMAGE_FAMILY}',
-         '-image-project=${PROJECT_ID}',
+         '-image-project=${_DEST_PROJECT}',
          '-labels=base_image=${_BASE_IMAGE}']
 timeout: '1800s'  # 30 minutes


### PR DESCRIPTION
By adding a command line arg for '_DEST_PROJECT', we can specify which project the preloaded image should be uploaded to. Previously, it would just use the default project in the gcloud config of whatever/whomever was invoking the dev_cloudbuild.yaml script.

Ideally, this will allow us to upload the preloaded image to the gcp-guest project, like the other preloaded images for other distros during the guest-package-build concourse pipeline.