### PR TITLE
Install new trixie config package on trixie only; remove special build config files

### DIFF
--- a/daisy_workflows/image_build/debian/fai_config/files/etc/ssh/sshd_config.d/90_google_kexchange.conf/TRIXIE
+++ b/daisy_workflows/image_build/debian/fai_config/files/etc/ssh/sshd_config.d/90_google_kexchange.conf/TRIXIE
@@ -1,3 +1,0 @@
-# Add required key exchange algorithms to support Google Compute Engine ssh-in-browser
-
-KexAlgorithms +diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1

--- a/daisy_workflows/image_build/debian/fai_config/files/etc/systemd/system/rsyslog.service.d/90_google_rsyslog_console.conf/TRIXIE
+++ b/daisy_workflows/image_build/debian/fai_config/files/etc/systemd/system/rsyslog.service.d/90_google_rsyslog_console.conf/TRIXIE
@@ -1,6 +1,0 @@
-# Override systemd settings to allow google agents to log to serial console
-
-[Service]
-PrivateDevices=no
-DeviceAllow=/dev/console rw
-DevicePolicy=closed

--- a/daisy_workflows/image_build/debian/fai_config/package_config/TRIXIE
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/TRIXIE
@@ -1,0 +1,4 @@
+PACKAGES install
+# Config package for trixie-specific configuration
+
+gce-configs-trixie


### PR DESCRIPTION
Add an install directive for the new Trixie configs package. Allows us to also remove the one-off configs that were in place to build in the meantime.