### PR TITLE
Switch to debian 12 worker

### DIFF
--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -18,7 +18,7 @@
       "Description": "list of GCE licenses to record in the exported image"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-11-worker",
+      "Value": "projects/compute-image-tools/global/images/family/debian-12-worker",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {

--- a/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
+++ b/daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-test",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-12-worker",
           "Type": "pd-ssd"
         }
       ]

--- a/daisy_workflows/sbom_validation/windows_sbom_validation.wf.json
+++ b/daisy_workflows/sbom_validation/windows_sbom_validation.wf.json
@@ -139,7 +139,7 @@
       "CreateDisks": [
         {
           "Name": "disk-test",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-12-worker",
           "Type": "pd-ssd"
         }
       ]


### PR DESCRIPTION
We will likely deprecate debian 10 and 11 workers, so we should switch to the debian 12 worker.