### PR TITLE
Use Deb12 worker to bootstrap Deb13 worker for ARM

### DIFF
--- a/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
@@ -16,7 +16,7 @@
           "build_date": "${build_date}",
           "debian_version": "trixie",
           "builder_machine_type": "t2a-standard-2",
-          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-13-worker-arm64"
+          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }
     },


### PR DESCRIPTION
Since the build chain has a circular dependency, the first build has to be with Deb12