### PR TITLE
Creating Python file that will create the Daisy workflow file to create the image & Added RHEL 10.0 for SAP

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/rhel_10.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-10",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,12 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-10",
-          "kickstart_config": "./kickstart/rhel_10.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
-          "installer_iso": "${installer_iso}"
+          "installer_iso": "${installer_iso}",
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10",
+          "version_lock": ""
         }
       }
     },
@@ -36,25 +50,33 @@
         {
           "Name": "rhel-10-v${build_date}",
           "SourceDisk": "el-install-disk",
-          "Licenses": ["projects/rhel-cloud/global/licenses/rhel-10-server"],
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-10-server"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10, x86_64 built on ${build_date}",
           "Family": "rhel-10",
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",
             "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
             "SEV_LIVE_MIGRATABLE",
             "SEV_LIVE_MIGRATABLE_V2",
-            "IDPF"
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
           ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-10_0_eus",
+  "Name": "build-rhel-10-0-eus",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,12 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-10-0",
-          "kickstart_config": "./kickstart/rhel_10_0_eus.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
-          "installer_iso": "${installer_iso}"
+          "installer_iso": "${installer_iso}",
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10-eus",
+          "version_lock": "10.0"
         }
       }
     },
@@ -38,25 +52,32 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-10-server",
-            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"],
+            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10.0 EUS, x86_64 built on ${build_date}",
           "Family": "rhel-10-0-eus",
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",
             "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
             "SEV_LIVE_MIGRATABLE",
             "SEV_LIVE_MIGRATABLE_V2",
-            "IDPF"
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
           ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-10-0-eus-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,15 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-10-0",
-          "kickstart_config": "./kickstart/rhel_10_0_eus_arm64.cfg",
+          "el_release": "rhel-10-0-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10-eus",
+          "version_lock": "10.0"
         }
       }
     },
@@ -41,18 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-10-server",
-            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"],
+            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10.0 EUS, aarch64 built on ${build_date}",
           "Family": "rhel-10-0-eus-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-10_0_eus_byos",
+  "Name": "build-rhel-10-0-eus-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-10-0",
-          "kickstart_config": "./kickstart/rhel_10_0_eus_byos.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10-eus",
+          "version_lock": "10.0"
         }
       }
     },
@@ -39,25 +52,32 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-10-byos",
-            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"],
+            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10.0 EUS, BYOS x86_64 built on ${build_date}",
-          "Family": "rhel-10-0-eus",
+          "Family": "rhel-10-0-eus-byos",
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",
             "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
             "SEV_LIVE_MIGRATABLE",
             "SEV_LIVE_MIGRATABLE_V2",
-            "IDPF"
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
           ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos_arm64.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-10-0-eus-arm64",
+  "Name": "build-rhel-10-0-eus-byos-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-10-0",
-          "kickstart_config": "./kickstart/rhel_10_0_eus_byos_arm64.cfg",
+          "el_release": "rhel-10-0-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "True",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10-eus",
+          "version_lock": "10.0"
         }
       }
     },
@@ -42,18 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-10-byos",
-            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"],
-          "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 10.0 EUS, aarch64 built on ${build_date}",
+            "projects/rhel-cloud/global/licenses/rhel-10-server-eus"
+          ],
+          "Description": "Red Hat, Red Hat Enterprise Linux, 10.0 EUS, BYOS aarch64 built on ${build_date}",
           "Family": "rhel-10-0-eus-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "build-rhel-9-lvm",
+  "Name": "build-rhel-10-0-sap",
   "Vars": {
     "auto-generated-file": {
       "Value": "",
@@ -11,7 +11,7 @@
     },
     "installer_iso": {
       "Required": true,
-      "Description": "The RHEL 9 installer ISO to build from."
+      "Description": "The RHEL 10 installer ISO to build from."
     },
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -26,36 +26,35 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./rhel_9_consolidated.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9",
+          "el_release": "rhel-10-0-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "pd-ssd",
           "machine_type": "e2-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
-          "el_install_disk_size": "50",
+          "el_install_disk_size": "20",
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_sap": "False",
-          "is_lvm": "True",
-          "rhui_package_name": "google-rhui-client-rhel9",
-          "version_lock": ""
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10-sap",
+          "version_lock": "10.0"
         }
       }
     },
     "create-image": {
       "CreateImages": [
         {
-          "Name": "rhel-9-lvm-v${build_date}",
+          "Name": "rhel-10-0-sap-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
-            "projects/rhel-cloud/global/licenses/rhel-9-server",
-            "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-sap-cloud/global/licenses/rhel-10-sap"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux, 9 (LVM), x86_64 with a LVM boot volume built on ${build_date}",
-          "Family": "rhel-9-lvm",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 10.0, x86_64 built on ${build_date}",
+          "Family": "rhel-10-0-sap",
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap_byos.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "build-rhel-9-lvm",
+  "Name": "build-rhel-10-0-sap-byos",
   "Vars": {
     "auto-generated-file": {
       "Value": "",
@@ -11,7 +11,7 @@
     },
     "installer_iso": {
       "Required": true,
-      "Description": "The RHEL 9 installer ISO to build from."
+      "Description": "The RHEL 10 installer ISO to build from."
     },
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -26,36 +26,35 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./rhel_9_consolidated.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9",
+          "el_release": "rhel-10-0-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "pd-ssd",
           "machine_type": "e2-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
-          "el_install_disk_size": "50",
+          "el_install_disk_size": "20",
           "is_arm": "False",
-          "is_byos": "False",
+          "is_byos": "True",
           "is_eus": "False",
-          "is_sap": "False",
-          "is_lvm": "True",
-          "rhui_package_name": "google-rhui-client-rhel9",
-          "version_lock": ""
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10-sap",
+          "version_lock": "10.0"
         }
       }
     },
     "create-image": {
       "CreateImages": [
         {
-          "Name": "rhel-9-lvm-v${build_date}",
+          "Name": "rhel-10-0-sap-byos-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
-            "projects/rhel-cloud/global/licenses/rhel-9-server",
-            "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-sap-cloud/global/licenses/rhel-10-sap-byos"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux, 9 (LVM), x86_64 with a LVM boot volume built on ${build_date}",
-          "Family": "rhel-9-lvm",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 10.0, x86_64 built on ${build_date}",
+          "Family": "rhel-10-0-sap-byos",
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-10-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,15 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-10",
-          "kickstart_config": "./kickstart/rhel_10_arm64.cfg",
+          "el_release": "rhel-10-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10",
+          "version_lock": ""
         }
       }
     },
@@ -39,18 +50,27 @@
         {
           "Name": "rhel-10-arm64-v${build_date}",
           "SourceDisk": "el-install-disk",
-          "Licenses": ["projects/rhel-cloud/global/licenses/rhel-10-server"],
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-10-server"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10, aarch64 built on ${build_date}",
           "Family": "rhel-10-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_byos.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-10-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-10",
-          "kickstart_config": "./kickstart/rhel_10_byos.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10",
+          "version_lock": ""
         }
       }
     },
