### PR TITLE
Fix RHEL 9.4 installation errors due to redhat-insights client.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9.cfg
@@ -56,6 +56,8 @@ rng-tools
 tar
 vim
 -subscription-manager
+-rhc
+-insights-client
 -alsa-utils
 -b43-fwcutter
 -dmraid

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_4_sap.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_4_sap.cfg
@@ -56,6 +56,8 @@ rng-tools
 tar
 vim
 -subscription-manager
+-rhc
+-insights-client
 -alsa-utils
 -b43-fwcutter
 -dmraid

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_arm64.cfg
@@ -56,6 +56,8 @@ rng-tools
 tar
 vim
 -subscription-manager
+-rhc
+-insights-client
 -alsa-utils
 -b43-fwcutter
 -dmraid


### PR DESCRIPTION
Since RHEL 9.4 (and possibly 9.3), installation fails at package selection due to the redhat-insights packages depending on subscription-manager. This only affects on demand as BYOS images have subscription-manager included.