### PR TITLE
Update "latest" Rocky Accel Descriptions

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-8-optimized-gcp-nvidia-latest",
       "Family": "rocky-linux-8-optimized-gcp-nvidia-latest",
-      "Description": "Rocky Linux, Rocky Linux, 8 optimized for GCP, x86_64 optimized for GCP with the Nvidia 570 driver built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 8 optimized for GCP, x86_64 optimized for GCP with the latest Nvidia driver (570) built on {{$time}}",
       "Architecture": "X86_64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-9-optimized-gcp-nvidia-550",
       "Family": "rocky-linux-9-optimized-gcp-nvidia-550",
-      "Description": "Rocky Linux, Rocky Linux, 9 optimized for GCP, x86_64 optimized for GCP with Nvidia driver 550 built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 9 optimized for GCP, x86_64 optimized for GCP with the Nvidia 550 driver built on {{$time}}",
       "Architecture": "X86_64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-550",

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-9-optimized-gcp-nvidia-latest",
       "Family": "rocky-linux-9-optimized-gcp-nvidia-latest",
-      "Description": "Rocky Linux, Rocky Linux, 9 optimized for GCP, x86_64 optimized for GCP with the 570 Nvidia driver built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 9 optimized for GCP, x86_64 optimized for GCP with the latest Nvidia driver (570) built on {{$time}}",
       "Architecture": "X86_64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",


### PR DESCRIPTION
In the Cloud Console, the current description is identical to the 570 one, making it confusing which is which.