### PR TITLE
Fix patch didn't apply issue for COS image

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
+++ b/daisy_workflows/image_build/install_package/cos/package_replacement/compile_debian_package.sh
@@ -44,6 +44,7 @@ apply_patches() {
   # Define a list of patches to ignore
   local ignore_patches=(
     "makefile-skip-proto-fetch-if-already-exists.patch"
+    "disable-cloud-logging-in-tpc.patch"
   )
 
   git clone https://cos.googlesource.com/cos/overlays/board-overlays --branch master


### PR DESCRIPTION
COS recently has a TPC patch that's added to the master branch. But the script didn't support google-guest-agent repo so applying the patch will complain on milestones < 125. Let's add the short-term fix for now to add the patch to the ignored list.

In the long term, we should migrate the script to add google-guest-agent repo and always use master branch.