### PR TITLE
Pass worker image in as an arg

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
+++ b/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
@@ -16,7 +16,7 @@
       "Description": "commit sha"
     },
     "worker_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-11-worker",
+      "Required": true,
       "Description": "worker image"
     },
     "machine_type": {


### PR DESCRIPTION
Depending on whether we are running on arm image or on amd image, the worker image will have to be either debian-11-worker or debian-11-worker-arm64 etc..

CCing @a-crate, @dorileo, and @zmarano.