### PR TITLE
Install MOFED instead of rdma-core in rocky accelerator preview images

### DIFF
--- a/daisy_workflows/image_build/accelerator_images/build_rocky_linux_8_optimized_gcp_accelerated.sh
+++ b/daisy_workflows/image_build/accelerator_images/build_rocky_linux_8_optimized_gcp_accelerated.sh
@@ -5,5 +5,11 @@ curl -L -o nvidia.run https://us.download.nvidia.com/tesla/550.90.12/NVIDIA-Linu
 chmod +x ./nvidia.run || echo "BuildFailure"
 # DKMS - not suitable for prod
 ./nvidia.run -s --kernel-source-path=/usr/src/kernels/4.18.0-553.8.1.el8_10.cloud.0.1.x86_64/ || echo "BuildFailure"
-dnf install -y rdma-core || echo "BuildFailure"
+dnf install -y createrepo gdb-headless libtool autoconf rpm-build kernel-rpm-macros patch automake wget lsof tk gcc-gfortran tcl pciutils || echo "BuildFailure"
+wget https://content.mellanox.com/ofed/MLNX_OFED-23.10-3.2.2.0/MLNX_OFED_LINUX-23.10-3.2.2.0-rhel8.9-x86_64.tgz || echo "BuildFailure"
+tar xf MLNX_OFED_LINUX-23.10-3.2.2.0-rhel8.9-x86_64.tgz || echo "BuildFailure"
+cd MLNX_OFED_LINUX-23.10-3.2.2.0-rhel8.9-x86_64 || echo "BuildFailure"
+./mlnxofedinstall --guest --force --skip-distro-check --add-kernel-support || echo "BuildFailure"
+cd ..
+rm -rf MLNX_OFED_LINUX-23.10-3.2.2.0-rhel8.9-x86_64 MLNX_OFED_LINUX-23.10-3.2.2.0-rhel8.9-x86_64.tgz
 echo "BuildSuccess"

--- a/daisy_workflows/image_build/accelerator_images/build_rocky_linux_9_optimized_gcp_accelerated.sh
+++ b/daisy_workflows/image_build/accelerator_images/build_rocky_linux_9_optimized_gcp_accelerated.sh
@@ -5,5 +5,11 @@ curl -L -o nvidia.run https://us.download.nvidia.com/tesla/550.90.12/NVIDIA-Linu
 chmod +x ./nvidia.run || echo "BuildFailure"
 # DKMS - not suitable for prod
 ./nvidia.run -s --kernel-source-path=/usr/src/kernels/5.14.0-427.28.1.el9_4.cloud.1.0.x86_64/ || echo "BuildFailure"
-dnf install -y rdma-core || echo "BuildFailure"
+dnf install -y perl-File-Find perl-File-Copy perl-File-Compare perl-sigtrap wget lsof tk gcc-gfortran tcl pciutils || echo "BuildFailure"
+wget https://content.mellanox.com/ofed/MLNX_OFED-23.10-3.2.2.0/MLNX_OFED_LINUX-23.10-3.2.2.0-rhel9.4-x86_64.tgz || echo "BuildFailure"
+tar xf MLNX_OFED_LINUX-23.10-3.2.2.0-rhel9.4-x86_64.tgz || echo "BuildFailure"
+cd MLNX_OFED_LINUX-23.10-3.2.2.0-rhel9.4-x86_64 || echo "BuildFailure"
+./mlnxofedinstall --guest --force || echo "BuildFailure"
+cd ..
+rm -rf MLNX_OFED_LINUX-23.10-3.2.2.0-rhel9.4-x86_64 MLNX_OFED_LINUX-23.10-3.2.2.0-rhel9.4-x86_64.tgz
 echo "BuildSuccess"


### PR DESCRIPTION
/assign @jjerger 
/hold
Waiting for my local Rocky 8 build to succeed before removing the hold, but I'm confident it will and this is ready for review.