### PR TITLE
Update trixie repos to correct values

### DIFF
--- a/daisy_workflows/image_build/debian/fai_config/files/etc/apt/sources.list.d/google-cloud.list/TRIXIE
+++ b/daisy_workflows/image_build/debian/fai_config/files/etc/apt/sources.list.d/google-cloud.list/TRIXIE
@@ -1,4 +1,2 @@
-deb https://us-central1-apt.pkg.dev/projects/gce-package-public/ google-compute-engine-trixie-unstable main
-deb https://us-central1-apt.pkg.dev/projects/gce-pkg-osconfig-public/ google-osconfig-agent-bookworm-stable main
-deb https://us-central1-apt.pkg.dev/projects/gce-pkg-ar-plugins-public/ google-cloud-packages-archive-keyring-bookworm-stable main
-deb https://packages.cloud.google.com/apt cloud-sdk-bookworm main
+deb https://us-central1-apt.pkg.dev/projects/gce-package-public/ google-compute-engine-trixie-stable main
+deb https://packages.cloud.google.com/apt cloud-sdk-trixie main


### PR DESCRIPTION
TEMPORARY until the proper redirection is in place. This will allow us to build with all the correct packages until then.