### PR TITLE
Add support for other COS milestones (+109, +105) and also ARM images

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
+++ b/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
@@ -15,10 +15,6 @@
       "Required": true,
       "Description": "commit sha"
     },
-    "cos_branch": {
-      "Required": true,
-      "Description": "cos_branch"
-    },
     "worker_image": {
       "Value": "projects/compute-image-tools/global/images/family/debian-11-worker",
       "Description": "worker image"
@@ -56,7 +52,6 @@
             "script": "replacepackage.sh",
 	    "source_image": "${source_image}",
 	    "dest_image": "${dest_image}",
-	    "cos_branch": "${cos_branch}",
 	    "commit_sha": "${commit_sha}"
           },
           "StartupScript": "startup_script",

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -26,9 +26,8 @@
 #
 # Most of the code here is sourced from: https://github.com/GoogleCloudPlatform/guest-test-infra/blob/master/packagebuild/daisy_startupscript_deb.sh
 #
-# Args: ./compile_debian_package [overlays_branch] [guest_agent_version]
-# Example: ./compile_debian_package release-R113 094ef227ddf92165abcb7b1241ca44728c3086d1
-#     $1 [overlays_branch]: the COS milestone version (to apply the correct patches).
+# Args: ./compile_debian_package [guest_agent_version]
+# Example: ./compile_debian_package 094ef227ddf92165abcb7b1241ca44728c3086d1
 #     $2 [commit_sha]: the guest agent commit sha (to upgrade to).
 
 set -o errexit
