### PR TITLE
Installing Python 3.12 for RHEL 9 Arm

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_consolidated.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/rhel_9_consolidated.cfg
@@ -342,9 +342,16 @@ if [ "${IS_LVM}" != "true" ]; then
 fi
 dnf install -y google-compute-engine google-osconfig-agent
 # Renabling Cloud SDK to install google-cloud-cli
+if [ "${IS_ARM}" == "true" ]; then
+    dnf install -y python3.12
+fi
 dnf config-manager --set-enabled google-cloud-sdk
 dnf -y install google-cloud-cli
 rpm -q google-cloud-cli
+if [ "${IS_ARM}" == "true" ]; then
+    echo 'export CLOUDSDK_PYTHON=/usr/bin/python3.12' | sudo tee /etc/profile.d/gcloud.sh
+    chmod +x /etc/profile.d/gcloud.sh
+fi
 
 # Send /root/anaconda-ks.cfg to our logs.
 cp /run/install/ks.cfg /tmp/anaconda-ks.cfg


### PR DESCRIPTION
/cc @bkatyl @lpleahy 

Installing Python 3.12 for RHEL 9 arm images. Previous Python 3.9 is no longer supported by gcloud. Following the same process as [PR](https://github.com/GoogleCloudPlatform/compute-image-tools/pull/2709)