@@ -37,26 +50,33 @@
         {
           "Name": "rhel-10-byos-v${build_date}",
           "SourceDisk": "el-install-disk",
-          "Licenses": ["projects/rhel-cloud/global/licenses/rhel-10-byos"],
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-10-byos"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10, BYOS x86_64 built on ${build_date}",
           "Family": "rhel-10-byos",
-          "Project": "${publish_project}",
-          "NoCleanup": true,
-          "ExactName": true,
           "GuestOsFeatures": [
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",
             "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
             "SEV_LIVE_MIGRATABLE",
             "SEV_LIVE_MIGRATABLE_V2",
             "GVNIC",
-            "IDPF"
-          ]
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_byos_arm64.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-10-arm64",
+  "Name": "build-rhel-10-byos-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-10",
-          "kickstart_config": "./kickstart/rhel_10_byos_arm64.cfg",
+          "el_release": "rhel-10-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel10",
+          "version_lock": ""
         }
       }
     },
@@ -40,18 +50,27 @@
         {
           "Name": "rhel-10-byos-arm64-v${build_date}",
           "SourceDisk": "el-install-disk",
-          "Licenses": ["projects/rhel-cloud/global/licenses/rhel-10-byos"],
-          "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 10, aarch64 built on ${build_date}",
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-10-byos"
+          ],
+          "Description": "Red Hat, Red Hat Enterprise Linux, 10, BYOS aarch64 built on ${build_date}",
           "Family": "rhel-10-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-10-lvm",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-10",
-          "kickstart_config": "./kickstart/rhel_10_lvm.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-	  "el_install_disk_size": "50"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "50",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "True",
+          "rhui_package_name": "google-rhui-client-rhel10",
+          "version_lock": ""
         }
       }
     },
@@ -39,7 +52,7 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-10-server",
-	    "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-cloud/global/licenses/rhel-lvm"
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10 (LVM), x86_64 with a LVM boot volume built on ${build_date}",
           "Family": "rhel-10-lvm",
@@ -47,18 +60,24 @@
             "UEFI_COMPATIBLE",
             "VIRTIO_SCSI_MULTIQUEUE",
             "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
             "SEV_LIVE_MIGRATABLE",
             "SEV_LIVE_MIGRATABLE_V2",
-            "IDPF"
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
           ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-10-lvm-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-10",
-          "kickstart_config": "./kickstart/rhel_10_lvm_arm64.cfg",
+          "el_release": "rhel-10-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-	  "el_install_disk_size": "50",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "50",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "True",
+          "rhui_package_name": "google-rhui-client-rhel10",
+          "version_lock": ""
         }
       }
     },
@@ -42,19 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-10-server",
-	    "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-cloud/global/licenses/rhel-lvm"
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 10 (LVM), aarch64 with a LVM boot volume built on ${build_date}",
           "Family": "rhel-10-lvm-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-8",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,12 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-8",
-          "kickstart_config": "./kickstart/rhel_8.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
-          "installer_iso": "${installer_iso}"
+          "installer_iso": "${installer_iso}",
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8",
+          "version_lock": ""
         }
       }
     },
@@ -41,15 +55,27 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8, x86_64 built on ${build_date}",
           "Family": "rhel-8",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-8-sap",
+  "Name": "build-rhel-8-10-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -13,10 +17,6 @@
       "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
