### PR TITLE
Remove python3-requests on Debian 13 worker images

### DIFF
--- a/daisy_workflows/image_build/debian/debian_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_worker.sh
@@ -64,7 +64,7 @@ fi
 # install from succeeding due to it being a system-installed package.
 # The newer verison of pip seems to error instead of skip pre-installed
 # system packages, so this is merely a workaround to let things work.
-if [[ ${DEBIAN_VERSION} == 13 ]]; then
+if [[ ${DEBIAN_VERSION} -eq 13 ]]; then
   echo "BuildStatus: Removing python3-requests from Debian 13"
   apt -y remove python3-requests
 fi

--- a/daisy_workflows/image_build/debian/debian_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_worker.sh
@@ -60,6 +60,15 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
+# On Debian 13, the python3-requests package prevents the later pip
+# install from succeeding due to it being a system-installed package.
+# The newer verison of pip seems to error instead of skip pre-installed
+# system packages, so this is merely a workaround to let things work.
+if [[ ${DEBIAN_VERSION} == 13 ]]; then
+  echo "BuildStatus: Removing python3-requests from Debian 13"
+  apt -y remove python3-requests
+fi
+
 echo "BuildStatus: Installing python3 libraries from pip."
 if [[ ${DEBIAN_VERSION} -ge 12 ]]; then
   pip3 install --break-system-packages -U ${PIP3_PACKAGES}


### PR DESCRIPTION
Currently, the Debian 13 worker image builds are failing due to being unable to uninstall the existing requests package due to a missing RECORD file (which only gets written if a package is installed by `pip`).

To workaround this, we uninstall the `requests` package installed by the system package manager so that the `pip` command will no longer try to uninstall it, which should let it work.

This was tested locally on a fresh Debian 13 instance, and the new flow seems to work fine.

/cc @SaswatPadhi 