### PR TITLE
Removing OOT GVNIC Driver variables from RHEL 8/9

### DIFF
--- a/daisy_workflows/build-publish/enterprise_linux/rhel_8_consolidated.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_8_consolidated.wf.json
@@ -72,17 +72,9 @@
         "Value": "false",
         "Description": "If the image supports the Logical Volume Manager (LVM)"
     },
-    "is_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has Out-of-Tree driver support"
-    },
     "is_sap": {
         "Value": "false",
         "Description": "If the image is RHEL for SAP"
-    },
-    "is_unsigned_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has an unsigned Out-of-Tree driver. This is for internal testing only"
     },
     "rhui_package_name": {
         "Value": "google-rhui-client-rhel8",
@@ -110,9 +102,7 @@
           "is_arm": "${is_arm}",
           "is_byos": "${is_byos}",
           "is_lvm": "${is_lvm}",
-          "is_oot_driver": "${is_oot_driver}",
           "is_sap": "${is_sap}",
-          "is_unsigned_oot_driver": "${is_unsigned_oot_driver}",
           "rhui_package_name": "${rhui_package_name}",
           "version_lock": "${version_lock}"
         }

--- a/daisy_workflows/build-publish/enterprise_linux/rhel_9_consolidated.wf.json
+++ b/daisy_workflows/build-publish/enterprise_linux/rhel_9_consolidated.wf.json
@@ -76,17 +76,9 @@
         "Value": "false",
         "Description": "If the image supports the Logical Volume Manager (LVM)"
     },
-    "is_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has Out-of-Tree driver support"
-    },
     "is_sap": {
         "Value": "false",
         "Description": "If the image is RHEL for SAP"
-    },
-    "is_unsigned_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has an unsigned Out-of-Tree driver. This is for internal testing only"
     },
     "rhui_package_name": {
         "Value": "google-rhui-client-rhel9",
@@ -115,9 +107,7 @@
           "is_byos": "${is_byos}",
           "is_eus": "${is_eus}",
           "is_lvm": "${is_lvm}",
-          "is_oot_driver": "${is_oot_driver}",
           "is_sap": "${is_sap}",
-          "is_unsigned_oot_driver": "${is_unsigned_oot_driver}",
           "rhui_package_name": "${rhui_package_name}",
           "version_lock": "${version_lock}"
         }

--- a/daisy_workflows/image_build/enterprise_linux/build_installer.py
+++ b/daisy_workflows/image_build/enterprise_linux/build_installer.py
@@ -133,9 +133,11 @@ def main():
       f.write(f'IS_BYOS={is_byos}\n')
       f.write(f'IS_EUS={is_eus}\n')
       f.write(f'IS_LVM={is_lvm}\n')
-      f.write(f'IS_OOT_DRIVER={is_oot_driver}\n')
+      if is_oot_driver:
+        f.write(f'IS_OOT_DRIVER={is_oot_driver}\n')
       f.write(f'IS_SAP={is_sap}\n')
-      f.write(f'IS_UNSIGNED_OOT_DRIVER={is_unsigned_oot_driver}\n')
+      if is_unsigned_oot_driver:
+        f.write(f'IS_UNSIGNED_OOT_DRIVER={is_unsigned_oot_driver}\n')
       f.write(f'RHUI_PACKAGE_NAME={str(rhui_package_name).lower()}\n')
       if version_lock:
         f.write(f'VERSION_LOCK="{version_lock}"\n')

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_byos_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_eus_lvm_byos_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-sap",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_0_sap_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-sap",
-          "version_lock": "10.0"
+          "version_lock": "10.0",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_beta.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_beta.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": "10.2"
+          "version_lock": "10.2",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_gvnic_baremetal.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_gvnic_baremetal.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.2"
+          "version_lock": "10.2",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_gvnic_baremetal_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_gvnic_baremetal_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.2"
+          "version_lock": "10.2",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_lvm_gvnic_baremetal.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_lvm_gvnic_baremetal.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.2"
+          "version_lock": "10.2",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_lvm_gvnic_baremetal_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_2_eus_lvm_gvnic_baremetal_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10-eus",
-          "version_lock": "10.2"
+          "version_lock": "10.2",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_byos_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal_unsigned.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal_unsigned.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "True",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "True"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal_unsigned_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_gvnic_baremetal_unsigned_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "True",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "True"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_byos_arm64.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "True",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "True",
+          "is_unsigned_oot_driver": "False"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal_unsigned.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal_unsigned.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "True",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "True"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal_unsigned_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_10_lvm_gvnic_baremetal_unsigned_byos.wf.json
@@ -38,12 +38,12 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "True",
           "rhui_package_name": "google-rhui-client-rhel10",
-          "version_lock": ""
+          "version_lock": "",
+          "is_oot_driver": "False",
+          "is_unsigned_oot_driver": "True"
         }
       }
     },

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel810-sap",
           "version_lock": "8.10"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_10_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel810-sap",
           "version_lock": "8.10"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8-sap",
           "version_lock": "8.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_6_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8-sap",
           "version_lock": "8.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8-sap",
           "version_lock": "8.8"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_8_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8-sap",
           "version_lock": "8.8"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_consolidated.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_consolidated.wf.json
@@ -49,17 +49,9 @@
         "Value": "false",
         "Description": "If the image supports the Logical Volume Manager (LVM)"
     },
