### PR TITLE
Add variable for sha256 text file

### DIFF
--- a/daisy_workflows/build-publish/debian/debian_10.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_10.wf.json
@@ -27,6 +27,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -57,7 +61,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-10",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/debian/debian_11.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_11.wf.json
@@ -27,6 +27,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -57,7 +61,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-11",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/debian/debian_11_arm64.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_11_arm64.wf.json
@@ -26,6 +26,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -56,7 +60,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-11",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/debian/debian_12.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_12.wf.json
@@ -27,6 +27,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -57,7 +61,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-12",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/debian/debian_12_arm64.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_12_arm64.wf.json
@@ -26,6 +26,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -56,7 +60,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "disk-debian-12",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_8.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_9.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_9_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_9_arm64.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_7.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/centos_stream_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_stream_8.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/centos_stream_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_stream_9.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_7_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_7_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_9_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_7_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_7_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_10_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_10_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_10_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_10_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_1_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_1_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_2_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_2_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_2_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_2_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_4_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_4_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_4_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_4_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_6_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_6_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_6_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_6_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_8_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_8_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_8_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_8_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored"
     }
   },
   "Steps": {
@@ -54,7 +58,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_0_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_0_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_0_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_0_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_2_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_2_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_2_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_2_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_4_sap.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_4_sap.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_4_sap_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_4_sap_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_arm64.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -52,7 +56,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos_arm64.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -52,7 +56,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -52,7 +56,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -52,7 +56,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_arm64.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -53,7 +57,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -52,7 +56,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -31,6 +31,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -52,7 +56,8 @@
           "destination": "${gcs_url}",
           "sbom_destination": "${sbom_destination}",
           "source_disk": "el-install-disk",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     },

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-enterprise-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-standard-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2014-web-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019-dc.wf.json
@@ -40,6 +40,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -68,7 +72,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-enterprise-windows-2019.wf.json
@@ -40,6 +40,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -68,7 +72,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-standard-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2016-web-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-enterprise-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2012-r2-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2012-r2-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2012-r2.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2012-r2.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-express-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-standard-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2016-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2016-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2016.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2016.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2017-web-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-enterprise-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-standard-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2019-web-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2025-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-enterprise-windows-2025-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-preview-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2025-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-standard-windows-2025-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2019-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2019-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2019.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2019.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2022-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2022-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2022.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2022.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2025-dc.wf.json
+++ b/daisy_workflows/build-publish/sqlserver/sql-2022-web-windows-2025-dc.wf.json
@@ -41,6 +41,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -69,7 +73,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${sbom_destination}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x86-bios.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-21h2-ent-x86-bios.wf.json
@@ -51,6 +51,10 @@
     "x86_build" : {
       "Value": "",
       "Description": "Marks the build for a 32 bit image."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -81,7 +85,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-10-22h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-22h2-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-10-22h2-ent-x86-bios.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-22h2-ent-x86-bios.wf.json
@@ -51,6 +51,10 @@
     "x86_build" : {
       "Value": "",
       "Description": "Marks the build for a 32 bit image."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -81,7 +85,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-10-next-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-10-next-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-21h2-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-11-22h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-22h2-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-11-23h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-23h2-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-11-24h2-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-24h2-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-11-preview-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-11-preview-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-81-ent-x64-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-bios.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-bios.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-dc-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2012-r2-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-bios.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-bios.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-dc-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2016-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-bios.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-bios.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-dc-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2019-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-bios.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-bios.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-dc-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2022-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2025-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2025-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2025-dc-core-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2025-dc-core-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2025-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2025-dc-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-2025-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-2025-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows-server-next-dc-uefi.wf.json
+++ b/daisy_workflows/build-publish/windows/windows-server-next-dc-uefi.wf.json
@@ -47,6 +47,10 @@
     "sbom_util_gcs_root": {
       "Value": "",
       "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -76,7 +80,8 @@
           "build_date": "${build_date}",
           "gcs_url": "${gcs_url}",
           "workflow_root": "${workflow_root}",
-          "existing_sbom_file_name": "${sbom_destination}"
+          "existing_sbom_file_name": "${sbom_destination}",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/build-publish/windows/windows_export.wf.json
+++ b/daisy_workflows/build-publish/windows/windows_export.wf.json
@@ -20,6 +20,10 @@
     "existing_sbom_file_name": {
       "Value": "${OUTSPATH}/export-image.sbom.json",
       "Description": "The name of the existing sbom file, generated earlier in the windows workflow."
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Steps": {
@@ -31,7 +35,8 @@
           "source_disk": "${install_disk}",
           "destination": "${gcs_url}",
           "existing_sbom_file_name": "${existing_sbom_file_name}",
-          "sbom_already_generated": "true"
+          "sbom_already_generated": "true",
+          "sha256_txt": "${sha256_txt}"
         }
       }
     }

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -52,6 +52,10 @@
     "existing_sbom_file_name": {
       "Value": "${OUTSPATH}/${NAME}.sbom.json",
       "Description": "Name of the existing sbom file, should only be passed in from windows workflows"
+    },
+    "sha256_txt": {
+       "Value": "",
+       "Description": "The file where the sha256 sum is stored."
     }
   },
   "Sources": {
@@ -82,7 +86,8 @@
             "startup-script": "${SOURCE:${NAME}_export_disk.sh}",
             "source-disk-name": "${source_disk}",
             "sbom-util-gcs-root": "${sbom_util_gcs_root}",
-            "sbom-already-generated": "${sbom_already_generated}"
+            "sbom-already-generated": "${sbom_already_generated}",
+            "sha256-txt": "${sha256_txt}"
           },
           "networkInterfaces": [
             {


### PR DESCRIPTION
Instead of generating the sha256 sum in concourse, generate it in export_disk.sh.

Later, we will edit the pipeline to pass in the GCS file with the sha256 sum so concourse and ARLE do not need to compute the hash.