### PR TITLE
Exclude rhui repos

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_arm64.cfg
@@ -158,7 +158,7 @@ EOL
 dnf config-manager --disable rhui-rhel-9-for-aarch64-appstream-rhui-debug-rpms
 
 # Install GCE guest packages.
-dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
+dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand --disablerepo="rhui*"
 rpm -q google-compute-engine google-osconfig-agent gce-disk-expand || { echo "Build Failed!" > /dev/ttyAMA0; exit 1; }
 
 # Install the Cloud SDK package.

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_x86.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_x86.cfg
@@ -158,7 +158,7 @@ EOL
 dnf config-manager --disable rhui-rhel-9-for-x86_64-appstream-rhui-debug-rpms
 
 # Install GCE guest packages.
-dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
+dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand --disablerepo="rhui*"
 rpm -q google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.


### PR DESCRIPTION
Exclude rhui repos for the initial build of the RHEL 10 image.

We are reusing the rhui client for rhel9 for now.