### PR TITLE
Update licenses on Daisy build workflows

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
@@ -32,9 +32,9 @@
           "Name": "rocky-linux-8-optimized-gcp-nvidia-550-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-8-accelerated",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-8-optimized-gcp"
+            "projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",
+            "projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-8-accelerated",
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-8-optimized-gcp"
           ],
 
           "Description": "Rocky Linux 8 optimized for gcp with Nvidia driver 550 built on ${build_date}",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
@@ -31,6 +31,12 @@
         {
           "Name": "rocky-linux-8-optimized-gcp-nvidia-550-v${build_date}",
           "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-8-accelerated",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-8-optimized-gcp"
+          ],
+
           "Description": "Rocky Linux 8 optimized for gcp with Nvidia driver 550 built on ${build_date}",
           "Family": "rocky-linux-8-optimized-gcp-nvidia-550",
           "Project": "${publish_project}",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
@@ -32,9 +32,9 @@
           "Name": "rocky-linux-8-optimized-gcp-nvidia-latest-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-8-accelerated",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-8-optimized-gcp"
+            "projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",
+            "projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-8-accelerated",
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-8-optimized-gcp"
           ],
           "Description": "Rocky Linux 8 optimized for gcp with latest Nvidia driver built on ${build_date}",
           "Family": "rocky-linux-8-optimized-gcp-nvidia-latest",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
@@ -31,6 +31,11 @@
         {
           "Name": "rocky-linux-8-optimized-gcp-nvidia-latest-v${build_date}",
           "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-8-accelerated",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-8-optimized-gcp"
+          ],
           "Description": "Rocky Linux 8 optimized for gcp with latest Nvidia driver built on ${build_date}",
           "Family": "rocky-linux-8-optimized-gcp-nvidia-latest",
           "Project": "${publish_project}",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
@@ -32,9 +32,9 @@
           "Name": "rocky-linux-9-optimized-gcp-nvidia-550-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-9-accelerated",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-9-optimized-gcp"
+            "projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",
+            "projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-9-accelerated",
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-9-optimized-gcp"
           ],
           "Description": "Rocky Linux 9 optimized for gcp with Nvidia driver 550 built on ${build_date}",
           "Family": "rocky-linux-9-optimized-gcp-nvidia-550",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
@@ -31,6 +31,11 @@
         {
           "Name": "rocky-linux-9-optimized-gcp-nvidia-550-v${build_date}",
           "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-9-accelerated",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-9-optimized-gcp"
+          ],
           "Description": "Rocky Linux 9 optimized for gcp with Nvidia driver 550 built on ${build_date}",
           "Family": "rocky-linux-9-optimized-gcp-nvidia-550",
           "Project": "${publish_project}",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
@@ -31,6 +31,11 @@
         {
           "Name": "rocky-linux-9-optimized-gcp-nvidia-latest-v${build_date}",
           "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-9-accelerated",
+            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-9-optimized-gcp"
+          ],
           "Description": "Rocky Linux 9 optimized for gcp with latest Nvidia driver built on ${build_date}",
           "Family": "rocky-linux-9-optimized-gcp-nvidia-latest",
           "Project": "${publish_project}",

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
@@ -32,9 +32,9 @@
           "Name": "rocky-linux-9-optimized-gcp-nvidia-latest-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-9-accelerated",
-            "https://www.googleapis.com/compute/v1/projects/rocky-linux-cloud/global/licenses/rocky-linux-9-optimized-gcp"
+            "projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",
+            "projects/rocky-linux-accelerator-cloud/global/licenses/rocky-linux-9-accelerated",
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-9-optimized-gcp"
           ],
           "Description": "Rocky Linux 9 optimized for gcp with latest Nvidia driver built on ${build_date}",
           "Family": "rocky-linux-9-optimized-gcp-nvidia-latest",


### PR DESCRIPTION
The publish can use the full URI but Daisy needs a relative path