### PR TITLE
Add IDPF tag to Deb13 guestOS features

### DIFF
--- a/daisy_workflows/build-publish/debian/debian_13.publish.json
+++ b/daisy_workflows/build-publish/debian/debian_13.publish.json
@@ -43,7 +43,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE_V2"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE_V2", "IDPF"]
     }
   ]
 }

--- a/daisy_workflows/build-publish/debian/debian_13_arm64.publish.json
+++ b/daisy_workflows/build-publish/debian/debian_13_arm64.publish.json
@@ -43,7 +43,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
     }
   ]
 }

--- a/daisy_workflows/build-publish/debian/debian_13_worker.publish.json
+++ b/daisy_workflows/build-publish/debian/debian_13_worker.publish.json
@@ -36,7 +36,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]
     }
   ]
 }

--- a/daisy_workflows/build-publish/debian/debian_13_worker_arm64.publish.json
+++ b/daisy_workflows/build-publish/debian/debian_13_worker_arm64.publish.json
@@ -36,7 +36,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
     }
   ]
 }

--- a/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
@@ -40,7 +40,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"],
           "Licenses": [
             "projects/debian-cloud/global/licenses/debian-13-trixie"
           ]

--- a/daisy_workflows/image_build/debian/debian_13_fai.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_fai.wf.json
@@ -38,7 +38,7 @@
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"],
           "Licenses": [
             "projects/debian-cloud/global/licenses/debian-13-trixie"
           ]


### PR DESCRIPTION
The module is present and loadable in the kernel on install, so we might as well add it