### PR TITLE
cos: update build script to install plugin manager

### DIFF
--- a/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
+++ b/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json
@@ -36,7 +36,8 @@
         {
           "Name": "disk-worker",
           "SourceImage": "${worker_image}",
-          "Type": "pd-ssd"
+          "Type": "pd-ssd",
+          "SizeGb": "100"
 	}
       ]
     },


### PR DESCRIPTION
Editted daisy_workflows/image_build/install_package/ cos/package_replacement/compile_debian_package.sh to install the new google-guest-agent repo (plugin manager).

The patches for the new repo in COS will be renamed with a common prefix. Will file another CL to update it in the build script.