-    "rhel_release": {
-      "Value": "rhel-8",
-      "Description": "RHEL release version to use."
-    },
     "publish_project": {
       "Value": "${PROJECT}",
       "Description": "A project to publish the resulting image to."
@@ -26,35 +26,55 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
-          "el_release": "${rhel_release}",
-          "kickstart_config": "./kickstart/rhel_8_10_sap.cfg",
+          "el_release": "rhel-8-10-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel810-sap",
+          "version_lock": "8.10"
         }
       }
     },
     "create-image": {
       "CreateImages": [
         {
-          "Name": "${rhel_release}-sap-v${build_date}",
+          "Name": "rhel-8-10-sap-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-sap-cloud/global/licenses/rhel-8-sap"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.10 x86_64 built on ${build_date}",
-          "Family": "${rhel_release}-sap",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.10, x86_64 built on ${build_date}",
+          "Family": "rhel-8-10-sap",
+          "GuestOsFeatures": [
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "UEFI_COMPATIBLE",
+            "SEV_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-8-sap-byos",
+  "Name": "build-rhel-8-10-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -13,10 +17,6 @@
       "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
-    "rhel_release": {
-      "Value": "rhel-8",
-      "Description": "RHEL release version to use."
-    },
     "publish_project": {
       "Value": "${PROJECT}",
       "Description": "A project to publish the resulting image to."
@@ -26,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-8",
-          "kickstart_config": "./kickstart/rhel_8_10_sap_byos.cfg",
+          "el_release": "rhel-8-10-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel810-sap",
+          "version_lock": "8.10"
         }
       }
     },
@@ -45,17 +53,28 @@
           "Licenses": [
             "projects/rhel-sap-cloud/global/licenses/rhel-8-sap-byos"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.10, BYOS x86_64 built on ${build_date}",
-          "Family": "rhel-8-8-sap-byos",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 8.10, x86_64 built on ${build_date}",
+          "Family": "rhel-8-10-sap-byos",
+          "GuestOsFeatures": [
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "UEFI_COMPATIBLE",
+            "SEV_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-8-sap",
+  "Name": "build-rhel-8-6-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -13,10 +17,6 @@
       "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
-    "rhel_release": {
-      "Value": "rhel-8",
-      "Description": "RHEL release version to use."
-    },
     "publish_project": {
       "Value": "${PROJECT}",
       "Description": "A project to publish the resulting image to."
@@ -26,35 +26,52 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
-          "el_release": "${rhel_release}",
-          "kickstart_config": "./kickstart/rhel_8_6_sap.cfg",
+          "el_release": "rhel-8-6-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8-sap",
+          "version_lock": "8.6"
         }
       }
     },
     "create-image": {
       "CreateImages": [
         {
-          "Name": "${rhel_release}-sap-v${build_date}",
+          "Name": "rhel-8-6-sap-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-sap-cloud/global/licenses/rhel-8-sap"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8, x86_64 built on ${build_date}",
-          "Family": "${rhel_release}-sap",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.6, x86_64 built on ${build_date}",
+          "Family": "rhel-8-6-sap",
+          "GuestOsFeatures": [
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "UEFI_COMPATIBLE",
+            "SEV_CAPABLE",
+            "GVNIC"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE",  "VIRTIO_SCSI_MULTIQUEUE"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-8-sap-byos",
+  "Name": "build-rhel-8-6-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -13,10 +17,6 @@
       "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
-    "rhel_release": {
-      "Value": "rhel-8",
-      "Description": "RHEL release version to use."
-    },
     "publish_project": {
       "Value": "${PROJECT}",
       "Description": "A project to publish the resulting image to."
@@ -26,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-8",
-          "kickstart_config": "./kickstart/rhel_8_6_sap_byos.cfg",
+          "el_release": "rhel-8-6-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8-sap",
+          "version_lock": "8.6"
         }
       }
     },
@@ -45,17 +53,25 @@
           "Licenses": [
             "projects/rhel-sap-cloud/global/licenses/rhel-8-sap-byos"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.6, BYOS x86_64 built on ${build_date}",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 8.6, x86_64 built on ${build_date}",
           "Family": "rhel-8-6-sap-byos",
+          "GuestOsFeatures": [
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "UEFI_COMPATIBLE",
+            "SEV_CAPABLE",
+            "GVNIC"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-8-sap",
+  "Name": "build-rhel-8-8-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -13,10 +17,6 @@
       "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
-    "rhel_release": {
-      "Value": "rhel-8",
-      "Description": "RHEL release version to use."
-    },
     "publish_project": {
       "Value": "${PROJECT}",
       "Description": "A project to publish the resulting image to."
@@ -26,35 +26,53 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
-          "el_release": "${rhel_release}",
-          "kickstart_config": "./kickstart/rhel_8_8_sap.cfg",
+          "el_release": "rhel-8-8-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8-sap",
+          "version_lock": "8.8"
         }
       }
     },
     "create-image": {
       "CreateImages": [
         {
-          "Name": "${rhel_release}-sap-v${build_date}",
+          "Name": "rhel-8-8-sap-v${build_date}",
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-sap-cloud/global/licenses/rhel-8-sap"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.8 x86_64 built on ${build_date}",
-          "Family": "${rhel_release}-sap",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.8, x86_64 built on ${build_date}",
+          "Family": "rhel-8-8-sap",
+          "GuestOsFeatures": [
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "UEFI_COMPATIBLE",
+            "SEV_CAPABLE",
+            "GVNIC",
+            "SEV_LIVE_MIGRATABLE_V2"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE",  "VIRTIO_SCSI_MULTIQUEUE", "GVNIC"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-8-sap-byos",
+  "Name": "build-rhel-8-8-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -13,10 +17,6 @@
       "Value": "${TIMESTAMP}",
       "Description": "Build datestamp used to version the image."
     },
-    "rhel_release": {
-      "Value": "rhel-8",
-      "Description": "RHEL release version to use."
-    },
     "publish_project": {
       "Value": "${PROJECT}",
       "Description": "A project to publish the resulting image to."
@@ -26,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-8",
-          "kickstart_config": "./kickstart/rhel_8_8_sap_byos.cfg",
+          "el_release": "rhel-8-8-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8-sap",
+          "version_lock": "8.8"
         }
       }
     },
@@ -45,17 +53,26 @@
           "Licenses": [
             "projects/rhel-sap-cloud/global/licenses/rhel-8-sap-byos"
           ],
-          "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 8.8, BYOS x86_64 built on ${build_date}",
+          "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 8.8, x86_64 built on ${build_date}",
           "Family": "rhel-8-8-sap-byos",
+          "GuestOsFeatures": [
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "UEFI_COMPATIBLE",
+            "SEV_CAPABLE",
+            "GVNIC",
+            "SEV_LIVE_MIGRATABLE_V2"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-8-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,15 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-8-arm64",
-          "kickstart_config": "./kickstart/rhel_8_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8",
+          "version_lock": ""
         }
       }
     },
@@ -44,15 +55,22 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8, aarch64 built on ${build_date}",
           "Family": "rhel-8-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_byos.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-8-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-8",
-          "kickstart_config": "./kickstart/rhel_8_byos.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8",
+          "version_lock": ""
         }
       }
     },
