### PR TITLE
Set IPV6_DHCP to highest priority (Deb11)

### DIFF
--- a/daisy_workflows/image_build/debian/build_fai.py
+++ b/daisy_workflows/image_build/debian/build_fai.py
@@ -104,9 +104,9 @@ def main():
 
   # Config fai-tool
   # Base classes used for everything
-  fai_classes = ['BASE', 'DEBIAN', 'CLOUD', 'GCE', 'EXTRAS', 'IPV6_DHCP',
+  fai_classes = ['BASE', 'DEBIAN', 'CLOUD', 'GCE', 'EXTRAS',
                  'GCE_SPECIFIC', 'GCE_CLEAN', 'LINUX_VARIANT_CLOUD',
-                 'BUILD_IMAGE', 'SYSTEM_BOOT']
+                 'BUILD_IMAGE', 'SYSTEM_BOOT', 'IPV6_DHCP']
 
   # Debian switched to systemd-timesyncd for ntp starting with bookworm
   if debian_version == 'buster' or debian_version == 'bullseye':


### PR DESCRIPTION
SYSTEM_BOOT will override things in Debian11. Setting IPV6_DHCP last so the dhcp configs take priority. This does not impact Deb 12 and 13 as they do not make use of it.