@@ -36,9 +35,11 @@ set -o pipefail
 set -o nounset
 
 apply_patches() {
-  # Download the repositories and apply COS specific patches.
+  # Download the repositories and apply COS specific patches. NOTE: The patches will be
+  # pulled from the master branch in COS. This is based on the assumption that master
+  # will have the most recent guest agent version, and therefore the most recent patches.
   echo -e "\nATTENTION: Downloading the board-overlays and guest-agent repos...\n"
-  git clone https://cos.googlesource.com/cos/overlays/board-overlays --branch ${overlays_branch}
+  git clone https://cos.googlesource.com/cos/overlays/board-overlays --branch master
   git clone https://github.com/GoogleCloudPlatform/guest-agent.git
   cd guest-agent
   git checkout ${commit_sha}
@@ -157,13 +158,12 @@ identify_replacement_files(){
 }
 
 main() {
-  if [ "$#" -ne 2 ]; then
-    echo "Arguments 'overlays_branch' and 'guest_agent_version' must be provided."
+  if [ "$#" -ne 1 ]; then
+    echo "Argument 'guest_agent_version' must be provided."
     exit 1
   fi
 
-  overlays_branch=$1
-  commit_sha=$2
+  commit_sha=$1
 
   echo -e "\nATTENTION: Starting compile_debian_package.sh...\n"
   apply_patches

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
@@ -31,8 +31,13 @@ steps:
          '-image-project=${_BASE_IMAGE_PROJECT}',
          '-gcs-bucket=${_DEST_PROJECT}_cloudbuild',
          '-gcs-workdir=customizer-$BUILD_ID']
+# This step disables auto updates on the machine. This replaces the
+# disable-auto-update step in COS Customizer since that step is not
+# compatible with ARM images.
 - name: '${_COS_CUSTOMIZER}'
-  args: ["disable-auto-update"]
+  args: ['run-script',
+         '-script=disable_auto_updates.sh',
+         '-env=KERNEL_PKG=${_KERNEL_PKG}']
 # This step disables the read-only root fs.
 - name: '${_COS_CUSTOMIZER}'
   args: ['run-script',
@@ -50,8 +55,9 @@ steps:
          '-env=KERNEL_PKG=${_KERNEL_PKG}']
 - name: '${_COS_CUSTOMIZER}'
   args: ['finish-image-build',
-         '-zone=us-west1-b',
+         '-zone=us-central1-a',
          '-project=${_DEST_PROJECT}',
+         '-machine-type=${_MACHINE_TYPE}',
          '-image-name=${_NEW_IMAGE}',
          '-image-family=${_NEW_IMAGE_FAMILY}',
          '-image-project=${_DEST_PROJECT}',

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
   args:
     - '-c'
     - |
-      ./compile_debian_package.sh $_OVERLAYS_BRANCH $_COMMIT_SHA
+      ./compile_debian_package.sh $_COMMIT_SHA
 # _DEST_PROJECT in the 'finish-image-build' step should should have access
 # to the gcs-bucket path specified here.
 - name: '${_COS_CUSTOMIZER}'

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/disable_auto_updates.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/disable_auto_updates.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Disables auto updates on machine.
+
+set -o errexit
+set -o pipefail
+set -x
+
+# This function disables auto updates on a runnning machine.
+disable_auto_updates() {
+  sudo systemctl stop update-engine
+  sudo systemctl mask update-engine
+}
+
+
+main() {
+  echo "disable_auto_updates"
+  disable_auto_updates
+}
+
+main

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/disable_readonly_rootfs.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/disable_readonly_rootfs.sh
@@ -41,6 +41,7 @@ disable_vboot() {
     reboot
     # Hang after reboot: the script should not continue executing (return) after
     # the reboot call due to COS customizer design.
+    echo "NOTE: infinite loop to prevent this script from continuing execution after the reboot call"
     while true; do sleep 1; done
   else
     umount "${dir}"

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -44,6 +44,7 @@ set_machine_type(){
 #   _DEST_PROJECT: The project that contains the resulting preloaded image.
 #   _NEW_IMAGE: The name of the resulting preloaded image.
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
+#   _MACHINE_TYPE: The machine type for the source image: default (n1-standard-1) or t2a-standard-1 for ARM.
 create_preloaded_image(){
   gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest",_MACHINE_TYPE="${MACHINE_TYPE}"
 }

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -52,6 +52,7 @@ main (){
   echo "Creating COS image with the new guest agent version..."
   set_files_executable
   get_vars
+  set_machine_type
   create_preloaded_image
 }
 

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -32,6 +32,12 @@ get_vars(){
   export DAISY_LOGS_PATH=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/daisy-logs-path)
 }
 
+set_machine_type(){
+  export MACHINE_TYPE="n1-standard-1"
+  if [[ "$SOURCE_IMAGE" == *"arm"* ]]; then
+      export MACHINE_TYPE="t2a-standard-1"
+  fi
+}
 # The following additional parameters are passed into the cloudbuild script:
 #   _BASE_IMAGE_PROJECT: The project that contains the base/source image.
 #   _BASE_IMAGE: The name of the base/source image.
@@ -39,7 +45,7 @@ get_vars(){
 #   _NEW_IMAGE: The name of the resulting preloaded image.
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
 create_preloaded_image(){
-  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
+  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest",_MACHINE_TYPE="${MACHINE_TYPE}"
 }
 
 main (){

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -29,7 +29,6 @@ get_vars(){
   export SOURCE_IMAGE=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/source_image)
   export DEST_IMAGE=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/dest_image)
   export COMMIT_SHA=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/commit_sha)
-  export COS_BRANCH=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cos_branch)
   export DAISY_LOGS_PATH=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/daisy-logs-path)
 }
 
@@ -40,7 +39,7 @@ get_vars(){
 #   _NEW_IMAGE: The name of the resulting preloaded image.
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
 create_preloaded_image(){
-  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_OVERLAYS_BRANCH="${COS_BRANCH}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
+  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest"
 }
 
 main (){


### PR DESCRIPTION
In order to add support for further milestones, we:
1) Take the patches from master and apply those (since these are the most recent patches).
2) Step 1 (above) then removes the requirement of specifying the overlays branch name, so that is removed from all occurrences.

In order to add support for arm images we:
1) make machine type configurable (t2a for arm images)
2) change zone to accommodate ARM (central)
3) replace COS customizer's disable auto update step with our own script (since the default step is not compatible with ARM images) 
4) rewrite the disabling read only root fs script (to not hang after the reboot).

CCing @a-crate, @dorileo, @zmarano.