### PR TITLE
Remove public-image- tag prefix from unwanted targets

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -32,7 +32,6 @@ steps:
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_image_publish:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_image_publish:$COMMIT_SHA
-  - --destination=gcr.io/$PROJECT_ID/gce_image_publish:public-image-$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_image_publish.Dockerfile
 
@@ -49,7 +48,6 @@ steps:
   args:
   - --destination=gcr.io/$PROJECT_ID/gce_export:$_RELEASE
   - --destination=gcr.io/$PROJECT_ID/gce_export:$COMMIT_SHA
-  - --destination=gcr.io/$PROJECT_ID/gce_export:public-image-$COMMIT_SHA
   - --context=/workspace
   - --dockerfile=gce_export.Dockerfile
 


### PR DESCRIPTION
This images should not be tagged as public image so removing the publish instruction for them.