@@ -42,15 +55,27 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8, BYOS x86_64 built on ${build_date}",
           "Family": "rhel-8-byos",
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_byos_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-8-byos-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-8-arm64",
-          "kickstart_config": "./kickstart/rhel_8_byos_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel8",
+          "version_lock": ""
         }
       }
     },
@@ -45,15 +55,22 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8, BYOS aarch64 built on ${build_date}",
           "Family": "rhel-8-byos-arm64",
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-8-lvm",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-8",
-          "kickstart_config": "./kickstart/rhel_8_lvm.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-	  "el_install_disk_size": "50"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "50",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "True",
+          "rhui_package_name": "google-rhui-client-rhel8",
+          "version_lock": ""
         }
       }
     },
@@ -39,20 +52,31 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-8-server",
-	    "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-cloud/global/licenses/rhel-lvm"
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8 (LVM), x86_64 with a LVM boot volume built on ${build_date}",
           "Family": "rhel-8-lvm",
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }
-

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-8-lvm-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_8_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-8-arm64",
-          "kickstart_config": "./kickstart/rhel_8_lvm_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-	  "el_install_disk_size": "50",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "50",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "True",
+          "rhui_package_name": "google-rhui-client-rhel8",
+          "version_lock": ""
         }
       }
     },
@@ -42,19 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-8-server",
-	    "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-cloud/global/licenses/rhel-lvm"
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 8 (LVM), aarch64 with a LVM boot volume built on ${build_date}",
           "Family": "rhel-8-lvm-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,12 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9",
-          "kickstart_config": "./kickstart/rhel_9.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
-          "installer_iso": "${installer_iso}"
+          "installer_iso": "${installer_iso}",
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9",
+          "version_lock": ""
         }
       }
     },
@@ -41,15 +55,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9, x86_64 built on ${build_date}",
           "Family": "rhel-9",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-sap",
+  "Name": "build-rhel-9-0-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_0_sap.cfg",
+          "el_release": "rhel-9-0-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.0"
         }
       }
     },
@@ -42,15 +55,23 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 9.0, x86_64 built on ${build_date}",
           "Family": "rhel-9-0-sap",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "GVNIC"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-byos-sap",
+  "Name": "build-rhel-9-0-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_0_sap_byos.cfg",
+          "el_release": "rhel-9-0-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.0"
         }
       }
     },
@@ -43,15 +55,23 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 9.0, x86_64 built on ${build_date}",
           "Family": "rhel-9-0-sap-byos",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "GVNIC"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-sap",
+  "Name": "build-rhel-9-2-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_2_sap.cfg",
+          "el_release": "rhel-9-2-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.2"
         }
       }
     },
@@ -42,15 +55,26 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 9.2, x86_64 built on ${build_date}",
           "Family": "rhel-9-2-sap",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "GVNIC",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-byos-sap",
+  "Name": "build-rhel-9-2-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_2_sap_byos.cfg",
+          "el_release": "rhel-9-2-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.2"
         }
       }
     },
@@ -43,15 +55,26 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 9.2, x86_64 built on ${build_date}",
           "Family": "rhel-9-2-sap-byos",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "GVNIC",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-4-eus",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,12 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9-4",
-          "kickstart_config": "./kickstart/rhel_9_4_eus.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
-          "installer_iso": "${installer_iso}"
+          "installer_iso": "${installer_iso}",
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.4"
         }
       }
     },
@@ -42,15 +56,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9.4 EUS, x86_64 built on ${build_date}",
           "Family": "rhel-9-4-eus",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-4-eus-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,15 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-4",
-          "kickstart_config": "./kickstart/rhel_9_4_eus_arm64.cfg",
+          "el_release": "rhel-9-4-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.4"
         }
       }
     },
@@ -41,18 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-9-server",
-            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"],
+            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9.4 EUS, aarch64 built on ${build_date}",
           "Family": "rhel-9-4-eus-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-4-eus-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9-4",
-          "kickstart_config": "./kickstart/rhel_9_4_eus_byos.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.4"
         }
       }
     },
@@ -43,15 +56,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9.4 EUS, BYOS x86_64 built on ${build_date}",
           "Family": "rhel-9-4-eus-byos",
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos_arm64.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-4-eus-arm64",
+  "Name": "build-rhel-9-4-eus-byos-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-4",
-          "kickstart_config": "./kickstart/rhel_9_4_eus_byos_arm64.cfg",
+          "el_release": "rhel-9-4-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "True",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.4"
         }
       }
     },
@@ -42,18 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-9-byos",
-            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"],
-          "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 9.4 EUS, aarch64 built on ${build_date}",
+            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"
+          ],
+          "Description": "Red Hat, Red Hat Enterprise Linux, 9.4 EUS, BYOS aarch64 built on ${build_date}",
           "Family": "rhel-9-4-eus-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-sap",
