### PR TITLE
Fix kickstart file syntax

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10_arm64.cfg
@@ -114,8 +114,8 @@ enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 priority=99
-EOF
-tee /etc/yum.repos.d/centos-stream-9-appstream.repo << EOF
+EOM
+tee /etc/yum.repos.d/centos-stream-9-appstream.repo << EOM
 [centos-stream-9-AppStream]
 name=CentOS Stream 9 - AppStream
 baseurl=http://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/
@@ -123,7 +123,7 @@ enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 priority=99
-EOF
+EOM
 
 dnf config-manager --set-enabled crb
 dnf install -y gdisk

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10_x86.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10_x86.cfg
@@ -109,8 +109,8 @@ enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 priority=99
-EOF
-tee /etc/yum.repos.d/centos-stream-9-appstream.repo << EOF
+EOM
+tee /etc/yum.repos.d/centos-stream-9-appstream.repo << EOM
 [centos-stream-9-AppStream]
 name=CentOS Stream 9 - AppStream
 baseurl=http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
@@ -118,7 +118,7 @@ enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 priority=99
-EOF
+EOM
 
 dnf clean all
 


### PR DESCRIPTION
Different labels `EOM` and `EOF` was used for `/etc/yum.repos.d/centos-stream9-baseos.repo`, use same and have consistency across file