### PR TITLE
Move keyring package outside of main dependency chain

### DIFF
--- a/daisy_workflows/image_build/debian/fai_config/files/etc/apt/sources.list.d/google-cloud.list/TRIXIE
+++ b/daisy_workflows/image_build/debian/fai_config/files/etc/apt/sources.list.d/google-cloud.list/TRIXIE
@@ -1,3 +1,2 @@
 deb [signed-by=/etc/apt/keyrings/google-keyring.gpg] https://packages.cloud.google.com/apt google-compute-engine-{%SUITE%}-stable main
 deb [signed-by=/etc/apt/keyrings/google-keyring.gpg] https://packages.cloud.google.com/apt cloud-sdk-{%SUITE%} main
-deb [signed-by=/etc/apt/keyrings/google-keyring.gpg] https://packages.cloud.google.com/apt google-cloud-packages-archive-keyring-bookworm-stable main

--- a/daisy_workflows/image_build/debian/fai_config/package_config/BOOKWORM
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/BOOKWORM
@@ -1,0 +1,3 @@
+PACKAGES install
+# Google Cloud package keyring
+google-cloud-packages-archive-keyring

--- a/daisy_workflows/image_build/debian/fai_config/package_config/BULLSEYE
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/BULLSEYE
@@ -1,0 +1,3 @@
+PACKAGES install
+# Google Cloud package keyring
+google-cloud-packages-archive-keyring

--- a/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
+++ b/daisy_workflows/image_build/debian/fai_config/package_config/GCE_SPECIFIC
@@ -5,9 +5,6 @@ haveged
 # Useful tools not already in the EXTRAS package config
 net-tools
 
-# Google Cloud package keyring
-google-cloud-packages-archive-keyring
-
 # ISC DHCP client until the agent can create systemd-networkd configs
 isc-dhcp-client
 


### PR DESCRIPTION
Needed for Debian13 to build without the keyring (installed to the correct location by the new config package).

Also remove an erroneous inclusion of the keyring used in Debian 12.