### PR TITLE
Fix CIT tests for COS

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -39,7 +39,7 @@ apply_patches() {
   # Download the repositories and apply COS specific patches. NOTE: The patches will be
   # pulled from the master branch in COS. This is based on the assumption that master
   # will have the most recent guest agent version, and therefore the most recent patches.
-  echo -e "\nATTENTION: Downloading the board-overlays and guest-agent repos...\n"
+  logger -p daemon.info "\nATTENTION: Downloading the board-overlays and guest-agent repos...\n"
   git clone https://cos.googlesource.com/cos/overlays/board-overlays --branch master
   git clone https://github.com/GoogleCloudPlatform/guest-agent.git
   cd guest-agent
@@ -48,7 +48,7 @@ apply_patches() {
   mv ./board-overlays/project-lakitu/app-admin/google-guest-agent/files ./guest-agent
   cd guest-agent
 
-  echo -e "\nATTENTION: Applying patches...\n"
+  logger -p daemon.info "\nATTENTION: Applying patches...\n"
   search_dir=./files
   for file in "$search_dir"/*
   do
@@ -60,7 +60,7 @@ apply_patches() {
 
 install_build_deps() {
   # Install the build dependencies.
-  echo -e "\nATTENTION: Installing build deps...\n"
+  logger -p daemon.info "\nATTENTION: Installing build deps...\n"
   apt-get -y update
   apt-get install -y --no-install-{suggests,recommends} git-core \
     debhelper devscripts build-essential equivs libdistro-info-perl
@@ -72,7 +72,7 @@ install_build_deps() {
 
 find_debian_version() {
   # Identify and store the debian version.
-  echo -e "\nATTENTION: Finding the debian version...\n"
+  logger -p daemon.info "\nATTENTION: Finding the debian version...\n"
   cat /etc/debian_version
   DEB_VERSION=$(</etc/debian_version)
   # deb_version=${DEB}
@@ -85,7 +85,7 @@ find_debian_version() {
 
 install_go(){
   # Install the correct version of Go.
-  echo -e "\nATTENTION: Installing go...\n"
+  logger -p daemon.info "\nATTENTION: Installing go...\n"
   cd ..
   source ./install_go.sh; install_go /tmp/go
 }
@@ -99,14 +99,14 @@ upstream_tarball() {
   export BUILD_DIR="/tmp/debpackage"
   export VERSION="041224"
   export TAR="${PKGNAME}_${VERSION}.orig.tar.gz"
-  echo -e "\nATTENTION: Creating build dir and upstream tarball...\n"
+  logger -p daemon.info "\nATTENTION: Creating build dir and upstream tarball...\n"
   tar czvf "${BUILD_DIR}/${TAR}" --exclude .git --exclude packaging \
     --transform "s/^\./${PKGNAME}-${VERSION}/" .
 }
 
 build_tarball(){
   # Extract and build the tarball.
-  echo -e "\nATTENTION: Extracting tarball and building...\n"
+  logger -p daemon.info "\nATTENTION: Extracting tarball and building...\n"
   tar -C "$BUILD_DIR" -xzvf "${BUILD_DIR}/${TAR}"
   cp -r packaging/debian "${BUILD_DIR}/${PKGNAME}-${VERSION}/"
   cd "${BUILD_DIR}/${PKGNAME}-${VERSION}"
@@ -124,17 +124,17 @@ unpack_binaries(){
   # (which provide installation paths) and 2) binaries in a localized dir format.
   # .deb file naming convention follows that in "upstream_tarball" function.
   # g111 is an arbitrary value given to the .deb file.
-  echo -e "\nATTENTION: Unpacking binaries in a directory...\n"
+  logger -p daemon.info "\nATTENTION: Unpacking binaries in a directory...\n"
   dpkg-deb -x google-guest-agent_${VERSION}-g111_${arch}64.deb debian_binaries
   dpkg-deb -c google-guest-agent_${VERSION}-g111_${arch}64.deb >> google-guest-agent-readable-deb.txt
-  echo -e "\nATTENTION: google-guest-agent.deb file contents below...\n"
+  logger -p daemon.info "\nATTENTION: google-guest-agent.deb file contents below...\n"
   cat google-guest-agent-readable-deb.txt
   mv debian_binaries /files/package_replacement
   mv google-guest-agent-readable-deb.txt /files/package_replacement
 }
 
 identify_replacement_files(){
-  echo -e "\nATTENTION: Creating a list of files to replace...\n"
+  logger -p daemon.info "\nATTENTION: Creating a list of files to replace...\n"
   file="/files/package_replacement/google-guest-agent-readable-deb.txt"
   repl_file="repl_files.txt"
 
@@ -169,7 +169,7 @@ main() {
   commit_sha=$1
   arch=$2
 
-  echo -e "\nATTENTION: Starting compile_debian_package.sh...\n"
+  logger -p daemon.info "\nATTENTION: Starting compile_debian_package.sh...\n"
   apply_patches
   install_build_deps
   find_debian_version

--- a/daisy_workflows/image_build/install_package/cos/package_replacement/preload.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/preload.sh
@@ -36,7 +36,7 @@ replace_files(){
     echo $file_name
 
     # Try to find the file and determine the installation path (will be empty if file not found) eg "/usr/bin/".
-    INSTALLATION_PATH=$(sudo find / -type f -name ${file_name} -not -path "/temp_debian_upload/*" | awk -F${file_name} '{print $1}')
+    INSTALLATION_PATH=$(sudo find /usr /etc /opt /var -type f -name ${file_name} | awk -F${file_name} '{print $1}')
 
     # If the file is found (results are not empty), then begin the replacement.
     if ! [[ -z "$INSTALLATION_PATH" ]]; then

--- a/daisy_workflows/image_build/install_package/cos/replacepackage.sh
+++ b/daisy_workflows/image_build/install_package/cos/replacepackage.sh
@@ -33,7 +33,10 @@ get_vars(){
 }
 
 compile_debian_binaries(){
-  sudo apt install -y git
+  logger -p daemon.info "Attempting to update apt package lists..."
+  sudo apt update 2>&1 | logger -t apt-update -p daemon.info
+  logger -p daemon.info "Attempting to install git..."
+  sudo apt install -y git 2>&1 | logger -t apt-install -p daemon.info
   ./compile_debian_package.sh ${COMMIT_SHA} ${ARCH}
 }
 
@@ -53,11 +56,13 @@ set_machine_and_arch_type(){
 #   _NEW_IMAGE_FAMILY: The new image family for the preloaded image.
 #   _MACHINE_TYPE: The machine type for the source image: default (n1-standard-1) or t2a-standard-1 for ARM.
 create_preloaded_image(){
-  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="gcp-guest",_MACHINE_TYPE="${MACHINE_TYPE}"
+  logger -p daemon.info "Attempting to submit gcloud build..."
+  gcloud builds submit . --config=dev_cloudbuild.yaml --disk-size=200 --gcs-log-dir="${DAISY_LOGS_PATH}" --substitutions=_NEW_IMAGE_FAMILY="cos-preloaded-images",_BASE_IMAGE_PROJECT="cos-cloud",_BASE_IMAGE="${SOURCE_IMAGE}",_NEW_IMAGE="${DEST_IMAGE}",_DEST_PROJECT="cloud-kernel-build",_MACHINE_TYPE="${MACHINE_TYPE}" 2>&1 | logger -t gcloud-build -p daemon.info
+  logger -p daemon.info "Finished attempting to submit gcloud build."
 }
 
 main (){
-  echo "Creating COS image with the new guest agent version..."
+  logger -p daemon.info "Creating COS image with the new guest agent version..."
   set_files_executable
   get_vars
   set_machine_and_arch_type


### PR DESCRIPTION
Currently the log does not show up in the serial log with echo. So we switch to use `logger daemon.info ""` to print the log.

Also fixed the commands that failed with errors. For example the `apt install git` and `find / -type f`.

Example error of find command:
```
find: â€˜/proc/729/task/729/netâ€™: Invalid argument
find: â€˜/proc/729/netâ€™: Invalid argument
```

To avoid error, we only scan necessary folders, for example, `/usr`, `/etc`, `/opt` and `/var`.