### PR TITLE
Disable APT Daily on Debian worker image to avoid APT lock contention

### DIFF
--- a/daisy_workflows/image_build/debian/debian_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_worker.sh
@@ -16,6 +16,10 @@
 # Builds a Debian based image for import, export, and build tasks. Preloads
 # dependencies and binaries for these workflows.
 
+echo "BuildStatus: Disabling APT Daily."
+systemctl disable apt-daily.timer
+systemctl stop apt-daily.timer
+
 echo "BuildStatus: Updating package cache."
 apt -y update
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
I saw at least one build failure that looked like this:

```
2024-11-18T16:02:40.781311+00:00 inst-installerprep-rocky-linux-8-build-build-rocky-pv6n7 google_metadata_script_runner[640]: startup-script-url: + DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
[   16.308162] google_metadata_script_runner[640]: startup-script-url: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1490 (apt-get)
2024-11-18T16:02:40.804449+00:00 inst-installerprep-rocky-linux-8-build-build-rocky-pv6n7 google_metadata_script_runner[640]: startup-script-url: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1490 (apt-get)
[   16.308314] google_metadata_script_runner[640]: startup-script-url: E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
2024-11-18T16:02:40.804603+00:00 inst-installerprep-rocky-linux-8-build-build-rocky-pv6n7 google_metadata_script_runner[640]: startup-script-url: E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```

Just a few lines before that, you can see:
```
2024-11-18T16:02:40.639958+00:00 inst-installerprep-rocky-linux-8-build-build-rocky-pv6n7 systemd[1]: Starting apt-daily-upgrade.service - Daily apt upgrade and clean activities...
```

So it seems that APT Daily can contend with what the workflow is trying to do.