### PR TITLE
Enable debug logging on test images

### DIFF
--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -63,6 +63,21 @@ def rebuild_rpm_db(image):
     logging.info('Image %s is not known to require rpm db rebuild', image)
 
 
+# Enable debug logging on guest-agent related test images.
+def enable_debug_logging():
+  config = """
+
+[Core]
+log_level = 4
+log_verbosity = 4
+"""
+
+  with open('/mnt/etc/default/instance_configs.cfg', 'a') as file:
+    file.write(config)
+
+  logging.info('Updated instance_configs.cfg to enable debug logging')
+
+
 def main():
   image = utils.GetMetadataAttribute('image', raise_on_not_found=True)
   package = utils.GetMetadataAttribute('gcs_package_path',
@@ -128,6 +143,8 @@ def main():
   elif target_path:
     os.symlink(target_path, '/mnt/etc/resolv.conf')
     logging.info("Recreating /mnt/etc/resolv.conf link to %s", target_path)
+
+  enable_debug_logging()
 
   # Best effort to unmount prior to shutdown.
   run('sync', check=False)

--- a/daisy_workflows/image_build/install_package/windows/installpackage.ps1
+++ b/daisy_workflows/image_build/install_package/windows/installpackage.ps1
@@ -67,8 +67,19 @@ function Install-Package {
     Remove-Item -Path "C:\Program Files\Google\Compute Engine\package.goo" -ErrorAction SilentlyContinue
 }
 
+$config = @'
+
+[Core]
+log_level = 4
+log_verbosity = 4
+'@
+
 try {
     Install-Package
+
+    Write-Host 'Enabling debug logging for guest-agent'
+    Add-Content -Path "C:\Program Files\Google\Compute Engine\instance_configs.cfg" -Value $config
+
     Write-Host 'Launching sysprep.'
     & 'C:\Program Files\Google\Compute Engine\sysprep\gcesysprep.bat'
 }


### PR DESCRIPTION
This will help triaging the test failures. Test no longer need to handle it individually and restart the agent.

/cc @dorileo @drewhli 


/hold