### PR TITLE
Replaced usage of pretty.Compare() with cmp.Diff()

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,4 +10,4 @@ approvers:
   - saswatpadhi
   - tylerjdao
   - shenpai35
-  - meetguogengli
+  - CarsonGL

--- a/gce_image_publish/go.mod
+++ b/gce_image_publish/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20260401175431-30321ee57c9b
-	github.com/kylelemons/godebug v1.1.0
+	github.com/google/go-cmp v0.7.0
 	google.golang.org/api v0.273.0
 )
 

--- a/gce_image_publish/publish/publish_test.go
+++ b/gce_image_publish/publish/publish_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
 	computeAlpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 )
@@ -427,11 +427,11 @@ func TestPublishImage(t *testing.T) {
 			t.Errorf("%s: did not get expected error from publishImage()", tt.desc)
 		}
 
-		if diff := pretty.Compare(dr, tt.wantCI); diff != "" {
-			t.Errorf("%s: returned CreateImages does not match expectation: (-got +want)\n%s", tt.desc, diff)
+		if diff := cmp.Diff(tt.wantCI, dr); diff != "" {
+			t.Errorf("%s: returned CreateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
-		if diff := pretty.Compare(di, tt.wantDI); diff != "" {
-			t.Errorf("%s: returned DeprecateImages does not match expectation: (-got +want)\n%s", tt.desc, diff)
+		if diff := cmp.Diff(tt.wantDI, di); diff != "" {
+			t.Errorf("%s: returned DeprecateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
 	}
 }
@@ -486,11 +486,11 @@ func TestRollbackImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		dr, di := rollbackImage(tt.p, tt.img, tt.pubImgs)
-		if diff := pretty.Compare(dr, tt.wantDR); diff != "" {
-			t.Errorf("%s: returned DeleteResources does not match expectation: (-got +want)\n%s", tt.desc, diff)
+		if diff := cmp.Diff(tt.wantDR, dr); diff != "" {
+			t.Errorf("%s: returned DeleteResources does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
-		if diff := pretty.Compare(di, tt.wantDI); diff != "" {
-			t.Errorf("%s: returned DeprecateImages does not match expectation: (-got +want)\n%s", tt.desc, diff)
+		if diff := cmp.Diff(tt.wantDI, di); diff != "" {
+			t.Errorf("%s: returned DeprecateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
 	}
 
@@ -528,8 +528,8 @@ func TestPopulateSteps(t *testing.T) {
 		DefaultTimeout: "10m",
 	}
 
-	if diff := (&pretty.Config{Diffable: true, Formatter: pretty.DefaultFormatter}).Compare(got, want); diff != "" {
-		t.Errorf("-got +want\n%s", diff)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want +got\n%s", diff)
 	}
 
 }
@@ -602,8 +602,8 @@ func TestPopulateWorkflow(t *testing.T) {
 		DefaultTimeout: "10m",
 	}
 
-	if diff := (&pretty.Config{Diffable: true, Formatter: pretty.DefaultFormatter}).Compare(got, want); diff != "" {
-		t.Errorf("-got +want\n%s", diff)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want +got\n%s", diff)
 	}
 
 }


### PR DESCRIPTION
Recommend using the cmp package for comparing complex structures in tests. `pretty.Compare` is based on visual representation and can miss subtle differences, such as between nil and empty slices.