### PR TITLE
Update rocky_linux_8_optimized_gcp_arm64.cfg

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
@@ -137,6 +137,10 @@ gpgcheck=1
 gpgkey=https://dl.rockylinux.org/pub/sig/8/cloud/aarch64/cloud-kernel/RPM-GPG-KEY-Rocky-SIG-Cloud
 priority=-1
 EOM
+# Be sure we don't get kernels from the BaseOS repo
+tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
+exclude=kernel*
+EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.
 %onerror


### PR DESCRIPTION
add exclude=kernel* to /etc/yum.repos.d/Rocky-BaseOS.repo to insure we don't update the kernel from that repo and get it from Rocky-CloudKernel.repo