### PR TITLE
Add back the RHEL 10 RHUI Beta Client to the RHEL 10.2 Beta image

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_consolidated.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_consolidated.cfg
@@ -171,7 +171,9 @@ if [ "${IS_ARM}" == "true" ]; then
 fi
 
 REPO_FILE="/etc/yum.repos.d/google-cloud.repo"
+BETA_REPO_FILE="/etc/yum.repos.d/rhui-rhel-beta.repo"
 rm -f ${REPO_FILE} # Start clean
+rm -f ${BETA_REPO_FILE} # Start clean
 
 cat >> ${REPO_FILE} << EOM
 [google-compute-engine]
@@ -205,6 +207,17 @@ gpgcheck=1
 repo_gpgcheck=0
 # POINT TO THE LOCAL BINARY FILE
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-google-v10.gpg
+EOM
+fi
+
+if [[ "${RHUI_PACKAGE_NAME}" == *beta* ]]; then
+cat >> ${BETA_REPO_FILE} << EOM
+[google-cloud-beta]
+name=Google Cloud Beta
+baseurl=https://us-central1-yum.pkg.dev/projects/gce-pkg-rhui-client-public/google-rhui-client-rhel10-beta-stable
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
 EOM
 fi
 %end

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_beta.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_beta.wf.json
@@ -40,7 +40,7 @@
           "is_eus": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "rhui_package_name": "google-rhui-client-rhel10",
+          "rhui_package_name": "google-rhui-client-rhel10-beta",
           "version_lock": "10.2"
         }
       }

--- a/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
+++ b/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
@@ -337,6 +337,8 @@ def write_workflow_file(major_version,
     rhui_package_name = "google-rhui-client-rhel" + major_version
     if minor_version == major_version + ".10":
         rhui_package_name += "10"
+    if is_beta:
+        rhui_package_name += "-beta"
     if is_eus:
         rhui_package_name += "-eus"
     if is_sap:


### PR DESCRIPTION
/cc @bkatyl @lpleahy 

We are reversing the RHUI Client change made in [PR](https://github.com/GoogleCloudPlatform/compute-image-tools/pull/2688) to use the RHEL Beta RHUI Client again. We are leaving out the version lock so that it will just use the latest version of each package.