### PR TITLE
Fix RHEL 9.4/9.6/10.0 EUS BYOS kickstart

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_0_eus_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_0_eus_byos.cfg
@@ -209,7 +209,7 @@ rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
   /etc/yum.repos.d/google-cloud-staging.repo
 
 # Remove the RHUI package 
-dnf -y remove google-rhui-client-rhel10
+dnf -y remove google-rhui-client-rhel10-eus
 
 # Clean up the cache for smaller images.
 dnf clean all

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_4_eus_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_4_eus_byos.cfg
@@ -127,11 +127,8 @@ echo "9.4" > /etc/dnf/vars/releasever
 %post --erroronfail
 set -ex
 exec &> /dev/ttyS0
-dnf config-manager --set-disabled google-cloud-cli
+dnf config-manager --set-disabled google-cloud-sdk
 dnf -y install google-rhui-client-rhel9-eus
-%end
-
-%end
 %end
 
 # Google Compute Engine kickstart config for Enterprise Linux 9.
@@ -174,7 +171,7 @@ rpm -q google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.
 # Re-enable the cloud SDK repo
-dnf config-manager --set-enabled google-cloud-cli
+dnf config-manager --set-enabled google-cloud-sdk
 dnf install -y google-cloud-cli
 rpm -q google-cloud-cli
 
@@ -220,6 +217,9 @@ systemctl enable dnf-automatic.timer
 # exist.
 rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
   /etc/yum.repos.d/google-cloud-staging.repo
+
+# Remove the RHUI package 
+dnf -y remove google-rhui-client-rhel9-eus
 
 # Clean up the cache for smaller images.
 dnf clean all

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_6_eus_byos.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_6_eus_byos.cfg
@@ -127,11 +127,8 @@ echo "9.6" > /etc/dnf/vars/releasever
 %post --erroronfail
 set -ex
 exec &> /dev/ttyS0
-dnf config-manager --set-disabled google-cloud-cli
+dnf config-manager --set-disabled google-cloud-sdk
 dnf -y install google-rhui-client-rhel9-eus
-%end
-
-%end
 %end
 
 # Google Compute Engine kickstart config for Enterprise Linux 9.
@@ -174,7 +171,7 @@ rpm -q google-compute-engine google-osconfig-agent gce-disk-expand
 
 # Install the Cloud SDK package.
 # Re-enable the cloud SDK repo
-dnf config-manager --set-enabled google-cloud-cli
+dnf config-manager --set-enabled google-cloud-sdk
 dnf install -y google-cloud-cli
 rpm -q google-cloud-cli
 
@@ -220,6 +217,9 @@ systemctl enable dnf-automatic.timer
 # exist.
 rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
   /etc/yum.repos.d/google-cloud-staging.repo
+
+# Remove the RHUI package 
+dnf -y remove google-rhui-client-rhel9-eus
 
 # Clean up the cache for smaller images.
 dnf clean all


### PR DESCRIPTION
Removed 2 "%end" left unintentionally
Added missing RHUI package removal command
Changed some config-manager from google-cloud-cli to google-cloud-sdk to align w/ base RHEL_X_byos.cfg kickstart
https://github.com/search?q=repo%3AGoogleCloudPlatform%2Fcompute-image-tools+%22google-cloud-sdk%22+byos+%22dnf+config-manager+--set-%22&type=code

/cc @bkatyl  @dorileo 