### PR TITLE
Reduce verbosity level on test images

### DIFF
--- a/daisy_workflows/image_build/install_package/installpackage.py
+++ b/daisy_workflows/image_build/install_package/installpackage.py
@@ -84,7 +84,7 @@ def enable_debug_logging():
 
 [Core]
 log_level = 4
-log_verbosity = 4
+log_verbosity = 2
 """
 
   with open('/mnt/etc/default/instance_configs.cfg', 'a') as file:

--- a/daisy_workflows/image_build/install_package/windows/installpackage.ps1
+++ b/daisy_workflows/image_build/install_package/windows/installpackage.ps1
@@ -74,7 +74,7 @@ $config = @'
 
 [Core]
 log_level = 4
-log_verbosity = 4
+log_verbosity = 2
 '@
 
 try {


### PR DESCRIPTION
Verbosity level 4 is generating too many logs and doesn't significantly help in triaging issues, downgrade it to level 2. See serial port logs for any test instance for details.