### PR TITLE
CentOS 10: Remove any debug kernels

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10.cfg
@@ -191,6 +191,9 @@ rm -fr /var/cache/dnf/*
 echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
 restorecon /etc/modprobe.d/blacklist-floppy.conf
 
+# Remove any debug kernels.
+dnf remove -y kernel-debug-core
+
 # Generate initramfs from latest kernel instead of the running kernel.
 kver="$(ls -1vr /lib/modules | head -n1)"
 dracut -f --kver="${kver}"

--- a/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10_arm64.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/centos_stream_10_arm64.cfg
@@ -192,6 +192,9 @@ rm -fr /var/cache/dnf/*
 echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
 restorecon /etc/modprobe.d/blacklist-floppy.conf
 
+# Remove any debug kernels.
+dnf remove -y kernel-debug-core
+
 # Generate initramfs from latest kernel instead of the running kernel.
 kver="$(ls -1vr /lib/modules | head -n1)"
 dracut -f --kver="${kver}"


### PR DESCRIPTION
Recent builds seem to be pulling `kernel-debug-` core and modules packages.