### PR TITLE
Update installpackage resolv.conf check

### DIFF
--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -60,8 +60,8 @@ def main():
   logging.info('Mount dev filesystem in chroot')
   run('mount -o bind /dev /mnt/dev')
 
-  # Enable DNS resolution in the chroot, for fetching dependencies. In some cases
-  # the symlink to resolv.conf will break, and needs to be unlinked.
+  # Enable DNS resolution in the chroot, for fetching dependencies. In some
+  # cases the symlink to resolv.conf will break, and needs to be unlinked.
   if os.path.islink('/mnt/etc/resolv.conf'):
     if os.path.isfile('mnt/etc/resolv.conf'):
       os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')

--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -63,11 +63,11 @@ def main():
   # Enable DNS resolution in the chroot, for fetching dependencies. In some
   # cases the symlink to resolv.conf will break, and needs to be unlinked.
   if os.path.islink('/mnt/etc/resolv.conf'):
-    if os.path.isfile('mnt/etc/resolv.conf'):
+    if os.path.isfile('/mnt/etc/resolv.conf'):
       os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')
     else:
       os.unlink('/mnt/etc/resolv.conf')
-  elif os.path.isfile('mnt/etc/resolv.conf'):
+  elif os.path.isfile('/mnt/etc/resolv.conf'):
       os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')
   utils.WriteFile('/mnt/etc/resolv.conf', utils.ReadFile('/etc/resolv.conf'))
 

--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -62,10 +62,13 @@ def main():
 
   # Enable DNS resolution in the chroot, for fetching dependencies. In some cases,
   # the symlink to resolv.conf will break, and needs to be unlinked.
-  if os.path.isfile('/mnt/etc/resolv.conf'):
-    os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')
-  else:
-    os.unlink('/mnt/etc/resolv.conf')
+  if os.path.islink('/mnt/etc/resolv.conf'):
+    if os.path.isfile('mnt/etc/resolv.conf'):
+      os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')
+    else:
+      os.unlink('/mnt/etc/resolv.conf')
+  elif os.path.isfile('mnt/etc/resolv.conf'):
+      os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')
   utils.WriteFile('/mnt/etc/resolv.conf', utils.ReadFile('/etc/resolv.conf'))
 
   utils.DownloadFile(package, f'/mnt/tmp/{package_name}')

--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -60,7 +60,7 @@ def main():
   logging.info('Mount dev filesystem in chroot')
   run('mount -o bind /dev /mnt/dev')
 
-  # Enable DNS resolution in the chroot, for fetching dependencies. In some cases,
+  # Enable DNS resolution in the chroot, for fetching dependencies. In some cases
   # the symlink to resolv.conf will break, and needs to be unlinked.
   if os.path.islink('/mnt/etc/resolv.conf'):
     if os.path.isfile('mnt/etc/resolv.conf'):

--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -60,9 +60,12 @@ def main():
   logging.info('Mount dev filesystem in chroot')
   run('mount -o bind /dev /mnt/dev')
 
-  # Enable DNS resolution in the chroot, for fetching dependencies.
+  # Enable DNS resolution in the chroot, for fetching dependencies. In some cases,
+  # the symlink to resolv.conf will break, and needs to be unlinked.
   if os.path.isfile('/mnt/etc/resolv.conf'):
     os.rename('/mnt/etc/resolv.conf', '/mnt/etc/resolv.conf.bak')
+  else:
+    os.unlink('/mnt/etc/resolv.conf')
   utils.WriteFile('/mnt/etc/resolv.conf', utils.ReadFile('/etc/resolv.conf'))
 
   utils.DownloadFile(package, f'/mnt/tmp/{package_name}')


### PR DESCRIPTION
Adds logic to check for and remove a broken symlink if one exists for resolv.conf while preserving the previous behavior for OSes that do not have a broken symlink or have a file at that location.

Context: Debian-13 moved to a symlink for resolv.conf which causes a terminating error when the builder finds a broken symlink it can't follow.

Verified that Rhel-8, Rhel-9, and Debian-12 can still build with this change.