### PR TITLE
Replacing RHEL 10 beta repo with the prod RHUI client & repo config

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_consolidated.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_consolidated.cfg
@@ -171,9 +171,7 @@ if [ "${IS_ARM}" == "true" ]; then
 fi
 
 REPO_FILE="/etc/yum.repos.d/google-cloud.repo"
-BETA_REPO_FILE="/etc/yum.repos.d/rhui-rhel-beta.repo"
 rm -f ${REPO_FILE} # Start clean
-rm -f ${BETA_REPO_FILE} # Start clean
 
 cat >> ${REPO_FILE} << EOM
 [google-compute-engine]
@@ -209,17 +207,6 @@ repo_gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-google-v10.gpg
 EOM
 fi
-
-if [[ "${RHUI_PACKAGE_NAME}" == *beta* ]]; then
-cat >> ${BETA_REPO_FILE} << EOM
-[google-cloud-beta]
-name=Google Cloud Beta
-baseurl=https://us-central1-yum.pkg.dev/projects/gce-pkg-rhui-client-public/google-rhui-client-rhel10-beta-stable
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-EOM
-fi
 %end
 
 %post --erroronfail
@@ -235,7 +222,7 @@ fi
 # disabling google-cloud-sdk to install other packages include GCE specific packages
 dnf config-manager --set-disabled google-cloud-sdk
 
-if [[ "${IS_EUS}" == "true" || "${IS_SAP}" == "true" || "${RHUI_PACKAGE_NAME}" == *beta* ]]; then
+if [[ "${IS_EUS}" == "true" || "${IS_SAP}" == "true" ]]; then
     echo "${VERSION_LOCK}" > /etc/dnf/vars/releasever
     if [ $? -eq 0 ]; then
         echo "DEBUG: Releasever file written successfully."

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_beta.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_beta.wf.json
@@ -28,7 +28,7 @@
       "IncludeWorkflow": {
         "Path": "./rhel_10_consolidated.wf.json",
         "Vars": {
-          "el_release": "rhel-10",
+          "el_release": "rhel-10-2-beta",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
           "disk_type": "pd-ssd",
@@ -40,7 +40,7 @@
           "is_eus": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "rhui_package_name": "google-rhui-client-rhel10-beta",
+          "rhui_package_name": "google-rhui-client-rhel10",
           "version_lock": "10.2"
         }
       }

--- a/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
+++ b/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
@@ -309,8 +309,10 @@ def write_workflow_file(major_version,
     description += " built on ${build_date}"
 
     el_release = "rhel-" + major_version
-    if is_eus or is_sap:
+    if is_eus or is_sap or is_beta:
         el_release += "-" + minor_version.split(".")[1]
+    if is_beta:
+        el_release += "-beta"
     if is_sap:
         el_release += "-sap"
     if arch == "arm64":
@@ -335,8 +337,6 @@ def write_workflow_file(major_version,
     rhui_package_name = "google-rhui-client-rhel" + major_version
     if minor_version == major_version + ".10":
         rhui_package_name += "10"
-    if is_beta:
-        rhui_package_name += "-beta"
     if is_eus:
         rhui_package_name += "-eus"
     if is_sap:


### PR DESCRIPTION
/cc @bkatyl  @lpleahy 

Red Hat has informed us that the RHUI Beta repos are only for the main version & that they don't release anything for any minor releases. To get these packages now we will be using the regular RHEL 10 RHUI Client. Removing version lock so it can use the latests for the RHUI Client

Update the el-release to include the minor version & beta