### PR TITLE
Enables auto IPv6 configuration if IPv6 is present for RHEL (kickstart).

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_consolidated.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_10_consolidated.cfg
@@ -7,7 +7,7 @@ harddrive --partition=/dev/disk/by-id/google-disk-installer-part2 --dir=/
 poweroff
 
 # Network configuration
-network --bootproto=dhcp --device=link
+network --bootproto=dhcp --device=link --ipv6=auto --activate
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_consolidated.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_8_consolidated.cfg
@@ -7,7 +7,7 @@ harddrive --partition=/dev/disk/by-id/google-disk-installer-part2 --dir=/
 poweroff
 
 # Network configuration
-network --bootproto=dhcp --device=link
+network --bootproto=dhcp --device=link --ipv6=auto --activate
 
 ### Installed system configuration.
 firewall --enabled

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_consolidated.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_consolidated.cfg
@@ -7,7 +7,7 @@ harddrive --partition=/dev/disk/by-id/google-disk-installer-part2 --dir=/
 poweroff
 
 # Network configuration
-network --bootproto=dhcp --device=link
+network --bootproto=dhcp --device=link --ipv6=auto --activate
 
 ### Installed system configuration.
 firewall --enabled


### PR DESCRIPTION
Using --bootproto=dhcp only will configure ipv4 on the device. By setting --ipv6=auto, it will automatically configure ipv6 if present. It does not change the behavior if there is only IPv4.  
See https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/kickstart-commands-and-options-reference_rhel-installer


Anaconda splits that single command into two completely separate configuration lanes for NetworkManager:

- The IPv4 Lane: It reads --bootproto=dhcp and writes ipv4.method=auto into the profile.
- The IPv6 Lane: It reads --ipv6=auto and writes ipv6.method=auto into the profile.

- If the VPC is Dual-Stack: It grabs a DHCPv4 lease and an IPv6 SLAAC address.

- If the VPC is IPv4-Only: The IPv6 request gracefully times out in the background, but IPv4 connects instantly.

- If the VPC is IPv6-Only: The IPv4 request gracefully falls back to the 169.254.1.2 stub, and the global IPv6 address connects instantly.
