### PR TITLE
Add ARM support for COS preloading

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
+++ b/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
@@ -20,7 +20,7 @@
       "Description": "worker image"
     },
     "machine_type": {
-      "Value": "e2-medium",
+      "Required": true,
       "Description": "machine type"
     }
   },

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -85,7 +85,7 @@ find_debian_version() {
 install_go(){
   # Install the correct version of Go.
   echo -e "\nATTENTION: Installing go...\n"
-  cd /workspace
+  cd ..
   source ./install_go.sh; install_go /tmp/go
 }
 
@@ -113,6 +113,7 @@ build_tarball(){
   export RELEASE="g1${DEB}"
   dch --create -M -v 1:${VERSION}-${RELEASE} --package $PKGNAME -D stable \
     "Debian packaging for ${PKGNAME}"
+  sudo rm -rf /etc/default/instance_configs.cfg
   debuild -us -uc
   cd ..
 }
@@ -123,18 +124,16 @@ unpack_binaries(){
   # .deb file naming convention follows that in "upstream_tarball" function.
   # g111 is an arbitrary value given to the .deb file.
   echo -e "\nATTENTION: Unpacking binaries in a directory...\n"
-  dpkg-deb -x google-guest-agent_${VERSION}-g111_amd64.deb debian_binaries
-  dpkg-deb -c google-guest-agent_${VERSION}-g111_amd64.deb >> google-guest-agent-readable-deb.txt
+  dpkg-deb -x google-guest-agent_${VERSION}-g111_${arch}64.deb debian_binaries
+  dpkg-deb -c google-guest-agent_${VERSION}-g111_${arch}64.deb >> google-guest-agent-readable-deb.txt
   echo -e "\nATTENTION: google-guest-agent.deb file contents below...\n"
   cat google-guest-agent-readable-deb.txt
-  mv debian_binaries /workspace/upload
-  mv google-guest-agent-readable-deb.txt /workspace
 }
 
 identify_replacement_files(){
   echo -e "\nATTENTION: Creating a list of files to replace...\n"
-  file="/workspace/google-guest-agent-readable-deb.txt"
-  repl_file="/workspace/repl_files.txt"
+  file="/files/package_replacement/google-guest-agent-readable-deb.txt"
+  repl_file="repl_files.txt"
 
   # Go through every line in the deb file...
   while read -r line; do
@@ -155,15 +154,17 @@ identify_replacement_files(){
     fi
   done <$file
   cat $repl_file
+  mv $repl_file /files/package_replacement
 }
 
 main() {
-  if [ "$#" -ne 1 ]; then
+  if [ "$#" -ne 2 ]; then
     echo "Argument 'guest_agent_version' must be provided."
     exit 1
   fi
 
   commit_sha=$1
+  arch=$2
 
   echo -e "\nATTENTION: Starting compile_debian_package.sh...\n"
   apply_patches

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -28,7 +28,8 @@
 #
 # Args: ./compile_debian_package [guest_agent_version]
 # Example: ./compile_debian_package 094ef227ddf92165abcb7b1241ca44728c3086d1
-#     $2 [commit_sha]: the guest agent commit sha (to upgrade to).
+#     $1 [commit_sha]: the guest agent commit sha (to upgrade to).
+#     $2 [arch]: the architecture (amd or arm).
 
 set -o errexit
 set -o pipefail

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -128,6 +128,8 @@ unpack_binaries(){
   dpkg-deb -c google-guest-agent_${VERSION}-g111_${arch}64.deb >> google-guest-agent-readable-deb.txt
   echo -e "\nATTENTION: google-guest-agent.deb file contents below...\n"
   cat google-guest-agent-readable-deb.txt
+  mv debian_binaries /files/package_replacement
+  mv google-guest-agent-readable-deb.txt /files/package_replacement
 }
 
 identify_replacement_files(){

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/dev_cloudbuild.yaml
@@ -3,26 +3,17 @@
 # This file is what manages the replacement process of the guest agent pkg in COS images.
 # This cloudbuild can be invoked using 'gcloud builds submit --config=dev_cloudbuild.yaml'.
 # The script does the following:
-#   1) Executes the debian compilation script in a docker container (this generates the
-#   list of binaries and their installation paths for the guest agent pkg).
-#   2) Uses COS-CUSTOMIZER to start a custom COS image...
-#   3) Executes a script that disables the read-only root fs of COS.
-#   4) Executes a script that performs pre-loading (pkg replacement).
-#   5) Executes a script that re-enables the read-only root fs of COS.
-#   6) Finishes COS-CUSTOMIZER by creating a custom image.
+#   1) Uses COS-CUSTOMIZER to start a custom COS image...
+#   2) Executes a script that disables the read-only root fs of COS.
+#   3) Executes a script that performs pre-loading (pkg replacement).
+#   4) Executes a script that re-enables the read-only root fs of COS.
+#   5) Finishes COS-CUSTOMIZER by creating a custom image.
 
 substitutions:
   '_COS_CUSTOMIZER': 'gcr.io/cos-cloud/cos-customizer:latest'
   '_KERNEL_PKG': ''
 
 steps:
-# This step compiles the debian packaging and stores it in /var.
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args:
-    - '-c'
-    - |
-      ./compile_debian_package.sh $_COMMIT_SHA
 # _DEST_PROJECT in the 'finish-image-build' step should should have access
 # to the gcs-bucket path specified here.
 - name: '${_COS_CUSTOMIZER}'

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/preload.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/preload.sh
@@ -6,6 +6,7 @@
 #   2) Find the file name on the system, if it exists, replace the file at the
 #   same lcoation.
 #   3) Delete all temp folders/files that are no longer needed.
+#   4) Enables logging in google-startup-scripts.service (needed for CIT tests).
 
 set -o errexit
 set -o pipefail
@@ -17,7 +18,7 @@ replace_files(){
 
   # Move all files to a temp folder under /.
   sudo mkdir /temp_debian_upload
-  sudo mv upload /temp_debian_upload
+  sudo mv debian_binaries /temp_debian_upload
 
   # Start guest agent replacement...
   file="repl_files.txt"
@@ -50,11 +51,11 @@ replace_files(){
       # If this is the startup script service file, enable logging so CIT tests
       # can exit successfully after 'finished-test' is written.
       if [[ "$file_name" == "google-startup-scripts.service" ]]; then
-        sudo sed -i '/KillMode=process/a StandardOutput=journal+console\nStandardError=journal+console' /temp_debian_upload/upload$dest/$file_name
+        sudo sed -i '/KillMode=process/a StandardOutput=journal+console\nStandardError=journal+console' /temp_debian_upload/debian_binaries$dest/$file_name
       fi
       
       # Move the deb file to the correct installation path.
-      sudo mv /temp_debian_upload/upload$dest/$file_name $INSTALLATION_PATH
+      sudo mv /temp_debian_upload/debian_binaries$dest/$file_name $INSTALLATION_PATH
     fi
   done <$file
 

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -34,13 +34,15 @@ get_vars(){
 
 compile_debian_binaries(){
   sudo apt install -y git
-  ./compile_debian_package.sh ${COMMIT_SHA}
+  ./compile_debian_package.sh ${COMMIT_SHA} ${ARCH}
 }
 
-set_machine_type(){
+set_machine_and_arch_type(){
   export MACHINE_TYPE="n1-standard-1"
+  export ARCH="amd"
   if [[ "$SOURCE_IMAGE" == *"arm"* ]]; then
       export MACHINE_TYPE="t2a-standard-1"
+      export ARCH="arm"
   fi
 }
 # The following additional parameters are passed into the cloudbuild script:
@@ -58,8 +60,8 @@ main (){
   echo "Creating COS image with the new guest agent version..."
   set_files_executable
   get_vars
+  set_machine_and_arch_type
   compile_debian_binaries
-  set_machine_type
   create_preloaded_image
 }
 

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -32,6 +32,11 @@ get_vars(){
   export DAISY_LOGS_PATH=$(curl -H "Metadata-Flavor:Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/daisy-logs-path)
 }
 
+compile_debian_binaries(){
+  sudo apt install -y git
+  ./compile_debian_package.sh ${COMMIT_SHA}
+}
+
 set_machine_type(){
   export MACHINE_TYPE="n1-standard-1"
   if [[ "$SOURCE_IMAGE" == *"arm"* ]]; then
@@ -46,13 +51,14 @@ set_machine_type(){
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
 #   _MACHINE_TYPE: The machine type for the source image: default (n1-standard-1) or t2a-standard-1 for ARM.
 create_preloaded_image(){
-  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_COMMIT_SHA="${COMMIT_SHA}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest",_MACHINE_TYPE="${MACHINE_TYPE}"
+  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest",_MACHINE_TYPE="${MACHINE_TYPE}"
 }
 
 main (){
   echo "Creating COS image with the new guest agent version..."
   set_files_executable
   get_vars
+  compile_debian_binaries
   set_machine_type
   create_preloaded_image
 }

--- a/daisy_workflows/image_build/install_package/install_package.wf.json
+++ b/daisy_workflows/image_build/install_package/install_package.wf.json
@@ -20,11 +20,11 @@
       "Description": "dest project"
     },
     "worker_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Required": true,
       "Description": "worker image"
     },
     "machine_type": {
-      "Value": "e2-medium",
+      "Required": true,
       "Description": "machine type"
     }
   },


### PR DESCRIPTION
This PR adds ARM support for COS preloading:

- Adds worker_machine and machine_type as args to the install_package_cos.wf.json: allows us to specify ARM specific machine types i.e. debian-11-worker-arm64, t2a-standard-1
- Moves compiling the debian package (compile_debian_package.sh) out of the cloudbuild and in the worker machine. This is because for ARM image, debian packaging should be compiled in an ARM env and cloudbuild does not support ARM.
- Delete's instance_config file in worker machine to pass all debian tests.

CCing @a-crate, @dorileo, and @zmarano.