### PR TITLE
Update rocky_linux_8_optimized_gcp_arm64.cfg to use python 39 instead…

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
@@ -55,7 +55,7 @@ dnf-automatic
 net-tools
 openssh-server
 python3
-python38
+python39
 rng-tools
 tar
 vim
@@ -98,7 +98,7 @@ vim
 %end
 
 %post
-dnf mark remove python38 || exit 1
+dnf mark remove python39 || exit 1
 tee -a /etc/yum.repos.d/google-cloud.repo << EOM
 [google-compute-engine]
 name=Google Compute Engine


### PR DESCRIPTION
This is the error in the image build:

gsutil help
WARNING:  Python 3.8 will be deprecated on July 15th, 2025. Please use Python version 3.9 and up.

If you have a compatible Python interpreter installed, you can use it by setting the CLOUDSDK_PYTHON environment variable to point to it.

Error: gsutil requires Python version 3.9-3.13, but a different version is installed. You are currently running Python 3.8
Follow the steps below to resolve this issue:
	1. Switch to Python 3.9-3.13 using your Python version manager or install an appropriate version.
	2. If you are unsure how to manage Python versions, visit [https://cloud.google.com/storage/docs/gsutil_install#specifications] for detailed instructions.