### PR TITLE
revert zone changes

### DIFF
--- a/daisy_workflows/build-publish/debian/debian_12_arm64.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_12_arm64.wf.json
@@ -48,7 +48,7 @@
           "Name": "disk-debian-12",
           "SourceImage": "debian-12-arm64-v${build_date}",
           "SizeGb": "10",
-          "Type": "hyperdisk-balanced"
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/build-publish/debian/debian_13_arm64.wf.json
+++ b/daisy_workflows/build-publish/debian/debian_13_arm64.wf.json
@@ -48,7 +48,7 @@
           "Name": "disk-debian-13",
           "SourceImage": "debian-13-arm64-v${build_date}",
           "SizeGb": "10",
-          "Type": "hyperdisk-balanced"
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_build/debian/debian_12_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_12_arm64.wf.json
@@ -15,7 +15,7 @@
         "Vars": {
           "build_date": "${build_date}",
           "debian_version": "bookworm",
-          "builder_machine_type": "c4a-standard-2",
+          "builder_machine_type": "t2a-standard-2",
           "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/daisy_workflows/image_build/debian/debian_12_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_12_arm64.wf.json
@@ -16,8 +16,7 @@
           "build_date": "${build_date}",
           "debian_version": "bookworm",
           "builder_machine_type": "c4a-standard-2",
-          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
-          "builder_disk_type": "hyperdisk-balanced"
+          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }
     },

--- a/daisy_workflows/image_build/debian/debian_12_worker_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_12_worker_arm64.wf.json
@@ -33,7 +33,7 @@
         {
           "Name": "inst-worker",
           "Disks": [{"Source": "disk-worker"}],
-          "MachineType": "c4a-standard-2",
+          "MachineType": "t2a-standard-4",
           "StartupScript": "debian_worker.sh",
           "MetaData": {
             "block-project-ssh-keys": "TRUE"

--- a/daisy_workflows/image_build/debian/debian_12_worker_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_12_worker_arm64.wf.json
@@ -24,7 +24,7 @@
         {
           "Name": "disk-worker",
           "SourceImage": "debian-12-arm64-v${build_date}",
-          "Type": "hyperdisk-balanced"
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
@@ -15,7 +15,7 @@
         "Vars": {
           "build_date": "${build_date}",
           "debian_version": "trixie",
-          "builder_machine_type": "c4a-standard-2",
+          "builder_machine_type": "t2a-standard-2",
           "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_arm64.wf.json
@@ -16,8 +16,7 @@
           "build_date": "${build_date}",
           "debian_version": "trixie",
           "builder_machine_type": "c4a-standard-2",
-          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64",
-          "builder_disk_type": "hyperdisk-balanced"
+          "builder_source_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }
     },

--- a/daisy_workflows/image_build/debian/debian_13_worker_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_worker_arm64.wf.json
@@ -33,7 +33,7 @@
         {
           "Name": "inst-worker",
           "Disks": [{"Source": "disk-worker"}],
-          "MachineType": "c4a-standard-2",
+          "MachineType": "t2a-standard-4",
           "StartupScript": "debian_worker.sh",
           "MetaData": {
             "block-project-ssh-keys": "TRUE"

--- a/daisy_workflows/image_build/debian/debian_13_worker_arm64.wf.json
+++ b/daisy_workflows/image_build/debian/debian_13_worker_arm64.wf.json
@@ -24,7 +24,7 @@
         {
           "Name": "disk-worker",
           "SourceImage": "debian-13-arm64-v${build_date}",
-          "Type": "hyperdisk-balanced"
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_build/debian/debian_fai.wf.json
+++ b/daisy_workflows/image_build/debian/debian_fai.wf.json
@@ -8,8 +8,7 @@
     "builder_source_image": {
       "Value": "projects/compute-image-tools/global/images/family/debian-12-worker",
       "Description": "Base image for builder instance."
-    },
-    "builder_disk_type" : { "Value": "pd-ssd", "Description": "Disk type for builder instance." }
+    }
   },
   "Sources": {
     "build_files/build.py": "./build_fai.py",
@@ -24,7 +23,7 @@
           "Name": "disk-builder",
           "SourceImage": "${builder_source_image}",
           "SizeGb": "50",
-          "Type": "${builder_disk_type}"
+          "Type": "pd-ssd"
         }
       ]
     },

--- a/daisy_workflows/image_build/enterprise_linux/centos_stream_10_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_stream_10_arm64.wf.json
@@ -28,8 +28,7 @@
           "kickstart_config": "./kickstart/centos_stream_10_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "machine_type": "c4a-standard-4",
-          "disk_type": "hyperdisk-balanced",
+          "machine_type": "t2a-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/daisy_workflows/image_build/enterprise_linux/centos_stream_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/centos_stream_9_arm64.wf.json
@@ -28,8 +28,7 @@
           "kickstart_config": "./kickstart/centos_stream_9_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "machine_type": "c4a-standard-4",
-          "disk_type": "hyperdisk-balanced",
+          "machine_type": "t2a-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }


### PR DESCRIPTION
- **Revert "migrate remaining t2a machines to c4a and use hyperdisk-balanced for them as well as pd-ssd is incompatible (#2692)"**
- **Revert "Reapply "Updating Debian arm builds to use c4a (#2685)" (#2686) (#2691)"**