+  "Name": "build-rhel-9-4-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_4_sap.cfg",
+          "el_release": "rhel-9-4-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.4"
         }
       }
     },
@@ -42,15 +55,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 9.4, x86_64 built on ${build_date}",
           "Family": "rhel-9-4-sap",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-byos-sap",
+  "Name": "build-rhel-9-4-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_4_sap_byos.cfg",
+          "el_release": "rhel-9-4-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.4"
         }
       }
     },
@@ -43,15 +55,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 9.4, x86_64 built on ${build_date}",
           "Family": "rhel-9-4-sap-byos",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-6-eus",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,12 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9-6",
-          "kickstart_config": "./kickstart/rhel_9_6_eus.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
-          "installer_iso": "${installer_iso}"
+          "installer_iso": "${installer_iso}",
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.6"
         }
       }
     },
@@ -42,15 +56,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9.6 EUS, x86_64 built on ${build_date}",
           "Family": "rhel-9-6-eus",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-6-eus-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,15 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-6",
-          "kickstart_config": "./kickstart/rhel_9_6_eus_arm64.cfg",
+          "el_release": "rhel-9-6-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.6"
         }
       }
     },
@@ -41,18 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-9-server",
-            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"],
+            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9.6 EUS, aarch64 built on ${build_date}",
           "Family": "rhel-9-6-eus-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-6-eus-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9-6",
-          "kickstart_config": "./kickstart/rhel_9_6_eus_byos.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.6"
         }
       }
     },
@@ -43,15 +56,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9.6 EUS, BYOS x86_64 built on ${build_date}",
           "Family": "rhel-9-6-eus-byos",
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos_arm64.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-6-eus-arm64",
+  "Name": "build-rhel-9-6-eus-byos-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-6",
-          "kickstart_config": "./kickstart/rhel_9_6_eus_byos_arm64.cfg",
+          "el_release": "rhel-9-6-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "True",
+          "is_eus": "True",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-eus",
+          "version_lock": "9.6"
         }
       }
     },
@@ -42,18 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-9-byos",
-            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"],
-          "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 9.6 EUS, aarch64 built on ${build_date}",
+            "projects/rhel-cloud/global/licenses/rhel-9-server-eus"
+          ],
+          "Description": "Red Hat, Red Hat Enterprise Linux, 9.6 EUS, BYOS aarch64 built on ${build_date}",
           "Family": "rhel-9-6-eus-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-sap",
+  "Name": "build-rhel-9-6-sap",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_6_sap.cfg",
+          "el_release": "rhel-9-6-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.6"
         }
       }
     },
@@ -42,15 +55,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP, 9.6, x86_64 built on ${build_date}",
           "Family": "rhel-9-6-sap",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap_byos.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-byos-sap",
+  "Name": "build-rhel-9-6-sap-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,14 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9-sap",
-          "kickstart_config": "./kickstart/rhel_9_6_sap_byos.cfg",
+          "el_release": "rhel-9-6-sap",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_sap": "true",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "True",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9-sap",
+          "version_lock": "9.6"
         }
       }
     },
@@ -43,15 +55,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux for SAP BYOS, 9.6, x86_64 built on ${build_date}",
           "Family": "rhel-9-6-sap-byos",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,15 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9",
-          "kickstart_config": "./kickstart/rhel_9_arm64.cfg",
+          "el_release": "rhel-9-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9",
+          "version_lock": ""
         }
       }
     },
@@ -39,18 +50,27 @@
         {
           "Name": "rhel-9-arm64-v${build_date}",
           "SourceDisk": "el-install-disk",
-          "Licenses": ["projects/rhel-cloud/global/licenses/rhel-9-server"],
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-9-server"
+          ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9, aarch64 built on ${build_date}",
           "Family": "rhel-9-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_byos.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-byos",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,13 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9",
-          "kickstart_config": "./kickstart/rhel_9_byos.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true"
+          "disk_type": "pd-ssd",
+          "machine_type": "e2-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker",
+          "el_install_disk_size": "20",
+          "is_arm": "False",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9",
+          "version_lock": ""
         }
       }
     },
@@ -42,15 +55,28 @@
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9, BYOS x86_64 built on ${build_date}",
           "Family": "rhel-9-byos",
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
           "ExactName": true,
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF"]
+          "Architecture": "X86_64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_byos_arm64.wf.json
@@ -1,6 +1,10 @@
 {
-  "Name": "build-rhel-9-arm64",
+  "Name": "build-rhel-9-byos-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-9",
-          "kickstart_config": "./kickstart/rhel_9_byos_arm64.cfg",
+          "el_release": "rhel-9-arm64",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "rhel_byos": "true",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "20",
+          "is_arm": "True",
+          "is_byos": "True",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "False",
+          "rhui_package_name": "google-rhui-client-rhel9",
+          "version_lock": ""
         }
       }
     },
