### PR TITLE
Install dnf-plugin-protected-kmods in Rocky Accelerators

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_accelerator.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_accelerator.cfg
@@ -186,7 +186,7 @@ dnf install -y google-cloud-cli
 # Install Accelerator components: nvidia and mellanox drivers
 dnf install -y https://depot.ciq.com/public/files/gce-accelerator/open-gpu-kernel-modules-el8-x86_64/nvidia-open-gpu-repos.noarch.rpm https://depot.ciq.com/public/files/gce-accelerator/open-gpu-kernel-modules-el8-x86_64/nvidia-mellanox-ofed-repos.noarch.rpm
 dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
-
+dnf install -y dnf-plugin-protected-kmods
 dnf install -y nvidia-open-gpu-kernel-modules nvidia-accelerated-graphics-driver mlnx-ofed-guest
 
 # Send /root/anaconda-ks.cfg to our logs.

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp_accelerator.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_9_optimized_gcp_accelerator.cfg
@@ -185,7 +185,7 @@ dnf install -y google-cloud-cli
 # Install Accelerator components: nvidia and mellanox drivers
 dnf install -y https://depot.ciq.com/public/files/gce-accelerator/open-gpu-kernel-modules-el9-x86_64/nvidia-open-gpu-repos.noarch.rpm https://depot.ciq.com/public/files/gce-accelerator/open-gpu-kernel-modules-el9-x86_64/nvidia-mellanox-ofed-repos.noarch.rpm
 dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-
+dnf install -y dnf-plugin-protected-kmods
 dnf install -y nvidia-open-gpu-kernel-modules nvidia-accelerated-graphics-driver mlnx-ofed-guest
 
 


### PR DESCRIPTION
Will filter out kernel updates that are incompatible with critical kmods. Will make things easier for users when upgrading.

/cc @jjerger @zmarano 
/hold