-    "is_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has Out-of-Tree driver support"
-    },
     "is_sap": {
         "Value": "false",
         "Description": "If the image is RHEL for SAP"
-    },
-    "is_unsigned_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has an unsigned Out-of-Tree driver. This is for internal testing only"
     },
     "rhui_package_name": {
         "Value": "google-rhui-client-rhel8",
@@ -88,8 +80,6 @@
           "rhel_sap": "${is_sap}",
           "is_arm": "${is_arm}",
           "is_lvm": "${is_lvm}",
-          "is_oot_driver": "${is_oot_driver}",
-          "is_unsigned_oot_driver": "${is_unsigned_oot_driver}",
           "rhui_package_name": "${rhui_package_name}",
           "use_dynamic_template": "true",
           "version_lock": "${version_lock}"

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_8_lvm_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel8",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.0"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_0_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.0"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.2"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_2_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.2"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_eus_lvm_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_4_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.4"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_eus_lvm_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "True",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-eus",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_6_sap_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "True",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9-sap",
           "version_lock": "9.6"
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "False",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_consolidated.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_consolidated.wf.json
@@ -49,17 +49,9 @@
         "Value": "false",
         "Description": "If the image supports the Logical Volume Manager (LVM)"
     },
-    "is_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has Out-of-Tree driver support"
-    },
     "is_sap": {
         "Value": "false",
         "Description": "If the image is RHEL for SAP"
-    },
-    "is_unsigned_oot_driver": {
-        "Value": "false",
-        "Description": "If the image has an unsigned Out-of-Tree driver. This is for internal testing only"
     },
     "rhui_package_name": {
         "Value": "google-rhui-client-rhel9",
@@ -89,8 +81,6 @@
           "is_arm": "${is_arm}",
           "is_eus": "${is_eus}",
           "is_lvm": "${is_lvm}",
-          "is_oot_driver": "${is_oot_driver}",
-          "is_unsigned_oot_driver": "${is_unsigned_oot_driver}",
           "rhui_package_name": "${rhui_package_name}",
           "use_dynamic_template": "true",
           "version_lock": "${version_lock}"

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "False",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_byos.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_byos.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "False",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_byos_arm64.wf.json
+++ b/daisy_workflows/image_build/enterprise_linux/rhel_9_lvm_byos_arm64.wf.json
@@ -38,10 +38,8 @@
           "is_arm": "True",
           "is_byos": "True",
           "is_eus": "False",
-          "is_oot_driver": "False",
           "is_sap": "False",
           "is_lvm": "True",
-          "is_unsigned_oot_driver": "False",
           "rhui_package_name": "google-rhui-client-rhel9",
           "version_lock": ""
         }

--- a/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
+++ b/daisy_workflows/image_build/enterprise_linux/write_image_build_workflow.py
@@ -191,6 +191,27 @@ def generate_workflow_file(image_name,
                            is_unsigned_oot_driver):
     workflow_name = f"build-{image_name}"
 
+    build_rhel_vars = {
+        "el_release": f"{el_release}",
+        "google_cloud_repo": "${google_cloud_repo}",
+        "installer_iso": "${installer_iso}",
+        "disk_type": f"{disk_type}",
+        "machine_type": f"{machine_type}",
+        "worker_image": f"{worker_image}",
+        "el_install_disk_size": f"{el_install_disk_size}",
+        "is_arm": f"{is_arm}",
+        "is_byos": f"{is_byos}",
+        "is_eus": f"{is_eus}",
+        "is_sap": f"{is_sap}",
+        "is_lvm": f"{is_lvm}",
+        "rhui_package_name": f"{rhui_package_name}",
+        "version_lock": f"{minor_version}"
+    }
+
+    if major_version == "10":
+        build_rhel_vars["is_oot_driver"] = f"{is_oot_driver}"
+        build_rhel_vars["is_unsigned_oot_driver"] = f"{is_unsigned_oot_driver}"
+
     wf = {
         "Name": workflow_name,
         "Vars": {
@@ -228,24 +249,7 @@ def generate_workflow_file(image_name,
                "Timeout": "60m",
                "IncludeWorkflow": {
                    "Path": f"./rhel_{major_version}_consolidated.wf.json",
-                   "Vars": {
-                       "el_release": f"{el_release}",
-                       "google_cloud_repo": "${google_cloud_repo}",
-                       "installer_iso": "${installer_iso}",
-                       "disk_type": f"{disk_type}",
-                       "machine_type": f"{machine_type}",
-                       "worker_image": f"{worker_image}",
-                       "el_install_disk_size": f"{el_install_disk_size}",
-                       "is_arm": f"{is_arm}",
-                       "is_byos": f"{is_byos}",
-                       "is_eus": f"{is_eus}",
-                       "is_oot_driver": f"{is_oot_driver}",
-                       "is_sap": f"{is_sap}",
-                       "is_lvm": f"{is_lvm}",
-                       "is_unsigned_oot_driver": f"{is_unsigned_oot_driver}",
-                       "rhui_package_name": f"{rhui_package_name}",
-                       "version_lock": f"{minor_version}"
-                    }
+                   "Vars": build_rhel_vars
                 }
             },
            "create-image": {


### PR DESCRIPTION
/cc @bkatyl @lpleahy 

The OOT GVNIC Driver is only for RHEL 10. Removing all related mentions & variables from RHEL 8/9