@@ -40,18 +50,27 @@
         {
           "Name": "rhel-9-byos-arm64-v${build_date}",
           "SourceDisk": "el-install-disk",
-          "Licenses": ["projects/rhel-cloud/global/licenses/rhel-9-byos"],
-          "Description": "Red Hat, Red Hat Enterprise Linux BYOS, 9, aarch64 built on ${build_date}",
+          "Licenses": [
+            "projects/rhel-cloud/global/licenses/rhel-9-byos"
+          ],
+          "Description": "Red Hat, Red Hat Enterprise Linux, 9, BYOS aarch64 built on ${build_date}",
           "Family": "rhel-9-byos-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_arm64.wf.json
@@ -1,6 +1,10 @@
 {
   "Name": "build-rhel-9-lvm-arm64",
   "Vars": {
+    "auto-generated-file": {
+      "Value": "",
+      "Description": "This file is Generated. Do not edit manually. Modify and run the generator script(write_image_build_workflow.py) instead. This variable is unused as a workaround to Daisy Workflow's lack of support for file-level comments."
+    },
     "google_cloud_repo": {
       "Value": "stable",
       "Description": "The Google Cloud Repo branch to use."
@@ -22,16 +26,22 @@
     "build-rhel": {
       "Timeout": "60m",
       "IncludeWorkflow": {
-        "Path": "./enterprise_linux.wf.json",
+        "Path": "./rhel_9_consolidated.wf.json",
         "Vars": {
           "el_release": "rhel-9-arm64",
-          "kickstart_config": "./kickstart/rhel_9_lvm_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-	  "el_install_disk_size": "50",
           "disk_type": "hyperdisk-balanced",
           "machine_type": "c4a-standard-4",
-          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
+          "el_install_disk_size": "50",
+          "is_arm": "True",
+          "is_byos": "False",
+          "is_eus": "False",
+          "is_sap": "False",
+          "is_lvm": "True",
+          "rhui_package_name": "google-rhui-client-rhel9",
+          "version_lock": ""
         }
       }
     },
@@ -42,19 +52,26 @@
           "SourceDisk": "el-install-disk",
           "Licenses": [
             "projects/rhel-cloud/global/licenses/rhel-9-server",
-	    "projects/rhel-cloud/global/licenses/rhel-lvm"
+            "projects/rhel-cloud/global/licenses/rhel-lvm"
           ],
           "Description": "Red Hat, Red Hat Enterprise Linux, 9 (LVM), aarch64 with a LVM boot volume built on ${build_date}",
           "Family": "rhel-9-lvm-arm64",
-          "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"],
+          "GuestOsFeatures": [
+            "UEFI_COMPATIBLE",
+            "GVNIC",
+            "IDPF"
+          ],
           "Project": "${publish_project}",
           "NoCleanup": true,
-          "ExactName": true
+          "ExactName": true,
+          "Architecture": "ARM64"
         }
       ]
     }
   },
   "Dependencies": {
-    "create-image": ["build-rhel"]
+    "create-image": [
+      "build-rhel"
+    ]
   }
 }

