### PR TITLE
New RHEL 9.4 ISO is to big to fit, had to make the partitions larger

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/build_installer.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer.py
@@ -53,10 +53,10 @@ def main():
   utils.Execute(['parted', installer_disk, 'mklabel', 'gpt'])
   utils.Execute(['sync'])
   utils.Execute(['parted', installer_disk, 'mkpart', 'primary', 'fat32', '1MB',
-                 '1024MB'])
+                 '2048MB'])
   utils.Execute(['sync'])
   utils.Execute(['parted', installer_disk, 'mkpart', 'primary', 'ext2',
-                 '1024MB', '100%'])
+                 '2048MB', '100%'])
   utils.Execute(['sync'])
   utils.Execute(['parted', installer_disk, 'set', '1', 'boot', 'on'])
   utils.Execute(['sync'])


### PR DESCRIPTION
New RHEL 9.4 ISO is to big to fit, had to make the partitions larger