### PR TITLE
Make the preloading script take a commit sha as input for the guest-agent repo (rather than a tag)

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
+++ b/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
@@ -11,9 +11,9 @@
       "Required": true,
       "Description": "dest image"
     },
-    "package_version": {
+    "commit_sha": {
       "Required": true,
-      "Description": "package version"
+      "Description": "commit sha"
     },
     "cos_branch": {
       "Required": true,
@@ -57,7 +57,7 @@
 	    "source_image": "${source_image}",
 	    "dest_image": "${dest_image}",
 	    "cos_branch": "${cos_branch}",
-	    "package_version": "${package_version}"
+	    "commit_sha": "${commit_sha}"
           },
           "StartupScript": "startup_script",
 	  "Scopes": [

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -29,7 +29,7 @@
 # Args: ./compile_debian_package [overlays_branch] [guest_agent_version]
 # Example: ./compile_debian_package master 20231214.00
 #     $1 [overlays_branch]: the COS milestone version (to apply the correct patches).
-#     $2 [guest_agent_version]: the guest agent version (to upgrade to).
+#     $2 [commit_sha]: the guest agent commit sha (to upgrade to).
 
 set -o errexit
 set -o pipefail
@@ -39,7 +39,10 @@ apply_patches() {
   # Download the repositories and apply COS specific patches.
   echo -e "\nATTENTION: Downloading the board-overlays and guest-agent repos...\n"
   git clone https://cos.googlesource.com/cos/overlays/board-overlays --branch ${overlays_branch}
-  git clone https://github.com/GoogleCloudPlatform/guest-agent.git --branch ${guest_agent_version}
+  git clone https://github.com/GoogleCloudPlatform/guest-agent.git
+  cd guest-agent
+  git checkout ${commit_sha}
+  cd ..
   mv ./board-overlays/project-lakitu/app-admin/google-guest-agent/files ./guest-agent
   cd guest-agent
 
@@ -47,7 +50,7 @@ apply_patches() {
   search_dir=./files
   for file in "$search_dir"/*
   do
-    if [[ "$file" == *"patch"* ]]; then
+    if ! [[ "$file" == *"homedir"* ]] && [[ "$file" == *"patch"* ]]; then
       git apply "$file"
     fi
   done
@@ -160,7 +163,7 @@ main() {
   fi
 
   overlays_branch=$1
-  guest_agent_version=$2
+  commit_sha=$2
 
   echo -e "\nATTENTION: Starting compile_debian_package.sh...\n"
   apply_patches

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -27,7 +27,7 @@
 # Most of the code here is sourced from: https://github.com/GoogleCloudPlatform/guest-test-infra/blob/master/packagebuild/daisy_startupscript_deb.sh
 #
 # Args: ./compile_debian_package [overlays_branch] [guest_agent_version]
-# Example: ./compile_debian_package master 20231214.00
+# Example: ./compile_debian_package release-R113 094ef227ddf92165abcb7b1241ca44728c3086d1
 #     $1 [overlays_branch]: the COS milestone version (to apply the correct patches).
 #     $2 [commit_sha]: the guest agent commit sha (to upgrade to).
 

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
   args:
     - '-c'
     - |
-      ./compile_debian_package.sh $_OVERLAYS_BRANCH $_GUEST_AGENT_VERSION
+      ./compile_debian_package.sh $_OVERLAYS_BRANCH $_COMMIT_SHA
 # _DEST_PROJECT in the 'finish-image-build' step should should have access
 # to the gcs-bucket path specified here.
 - name: '${_COS_CUSTOMIZER}'

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -28,7 +28,7 @@ set_files_executable(){
 get_vars(){
   export SOURCE_IMAGE=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/source_image)
   export DEST_IMAGE=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/dest_image)
-  export PACKAGE_VERSION=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/package_version)
+  export COMMIT_SHA=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/commit_sha)
   export COS_BRANCH=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cos_branch)
 }
 
@@ -39,7 +39,7 @@ get_vars(){
 #   _NEW_IMAGE: The name of the resulting preloaded image.
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
 create_preloaded_image(){
-  gcloud builds submit --config=dev_cloudbuild.yaml --disk-size=200 . --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_OVERLAYS_BRANCH="${COS_BRANCH}",_GUEST_AGENT_VERSION="${PACKAGE_VERSION}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
+  gcloud builds submit --config=dev_cloudbuild.yaml --disk-size=200 . --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_OVERLAYS_BRANCH="${COS_BRANCH}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
 }
 
 main (){

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -5,7 +5,7 @@
 #   1) The script sets all the preloading scripts as executable (located in
 #   /cos/package_replacement).
 #   2) Then, collects all passed in data through metadata API (name of source
-#   image, dest image, package version, cos branch).
+#   image, dest image, commit sha, cos branch).
 #     - cos_branch: the name of the branch associated with a COS milestone (ie
 #     for cos-113, cos_branch=release-R113).
 #   3) Runs a gcloud submit command to invoke the cloudbuild responsible for


### PR DESCRIPTION
In the concourse pipeline, the guest agent repo is checked out using the most recent commit. Then once the tests have passed on that commit, a tag is created. So at the time of preloading a COS image for testing, a tag won't exist. The preloading script should then take the commit sha as input.

Additionally, the homedir patch that is currently present in the COS code base for the guest agent package is no longer needed for updating to newer versions of guest agent since it was upstreamed, so that patch can be skipped.

CCing @dorileo, @a-crate, @zmarano.