### PR TITLE
Update golang dependency

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/package_replacement/install_go.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/install_go.sh
@@ -27,7 +27,7 @@ install_go() {
   fi
 
   # See header file for version specifics.
-  local GOLANG="go1.22.2.linux-${arch}.tar.gz"
+  local GOLANG="go1.23.2.linux-${arch}.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 


### PR DESCRIPTION
COS builds are complaining with error `go: golang.org/x/crypto@v0.35.0 requires go >= 1.23.0 (running go 1.22.2)`. Update golang dependency to [match with other Guest Packages](https://github.com/GoogleCloudPlatform/guest-test-infra/blob/34a575c40a725468ccc9a71663b2b3203e5ead95/packagebuild/common.sh#L57C3-L57C47)