### PR TITLE
Update Optimized Rocky to be sure to use cloud-kernel 

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp.cfg
@@ -137,6 +137,10 @@ gpgcheck=1
 gpgkey=https://dl.rockylinux.org/pub/sig/8/cloud/x86_64/cloud-kernel/RPM-GPG-KEY-Rocky-SIG-Cloud
 priority=-1
 EOM
+# Be sure we don't get kernels from the BaseOS repo
+tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
+exclude=kernel*
+EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.
 %onerror

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp.cfg
@@ -137,6 +137,10 @@ gpgcheck=1
 gpgkey=https://dl.rockylinux.org/pub/sig/9/cloud/x86_64/cloud-kernel/RPM-GPG-KEY-Rocky-SIG-Cloud
 priority=-1
 EOM
+# Be sure we don't get kernels from the BaseOS repo
+tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
+exclude=kernel*
+EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 9.
 %onerror

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp.cfg
@@ -138,9 +138,7 @@ gpgkey=https://dl.rockylinux.org/pub/sig/9/cloud/x86_64/cloud-kernel/RPM-GPG-KEY
 priority=-1
 EOM
 # Be sure we don't get kernels from the BaseOS repo
-tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
-EOM
+sed -i '/\[baseos\]/a exclude=kernel*' /etc/yum.repos.d/rocky.repo
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 9.
 %onerror

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp_arm64.cfg
@@ -137,6 +137,10 @@ gpgcheck=1
 gpgkey=https://dl.rockylinux.org/pub/sig/9/cloud/aarch64/cloud-kernel/RPM-GPG-KEY-Rocky-SIG-Cloud
 priority=-1
 EOM
+# Be sure we don't get kernels from the BaseOS repo
+tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
+exclude=kernel*
+EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 9.
 %onerror

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp_arm64.cfg
@@ -138,9 +138,7 @@ gpgkey=https://dl.rockylinux.org/pub/sig/9/cloud/aarch64/cloud-kernel/RPM-GPG-KE
 priority=-1
 EOM
 # Be sure we don't get kernels from the BaseOS repo
-tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
-EOM
+sed -i '/\[baseos\]/a exclude=kernel*' /etc/yum.repos.d/rocky.repo
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 9.
 %onerror


### PR DESCRIPTION
Make sure that Optimized Rocky doesn't use a kernel from Rock-BaseOS.repo and always uses the kernel from Rocky-CloudKernel.repo