### PR TITLE
Specify source after 'gcloud builds submit'

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -39,7 +39,7 @@ get_vars(){
 #   _NEW_IMAGE: The name of the resulting preloaded image.
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
 create_preloaded_image(){
-  gcloud builds submit --config=dev_cloudbuild.yaml --disk-size=200 . --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_OVERLAYS_BRANCH="${COS_BRANCH}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
+  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_OVERLAYS_BRANCH="${COS_BRANCH}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
 }
 
 main (){


### PR DESCRIPTION
In order to avoid gcloud builds submit errors in the concourse guest package build workflow, specify the source after gcloud builds submit,

CCing @dorileo, @a-crate , @zmarano.