--- a/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
+++ b/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+
+RHEL_MAJOR_VERSIONS = ["8", "9", "10"]
+RHEL_MINOR_VERSIONS = {
+    "8": ["8.6", "8.8", "8.10"],
+    "9": ["9.0", "9.2", "9.4", "9.6"],
+    "10": ["10.0"],
+}
+
+RHEL_EUS_VERSIONS = ["9.4", "9.6", "10.0"]
+RHEL_LVM_VERSIONS = ["8", "9", "10"]
+RHEL_SAP_VERSIONS = ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "10.0"]
+
+ARCHITECTURES = ["x86_64", "arm64"]
+PLANS = ["payg", "byos"]
+
+
+def get_licenses(major_version, plan, is_eus, is_lvm, is_sap):
+    licenses = []
+    if is_sap and plan == "byos":
+        licenses.append(
+            "projects/rhel-sap-cloud/global/licenses/rhel-"
+            f"{major_version}-sap-byos"
+        )
+    elif is_sap:
+        licenses.append(
+            "projects/rhel-sap-cloud/global/licenses/rhel-"
+            f"{major_version}-sap"
+        )
+    elif plan == "byos":
+        licenses.append(
+            "projects/rhel-cloud/global/licenses/rhel-"
+            f"{major_version}-byos"
+        )
+    else:
+        licenses.append(
+            "projects/rhel-cloud/global/licenses/rhel-"
+            f"{major_version}-server"
+        )
+
+    if is_eus:
+        licenses.append(
+            "projects/rhel-cloud/global/licenses/rhel-"
+            f"{major_version}-server-eus"
+        )
+    if is_lvm:
+        licenses.append("projects/rhel-cloud/global/licenses/rhel-lvm")
+    return licenses
+
+
+def get_guest_os_features(major_version, arch, is_sap, minor_version):
+    if arch == "arm64":
+        return ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
+    if major_version == "10":  # RHEL 10 x86_64 images
+        return [
+            "UEFI_COMPATIBLE",
+            "VIRTIO_SCSI_MULTIQUEUE",
+            "SEV_CAPABLE",
+            "SEV_SNP_CAPABLE",
+            "SEV_LIVE_MIGRATABLE",
+            "SEV_LIVE_MIGRATABLE_V2",
+            "GVNIC",
+            "IDPF",
+            "TDX_CAPABLE"
+        ]
+    elif major_version == "9":  # RHEL 9 x86_64 images
+        if is_sap and minor_version and minor_version == "9.0":
+            return [
+                "UEFI_COMPATIBLE",
+                "VIRTIO_SCSI_MULTIQUEUE",
+                "SEV_CAPABLE",
+                "GVNIC"
+            ]
+        elif is_sap and minor_version and minor_version == "9.2":
+            return [
+                "UEFI_COMPATIBLE",
+                "VIRTIO_SCSI_MULTIQUEUE",
+                "SEV_CAPABLE",
+                "SEV_SNP_CAPABLE",
+                "GVNIC",
+                "SEV_LIVE_MIGRATABLE",
+                "SEV_LIVE_MIGRATABLE_V2"
+            ]
+        else:
+            return [
+                "UEFI_COMPATIBLE",
+                "VIRTIO_SCSI_MULTIQUEUE",
+                "SEV_CAPABLE",
+                "SEV_SNP_CAPABLE",
+                "SEV_LIVE_MIGRATABLE",
+                "SEV_LIVE_MIGRATABLE_V2",
+                "GVNIC",
+                "IDPF",
+                "TDX_CAPABLE"
+            ]
+    else:  # RHEL 8 x86_64 images
+       if is_sap:
+           if minor_version and minor_version == "8.6":
+               return [
+                   "VIRTIO_SCSI_MULTIQUEUE",
+                   "UEFI_COMPATIBLE",
+                   "SEV_CAPABLE",
+                   "GVNIC"
+                ]
+           elif minor_version and minor_version == "8.8":
+               return [
+                   "VIRTIO_SCSI_MULTIQUEUE",
+                   "UEFI_COMPATIBLE",
+                   "SEV_CAPABLE",
+                   "GVNIC",
+                   "SEV_LIVE_MIGRATABLE_V2"
+                ]
+           else:  # RHEL 8.10 SAP
+               return [
+                   "VIRTIO_SCSI_MULTIQUEUE",
+                   "UEFI_COMPATIBLE",
+                   "SEV_CAPABLE",
+                   "SEV_LIVE_MIGRATABLE",
+                   "SEV_LIVE_MIGRATABLE_V2",
+                   "GVNIC",
+                   "IDPF"
+                ]
+       else:
+           return [
+               "UEFI_COMPATIBLE",
+               "VIRTIO_SCSI_MULTIQUEUE",
+               "SEV_CAPABLE",
+               "SEV_SNP_CAPABLE",
+               "SEV_LIVE_MIGRATABLE",
+               "SEV_LIVE_MIGRATABLE_V2",
+               "GVNIC",
+               "IDPF"
+            ]
+
+
+def generate_workflow_file(image_name,
+                           major_version,
+                           licenses,
+                           description,
+                           guest_os_features,
+                           arch,
+                           is_arm,
+                           is_byos,
+                           is_eus,
+                           is_lvm,
+                           is_sap,
+                           minor_version,
+                           disk_type,
+                           machine_type,
+                           worker_image,
+                           el_install_disk_size,
+                           rhui_package_name,
+                           el_release):
+    workflow_name = f"build-{image_name}"
+
+    wf = {
+        "Name": workflow_name,
+        "Vars": {
+            "auto-generated-file": {
+                "Value": "",
+                "Description": (
+                    "This file is Generated. Do not edit manually. Modify and"
+                    " run the generator script"
+                    "(write_image_build_workflow.py) instead. This variable"
+                    " is unused as a workaround to Daisy Workflow's lack of"
+                    " support for file-level comments."
+                )
+            },
+            "google_cloud_repo": {
+               "Value": "stable",
+               "Description": "The Google Cloud Repo branch to use."
+            },
+            "installer_iso": {
+               "Required": True,
+               "Description": (
+                   f"The RHEL {major_version} installer ISO to build from."
+               )
+            },
+            "build_date": {
+               "Value": "${TIMESTAMP}",
+               "Description": "Build datestamp used to version the image."
+            },
+            "publish_project": {
+               "Value": "${PROJECT}",
+               "Description": "A project to publish the resulting image to."
+            },
+        },
+        "Steps": {
+           "build-rhel": {
+               "Timeout": "60m",
+               "IncludeWorkflow": {
+                   "Path": f"./rhel_{major_version}_consolidated.wf.json",
+                   "Vars": {
+                       "el_release": f"{el_release}",
+                       "google_cloud_repo": "${google_cloud_repo}",
+                       "installer_iso": "${installer_iso}",
+                       "disk_type": f"{disk_type}",
+                       "machine_type": f"{machine_type}",
+                       "worker_image": f"{worker_image}",
+                       "el_install_disk_size": f"{el_install_disk_size}",
+                       "is_arm": f"{is_arm}",
+                       "is_byos": f"{is_byos}",
+                       "is_eus": f"{is_eus}",
+                       "is_sap": f"{is_sap}",
+                       "is_lvm": f"{is_lvm}",
+                       "rhui_package_name": f"{rhui_package_name}",
+                       "version_lock": f"{minor_version}"
+                    }
+                }
+            },
+           "create-image": {
+               "CreateImages": [
+                   {
+                       "Name": f"{image_name}-v${{build_date}}",
+                       "SourceDisk": "el-install-disk",
+                       "Licenses": licenses,
+                       "Description": description,
+                       "Family": image_name,
+                       "GuestOsFeatures": guest_os_features,
+                       "Project": "${publish_project}",
+                       "NoCleanup": True,
+                       "ExactName": True,
+                       "Architecture": arch
+                   }
+                ]
+            }
+        },
+        "Dependencies": {
+           "create-image": ["build-rhel"]
+        }
+    }
+    return wf
+
+
+def write_workflow_file(major_version,
+                        plan,
+                        is_eus,
+                        is_lvm,
+                        is_sap,
+                        arch,
+                        minor_version):
+    image_name = "rhel-"
+    if minor_version:
+        image_name += minor_version.replace('.', '-')
+    else:
+        image_name += major_version
+    if is_eus:
+       image_name += "-eus"
+    if is_sap:
+       image_name += "-sap"
+    if plan == "byos":
+       image_name += "-byos"
+    if is_lvm:
+       image_name += "-lvm"
+    if arch == "arm64":
+       image_name += "-arm64"
+
+    description = "Red Hat, Red Hat Enterprise Linux"
+    if is_sap:
+        description += " for SAP"
+        if plan == "byos":
+            description += " BYOS"
+    description += ", "
+    if minor_version:
+        description += minor_version
+    else:
+        description += major_version
+    if is_eus:
+        description += " EUS"
+    if is_lvm:
+        description += " (LVM)"
+    description += ","
+    if plan == "byos" and not is_sap:
+        description += " BYOS"
+    if arch == "x86_64":
+        description += " x86_64"
+    else:
+        description += " aarch64"
+    if is_lvm:
+        description += " with a LVM boot volume"
+    description += " built on ${build_date}"
+
+    el_release = "rhel-" + major_version
+    if is_eus or is_sap:
+        el_release += "-" + minor_version.split(".")[1]
+    if is_sap:
+        el_release += "-sap"
+    if arch == "arm64":
+        el_release += "-arm64"
+
+    disk_type = "pd-ssd"
+    machine_type = "e2-standard-4"
+    worker_image = (
+        "projects/compute-image-tools/global/images/family/debian-12-worker"
+    )
+    el_install_disk_size = "20"
+    if arch == "arm64":
+        disk_type = "hyperdisk-balanced"
+        machine_type = "c4a-standard-4"
+        worker_image = (
+            "projects/compute-image-tools/global/images/family/"
+            "debian-12-worker-arm64"
+        )
+    if is_lvm:
+        el_install_disk_size = "50"
+
+    rhui_package_name = "google-rhui-client-rhel" + major_version
+    if minor_version == major_version + ".10":
+        rhui_package_name += "10"
+    if is_eus:
+        rhui_package_name += "-eus"
+    if is_sap:
+        rhui_package_name += "-sap"
+
+    licenses = get_licenses(major_version, plan, is_eus, is_lvm, is_sap)
+    guest_os_features = get_guest_os_features(major_version,
+                                              arch,
+                                              is_sap,
+                                              minor_version)
+    wf = generate_workflow_file(image_name,
+                                major_version,
+                                licenses,
+                                description,
+                                guest_os_features,
+                                arch.upper(),
+                                arch == "arm64",
+                                plan == "byos",
+                                is_eus,
+                                is_lvm,
+                                is_sap,
+                                minor_version,
+                                disk_type,
+                                machine_type,
+                                worker_image,
+                                el_install_disk_size,
+                                rhui_package_name,
+                                el_release)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    image_name = image_name.replace('-', '_')
+    file_name = os.path.join(script_dir, f"{image_name}.wf.json")
+    with open(file_name, 'w') as f:
+        json.dump(wf, f, indent=2)
+    logging.info(f'Wrote workflow file: {file_name}')
+
+
+def main():
+    is_eus = False
+    is_lvm = False
+    is_sap = False
+
+    for arch in ARCHITECTURES:
+        for plan in PLANS:
+            for major_version in RHEL_MAJOR_VERSIONS:
+                # LVM is only for PAYG images
+                # LVM is currently only avaliable for major versions
+                if (plan == "payg"
+                    and major_version in RHEL_LVM_VERSIONS):
+                    is_lvm = True
+                    write_workflow_file(major_version,
+                                        plan,
+                                        is_eus,
+                                        is_lvm,
+                                        is_sap,
+                                        arch,
+                                        '')  # LVM
+                is_lvm = False
+                write_workflow_file(major_version,
+                                    plan,
+                                    is_eus,
+                                    is_lvm,
+                                    is_sap,
+                                    arch,
+                                    '')  # Base image
+                for minor_version in RHEL_MINOR_VERSIONS[major_version]:
+                    if minor_version not in RHEL_EUS_VERSIONS \
+                            and minor_version not in RHEL_SAP_VERSIONS:
+                        continue
+                    if minor_version in RHEL_EUS_VERSIONS:
+                        is_eus = True
+                        write_workflow_file(major_version,
+                                            plan,
+                                            is_eus,
+                                            is_lvm,
+                                            is_sap,
+                                            arch,
+                                            minor_version)  # EUS
+                    is_eus = False
+                    # SAP only supports x86_64
+                    if (arch == "x86_64"
+                        and minor_version in RHEL_SAP_VERSIONS):
+                        is_sap = True
+                        write_workflow_file(major_version,
+                                            plan,
+                                            is_eus,
+                                            is_lvm,
+                                            is_sap,
+                                            arch,
+                                            minor_version)  # SAP
+                    is_sap = False
+
+
+if __name__ == '__main__':
+  try:
+    main()
+    logging.info('Daisy image_build workflow files written successful!')
+  except Exception as e:
+    logging.error(
+        'Writing Daisy image_build workflow files failed: %s' % str(e))


### PR DESCRIPTION
/cc @bkatyl 

This is a script that will be used to generate the image_build workflow files. This is to reduce the need for manual building & editing of these files. This script will need to be updated anytime a new image is to be released or changes are needed.

I've also ran the script and these are the initial changes that it will make to the existing image_build workflow files.
Changes include
1. Formatting changes due to how Python handles workflow writing
2. Adding in Missing GuestOsFeatures. The source of truth I used was the build-publish publish.json files since they are up to date while the build-publish wf.json files are not
3. Changed the build-rhel call to the consolidated image_build workflow which will also call the new consolidated kickstart file
4. Fixed inconsistencies w/ naming of image_name/family
5. Adding Architecture parameter to the image_build.wf.json files. Previously the "Arm" image_build.wf.json files would've created X86 images. We only set the Architecture in the build-publish.publish.json files so this workflow was missing them

Also added the files for RHEL 10.0 SAP & RHEL 10.0 SAP BYOS