### PR TITLE
Rhel 8 arm64

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/build_installer_arm64-64.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer_arm64-64.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert EL ISO to GCE Image and prep for installation.
+
+Parameters (retrieved from instance metadata):
+el_release: The EL release to build.
+el_savelogs: true to ask Anaconda to save logs (for debugging).
+"""
+
+import difflib
+import logging
+import os
+import re
+
+import utils
+
+
+def main():
+  # Get Parameters
+  release = utils.GetMetadataAttribute('el_release', raise_on_not_found=True)
+  savelogs = utils.GetMetadataAttribute('el_savelogs') == 'true'
+
+  logging.info('EL Release: %s' % release)
+  logging.info('Build working directory: %s' % os.getcwd())
+
+  iso_file = '/files/installer.iso'
+  ks_cfg = '/files/ks.cfg'
+
+  utils.AptGetInstall(['rsync'])
+
+  # Write the installer disk. Write GPT label, create partition,
+  # copy installer boot files over.
+  logging.info('Writing installer disk.')
+
+  installer_disk = ('/dev/' + os.path.basename(
+      os.readlink('/dev/disk/by-id/google-disk-installer')))
+  #installer_disk1 = installer_disk + '1' # this works for pd disk, below p1,p2 for new disks types
+  #installer_disk2 = installer_disk + '2' #TODO just make one script that checks what kind of disks
+  installer_disk1 = installer_disk + 'p1'
+  installer_disk2 = installer_disk + 'p2'
+
+  utils.Execute(['parted', installer_disk, 'mklabel', 'gpt'])
+  utils.Execute(['sync'])
+  utils.Execute(['parted', installer_disk, 'mkpart', 'primary', 'fat32', '1MB',
+                 '2048MB'])
+  utils.Execute(['sync'])
+  utils.Execute(['parted', installer_disk, 'mkpart', 'primary', 'ext2',
+                 '2048MB', '100%'])
+  utils.Execute(['sync'])
+  utils.Execute(['parted', installer_disk, 'set', '1', 'boot', 'on'])
+  utils.Execute(['sync'])
+  utils.Execute(['parted', installer_disk, 'set', '1', 'esp', 'on'])
+  utils.Execute(['sync'])
+  #import time
+  #time.sleep(5*60*60)
+  utils.Execute(['mkfs.vfat', '-F', '32', installer_disk1])
+  utils.Execute(['sync'])
+  utils.Execute(['fatlabel', installer_disk1, 'ESP'])
+  utils.Execute(['sync'])
+  utils.Execute(['mkfs.ext2', '-L', 'INSTALLER', installer_disk2])
+  utils.Execute(['sync'])
+
+  utils.Execute(['mkdir', '-vp', 'iso', 'installer', 'boot'])
+  utils.Execute(['mount', '-o', 'ro,loop', '-t', 'iso9660', iso_file, 'iso'])
+  utils.Execute(['mount', '-t', 'vfat', installer_disk1, 'boot'])
+  utils.Execute(['mount', '-t', 'ext2', installer_disk2, 'installer'])
+  utils.Execute(['cp', '-r', 'iso/EFI', 'boot/'])
+  utils.Execute(['cp', '-r', 'iso/images', 'boot/'])
+  utils.Execute(['cp', iso_file, 'installer/'])
+  utils.Execute(['cp', ks_cfg, 'installer/'])
+
+  # The kickstart config contains a preinstall script copying, reloading, and
+  # triggering this rule in the install environment. This allows us to use
+  # predictable names for block devices. It would be perferable to take a
+  # simpler approach such as selecting the disk with an unkown partition table
+  # but kickstart does not believe the default google nvme device names are
+  # are deterministic and refuses to use them without user input.
+
+  utils.Execute(['cp', '-L', '/usr/lib/udev/rules.d/65-gce-disk-naming.rules',
+  'installer/'])
+  utils.Execute(['cp', '-L', '/usr/lib/udev/google_nvme_id', 'installer/'])
+
+  # Modify boot config.
+  with open('boot/EFI/BOOT/grub.cfg', 'r+') as f:
+    oldcfg = f.read()
+    cfg = re.sub(r'-l .RHEL.*', r"""-l 'ESP'""", oldcfg)
+    cfg = re.sub(r'timeout=60', 'timeout=1', cfg)
+    cfg = re.sub(r'set default=.*', 'set default="0"', cfg)
+    cfg = re.sub(r'load_video\n',
+           r'serial --speed=115200 --unit=0 --word=8 --parity=no\n'
+           'terminal_input serial\nterminal_output serial\n', cfg)
+
+    # Change boot args.
+    args = ' '.join([
+      'inst.text', 'inst.ks=hd:LABEL=INSTALLER:/%s' % ks_cfg,
+      'console=ttyS0,115200', 'inst.gpt', 'inst.loglevel=debug'
+    ])
+
+    # Tell Anaconda not to store its logs in the installed image,
+    # unless requested to keep them for debugging.
+    if not savelogs:
+      args += ' inst.nosave=all'
+    cfg = re.sub(r'inst\.stage2.*', r'\g<0> %s' % args, cfg)
+
+    # Change labels to explicit partitions.
+    cfg = re.sub(r'LABEL=[^ ]+', 'LABEL=INSTALLER', cfg)
+
+    # Print out a the modifications.
+    diff = difflib.Differ().compare(
+        oldcfg.splitlines(1),
+        cfg.splitlines(1))
+    logging.info('Modified grub.cfg:\n%s' % '\n'.join(diff))
+
+    f.seek(0)
+    f.write(cfg)
+    f.truncate()
+
+  # Update google_nvme_id to remove xxd dependency, if necessary
+  # The current worker uses an older version
+  with open('installer/google_nvme_id', 'r+') as f:
+    old = f.read()
+    new = re.sub(r'xxd -p -seek 384 \| xxd -p -r',
+    'dd bs=1 skip=384 2>/dev/null',
+    old)
+    f.seek(0)
+    f.write(new)
+    f.truncate()
+
+  utils.Execute(['umount', 'installer'])
+  utils.Execute(['umount', 'iso'])
+  utils.Execute(['umount', 'boot'])
+
+
+if __name__ == '__main__':
+  try:
+    main()
+    logging.success('EL Installer build successful!')
+  except Exception as e:
+    logging.error('EL Installer build failed: %s' % str(e))

--- a/daisy_workflows/image_build/enterprise_linux/enterprise_linux_arm64_64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/enterprise_linux_arm64_64.wf.json
@@ -1,0 +1,137 @@
+{
+  "Name": "build-el",
+  "DefaultTimeout": "60m",
+  "Vars": {
+    "el_release": {
+      "Required": true,
+      "Description": "The EL release name."
+    },
+    "kickstart_config": {
+      "Required": true,
+      "Description": "Path to kickstart config file."
+    },
+    "machine_type": {
+      "Value": "c4a-standard-4",
+      "Description": "The machine type to use during build."
+    },
+    "el_savelogs": {
+      "Value": "false",
+      "Description": "Save anaconda logs to the image (useful for debugging)."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "installer_iso": {
+      "Required": true,
+      "Description": "The path to the EL installation ISO."
+    },
+    "rhel_byos": {
+      "Value": "false",
+      "Description": "Create a BYOS RHEL image."
+    },
+    "rhel_sap": {
+      "Value": "false",
+      "Description": "Create a RHEL for SAP image."
+    }
+  },
+  "Sources": {
+    "build_files/build_installer_arm64-64.py": "./build_installer_arm64-64.py",
+    "build_files/installer.iso": "${installer_iso}",
+    "build_files/utils": "../../linux_common/utils",
+    "build_files/ks.cfg": "${kickstart_config}",
+    "installerprep_startup_script": "../../linux_common/bootstrap.sh"
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-installerprep",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker",
+          "SizeGb": "50",
+          "Type": "hyperdisk-balanced"
+        },
+        {
+          "Name": "disk-installer",
+          "SizeGb": "50",
+          "Type": "hyperdisk-balanced",
+          "GuestOsFeatures": [{"type": "UEFI_COMPATIBLE"}, {"type": "GVNIC"}]
+        },
+        {
+          "Name": "el-install-disk",
+          "SizeGb": "20",
+          "Type": "hyperdisk-balanced",
+          "GuestOsFeatures": [{"type": "UEFI_COMPATIBLE"}, {"type": "GVNIC"}]
+        }
+      ]
+    },
+    "run-installer-prep": {
+      "CreateInstances": [
+        {
+          "Name": "inst-installerprep",
+          "Disks": [{"Source": "disk-installerprep"}, {"Source": "disk-installer"}],
+          "MachineType": "c3-standard-4",
+          "Metadata": {
+            "files_gcs_dir": "${SOURCESPATH}/build_files",
+            "debian_install_google_api_python_client": "yes",
+            "script": "build_installer_arm64-64.py",
+            "script_prints_status": "no",
+            "prefix": "Build",
+            "el_release": "${el_release}",
+            "el_savelogs": "${el_savelogs}",
+            "google_cloud_repo": "${google_cloud_repo}",
+            "rhel_byos": "${rhel_byos}",
+            "rhel_sap": "${rhel_sap}"
+          },
+          "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],
+          "StartupScript": "installerprep_startup_script"
+        }
+      ]
+    },
+    "wait-installer-prep": {
+      "Timeout": "60m",
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-installerprep",
+          "SerialOutput": {
+            "Port": 1,
+            "FailureMatch": "BuildFailed:",
+            "SuccessMatch": "BuildSuccess:",
+            "StatusMatch": "BuildStatus:"
+          }
+        }
+      ]
+    },
+    "cleanup-installer-prep": {
+      "DeleteResources": {
+        "Instances": ["inst-installerprep"]
+      }
+    },
+    "run-installation": {
+      "CreateInstances": [
+        {
+          "Name": "inst-build",
+          "Disks": [{"Source": "disk-installer"}, {"Source": "el-install-disk"}],
+          "MachineType": "${machine_type}"
+        }
+      ]
+    },
+    "wait-installation": {
+      "Timeout": "60m",
+      "WaitForInstancesSignal": [{"Name": "inst-build", "Stopped": true}]
+    },
+    "cleanup-inst-build": {
+      "DeleteResources": {
+        "Instances": ["inst-build"]
+      }
+    }
+  },
+  "Dependencies": {
+    "run-installer-prep": ["setup-disks"],
+    "wait-installer-prep": ["run-installer-prep"],
+    "cleanup-installer-prep": ["wait-installer-prep"],
+    "run-installation": ["cleanup-installer-prep"],
+    "wait-installation": ["run-installation"],
+    "cleanup-inst-build": ["wait-installation"]
+  }
+}

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_arm64.cfg
@@ -1,0 +1,237 @@
+# rhel8-options.cfg
+
+### Anaconda installer configuration.
+# Install in text mode.
+text --non-interactive
+harddrive --partition=/dev/disk/by-id/google-disk-installer-part2 --dir=/
+poweroff
+
+# Network configuration
+network --bootproto=dhcp --device=link
+
+### Installed system configuration.
+firewall --enabled
+services --enabled=sshd,rngd --disabled=sshd-keygen@
+skipx
+timezone --utc UTC --ntpservers=metadata.google.internal
+rootpw --iscrypted --lock *
+firstboot --disabled
+user --name=gce --lock
+
+### Disk configuration.
+# Disk configuration is done by including a separate file with disk configuration, otherwise anaconda will try to validate that the disk exists before we configure udev rules.
+%pre --interpreter=/usr/bin/bash
+cp /run/install/isodir/65-gce-disk-naming.rules /etc/udev/rules.d/
+cp /run/install/isodir/google_nvme_id /usr/lib/udev/
+chmod +x /usr/lib/udev/google_nvme_id
+# Wait for coldplug events from boot to settle, or we won't generate new events for the reload/trigger
+udevadm settle
+udevadm control --reload
+udevadm trigger --settle
+tee -a /tmp/disk-config << EOM
+# build_installer.py will replace with the id of the install disk to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/google-el-install-disk --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# EFI partitioning, creates a GPT partitioned disk.
+clearpart --drives=/dev/disk/by-id/google-el-install-disk --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/google-el-install-disk
+part / --size=100 --grow --ondrive=/dev/disk/by-id/google-el-install-disk --label=root --fstype=xfs
+EOM
+%end
+%include /tmp/disk-config
+
+# packages.cfg
+# Contains a list of packages to be installed, or not, on all flavors.
+# The %package command begins the package selection section of kickstart.
+# Packages can be specified by group, or package name. @Base and @Core are
+# always selected by default so they do not need to be specified.
+
+%packages
+acpid
+dhcp-client
+dnf-automatic
+net-tools
+openssh-server
+python3
+rng-tools
+tar
+vim
+nvme-cli
+-subscription-manager
+-rhc
+-insights-client
+-alsa-utils
+-b43-fwcutter
+-dmraid
+-eject
+-gpm
+-irqbalance
+-microcode_ctl
+-smartmontools
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-kernel-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+%end
+
+%post
+tee -a /etc/yum.repos.d/google-cloud.repo << EOM
+[google-compute-engine]
+name=Google Compute Engine
+baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-aarch64-stable
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+tee -a /etc/yum.repos.d/google-cloud.repo << EOM
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-aarch64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+%end
+%post --erroronfail
+set -x
+exec &> /dev/ttyAMA0
+# possibly change to unstable repos to test new rhui
+dnf -y install google-rhui-client-rhel8
+dnf -y install google-compute-engine-oslogin
+dnf -y install google-osconfig-agent
+# add disable all x86_64 repos per redhat bug https://access.redhat.com/support/cases/#/case/03928468
+# to avoid eclipse module error
+%end
+
+# Google Compute Engine kickstart config for Enterprise Linux 8.
+%onerror
+echo "Build Failed!" > /dev/ttyAMA0
+shutdown -h now
+%end
+
+%post --erroronfail
+set -x
+exec &> /dev/ttyAMA0
+# Delete the dummy user account.
+userdel -r gce
+
+# Import all RPM GPG keys.
+curl -o /etc/pki/rpm-gpg/google-rpm-package-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+curl -o /etc/pki/rpm-gpg/google-key.gpg https://packages.cloud.google.com/yum/doc/yum-key.gpg
+rpm --import /etc/pki/rpm-gpg/*
+
+# Configure the network for GCE.
+# Given that GCE users typically control the firewall at the network API level,
+# we want to leave the standard Linux firewall setup enabled but all-open.
+firewall-offline-cmd --set-default-zone=trusted
+
+cat >>/etc/dhcp/dhclient.conf <<EOL
+# Set the dhclient retry interval to 10 seconds instead of 5 minutes.
+retry 10;
+EOL
+
+# Disable IPv6 for DNF.
+echo "ip_resolve=4" >> /etc/dnf/dnf.conf
+
+# Set google-compute-engine config for EL8.
+cat >>/etc/default/instance_configs.cfg.distro << EOL
+# Disable boto plugin setup.
+[InstanceSetup]
+set_boto_config = false
+EOL
+
+# Install GCE guest packages.
+dnf install -y google-compute-engine 
+dnf install -y google-osconfig-agent 
+dnf install -y gce-disk-expand
+
+# Install the Cloud SDK package.
+dnf install -y google-cloud-cli
+
+# Send /root/anaconda-ks.cfg to our logs.
+cp /run/install/ks.cfg /tmp/anaconda-ks.cfg
+
+# Remove files which shouldn't make it into the image. Its possible these files
+# will not exist.
+rm -f /etc/boto.cfg /etc/udev/rules.d/70-persistent-net.rules
+
+# Remove ens4 config from installer.
+rm -f /etc/sysconfig/network-scripts/ifcfg-ens4
+
+# Disable password authentication by default.
+sed -i -e '/^PasswordAuthentication /s/ yes$/ no/' /etc/ssh/sshd_config
+
+# Set ServerAliveInterval and ClientAliveInterval to prevent SSH
+# disconnections. The pattern match is tuned to each source config file.
+# The $'...' quoting syntax tells the shell to expand escape characters.
+sed -i -e $'/^\tServerAliveInterval/d' /etc/ssh/ssh_config
+sed -i -e $'/^Host \\*$/a \\\tServerAliveInterval 420' /etc/ssh/ssh_config
+sed -i -e '/ClientAliveInterval/s/^.*/ClientAliveInterval 420/' /etc/ssh/sshd_config
+
+# Disable root login via SSH by default.
+sed -i -e '/PermitRootLogin yes/s/^.*/PermitRootLogin no/' /etc/ssh/sshd_config
+
+# Update all packages.
+dnf -y update
+
+# Make changes to dnf automatic.conf
+# Apply updates for security (RHEL) by default. NOTE this will not work in CentOS.
+sed -i 's/upgrade_type =.*/upgrade_type = security/' /etc/dnf/automatic.conf
+sed -i 's/apply_updates =.*/apply_updates = yes/' /etc/dnf/automatic.conf
+# Enable the DNF automatic timer service.
+systemctl enable dnf-automatic.timer
+
+# Cleanup this repo- we don't want to continue updating with it.
+# Depending which repos are used in build, one or more of these files will not
+# exist.
+rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
+  /etc/yum.repos.d/google-cloud-staging.repo
+
+# Clean up the cache for smaller images.
+dnf clean all
+rm -fr /var/cache/dnf/*
+
+# Blacklist the floppy module.
+echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
+restorecon /etc/modprobe.d/blacklist-floppy.conf
+
+# Generate initramfs from latest kernel instead of the running kernel.
+kver="$(ls -t /lib/modules | head -n1)"
+dracut -f --kver="${kver}"
+
+# Fix selinux contexts on /etc/resolv.conf.
+restorecon /etc/resolv.conf
+%end
+
+# Cleanup.
+%post --nochroot --log=/dev/ttyAMA0
+set -x
+rm -Rf /mnt/sysimage/tmp/*
+%end
+

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
@@ -1,0 +1,56 @@
+{
+  "Name": "build-rhel-8-arm64",
+  "Vars": {
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "installer_iso": {
+      "Required": true,
+      "Description": "The RHEL 8 installer ISO to build from."
+    },
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "publish_project": {
+      "Value": "${PROJECT}",
+      "Description": "A project to publish the resulting image to."
+    }
+  },
+  "Steps": {
+    "build-rhel": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "./enterprise_linux_arm64_64.wf.json",
+        "Vars": {
+          "el_release": "rhel-8-arm64",
+          "kickstart_config": "./kickstart/rhel_8_arm64.cfg",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "installer_iso": "${installer_iso}",
+          "machine_type": "c4a-standard-4"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "rhel-8-arm64-v${build_date}",
+          "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-8-server"
+          ],
+          "Description": "Red Hat, Red Hat Enterprise Linux, 8, arm64 built on ${build_date}",
+          "Family": "rhel-8-arm64",
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"],
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-rhel"]
+  }
+}


### PR DESCRIPTION
In the future
build_installer.py should just check for disk types, instead of a separate script
and enterprise_linux.wf.json should extract the variables that change to there scripts and it can stay generic for everything
