### PR TITLE
Update rollback logic to deprecate image instead of delete.

### DIFF
--- a/gce_image_publish/main.go
+++ b/gce_image_publish/main.go
@@ -45,6 +45,7 @@ var (
 	noRoot         = flag.Bool("no_root", false, "with -source_gcs_path, append .tar.gz instead of /root.tar.gz")
 	replace        = flag.Bool("replace", false, "replace any images that already exist, should not be used along with -skip_duplicates")
 	rollback       = flag.Bool("rollback", false, "rollback image publish")
+	deprecate			 = flag.Bool("deprecate", false, "deprecate rollback image, defaults to delete")
 	print          = flag.Bool("print", false, "print out the parsed workflow for debugging")
 	validate       = flag.Bool("validate", false, "validate the workflow and exit")
 	noConfirm      = flag.Bool("skip_confirmation", false, "don't ask for confirmation")
@@ -157,7 +158,7 @@ func main() {
 			errs = append(errs, loadErr)
 			continue
 		}
-		w, err := p.CreateWorkflows(ctx, varMap, regex, *rollback, *skipDup, *replace, *noRoot, *oauth, time.Now(), *rolloutRate)
+		w, err := p.CreateWorkflows(ctx, varMap, regex, *rollback, *deprecate, *skipDup, *replace, *noRoot, *oauth, time.Now(), *rolloutRate)
 		if err != nil {
 			createWorkflowErr := fmt.Errorf("Workflow creation error: %s", err)
 			fmt.Println(createWorkflowErr)

--- a/gce_image_publish/main.go
+++ b/gce_image_publish/main.go
@@ -45,12 +45,12 @@ var (
 	noRoot         = flag.Bool("no_root", false, "with -source_gcs_path, append .tar.gz instead of /root.tar.gz")
 	replace        = flag.Bool("replace", false, "replace any images that already exist, should not be used along with -skip_duplicates")
 	rollback       = flag.Bool("rollback", false, "rollback image publish")
-	deprecate			 = flag.Bool("deprecate", false, "deprecate rollback image, defaults to delete")
 	print          = flag.Bool("print", false, "print out the parsed workflow for debugging")
 	validate       = flag.Bool("validate", false, "validate the workflow and exit")
 	noConfirm      = flag.Bool("skip_confirmation", false, "don't ask for confirmation")
 	ce             = flag.String("compute_endpoint_override", "", "API endpoint to override default, will override ComputeEndpoint in template")
 	filter         = flag.String("filter", "", "regular expression to filter images to publish by prefixes")
+	rollbackOperation = flag.String("rollback_operation", "", "deprecate, obsolete, or delete the target image")
 	rolloutRate    = flag.Int("rollout_rate", 60, "The number of minutes between the image rolling out between zones. 0 minutes will not use a rollout policy.")
 )
 
@@ -143,6 +143,12 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if *rollback {
+		if *rollbackOperation != "delete" && *rollbackOperation != "deprecate" && *rollbackOperation != "obsolete" {
+			fmt.Println("-rollback_operation must be one of delete, deprecate, obsolete.")
+			os.Exit(1)
+		}
+	}
 
 	ctx := context.Background()
 
@@ -158,7 +164,7 @@ func main() {
 			errs = append(errs, loadErr)
 			continue
 		}
-		w, err := p.CreateWorkflows(ctx, varMap, regex, *rollback, *deprecate, *skipDup, *replace, *noRoot, *oauth, time.Now(), *rolloutRate)
+		w, err := p.CreateWorkflows(ctx, varMap, regex, *rollback, *skipDup, *replace, *noRoot, *oauth, *rollbackOperation, time.Now(), *rolloutRate)
 		if err != nil {
 			createWorkflowErr := fmt.Errorf("Workflow creation error: %s", err)
 			fmt.Println(createWorkflowErr)

--- a/gce_image_publish/publish/publish.go
+++ b/gce_image_publish/publish/publish.go
@@ -398,7 +398,7 @@ func rollbackImageObsolete(p *Publish, img *Image, pubImgs []*computeAlpha.Image
 	dis := &daisy.DeprecateImages{}
 
 	for _, pubImg := range pubImgs {
-		if pubImg.Family != img.Family || pubImg.Deprecated != nil {
+		if pubImg.Name != publishName || pubImg.Deprecated != nil {
 			continue
 		}
 		dr.Images = []string{fmt.Sprintf("projects/%s/global/images/%s", p.PublishProject, publishName)}

--- a/gce_image_publish/publish/publish.go
+++ b/gce_image_publish/publish/publish.go
@@ -392,7 +392,41 @@ func publishImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image, skipDup
 	return cis, dis, drs, nil
 }
 
-func rollbackImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeprecateImages) {
+func rollbackImageObsolete(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeleteResources, *daisy.DeprecateImages) {
+	publishName := fmt.Sprintf("%s-%s", img.Prefix, p.publishVersion)
+	dr := &daisy.DeleteResources{}
+	dis := &daisy.DeprecateImages{}
+
+	for _, pubImg := range pubImgs {
+		if pubImg.Family != img.Family || pubImg.Deprecated != nil {
+			continue
+		}
+		dr.Images = []string{fmt.Sprintf("projects/%s/global/images/%s", p.PublishProject, publishName)}
+	}
+
+	if len(dr.Images) == 0 {
+		fmt.Printf("   %q does not exist in %q, not rolling back\n", publishName, p.PublishProject)
+		return nil, nil
+	}
+
+	for _, pubImg := range pubImgs {
+		// Un-deprecate the first deprecated image in the family based on insertion time.
+		if pubImg.Family == img.Family && pubImg.Deprecated != nil {
+			*dis = append(*dis, &daisy.DeprecateImage{
+				Image:   pubImg.Name,
+				Project: p.PublishProject,
+				DeprecationStatusAlpha: computeAlpha.DeprecationStatus{
+					State:         "ACTIVE",
+					StateOverride: img.RolloutPolicy,
+				},
+			})
+			break
+		}
+	}
+	return dr, dis
+}
+
+func rollbackImageDeprecate(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeprecateImages) {
 	publishName := fmt.Sprintf("%s-%s", img.Prefix, p.publishVersion)
 	dis := &daisy.DeprecateImages{}
 	var deprecateFound bool = false
@@ -439,7 +473,6 @@ func rollbackImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*dais
 			},
 		})
 	}
-
 	return dis
 }
 

--- a/gce_image_publish/publish/publish.go
+++ b/gce_image_publish/publish/publish.go
@@ -209,15 +209,16 @@ func (p *Publish) SetExpire() error {
 }
 
 // CreateWorkflows creates a list of daisy workflows from the publish object
-func (p *Publish) CreateWorkflows(ctx context.Context, varMap map[string]string, regex *regexp.Regexp, rollback, deprecate, skipDup, replace, noRoot bool, oauth string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) ([]*daisy.Workflow, error) {
+func (p *Publish) CreateWorkflows(ctx context.Context, varMap map[string]string, regex *regexp.Regexp, rollback, skipDup, replace, noRoot bool, oauth, rbOperation string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) ([]*daisy.Workflow, error) {
 	fmt.Printf("[%q] Preparing workflows from template\n", p.Name)
 
 	var ws []*daisy.Workflow
+	rbOperation = strings.ToLower(rbOperation)
 	for _, img := range p.Images {
 		if regex != nil && !regex.MatchString(img.Prefix) {
 			continue
 		}
-		w, err := p.createWorkflow(ctx, img, varMap, rollback, deprecate, skipDup, replace, noRoot, oauth, rolloutStartTime, rolloutRate, clientOptions...)
+		w, err := p.createWorkflow(ctx, img, varMap, rollback, skipDup, replace, noRoot, oauth, rbOperation, rolloutStartTime, rolloutRate, clientOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -392,7 +393,7 @@ func publishImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image, skipDup
 	return cis, dis, drs, nil
 }
 
-func rollbackImageObsolete(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeleteResources, *daisy.DeprecateImages) {
+func rollbackImageDelete(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeleteResources, *daisy.DeprecateImages) {
 	publishName := fmt.Sprintf("%s-%s", img.Prefix, p.publishVersion)
 	dr := &daisy.DeleteResources{}
 	dis := &daisy.DeprecateImages{}
@@ -426,11 +427,14 @@ func rollbackImageObsolete(p *Publish, img *Image, pubImgs []*computeAlpha.Image
 	return dr, dis
 }
 
-func rollbackImageDeprecate(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeprecateImages) {
+func rollbackImageDeprecate(p *Publish, img *Image, pubImgs []*computeAlpha.Image, rbo string) (*daisy.DeprecateImages) {
 	publishName := fmt.Sprintf("%s-%s", img.Prefix, p.publishVersion)
 	dis := &daisy.DeprecateImages{}
 	var deprecateFound bool = false
 	var undeprecateName string
+	if rbo == "deprecate" {
+		rbo = rbo + "D"
+	}
 
 	// Find and store name of the image to un-deprecate later.
 	for _, pubImg := range pubImgs {
@@ -450,7 +454,7 @@ func rollbackImageDeprecate(p *Publish, img *Image, pubImgs []*computeAlpha.Imag
 			Image:   pubImg.Name,
 			Project: p.PublishProject,
 			DeprecationStatusAlpha: computeAlpha.DeprecationStatus{
-				State:         "DEPRECATED",
+				State:         strings.ToUpper(rbo),
 				StateOverride: img.RolloutPolicy,
 			},
 		})
@@ -577,17 +581,17 @@ func (p *Publish) rolloutPolicyPrintOut(rp *computeAlpha.RolloutPolicy) {
 	}
 }
 
-func (p *Publish) populateWorkflow(ctx context.Context, w *daisy.Workflow, pubImgs []*computeAlpha.Image, img *Image, rb, dep, sd, rep, noRoot bool) error {
+func (p *Publish) populateWorkflow(ctx context.Context, w *daisy.Workflow, pubImgs []*computeAlpha.Image, img *Image, rb, sd, rep, noRoot bool, rbo string) error {
 	var err error
 	var createImages *daisy.CreateImages
 	var deprecateImages *daisy.DeprecateImages
 	var deleteResources *daisy.DeleteResources
 
 	if rb {
-		if dep {
-			deprecateImages = rollbackImageDeprecate(p, img, pubImgs)
-		} else {
-			deleteResources, deprecateImages = rollbackImageObsolete(p, img, pubImgs)
+		if rbo == "delete" {
+			deleteResources, deprecateImages = rollbackImageDelete(p, img, pubImgs)
+		} else if rbo == "deprecate" || rbo == "obsolete" {
+				deprecateImages = rollbackImageDeprecate(p, img, pubImgs, rbo)
 		}
 	} else {
 		createImages, deprecateImages, deleteResources, err = publishImage(p, img, pubImgs, sd, rep, noRoot)
@@ -608,7 +612,7 @@ func (p *Publish) populateWorkflow(ctx context.Context, w *daisy.Workflow, pubIm
 	return nil
 }
 
-func (p *Publish) createWorkflow(ctx context.Context, img *Image, varMap map[string]string, rb, dep, sd, rep, noRoot bool, oauth string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) (*daisy.Workflow, error) {
+func (p *Publish) createWorkflow(ctx context.Context, img *Image, varMap map[string]string, rb, sd, rep, noRoot bool, oauth, rbo string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) (*daisy.Workflow, error) {
 	fmt.Printf("  - Creating publish workflow for %q\n", img.Prefix)
 	w := daisy.New()
 	for k, v := range varMap {
@@ -650,7 +654,7 @@ func (p *Publish) createWorkflow(ctx context.Context, img *Image, varMap map[str
 	}
 	img.RolloutPolicy = createRollOut(zones, rolloutStartTime, rolloutRate)
 
-	if err := p.populateWorkflow(ctx, w, pubImgs, img, rb, dep, sd, rep, noRoot); err != nil {
+	if err := p.populateWorkflow(ctx, w, pubImgs, img, rb, sd, rep, noRoot, rbo); err != nil {
 		return nil, fmt.Errorf("populateWorkflow failed: %s", err)
 	}
 	if len(w.Steps) == 0 {

--- a/gce_image_publish/publish/publish.go
+++ b/gce_image_publish/publish/publish.go
@@ -392,37 +392,55 @@ func publishImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image, skipDup
 	return cis, dis, drs, nil
 }
 
-func rollbackImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeleteResources, *daisy.DeprecateImages) {
+func rollbackImage(p *Publish, img *Image, pubImgs []*computeAlpha.Image) (*daisy.DeprecateImages) {
 	publishName := fmt.Sprintf("%s-%s", img.Prefix, p.publishVersion)
-	dr := &daisy.DeleteResources{}
 	dis := &daisy.DeprecateImages{}
+	var deprecateFound bool = false
+	var undeprecateName string
+
+	// Find and store name of the image to un-deprecate later.
+	for _, pubImg := range pubImgs {
+		if pubImg.Family == img.Family && pubImg.Deprecated != nil {
+			undeprecateName = pubImg.Name
+			break
+		}
+	}
+
+	// Deprecate the published image.
 	for _, pubImg := range pubImgs {
 		if pubImg.Name != publishName || pubImg.Deprecated != nil {
 			continue
 		}
-		dr.Images = []string{fmt.Sprintf("projects/%s/global/images/%s", p.PublishProject, publishName)}
-	}
 
-	if len(dr.Images) == 0 {
+		*dis = append(*dis, &daisy.DeprecateImage{
+			Image:   pubImg.Name,
+			Project: p.PublishProject,
+			DeprecationStatusAlpha: computeAlpha.DeprecationStatus{
+				State:         "DEPRECATED",
+				StateOverride: img.RolloutPolicy,
+			},
+		})
+		deprecateFound = true
+		break
+	}
+	if !deprecateFound {
 		fmt.Printf("   %q does not exist in %q, not rolling back\n", publishName, p.PublishProject)
-		return nil, nil
+		return nil
 	}
 
-	for _, pubImg := range pubImgs {
-		// Un-deprecate the first deprecated image in the family based on insertion time.
-		if pubImg.Family == img.Family && pubImg.Deprecated != nil {
-			*dis = append(*dis, &daisy.DeprecateImage{
-				Image:   pubImg.Name,
-				Project: p.PublishProject,
-				DeprecationStatusAlpha: computeAlpha.DeprecationStatus{
-					State:         "ACTIVE",
-					StateOverride: img.RolloutPolicy,
-				},
-			})
-			break
-		}
+	// Un-deprecate the most recent previous image.
+	if undeprecateName != "" {
+		*dis = append(*dis, &daisy.DeprecateImage{
+			Image:   undeprecateName,
+			Project: p.PublishProject,
+			DeprecationStatusAlpha: computeAlpha.DeprecationStatus{
+				State:         "ACTIVE",
+				StateOverride: img.RolloutPolicy,
+			},
+		})
 	}
-	return dr, dis
+
+	return dis
 }
 
 func populateSteps(w *daisy.Workflow, prefix string, createImages *daisy.CreateImages, deprecateImages *daisy.DeprecateImages, deleteResources *daisy.DeleteResources) error {

--- a/gce_image_publish/publish/publish.go
+++ b/gce_image_publish/publish/publish.go
@@ -209,7 +209,7 @@ func (p *Publish) SetExpire() error {
 }
 
 // CreateWorkflows creates a list of daisy workflows from the publish object
-func (p *Publish) CreateWorkflows(ctx context.Context, varMap map[string]string, regex *regexp.Regexp, rollback, skipDup, replace, noRoot bool, oauth string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) ([]*daisy.Workflow, error) {
+func (p *Publish) CreateWorkflows(ctx context.Context, varMap map[string]string, regex *regexp.Regexp, rollback, deprecate, skipDup, replace, noRoot bool, oauth string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) ([]*daisy.Workflow, error) {
 	fmt.Printf("[%q] Preparing workflows from template\n", p.Name)
 
 	var ws []*daisy.Workflow
@@ -217,7 +217,7 @@ func (p *Publish) CreateWorkflows(ctx context.Context, varMap map[string]string,
 		if regex != nil && !regex.MatchString(img.Prefix) {
 			continue
 		}
-		w, err := p.createWorkflow(ctx, img, varMap, rollback, skipDup, replace, noRoot, oauth, rolloutStartTime, rolloutRate, clientOptions...)
+		w, err := p.createWorkflow(ctx, img, varMap, rollback, deprecate, skipDup, replace, noRoot, oauth, rolloutStartTime, rolloutRate, clientOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -577,14 +577,18 @@ func (p *Publish) rolloutPolicyPrintOut(rp *computeAlpha.RolloutPolicy) {
 	}
 }
 
-func (p *Publish) populateWorkflow(ctx context.Context, w *daisy.Workflow, pubImgs []*computeAlpha.Image, img *Image, rb, sd, rep, noRoot bool) error {
+func (p *Publish) populateWorkflow(ctx context.Context, w *daisy.Workflow, pubImgs []*computeAlpha.Image, img *Image, rb, dep, sd, rep, noRoot bool) error {
 	var err error
 	var createImages *daisy.CreateImages
 	var deprecateImages *daisy.DeprecateImages
 	var deleteResources *daisy.DeleteResources
 
 	if rb {
-		deleteResources, deprecateImages = rollbackImage(p, img, pubImgs)
+		if dep {
+			deprecateImages = rollbackImageDeprecate(p, img, pubImgs)
+		} else {
+			deleteResources, deprecateImages = rollbackImageObsolete(p, img, pubImgs)
+		}
 	} else {
 		createImages, deprecateImages, deleteResources, err = publishImage(p, img, pubImgs, sd, rep, noRoot)
 		if err != nil {
@@ -604,7 +608,7 @@ func (p *Publish) populateWorkflow(ctx context.Context, w *daisy.Workflow, pubIm
 	return nil
 }
 
-func (p *Publish) createWorkflow(ctx context.Context, img *Image, varMap map[string]string, rb, sd, rep, noRoot bool, oauth string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) (*daisy.Workflow, error) {
+func (p *Publish) createWorkflow(ctx context.Context, img *Image, varMap map[string]string, rb, dep, sd, rep, noRoot bool, oauth string, rolloutStartTime time.Time, rolloutRate int, clientOptions ...option.ClientOption) (*daisy.Workflow, error) {
 	fmt.Printf("  - Creating publish workflow for %q\n", img.Prefix)
 	w := daisy.New()
 	for k, v := range varMap {
@@ -646,7 +650,7 @@ func (p *Publish) createWorkflow(ctx context.Context, img *Image, varMap map[str
 	}
 	img.RolloutPolicy = createRollOut(zones, rolloutStartTime, rolloutRate)
 
-	if err := p.populateWorkflow(ctx, w, pubImgs, img, rb, sd, rep, noRoot); err != nil {
+	if err := p.populateWorkflow(ctx, w, pubImgs, img, rb, dep, sd, rep, noRoot); err != nil {
 		return nil, fmt.Errorf("populateWorkflow failed: %s", err)
 	}
 	if len(w.Steps) == 0 {

--- a/gce_image_publish/publish/publish_test.go
+++ b/gce_image_publish/publish/publish_test.go
@@ -437,7 +437,66 @@ func TestPublishImage(t *testing.T) {
 	}
 }
 
-func TestRollbackImage(t *testing.T) {
+func TestRollbackImageObsolete(t *testing.T) {
+	tests := []struct {
+		desc    string
+		p       *Publish
+		img     *Image
+		pubImgs []*computeAlpha.Image
+		wantDR	*daisy.DeleteResources
+		wantDI  *daisy.DeprecateImages
+	}{
+		{
+			"normal case",
+			&Publish{PublishProject: "foo-project", publishVersion: "3"},
+			&Image{Prefix: "foo", Family: "foo-family"},
+			[]*computeAlpha.Image{
+				{Name: "bar-3", Family: "bar-family"},
+				{Name: "foo-3", Family: "foo-family"},
+				{Name: "bar-2", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "foo-2", Family: "foo-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "foo-1", Family: "foo-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+			},
+			&daisy.DeleteResources{Images: []string{"projects/foo-project/global/images/foo-3"}},
+			&daisy.DeprecateImages{{Image: "foo-2", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "ACTIVE"}}},
+		},
+		{
+			"no image to undeprecate",
+			&Publish{PublishProject: "foo-project", publishVersion: "3"},
+			&Image{Prefix: "foo", Family: "foo-family"},
+			[]*computeAlpha.Image{
+				{Name: "bar-3", Family: "bar-family"},
+				{Name: "foo-3", Family: "foo-family"},
+				{Name: "bar-2", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+			},
+			&daisy.DeleteResources{Images: []string{"projects/foo-project/global/images/foo-3"}},
+			&daisy.DeprecateImages{},
+		},
+		{
+			"image DNE",
+			&Publish{PublishProject: "foo-project", publishVersion: "1"},
+			&Image{Prefix: "foo", Family: "foo-family"},
+			[]*computeAlpha.Image{
+				{Name: "bar-1", Family: "bar-family"},
+			},
+			nil,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		dr, di := rollbackImageObsolete(tt.p, tt.img, tt.pubImgs)
+		if diff := cmp.Diff(tt.wantDR, dr); diff != "" {
+			t.Errorf("%s: returned DeleteResources does not match expectation: (-want +got)\n%s", tt.desc, diff)
+		}
+		if diff := cmp.Diff(tt.wantDI, di); diff != "" {
+			t.Errorf("%s: returned DeprecateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
+		}
+	}
+}
+
+func TestRollbackImageDeprecate(t *testing.T) {
 	tests := []struct {
 		desc    string
 		p       *Publish
@@ -459,7 +518,7 @@ func TestRollbackImage(t *testing.T) {
 			},
 			&daisy.DeprecateImages{
 				{Image: "foo-3", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
-				{Image: "foo-2", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "ACTIVE"}}
+				{Image: "foo-2", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "ACTIVE"}},
 			},
 		},
 		{
@@ -485,7 +544,7 @@ func TestRollbackImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		di := rollbackImage(tt.p, tt.img, tt.pubImgs)
+		di := rollbackImageDeprecate(tt.p, tt.img, tt.pubImgs)
 		if diff := cmp.Diff(tt.wantDI, di); diff != "" {
 			t.Errorf("%s: returned DeprecateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}

--- a/gce_image_publish/publish/publish_test.go
+++ b/gce_image_publish/publish/publish_test.go
@@ -437,7 +437,7 @@ func TestPublishImage(t *testing.T) {
 	}
 }
 
-func TestRollbackImageObsolete(t *testing.T) {
+func TestRollbackImageDelete(t *testing.T) {
 	tests := []struct {
 		desc    string
 		p       *Publish
@@ -486,7 +486,7 @@ func TestRollbackImageObsolete(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		dr, di := rollbackImageObsolete(tt.p, tt.img, tt.pubImgs)
+		dr, di := rollbackImageDelete(tt.p, tt.img, tt.pubImgs)
 		if diff := cmp.Diff(tt.wantDR, dr); diff != "" {
 			t.Errorf("%s: returned DeleteResources does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
@@ -544,7 +544,7 @@ func TestRollbackImageDeprecate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		di := rollbackImageDeprecate(tt.p, tt.img, tt.pubImgs)
+		di := rollbackImageDeprecate(tt.p, tt.img, tt.pubImgs, "deprecate")
 		if diff := cmp.Diff(tt.wantDI, di); diff != "" {
 			t.Errorf("%s: returned DeprecateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
@@ -620,7 +620,7 @@ func TestPopulateWorkflow(t *testing.T) {
 		false,
 		false,
 		false,
-		false,
+		"obsolete",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/gce_image_publish/publish/publish_test.go
+++ b/gce_image_publish/publish/publish_test.go
@@ -620,6 +620,7 @@ func TestPopulateWorkflow(t *testing.T) {
 		false,
 		false,
 		false,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/gce_image_publish/publish/publish_test.go
+++ b/gce_image_publish/publish/publish_test.go
@@ -443,7 +443,6 @@ func TestRollbackImage(t *testing.T) {
 		p       *Publish
 		img     *Image
 		pubImgs []*computeAlpha.Image
-		wantDR  *daisy.DeleteResources
 		wantDI  *daisy.DeprecateImages
 	}{
 		{
@@ -458,8 +457,10 @@ func TestRollbackImage(t *testing.T) {
 				{Name: "foo-1", Family: "foo-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 			},
-			&daisy.DeleteResources{Images: []string{"projects/foo-project/global/images/foo-3"}},
-			&daisy.DeprecateImages{{Image: "foo-2", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "ACTIVE"}}},
+			&daisy.DeprecateImages{
+				{Image: "foo-3", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
+				{Image: "foo-2", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "ACTIVE"}}
+			},
 		},
 		{
 			"no image to undeprecate",
@@ -471,8 +472,7 @@ func TestRollbackImage(t *testing.T) {
 				{Name: "bar-2", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 				{Name: "bar-1", Family: "bar-family", Deprecated: &computeAlpha.DeprecationStatus{State: "DEPRECATED"}},
 			},
-			&daisy.DeleteResources{Images: []string{"projects/foo-project/global/images/foo-3"}},
-			&daisy.DeprecateImages{},
+			&daisy.DeprecateImages{{Image: "foo-3", Project: "foo-project", DeprecationStatusAlpha: computeAlpha.DeprecationStatus{State: "DEPRECATED"}}},
 		},
 		{
 			"image DNE",
@@ -482,19 +482,14 @@ func TestRollbackImage(t *testing.T) {
 				{Name: "bar-1", Family: "bar-family"},
 			},
 			nil,
-			nil,
 		},
 	}
 	for _, tt := range tests {
-		dr, di := rollbackImage(tt.p, tt.img, tt.pubImgs)
-		if diff := cmp.Diff(tt.wantDR, dr); diff != "" {
-			t.Errorf("%s: returned DeleteResources does not match expectation: (-want +got)\n%s", tt.desc, diff)
-		}
+		di := rollbackImage(tt.p, tt.img, tt.pubImgs)
 		if diff := cmp.Diff(tt.wantDI, di); diff != "" {
 			t.Errorf("%s: returned DeprecateImages does not match expectation: (-want +got)\n%s", tt.desc, diff)
 		}
 	}
-
 }
 
 func TestPopulateSteps(t *testing.T) {


### PR DESCRIPTION
Updated functionality for publish library allows for rollback image deprecation with introduction of -deprecate flag. Original operations for image deletion still remain intact for smooth migration.