### PR TITLE
Add IDPF tag to EL ARM images.

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/almalinux_9_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/almalinux_9_arm64.publish.json
@@ -25,7 +25,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/centos_stream_10_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_stream_10_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/centos_stream_9_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/centos_stream_9_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_10_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_10_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_10_byos_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_10_byos_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_byos_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_byos_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.publish.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/daisy_workflows/image_build/enterprise_linux/almalinux_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/almalinux_9_arm64.wf.json
@@ -46,7 +46,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/centos_stream_10_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_stream_10_arm64.wf.json
@@ -46,7 +46,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/centos_stream_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_stream_9_arm64.wf.json
@@ -46,7 +46,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_arm64.wf.json
@@ -45,7 +45,8 @@
           "Family": "rhel-10-arm64",
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
-            "GVNIC"
+            "GVNIC",
+            "IDPF"
           ],
           "Project": "${publish_project}",
           "NoCleanup": true,

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_byos_arm64.wf.json
@@ -42,7 +42,7 @@
           "Licenses": ["projects/rhel-cloud/global/licenses/rhel-10-byos"],
           "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 10, aarch64 built on ${build_date}",
           "Family": "rhel-10-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
@@ -44,7 +44,7 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8, aarch64 built on ${build_date}",
           "Family": "rhel-8-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_byos_arm64.wf.json
@@ -48,7 +48,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_arm64.wf.json
@@ -43,7 +43,7 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9, aarch64 built on ${build_date}",
           "Family": "rhel-9-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_byos_arm64.wf.json
@@ -44,7 +44,7 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 9, aarch64 built on ${build_date}",
           "Family": "rhel-9-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -41,7 +41,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_arm64.wf.json
@@ -46,7 +46,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }

--- a/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -41,7 +41,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
         }
       ]
     }


### PR DESCRIPTION
The drivers seem to be also present on all the EL ARM images. Given that we added the tag to all the EL x86_64 images, it makes sense to do the same for ARM.

/hold