### PR TITLE
Drop nvidia-smi from build script

### DIFF
--- a/daisy_workflows/image_build/accelerator_images/build_rocky_linux_8_optimized_gcp_accelerated.sh
+++ b/daisy_workflows/image_build/accelerator_images/build_rocky_linux_8_optimized_gcp_accelerated.sh
@@ -6,5 +6,4 @@ chmod +x ./nvidia.run || echo "BuildFailure"
 # DKMS - not suitable for prod
 ./nvidia.run -s --kernel-source-path=/usr/src/kernels/4.18.0-553.8.1.el8_10.cloud.0.1.x86_64/ || echo "BuildFailure"
 dnf install -y rdma-core || echo "BuildFailure"
-nvidia-smi || echo "BuildFailure"
 echo "BuildSuccess"

--- a/daisy_workflows/image_build/accelerator_images/build_rocky_linux_9_optimized_gcp_accelerated.sh
+++ b/daisy_workflows/image_build/accelerator_images/build_rocky_linux_9_optimized_gcp_accelerated.sh
@@ -6,5 +6,4 @@ chmod +x ./nvidia.run || echo "BuildFailure"
 # DKMS - not suitable for prod
 ./nvidia.run -s --kernel-source-path=/usr/src/kernels/5.14.0-427.28.1.el9_4.cloud.1.0.x86_64/ || echo "BuildFailure"
 dnf install -y rdma-core || echo "BuildFailure"
-nvidia-smi || echo "BuildFailure"
 echo "BuildSuccess"


### PR DESCRIPTION
We aren't building with GPU machines so this is guaranteed to fail