### PR TITLE
Use new images after EOL

### DIFF
--- a/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
+++ b/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "export-centos-7-test",
+  "Name": "export-centos-stream-9-test",
   "Zone": "us-central1-b",
   "Vars": {
     "workflow_root": {
@@ -23,7 +23,7 @@
       "CreateDisks": [
         {
           "Name": "disk-export",
-          "SourceImage": "projects/centos-cloud/global/images/family/centos-7",
+          "SourceImage": "projects/centos-cloud/global/images/family/centos-stream-9",
           "Type": "pd-ssd"
         }
       ]
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-test",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker",
           "Type": "pd-ssd"
         }
       ]


### PR DESCRIPTION
EL 7 and Debian 10 are EOL next week, use a newer disk image for the presubmit