### PR TITLE
Update image path for Ubuntu 2204 accelerator build

### DIFF
--- a/daisy_workflows/image_build/accelerator_images/ubuntu_2204_with_nvidia_550.wf.json
+++ b/daisy_workflows/image_build/accelerator_images/ubuntu_2204_with_nvidia_550.wf.json
@@ -6,7 +6,7 @@
       "Description": "The machine type to use during build."
     },
     "source_image": {
-      "Value": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts-amd64",
+      "Value": "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts",
       "Description": "The image to use for the build"
     },
     "ubuntu_version": {


### PR DESCRIPTION
There is no amd64, although 2404 has it.