### PR TITLE
Use 20 GB so windows image copy has enough space

### DIFF
--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -22,8 +22,8 @@
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {
-      "Value": "200",
-      "Description": "size of the export instances disk, this disk is unused for the export but a larger size increase PD read speed"
+      "Value": "20",
+      "Description": "size of the export instances disk, must be larger than the image size in GB so it can be copied for shasum. A larger size increase PD read speed"
     },
     "export_instance_disk_type": {
       "Value": "pd-ssd",
@@ -66,7 +66,7 @@
       "CreateDisks": [
         {
           "Name": "disk-${NAME}",
-          "SizeGb": "20",
+          "SizeGb": "${export_instance_disk_size}",
           "SourceImage": "${export_instance_disk_image}",
           "Type": "${export_instance_disk_type}"
         }

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -66,6 +66,7 @@
       "CreateDisks": [
         {
           "Name": "disk-${NAME}",
+          "SizeGb": "20",
           "SourceImage": "${export_instance_disk_image}",
           "Type": "${export_instance_disk_type}"
         }


### PR DESCRIPTION
To generate the sha sum, we need to copy the tar gz file.

The windows images are 10 GB, SQL server images are 14 GB. Default disk size is 10 GB it seems, so 20 GB is a safe size.