### PR TITLE
Disable the eclipse module for RHEL 8 aarch64 to avoid warnings from dnf.

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_arm64.cfg
@@ -122,6 +122,8 @@ EOM
 set -x
 exec &> /dev/ttyAMA0
 dnf -y install google-rhui-client-rhel8
+# Disable the eclipse dnf module which doesn't exist for aarch64.
+dnf -y module disable eclipse
 %end
 
 # Google Compute Engine kickstart config for Enterprise Linux 8.


### PR DESCRIPTION
Removes warnings for nonexistent eclipse aarch64 module in RHEL 8.

```
Modular dependency problems:

 Problem 1: nothing provides requested module(eclipse:rhel8:8020120200522125903)
 Problem 2: nothing provides requested module(eclipse:rhel8:8030020201023061315)
Dependencies resolved.
```